### PR TITLE
Manoz@Area54: chore: release v0.55.31

### DIFF
--- a/.changesets/1788224235-fix-agent-agent-open-looked-for-the-cli-at-a-path-that-never-363l.md
+++ b/.changesets/1788224235-fix-agent-agent-open-looked-for-the-cli-at-a-path-that-never-363l.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): agent.open looked for the CLI at a path that never existed

--- a/.changesets/1788224235-fix-container-container-turns-hung-forever-stdin-can-never-r-ievy.md
+++ b/.changesets/1788224235-fix-container-container-turns-hung-forever-stdin-can-never-r-ievy.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(container): container turns hung forever — stdin can never reach EOF

--- a/.changesets/1788271781-feat-cef-resolve-which-browser-pane-a-cef-browser-belongs-to-ok7h.md
+++ b/.changesets/1788271781-feat-cef-resolve-which-browser-pane-a-cef-browser-belongs-to-ok7h.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(cef): resolve which browser pane a CEF Browser belongs to (camera Phase 1)

--- a/.changesets/1788272085-fix-identity-make-provider-auth-dir-isolation-correct-by-con-8lg7.md
+++ b/.changesets/1788272085-fix-identity-make-provider-auth-dir-isolation-correct-by-con-8lg7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(identity): make provider auth-dir isolation correct by construction

--- a/.changesets/1788272119-feat-cef-per-pane-per-origin-media-grant-store-camera-phase--6vk9.md
+++ b/.changesets/1788272119-feat-cef-per-pane-per-origin-media-grant-store-camera-phase--6vk9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(cef): per-pane per-origin media grant store (camera Phase 2a)

--- a/.changesets/1788272250-fix-cef-close-a-toctou-in-block-id-for-browser-lifecycle-che-tghs.md
+++ b/.changesets/1788272250-fix-cef-close-a-toctou-in-block-id-for-browser-lifecycle-che-tghs.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(cef): close a TOCTOU in block_id_for_browser lifecycle check

--- a/.changesets/1788272736-feat-cef-grant-store-driven-permission-handler-for-browser-p-neyb.md
+++ b/.changesets/1788272736-feat-cef-grant-store-driven-permission-handler-for-browser-p-neyb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(cef): grant-store-driven permission handler for browser panes (camera Phase 2b)

--- a/.changesets/1788272778-feat-muxqueue-universal-agent-work-queue-store-claim-protoco-mqe4.md
+++ b/.changesets/1788272778-feat-muxqueue-universal-agent-work-queue-store-claim-protoco-mqe4.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(muxqueue): universal agent work queue — store + claim protocol

--- a/.changesets/1788273361-feat-browser-pane-camera-mic-access-with-a-per-pane-permissi-ou8x.md
+++ b/.changesets/1788273361-feat-browser-pane-camera-mic-access-with-a-per-pane-permissi-ou8x.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(browser-pane): camera/mic access with a per-pane permission prompt (camera Phase 2c)

--- a/.changesets/1788273379-feat-armory-drop-the-host-cli-config-block-from-global-memor-mgtl.md
+++ b/.changesets/1788273379-feat-armory-drop-the-host-cli-config-block-from-global-memor-mgtl.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(armory): drop the host CLI config block from Global Memory

--- a/.changesets/1788273607-fix-memory-personal-memory-empty-for-agents-with-a-blank-wor-a5qi.md
+++ b/.changesets/1788273607-fix-memory-personal-memory-empty-for-agents-with-a-blank-wor-a5qi.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(memory): Personal Memory empty for agents with a blank working_directory

--- a/.changesets/1788274136-feat-muxqueue-http-routes-six-mcp-tools-slice-2-83ba.md
+++ b/.changesets/1788274136-feat-muxqueue-http-routes-six-mcp-tools-slice-2-83ba.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(muxqueue): HTTP routes + six MCP tools (slice 2)

--- a/.changesets/1788275734-feat-muxspect-work-inspect-the-muxqueue-backlog-from-the-cli-mw5v.md
+++ b/.changesets/1788275734-feat-muxspect-work-inspect-the-muxqueue-backlog-from-the-cli-mw5v.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(muxspect): work — inspect the Muxqueue backlog from the CLI

--- a/.changesets/1788292572-docs-execution-plan-for-the-docs-cleanup-executes-unshipped--m6fs.md
+++ b/.changesets/1788292572-docs-execution-plan-for-the-docs-cleanup-executes-unshipped--m6fs.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: execution plan for the docs cleanup (executes unshipped hardening phases)

--- a/.changesets/1788292739-docs-fix-status-on-the-docs-i-made-stale-this-session-cleanu-hgl2.md
+++ b/.changesets/1788292739-docs-fix-status-on-the-docs-i-made-stale-this-session-cleanu-hgl2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: fix status on the docs I made stale this session (cleanup batch A)

--- a/.changesets/1788292856-docs-resolve-superseded-docs-missing-their-required-pointer--3oji.md
+++ b/.changesets/1788292856-docs-resolve-superseded-docs-missing-their-required-pointer--3oji.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: resolve superseded docs missing their required pointer (cleanup batch B)

--- a/.changesets/1788293170-revert-cef-remove-non-functional-floater-ctrl-wheel-hook-3n54.md
+++ b/.changesets/1788293170-revert-cef-remove-non-functional-floater-ctrl-wheel-hook-3n54.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-revert(cef): remove non-functional floater ctrl+wheel hook

--- a/.changesets/1788293231-test-srv-raise-subprocess-io-liveness-timeouts-to-fix-a-recu-tzl1.md
+++ b/.changesets/1788293231-test-srv-raise-subprocess-io-liveness-timeouts-to-fix-a-recu-tzl1.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-test(srv): raise subprocess_io liveness timeouts to fix a recurring CI flake

--- a/.changesets/1788293613-ci-enforce-the-docs-status-vocabulary-and-run-the-orphaned-g-j5fu.md
+++ b/.changesets/1788293613-ci-enforce-the-docs-status-vocabulary-and-run-the-orphaned-g-j5fu.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-ci: enforce the docs Status vocabulary and run the orphaned grep gates (cleanup batch E)

--- a/.changesets/1788295212-docs-generate-the-specs-index-by-status-so-it-stops-going-st-9ijs.md
+++ b/.changesets/1788295212-docs-generate-the-specs-index-by-status-so-it-stops-going-st-9ijs.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: generate the specs index by status so it stops going stale (cleanup batch D)

--- a/.changesets/1788296814-docs-record-what-the-cleanup-plan-actually-executed-ozzj.md
+++ b/.changesets/1788296814-docs-record-what-the-cleanup-plan-actually-executed-ozzj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: record what the cleanup plan actually executed

--- a/.changesets/1788311088-feat-armory-browse-personal-memory-by-agent-block-instead-of-iyu7.md
+++ b/.changesets/1788311088-feat-armory-browse-personal-memory-by-agent-block-instead-of-iyu7.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): browse Personal Memory by agent block instead of a dropdown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.30"
+version = "0.55.31"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.30"
+version = "0.55.31"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.30"
+version = "0.55.31"
 dependencies = [
  "base64",
  "dirs",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.30"
+version = "0.55.31"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.30"
+version = "0.55.31"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.30"
+version = "0.55.31"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.30"
+version = "0.55.31"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,31 @@
 # AgentMux Version History
 
+## 0.55.31 — 2026-09-01
+
+- fix(agent): agent.open looked for the CLI at a path that never existed
+- fix(container): container turns hung forever — stdin can never reach EOF
+- feat(cef): resolve which browser pane a CEF Browser belongs to (camera Phase 1)
+- fix(identity): make provider auth-dir isolation correct by construction
+- feat(cef): per-pane per-origin media grant store (camera Phase 2a)
+- fix(cef): close a TOCTOU in block_id_for_browser lifecycle check
+- feat(cef): grant-store-driven permission handler for browser panes (camera Phase 2b)
+- feat(muxqueue): universal agent work queue — store + claim protocol
+- feat(browser-pane): camera/mic access with a per-pane permission prompt (camera Phase 2c)
+- feat(armory): drop the host CLI config block from Global Memory
+- fix(memory): Personal Memory empty for agents with a blank working_directory
+- feat(muxqueue): HTTP routes + six MCP tools (slice 2)
+- feat(muxspect): work — inspect the Muxqueue backlog from the CLI
+- docs: execution plan for the docs cleanup (executes unshipped hardening phases)
+- docs: fix status on the docs I made stale this session (cleanup batch A)
+- docs: resolve superseded docs missing their required pointer (cleanup batch B)
+- revert(cef): remove non-functional floater ctrl+wheel hook
+- test(srv): raise subprocess_io liveness timeouts to fix a recurring CI flake
+- ci: enforce the docs Status vocabulary and run the orphaned grep gates (cleanup batch E)
+- docs: generate the specs index by status so it stops going stale (cleanup batch D)
+- docs: record what the cleanup plan actually executed
+- feat(armory): browse Personal Memory by agent block instead of a dropdown
+
+
 ## 0.55.30 — 2026-08-31
 
 - fix(agent-pane): peek panel shrink-wraps, floats right, and shows 12-hour AM/PM time

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.30",
+  "version": "0.55.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.30",
+      "version": "0.55.31",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.30",
+  "version": "0.55.31",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release PR consuming all 22 pending changesets. **Forced patch bump** via `task release -- --as patch`, per request.

`0.55.30 → 0.55.31`

## ⚠️ Forced-lower bump — read this

The queued changesets were **4 minor + 18 patch**, so the computed type would have been **minor (0.56.0)**. The `--as patch` override ships them under a patch version instead, and the release script printed its loud warning as designed:

```
WARNING: forcing a LOWER bump than the changesets request — some
         minor-level change(s) will ship under a patch version.
```

The four feature changesets riding under this patch:
- `feat(muxqueue)`: universal agent work queue — store + claim protocol
- `feat(muxqueue)`: HTTP routes + six MCP tools (slice 2)
- `feat(browser-pane)`: camera/mic access with a per-pane permission prompt
- `feat(armory)`: browse Personal Memory by agent block instead of a dropdown

Confirmed **no `major`** changeset was queued before forcing.

## Version consistency invariant

Verified independently of the script — all five locations agree at **0.55.31**:

| Location | Value |
|---|---|
| `VERSION_HISTORY.md` head | `## 0.55.31 — 2026-09-01` |
| `package.json.version` | 0.55.31 |
| `Cargo.toml [workspace.package]` | 0.55.31 |
| `Cargo.lock` workspace member (`agentmux-cef`) | 0.55.31 |
| `package-lock.json` root | 0.55.31 |

22 changesets consumed and deleted; `.changesets/README.md` correctly preserved (it's directory docs, not a changeset).

## Test plan
- [x] `task release -- --as patch` completed; script's own 5-location re-read passed
- [x] Re-verified the invariant by hand (table above) rather than trusting the script alone
- [x] Staged diff touches only version files + `VERSION_HISTORY.md` + changeset deletions — no source changes
- [x] All 22 changeset descriptions present in the new `VERSION_HISTORY` section

<!-- agentmux:agent_id=manoz -->