### PR TITLE
fix(agent): stand down the Working row on promotion, move it above the composer

### DIFF
--- a/.changesets/1788314332-fix-agent-hide-working-row-once-a-tool-is-promoted-to-the-do-6i96.md
+++ b/.changesets/1788314332-fix-agent-hide-working-row-once-a-tool-is-promoted-to-the-do-6i96.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): hide Working row once a tool is promoted to the dock; move it above the composer

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -201,7 +201,7 @@ deliberately do not.
 | [`SPEC_AGENT_TOOL_CALL_TONES_2026_06_05`](SPEC_AGENT_TOOL_CALL_TONES_2026_06_05.md) | SPEC — Agent tool-call tones (subliminal "talking" voice) |
 | [`SPEC_AGENT_TURN_PHASE_TIMELINE_LOGGING_2026_08_18`](SPEC_AGENT_TURN_PHASE_TIMELINE_LOGGING_2026_08_18.md) | SPEC: Agent turn-phase timeline — unified, replayable phase-history logging + `muxlog phases` |
 | [`SPEC_AGENT_VIEW_SCSS_SPLIT_2026_04_24`](SPEC_AGENT_VIEW_SCSS_SPLIT_2026_04_24.md) | Spec: agent-view.scss Decomposition |
-| [`SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06`](SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md) | Spec: Continuous AgentWorkingRow background through the scrollbar gutter |
+| [`SPEC_AGENT_WORKING_ROW_ABOVE_COMPOSER_2026_09_01`](SPEC_AGENT_WORKING_ROW_ABOVE_COMPOSER_2026_09_01.md) | Working row: stand down on promotion, and sit above the composer |
 | [`SPEC_AMBIENT_PANE_TITLE_OVERALL_GOAL_TRACKING_2026_08_17`](SPEC_AMBIENT_PANE_TITLE_OVERALL_GOAL_TRACKING_2026_08_17.md) | SPEC: Pane title tracks the session's overall goal, not the latest micro-step |
 | [`SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09`](SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md) | SPEC — Armory "Bind to Agent" context menu on account rows |
 | [`SPEC_ARMORY_MEMORY_GLOBAL_PERSONAL_RENAME_2026_08_22`](SPEC_ARMORY_MEMORY_GLOBAL_PERSONAL_RENAME_2026_08_22.md) | Spec: Armory rail — "Global Memory" / "Personal Memory" rename + reposition |
@@ -611,11 +611,12 @@ deliberately do not.
 | [`SPEC_DECISION_PROMPT_DESIGN_2026_04_25`](SPEC_DECISION_PROMPT_DESIGN_2026_04_25.md) | Decision Prompt — Cohesive Design (Step-Back Doc) |
 | [`SPEC_POOL_COVERAGE_AND_ROADMAP_2026_06_20`](SPEC_POOL_COVERAGE_AND_ROADMAP_2026_06_20.md) | Pre-warmed Window Pool — Coverage Map and Implementation Roadmap |
 
-### superseded (2)
+### superseded (3)
 
 | Spec | Title |
 |---|---|
 | [`SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09`](SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md) | SPEC — Account adoption: piggyback an unlinked agent onto an existing login |
+| [`SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06`](SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md) | Spec: Continuous AgentWorkingRow background through the scrollbar gutter |
 | [`SPEC_COMPOSER_STRIP_LEFT_RIGHT_BALANCE_2026_08_24`](SPEC_COMPOSER_STRIP_LEFT_RIGHT_BALANCE_2026_08_24.md) | SPEC: Composer strip — balance misc elements across left/right zones |
 
 ### no status line (125)

--- a/docs/specs/SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md
+++ b/docs/specs/SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md
@@ -1,7 +1,17 @@
 # SPEC: Agent pane — fix silent auto-scroll-follow drops, extend the message-list scrollbar past the Working/Host status rows
 
 **Date:** 2026-07-24
-**Status:** Implemented
+**Status:** Implemented — except **§3.2**, superseded 2026-09-01 by
+`SPEC_AGENT_WORKING_ROW_ABOVE_COMPOSER_2026_09_01.md`.
+
+> **§3.2 only.** The floating-overlay arrangement described there
+> (AgentWorkingRow absolutely positioned over `.agent-document-scroll-region`'s
+> bottom edge, with `.agent-document` reserving matching padding) is gone: the
+> row is now a normal-flow sibling between the ActivityDock and the composer.
+> **Everything else in this spec stands and is still load-bearing** — in
+> particular §2's scroll-follow analysis and both re-pin observers. The 09-01
+> change actually leans on §3.3's normal-flow-sibling handling (the working row
+> simply joined that family) rather than contradicting it.
 **Scope:** `frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx`, `frontend/app/view/agent/agent-view.tsx`, `frontend/app/view/agent/components/AgentFooter.tsx`, `frontend/app/view/agent/components/AgentComposerStrip.tsx`, `frontend/app/view/agent/styles/_document.scss`, `frontend/app/view/agent/styles/_control-bar.scss`, `frontend/app/view/agent/styles/_composer-strip.scss`
 **Author:** Agent3
 

--- a/docs/specs/SPEC_AGENT_WORKING_ROW_ABOVE_COMPOSER_2026_09_01.md
+++ b/docs/specs/SPEC_AGENT_WORKING_ROW_ABOVE_COMPOSER_2026_09_01.md
@@ -1,0 +1,145 @@
+# Working row: stand down on promotion, and sit above the composer
+
+**Date:** 2026-09-01
+**Status:** Implemented
+**Supersedes (in part):** `SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md` §3.2,
+`SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md` (entirely — see §4)
+
+Two changes to `AgentWorkingRow`, both about the same thing: making the agent
+pane's bottom stack say each fact exactly once, in the place the eye already
+is.
+
+---
+
+## 1. The working row stands down when the dock takes over
+
+### Problem
+
+Long-running shells are auto-promoted into the ActivityDock after
+`TOOL_PROMOTION_MS` (or immediately, for a declared `sleep` — the case that
+prompted this). Promotion is the moment the work stops being *"the pane is
+blocked on this"* and becomes *"this is running in the background, tracked
+over there, with its own live countdown."*
+
+The `Working…` row kept rendering straight through that transition. So the
+pane showed two rows for one fact, and the louder of the two asserted the
+opposite of what had just happened: `Working…` says the pane is busy waiting,
+when backgrounding the task is precisely what made it not busy.
+
+`toolPromoted` was already plumbed into `AgentWorkingRow`, but it only
+suppressed the *label* (`AgentFooter.tsx` — `props.currentTool &&
+!props.toolPromoted`), never the row. The spinner and elapsed timer stayed.
+
+### Fix
+
+`workingRowSupersededByDock` (`activity/working-row-supersession.ts`) gates
+`workingRowLoading`. With no other reason to be visible — `sessionStats` is
+cleared at turn submit, so a stale "✓ Worked · Ns" can't stand in — the row
+hides outright.
+
+**Deliberately narrow.** It suppresses only the plain "a promoted tool is
+running and nothing else is happening" case. Everything the dock has no
+vocabulary for keeps the row:
+
+| State | Why the dock can't express it |
+|---|---|
+| launch activity | the pane isn't up yet; the dock says nothing about launch |
+| `Interrupting` | "Stopping…" is about the turn, not the tool |
+| `waitingReason` (rate limited / retrying) | a real condition with no dock representation — and the one the user most needs to see |
+| compacting | not a tool |
+| reconnecting | not a tool |
+
+The predicate is a pure function with its own tests rather than a closure
+inside `agent-view.tsx`, because the interesting part *is* that exception
+list: the failure mode of this feature is silently swallowing one of those
+five states, and that is exactly what a test can pin.
+
+---
+
+## 2. The row moves to sit directly above the composer
+
+### Problem
+
+Reading bottom-up, the pane's stack put this turn's own live status
+*furthest* from the composer, above the dock's background tasks — the
+opposite of how attention narrows.
+
+### Fix
+
+DOM order is now:
+
+```
+ActivityDock          ← long-running background tasks
+AgentWorkingRow       ← what this turn is doing right now
+AgentComposerStrip    ← where you type
+```
+
+Bottom-up, scope narrows: what's running in the background → what's happening
+this instant → where you act.
+
+---
+
+## 3. What this deleted
+
+The row previously floated over `.agent-document-scroll-region`'s bottom edge
+as an absolutely-positioned overlay (07-24 §3.2), so the message list's
+scrollbar could run that box's full height. That one decision required a
+surprising amount of scaffolding to hold up — all of which the move removes,
+because **a row that is not inside the scroll region cannot overlap its
+scrollbar or its content in the first place.**
+
+| Removed | What it was compensating for |
+|---|---|
+| `workingRowHeight` signal + ref-callback `ResizeObserver` (`agent-view.tsx`) | measuring the overlay so the document could reserve space under it |
+| `--agent-working-row-height` custom property | shipping that measurement across two component boundaries via the CSS cascade |
+| `.agent-document`'s `padding-bottom: calc(… + var(…))` | keeping the last message from hiding beneath the overlay at true bottom |
+| `workingRowHeight` prop through `AgentDocumentView` → `AgentDocumentVirtualList` | — |
+| that prop as a third stick-to-bottom dependency | overlay growth changing effective content height with no node/layout change (reagent P1 on #2292) |
+| `.agent-working-row-backdrop` (element, both style variants, and its `<Show>`) | coloring the scrollbar gutter the overlay had to stay inset from (08-06, entirely) |
+| the anchor's `right: var(--agent-document-scrollbar-width)` inset | stopping the row's opaque background from painting over the native scrollbar |
+| the anchor's `z-index: 2` + `pointer-events: none` / row-level `auto` | paint order against `.agent-document`, and stopping the anchor's empty margin from swallowing clicks meant for the message list |
+| `.agent-view--working-row-visible` class + its margin rule | closing the gap between the row's color and the panel directly below it |
+
+Net: **−32 lines** across the two scroll/virtualization files alone, plus two
+CSS blocks, with no behavior traded away.
+
+### Scroll-follow is still correct
+
+The one real question this raises. As a normal-flow sibling, the row changes
+the scroll region's **`clientHeight`** when it appears or disappears — not its
+content height.
+
+`AgentDocumentVirtualList`'s `clientHeight` `ResizeObserver` already re-pins on
+exactly that, and was written for exactly this family of siblings: its own
+comment names "the retry bar, AgentDecisionPanel, AgentQuestionPanel, or
+PendingMessagesPanel appearing/growing mid-turn — all normal-flow,
+flex-shrink:0 rows." The working row simply joins that list. It needs no
+tracked height signal of its own, which is why removing the dependency above
+is safe rather than a regression waiting to happen — the observer was
+introduced specifically to stop the per-panel-signal whack-a-mole that the
+overlay's own tracked dependency was an instance of.
+
+---
+
+## 4. Note on the superseded specs
+
+`SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md` is superseded in full:
+every element it introduced existed to serve the overlay geometry, and the
+bug it fixed (the scrollbar gutter showing plain pane background instead of
+the row's color) cannot occur for a row outside the scroll region.
+
+`SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md` is superseded
+only at **§3.2** (the overlay itself). Its §2 scroll-follow analysis and the
+`clientHeight`/content-resize observers remain load-bearing and unchanged —
+this change leans on §3.3's normal-flow-sibling handling rather than
+contradicting it.
+
+---
+
+## 5. Verification
+
+- `workingRowSupersession.test.ts` — 9 tests: the promotion case, the
+  no-promotion case, all five keep-the-row exceptions, and two guards on
+  reading the optional `waitingReason` off a non-`Streaming` variant.
+- `npx tsc --noEmit` clean.
+- Full `frontend/app/view/agent` suite green.

--- a/docs/specs/SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md
+++ b/docs/specs/SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md
@@ -1,7 +1,9 @@
 # Spec: Continuous AgentWorkingRow background through the scrollbar gutter
 
 **Date:** 2026-08-06
-**Status:** superseded — by `SPEC_AGENT_WORKING_ROW_ABOVE_COMPOSER_2026_09_01.md` (2026-09-01).
+**Status:** superseded — 2026-09-01, see `Superseded-by:` below.
+**Superseded-by:** [`SPEC_AGENT_WORKING_ROW_ABOVE_COMPOSER_2026_09_01.md`](./SPEC_AGENT_WORKING_ROW_ABOVE_COMPOSER_2026_09_01.md)
+
 Was implemented in PR #2439 (backdrop-layer fix) and verified in code 2026-08-10.
 Superseded **in full**: every element this spec introduced — the
 `.agent-working-row-backdrop` layer, the anchor's scrollbar-width inset, and

--- a/docs/specs/SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md
+++ b/docs/specs/SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md
@@ -1,7 +1,16 @@
 # Spec: Continuous AgentWorkingRow background through the scrollbar gutter
 
 **Date:** 2026-08-06
-**Status:** implemented — PR #2439 (backdrop-layer fix); verified in code 2026-08-10.
+**Status:** superseded — by `SPEC_AGENT_WORKING_ROW_ABOVE_COMPOSER_2026_09_01.md` (2026-09-01).
+Was implemented in PR #2439 (backdrop-layer fix) and verified in code 2026-08-10.
+Superseded **in full**: every element this spec introduced — the
+`.agent-working-row-backdrop` layer, the anchor's scrollbar-width inset, and
+the stacking-context reasoning that ordered them — existed to serve the
+floating-overlay geometry of `SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md`
+§3.2. The working row is now a normal-flow sibling below the ActivityDock,
+outside `.agent-document-scroll-region` entirely, so it cannot paint over the
+message list's scrollbar and the gutter-color gap this spec fixed cannot
+occur. Retained for history, not as a description of current code.
 **Scope:** `frontend/app/view/agent/agent-view.tsx`, `frontend/app/view/agent/styles/_control-bar.scss`, `frontend/app/view/agent/styles/_document.scss`
 **Related:** `SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md` §3.2 (introduced the floating-overlay architecture this spec builds on), the `.agent-working-row-anchor` z-index-obscures-scrollbar comment in `_control-bar.scss` (the earlier bug this spec must not reintroduce)
 

--- a/frontend/app/view/agent/activity/working-row-supersession.test.ts
+++ b/frontend/app/view/agent/activity/working-row-supersession.test.ts
@@ -1,0 +1,77 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import type { TurnPhase } from "@/app/store/agent-pane-state/types";
+import { workingRowSupersededByDock, type WorkingRowSupersessionInput } from "./working-row-supersession";
+
+const STREAMING: TurnPhase = { kind: "Streaming", bufferSize: 0, toolsActive: 1, lastEventMs: 0 };
+
+/** The case the feature exists for: a promoted tool is running and nothing
+ *  else about this turn needs saying. Individual tests override one field. */
+function busyWithPromotedTool(over: Partial<WorkingRowSupersessionInput> = {}): WorkingRowSupersessionInput {
+    return {
+        hasPromotedTool: true,
+        showingLaunchActivity: false,
+        turnPhase: STREAMING,
+        compacting: null,
+        reconnecting: null,
+        ...over,
+    };
+}
+
+describe("workingRowSupersededByDock", () => {
+    it("supersedes the working row once a tool is promoted to the dock", () => {
+        // The whole point of auto-backgrounding: the dock owns this work now,
+        // with its own live countdown. "Working…" on top of that claims the
+        // pane is blocked when backgrounding it is exactly what just happened.
+        expect(workingRowSupersededByDock(busyWithPromotedTool())).toBe(true);
+    });
+
+    it("keeps the working row while no tool has been promoted", () => {
+        // Ordinary in-flight turn — nothing in the dock to defer to.
+        expect(workingRowSupersededByDock(busyWithPromotedTool({ hasPromotedTool: false }))).toBe(false);
+    });
+
+    describe("keeps the row for every state the dock cannot express", () => {
+        // Each of these can co-occur with a promoted tool. The dock has no
+        // vocabulary for any of them, so suppressing the row would drop the
+        // information entirely rather than relocate it.
+
+        it("launch activity — the pane isn't even up yet", () => {
+            expect(workingRowSupersededByDock(busyWithPromotedTool({ showingLaunchActivity: true }))).toBe(false);
+        });
+
+        it("Interrupting — 'Stopping…' is about the turn, not the tool", () => {
+            const turnPhase: TurnPhase = { kind: "Interrupting", reason: "user", sigintSentAt: 0 };
+            expect(workingRowSupersededByDock(busyWithPromotedTool({ turnPhase }))).toBe(false);
+        });
+
+        it("rate-limited — the condition the user most needs to see", () => {
+            const turnPhase: TurnPhase = { ...STREAMING, waitingReason: "rate_limited" };
+            expect(workingRowSupersededByDock(busyWithPromotedTool({ turnPhase }))).toBe(false);
+        });
+
+        it("compacting", () => {
+            expect(workingRowSupersededByDock(busyWithPromotedTool({ compacting: { startedAt: 0 } }))).toBe(false);
+        });
+
+        it("reconnecting", () => {
+            expect(workingRowSupersededByDock(busyWithPromotedTool({ reconnecting: { attempt: 1 } }))).toBe(false);
+        });
+    });
+
+    it("does not treat a plain Streaming phase without waitingReason as special", () => {
+        // Guards the optional-field read: `waitingReason` is absent (not
+        // null/false) on an ordinary Streaming phase, so a truthiness check
+        // that mishandled `undefined` would silently keep the row forever.
+        const turnPhase: TurnPhase = { ...STREAMING, waitingReason: undefined };
+        expect(workingRowSupersededByDock(busyWithPromotedTool({ turnPhase }))).toBe(true);
+    });
+
+    it("only consults waitingReason on a Streaming phase", () => {
+        // Idle carries no waitingReason field at all — reading it off a
+        // non-Streaming variant must not throw or flip the result.
+        expect(workingRowSupersededByDock(busyWithPromotedTool({ turnPhase: { kind: "Idle" } }))).toBe(true);
+    });
+});

--- a/frontend/app/view/agent/activity/working-row-supersession.ts
+++ b/frontend/app/view/agent/activity/working-row-supersession.ts
@@ -1,0 +1,63 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Should the "Working…" row stand down because the ActivityDock is already
+ * showing this work?
+ *
+ * Promotion (tool-adapter.ts) is the point at which a tool call stops being
+ * "the pane is blocked on this" and becomes "this is running in the
+ * background, tracked over there, with its own live countdown". That is the
+ * entire purpose of auto-backgrounding a long-running shell — so continuing
+ * to render `Working…` on top of it asserts the pane is busy waiting when
+ * the whole point was that it no longer is. Two rows for one fact, and the
+ * louder one is the wrong one.
+ *
+ * Deliberately narrow: this suppresses ONLY the plain "a promoted tool is
+ * running and nothing else is happening" case. Every state the dock cannot
+ * express keeps the row — see the individual guards below. The dock speaks
+ * in tools and elapsed time; anything outside that vocabulary would be lost,
+ * not relocated, if the row went away.
+ *
+ * Pure and separately tested (working-row-supersession.test.ts) rather than
+ * inlined in agent-view.tsx: the interesting part is precisely the list of
+ * exceptions, and that list is worth pinning against regression.
+ *
+ * See SPEC_AGENT_WORKING_ROW_ABOVE_COMPOSER_2026_09_01.md.
+ */
+
+import type { TurnPhase } from "@/app/store/agent-pane-state/types";
+
+export interface WorkingRowSupersessionInput {
+    /** A Bash tool call in this pane is running AND has been promoted to a
+     *  live dock row (`hasRunningPromotedTool`, tool-adapter.ts). */
+    hasPromotedTool: boolean;
+    /** The pane is still starting up / authenticating. */
+    showingLaunchActivity: boolean;
+    turnPhase: TurnPhase;
+    /** Non-null while a context compaction is in flight. */
+    compacting: unknown;
+    /** Non-null while the stream is reconnecting. */
+    reconnecting: unknown;
+}
+
+export function workingRowSupersededByDock(input: WorkingRowSupersessionInput): boolean {
+    // Nothing in the dock to defer to.
+    if (!input.hasPromotedTool) return false;
+
+    // The pane isn't up yet; the dock says nothing about launch.
+    if (input.showingLaunchActivity) return false;
+
+    // "Stopping…" is about the turn, not the tool.
+    if (input.turnPhase.kind === "Interrupting") return false;
+
+    // Rate-limited / retrying — a real condition the dock has no vocabulary
+    // for, and the one the user most needs to see.
+    if (input.turnPhase.kind === "Streaming" && input.turnPhase.waitingReason) return false;
+
+    // Same reasoning: neither is a tool, so neither appears in the dock.
+    if (input.compacting != null) return false;
+    if (input.reconnecting != null) return false;
+
+    return true;
+}

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -62,6 +62,7 @@ import { Portal } from "solid-js/web";
 import { earliestLiveAttachedStartMs } from "./activity/attached-task";
 import { allSubagentsAtom } from "./activity/subagent-source";
 import { hasRunningPromotedTool, nextToolPromotionAt } from "./activity/tool-adapter";
+import { workingRowSupersededByDock } from "./activity/working-row-supersession";
 import type { AgentViewModel } from "./agent-model";
 import "./agent-view.scss";
 import { ActivityDock } from "./components/ActivityDock";
@@ -1548,62 +1549,6 @@ const AgentPresentationView = ({
     // mounts via scrollToBottomRef.
     let scrollToBottomFn: (() => void) | null = null;
 
-    // Tracks AgentWorkingRow's rendered height (0 when hidden) so
-    // .agent-document can reserve exactly that much bottom padding — the
-    // row now floats over the scroll region instead of pushing it up as a
-    // normal-flow sibling (SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md
-    // §3.2), so without this, "scrolled to true bottom" would leave the
-    // last message hidden underneath the floating row instead of above it.
-    // Exposed to .agent-document (nested inside AgentDocumentView, several
-    // component boundaries away) via a CSS custom property set on the
-    // shared .agent-document-scroll-region ancestor — custom properties
-    // cascade through the DOM tree regardless of component boundaries.
-    const [workingRowHeight, setWorkingRowHeight] = createSignal(0);
-
-    // Shared by the anchor's <Show> and the backdrop's <Show>/color below
-    // (SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md §5) so the two
-    // can't drift out of sync — both need to agree on "is the row visible
-    // at all" and "is it the loading (vs. worked) variant" independent of
-    // the anchor's own inset-from-scrollbar geometry.
-    const workingRowLoading = createMemo(
-        () => showingLaunchActivity() || workingFromPhase(agentAtoms().turnPhaseAtom[0]())
-    );
-    const workingRowVisible = createMemo(
-        () =>
-            workingRowLoading() ||
-            agentAtoms().sessionStatsAtom[0]() != null ||
-            agentAtoms().compactingAtom[0]() != null ||
-            agentAtoms().reconnectingAtom[0]() != null,
-    );
-
-    // Ref CALLBACK, not a one-shot onMount(): originally fixed a bug where
-    // Agent History's now-removed `bodyMode` in-place swap (PR #2509)
-    // remounted this anchor div WITHIN one persistent AgentPresentationView
-    // instance, while a plain onMount (this component's own, firing once
-    // for the instance's whole lifetime) kept observing the stale, now-
-    // detached pre-swap node — `workingRowHeight` silently froze and the
-    // floating AgentWorkingRow visibly overlapped the last message. That
-    // specific in-place remount is gone now that Agent History is its own
-    // tab (SPEC_AGENT_HISTORY_AS_TAB_AND_DRAFT_PRESERVATION_2026_08_11.md
-    // §3.1) — but a ref callback (re-observing on every mount of THIS
-    // element, not just the component's first) is still the more robust
-    // shape in general, so it stays: correct whether this component mounts
-    // once or many times over its host block's life (which, per §1 of that
-    // spec, it now does on every ordinary tab switch too).
-    let workingRowRO: ResizeObserver | undefined;
-    const attachWorkingRowAnchor = (el: HTMLDivElement) => {
-        workingRowRO?.disconnect();
-        workingRowRO = undefined;
-        if (typeof ResizeObserver === "undefined") return;
-        const ro = new ResizeObserver((entries) => {
-            const h = entries[0]?.contentRect.height ?? 0;
-            setWorkingRowHeight(h);
-        });
-        ro.observe(el);
-        workingRowRO = ro;
-    };
-    onCleanup(() => workingRowRO?.disconnect());
-
     // True once the pane's in-flight Bash tool call has been promoted to a
     // live ActivityDock row (tool-adapter.ts) — AgentWorkingRow suppresses
     // its own "tool · arg" text once this flips, so the dock and the working
@@ -1630,6 +1575,34 @@ const AgentPresentationView = ({
         const timer = setTimeout(() => setToolPromotionCheckNonce((n) => n + 1), Math.max(0, at - now) + 50);
         onCleanup(() => clearTimeout(timer));
     });
+
+    // True when the ONLY thing keeping this turn busy is a tool call that has
+    // already been promoted into the ActivityDock — i.e. auto-backgrounded, so
+    // the dock is already saying everything this row would. Rationale and the
+    // full list of states that deliberately KEEP the row live in
+    // activity/working-row-supersession.ts, which is separately tested.
+    const supersededByDock = createMemo(() =>
+        workingRowSupersededByDock({
+            hasPromotedTool: hasPromotedTool(),
+            showingLaunchActivity: showingLaunchActivity(),
+            turnPhase: agentAtoms().turnPhaseAtom[0](),
+            compacting: agentAtoms().compactingAtom[0](),
+            reconnecting: agentAtoms().reconnectingAtom[0](),
+        })
+    );
+
+    const workingRowLoading = createMemo(
+        () =>
+            !supersededByDock() &&
+            (showingLaunchActivity() || workingFromPhase(agentAtoms().turnPhaseAtom[0]()))
+    );
+    const workingRowVisible = createMemo(
+        () =>
+            workingRowLoading() ||
+            agentAtoms().sessionStatsAtom[0]() != null ||
+            agentAtoms().compactingAtom[0]() != null ||
+            agentAtoms().reconnectingAtom[0]() != null,
+    );
 
     // Attached-task axis dispatch — the deferred §6.1 call site of
     // SPEC_ATTACHED_TASK_STATUS_AXIS_2026_08_02.md. Derives "≥1 live
@@ -2049,7 +2022,6 @@ const AgentPresentationView = ({
         <div
             ref={rootRef}
             class="agent-view agent-view--presentation"
-            classList={{ "agent-view--working-row-visible": workingRowVisible() }}
             style={{ zoom: zoomFactor(), "--agent-pane-zoom": String(zoomFactor()) }}
             onContextMenu={handleContextMenu}
             tabIndex={-1}
@@ -2127,51 +2099,24 @@ const AgentPresentationView = ({
                 scrolls with the transcript instead of staying fixed in
                 place. See SPEC_AGENT_HISTORY_AS_TAB_AND_DRAFT_PRESERVATION_2026_08_11.md §3.2. */}
             {/* Scroll region wrapper — .agent-document (inside AgentDocumentView)
-                is absolutely positioned to fill this box, and AgentWorkingRow
-                floats over its bottom edge instead of pushing it up as a
-                normal-flow sibling. Lets the message list's scrollbar reach
-                all the way to the bottom of this region instead of stopping
-                short by AgentWorkingRow's own height.
-                See docs/specs/SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md §3.2. */}
-            <div
-                class="agent-document-scroll-region"
-                style={{ "--agent-working-row-height": `${workingRowHeight()}px` }}
-            >
-                {/* Full-width decorative backdrop, stacked below
-                    .agent-document (and thus below its scrollbar) so the
-                    working row's color reaches the pane's true right edge
-                    without ever painting over the scrollbar — the anchor
-                    below stays inset from the scrollbar gutter for that
-                    reason, but nothing filled the gutter itself with a
-                    matching color until now (the scrollbar track is
-                    fully transparent). See
-                    docs/specs/SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md. */}
-                <Show when={workingRowVisible()}>
-                    <div
-                        class="agent-working-row-backdrop"
-                        classList={{
-                            // Must mirror AgentWorkingRow's OWN loading gate
-                            // (`props.loading || !!props.compacting ||
-                            // !!props.reconnecting`, AgentFooter.tsx), not
-                            // just `workingRowLoading()` — reagent P1 on
-                            // PR #2826: since `workingRowVisible()` above
-                            // already renders this backdrop for
-                            // compacting/reconnecting too, using only
-                            // `workingRowLoading()` here left the backdrop in
-                            // its `--worked` (non-loading) color while the
-                            // row itself rendered its loading/accent-tinted
-                            // variant during those two states — the exact
-                            // backdrop/row color-mismatch
-                            // SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md
-                            // fixed for the plain loading case.
-                            "agent-working-row-backdrop--loading":
-                                workingRowLoading() ||
-                                agentAtoms().compactingAtom[0]() != null ||
-                                agentAtoms().reconnectingAtom[0]() != null,
-                        }}
-                    />
-                </Show>
+                is absolutely positioned to fill this box.
 
+                AgentWorkingRow used to float over this box's bottom edge
+                (SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md
+                §3.2) so the message list's scrollbar could run the full height
+                of the region. As of
+                SPEC_AGENT_WORKING_ROW_ABOVE_COMPOSER_2026_09_01.md the row is
+                a normal-flow sibling below the dock instead — which reaches
+                the same goal more simply, since a row that is no longer
+                *inside* this box cannot cover the scrollbar or the last
+                message in the first place. That removed the overlay's whole
+                support apparatus: the height-measuring ResizeObserver, the
+                --agent-working-row-height custom property, .agent-document's
+                matching padding-bottom reservation, and the full-width
+                backdrop that existed only to color the scrollbar gutter the
+                overlay had to stay inset from
+                (SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md). */}
+            <div class="agent-document-scroll-region">
                 <AgentDocumentView
                     documentAtom={displayDocumentAtom}
                     documentStateAtom={agentAtoms().documentStateAtom}
@@ -2204,43 +2149,7 @@ const AgentPresentationView = ({
                     zoomFactor={zoomFactor}
                     blockId={model.blockId}
                     layoutView={layoutView}
-                    workingRowHeight={workingRowHeight}
                 />
-
-                {/* Working indicator — floats over the bottom of the scroll
-                    region instead of occupying its own flex row. The ref'd
-                    wrapper collapses to 0 height when the Show is false, so
-                    the ResizeObserver above naturally reports 0 (no working
-                    row currently rendered) without extra branching.
-                    Shows spinner + elapsed while loading, "✓ Worked · Ns" on completion.
-                    Acts as a visual turn delimiter; stays until next message is sent.
-                    See SPEC_AGENT_PANE_STATUS_GRADIENT_2026_06_14.md §2. */}
-                <div class="agent-working-row-anchor" ref={attachWorkingRowAnchor}>
-                    <Show when={workingRowVisible()}>
-                        <AgentWorkingRow
-                            loading={workingRowLoading()}
-                            stopping={agentAtoms().turnPhaseAtom[0]().kind === "Interrupting"}
-                            currentTool={agentAtoms().currentToolAtom[0]()}
-                            currentToolArg={agentAtoms().currentToolArgAtom[0]()}
-                            toolPromoted={hasPromotedTool()}
-                            sessionStats={agentAtoms().sessionStatsAtom[0]()}
-                            turnTokens={agentAtoms().turnTokensAtom[0]()}
-                            launchPhase={status.launchPhase()}
-                            onCancelLogin={status.cancelLogin}
-                            hasAuthUrl={!!status.authUrl()}
-                            waitingReason={(() => {
-                                const phase = agentAtoms().turnPhaseAtom[0]();
-                                return phase.kind === "Streaming" ? (phase.waitingReason ?? null) : null;
-                            })()}
-                            retryAfterMs={(() => {
-                                const phase = agentAtoms().turnPhaseAtom[0]();
-                                return phase.kind === "Streaming" ? (phase.retryAfterMs ?? null) : null;
-                            })()}
-                            compacting={agentAtoms().compactingAtom[0]()}
-                            reconnecting={agentAtoms().reconnectingAtom[0]()}
-                        />
-                    </Show>
-                </div>
             </div>
 
             {/* Login UI — bottom-docked like AgentDecisionPanel/
@@ -2381,6 +2290,54 @@ const AgentPresentationView = ({
                 blockId={model.blockId}
                 backgroundTasksAtom={backgroundTasksAtom}
             />
+
+            {/* Working indicator — the turn's own status, so it sits directly
+                above the composer, with the dock's long-running tasks stacked
+                above it. Reads bottom-up as narrowing scope: what's running in
+                the background (dock) → what this turn is doing right now
+                (here) → where you type.
+
+                Normal-flow row, not the overlay it used to be — see the
+                .agent-document-scroll-region comment above for what that
+                change removed. When it appears or disappears it changes the
+                scroll region's clientHeight, which
+                AgentDocumentVirtualList's clientHeight ResizeObserver already
+                re-pins on; that observer was written for exactly this family
+                of normal-flow siblings (the retry bar, decision/question
+                panels, PendingMessagesPanel), so the row simply joins them
+                rather than needing its own tracked height signal.
+
+                Shows spinner + elapsed while loading, "✓ Worked · Ns" on
+                completion. Acts as a visual turn delimiter; stays until the
+                next message is sent.
+                See SPEC_AGENT_PANE_STATUS_GRADIENT_2026_06_14.md §2 and
+                SPEC_AGENT_WORKING_ROW_ABOVE_COMPOSER_2026_09_01.md. */}
+            <div class="agent-working-row-anchor">
+                <Show when={workingRowVisible()}>
+                    <AgentWorkingRow
+                        loading={workingRowLoading()}
+                        stopping={agentAtoms().turnPhaseAtom[0]().kind === "Interrupting"}
+                        currentTool={agentAtoms().currentToolAtom[0]()}
+                        currentToolArg={agentAtoms().currentToolArgAtom[0]()}
+                        toolPromoted={hasPromotedTool()}
+                        sessionStats={agentAtoms().sessionStatsAtom[0]()}
+                        turnTokens={agentAtoms().turnTokensAtom[0]()}
+                        launchPhase={status.launchPhase()}
+                        onCancelLogin={status.cancelLogin}
+                        hasAuthUrl={!!status.authUrl()}
+                        waitingReason={(() => {
+                            const phase = agentAtoms().turnPhaseAtom[0]();
+                            return phase.kind === "Streaming" ? (phase.waitingReason ?? null) : null;
+                        })()}
+                        retryAfterMs={(() => {
+                            const phase = agentAtoms().turnPhaseAtom[0]();
+                            return phase.kind === "Streaming" ? (phase.retryAfterMs ?? null) : null;
+                        })()}
+                        compacting={agentAtoms().compactingAtom[0]()}
+                        reconnecting={agentAtoms().reconnectingAtom[0]()}
+                    />
+                </Show>
+            </div>
 
             {/* Composer status strip — single 28-32px row with live
                 activity ticker and Log button that toggles the log panel.

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -85,9 +85,6 @@ interface AgentDocumentViewProps {
     /** Derived layout view from the agent-pane-layout slice (Phase 3) —
      *  forwarded to the list, which renders rows from its prefix-sum positions. */
     layoutView?: Accessor<LayoutView | null>;
-    /** AgentWorkingRow's current height — forwarded to the list's
-     *  stick-to-bottom effect. See AgentDocumentVirtualListProps.workingRowHeight. */
-    workingRowHeight?: Accessor<number>;
     /** Open/focus the Agent History tab — forwarded to the list so a
      *  `history_link` synthetic row can act on click. See
      *  SPEC_AGENT_HISTORY_AS_TAB_AND_DRAFT_PRESERVATION_2026_08_11.md §3.2. */
@@ -201,7 +198,6 @@ export const AgentDocumentView = (props: AgentDocumentViewProps): JSX.Element =>
             zoomFactor={props.zoomFactor}
             blockId={props.blockId}
             layoutView={props.layoutView}
-            workingRowHeight={props.workingRowHeight}
             onOpenHistory={props.onOpenHistory}
             headerSlot={headerSlot()}
             dispatchMatches={dispatchMatches}

--- a/frontend/app/view/agent/styles/_control-bar.scss
+++ b/frontend/app/view/agent/styles/_control-bar.scss
@@ -219,16 +219,25 @@
         &--worked {
             color: var(--secondary-text-color);
             justify-content: space-between;
-            // Opaque — this row floats over the scrollable message list now
+            // Opaque background, with the dimming applied to the text-bearing
+            // children below rather than to the whole row.
+            //
+            // History: opacity DID live on the whole row back when it was a
+            // normal-flow sibling with nothing behind it. When the row became
+            // an overlay floating over the message list
             // (SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md
-            // §3.2). Opacity used to live on the whole row when it was a
-            // normal-flow sibling with nothing behind it; now that scrolled
-            // history passes underneath, dimming the WHOLE row (background
-            // included) let that history bleed through and visually
-            // distort the "Worked · Ns" text. Background stays fully
-            // opaque; opacity moves onto the text-bearing children below so
-            // the same dimmed look is preserved without exposing what's
-            // scrolling past behind it. --block-bg-color is only 50% alpha
+            // §3.2), dimming the whole row let scrolled history bleed through
+            // and visually distort the "Worked · Ns" text, so the opacity was
+            // pushed down onto the children.
+            //
+            // The row is a normal-flow sibling again as of
+            // SPEC_AGENT_WORKING_ROW_ABOVE_COMPOSER_2026_09_01.md, so that
+            // specific bleed-through can no longer happen — but this split is
+            // kept deliberately rather than reverted: it renders identically,
+            // and an opaque band directly above the composer is what makes the
+            // row read as its own zone instead of picking up whatever sits
+            // behind the pane at low --window-opacity.
+            // --block-bg-color is only 50% alpha
             // (confirmed via computed style) — not opaque enough. Reagent
             // P1 on a later round: --main-bg-color isn't opaque either — it's
             // `rgba(34, 34, 34, var(--window-opacity, 0.45))`, alpha-aware

--- a/frontend/app/view/agent/styles/_control-bar.scss
+++ b/frontend/app/view/agent/styles/_control-bar.scss
@@ -73,83 +73,36 @@
     }
 
     // === Working Row ===
-    // Floats over the bottom of .agent-document-scroll-region instead of
-    // occupying its own flex row (SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md
-    // §3.2) — the anchor wrapper is the positioning + ResizeObserver target;
-    // .agent-working-row-anchor scopes this selector so it can't collide
-    // with any .agent-working-row rendered elsewhere.
+    // A normal-flow row between the ActivityDock and the composer strip
+    // (SPEC_AGENT_WORKING_ROW_ABOVE_COMPOSER_2026_09_01.md): dock's
+    // long-running tasks on top, this turn's live status directly above
+    // where the user types.
+    //
+    // It previously floated over the bottom of
+    // .agent-document-scroll-region as an absolutely-positioned overlay
+    // (SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md §3.2)
+    // so the message list's scrollbar could run that box's full height.
+    // Everything that arrangement needed to work is gone with it:
+    //   - the right: var(--agent-document-scrollbar-width) inset, which kept
+    //     the row's opaque background off .agent-document's native scrollbar
+    //   - .agent-working-row-backdrop, a decorative full-width layer that
+    //     existed only to fill the gutter that inset necessarily left
+    //     uncolored (SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md)
+    //   - z-index: 2 and the pointer-events: none / auto dance that stopped
+    //     the anchor's empty margin from swallowing clicks meant for the
+    //     message list underneath
+    // A row that isn't inside the scroll region can't overlap its scrollbar
+    // or its content, so none of those problems exist to solve.
+    //
+    // The wrapper stays (rather than putting these styles on
+    // .agent-working-row directly) for the reason it always had: it scopes
+    // the selector below so it can't collide with any .agent-working-row
+    // rendered elsewhere.
     // No idle placeholder — component returns null when neither loading nor
     // has completed stats.
     // SPEC_AGENT_PANE_STATUS_GRADIENT_2026_06_14.md §2.
-    //
-    // Purely decorative full-width layer, .agent-document-scroll-region's
-    // FIRST child in DOM order and left at z-index: auto (the implicit
-    // "0/auto" stacking group, ordered by DOM order within that group per
-    // spec — see .agent-document-scroll-region's own z-index:0 comment in
-    // _document.scss) — so it paints below .agent-document (also in that
-    // group, but later in DOM order) and thus below .agent-document's own
-    // scrollbar, while .agent-working-row-anchor's explicit z-index: 2
-    // keeps the real text-bearing row above both, unchanged. Closes the
-    // gap .agent-working-row-anchor's own scrollbar-width inset
-    // (below) necessarily leaves empty — that inset stops the row's
-    // opaque background from ever covering the scrollbar, but does
-    // nothing to fill that gutter with a matching color, and the
-    // scrollbar track itself is fully transparent
-    // (--scrollbar-background-color, theme.scss), so the gutter used to
-    // show the plain pane background instead of continuing this color.
-    // See docs/specs/SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md.
-    .agent-working-row-backdrop {
-        position: absolute;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        // Same source of truth .agent-document's own padding-bottom uses
-        // (agent-view.tsx's ResizeObserver on the real row) — 0 whenever
-        // the row isn't rendered, so this never needs its own visibility
-        // logic beyond the <Show> that already gates it in agent-view.tsx.
-        height: var(--agent-working-row-height, 0px);
-        pointer-events: none;
-        // Default/fallback matches .agent-working-row--worked's own
-        // background exactly (below) — the common case once a turn
-        // completes, and a safe non-flashing color if this ever paints
-        // for a tick before the --loading class below applies.
-        background: var(--elevated-bg-color);
-
-        &--loading {
-            // Exact match to .agent-working-row--loading's own background
-            // (below), not an approximation — a visibly different tint in
-            // this 14px strip would look like a new, smaller version of
-            // the same bug this element exists to fix.
-            background: color-mix(in srgb, var(--accent-color) 4%, var(--elevated-bg-color));
-        }
-    }
-
     .agent-working-row-anchor {
-        position: absolute;
-        left: 0;
-        // Inset from the scrollbar gutter, not flush against it (right: 0)
-        // — .agent-working-row's opaque background (see --loading/--worked
-        // below) previously extended the full anchor width, painting over
-        // .agent-document's native scrollbar in that strip since this
-        // anchor's z-index: 2 sits above .agent-document's implicit
-        // z-index: auto. A right padding on the row used to compensate for
-        // the TEXT overlapping the scrollbar, but never stopped the row's
-        // own BACKGROUND from covering it — the scrollbar was still there,
-        // just invisible underneath. Insetting the anchor itself means
-        // nothing painted inside it can ever reach that strip, so the
-        // scrollbar stays visible and clickable without any z-index
-        // fight (which would also make .agent-document's own content
-        // paint over this row's text, defeating the overlay).
-        right: var(--agent-document-scrollbar-width, 14px);
-        bottom: 0;
-        z-index: 2;
-        // The anchor spans the full pane width (left:0/right:<scrollbar
-        // width>) but the row itself only fills its own content width —
-        // without this, the empty margin beside the row would still
-        // intercept clicks meant for the message list underneath.
-        // Re-enabled on .agent-working-row itself below so its own text
-        // stays selectable/clickable.
-        pointer-events: none;
+        flex-shrink: 0;
     }
 
     .agent-working-row-anchor .agent-working-row {
@@ -158,19 +111,21 @@
         display: flex;
         align-items: center;
         gap: 5px;
-        // Right padding now matches the other three sides — the anchor's
-        // own right inset (above) already clears the scrollbar gutter, so
-        // this no longer needs the extra buffer that used to compensate
-        // for the row extending flush against it.
+        // Symmetric padding on all four sides. There is no scrollbar gutter
+        // to clear any more (the row left the scroll region entirely — see
+        // the anchor above), so no side needs a compensating buffer.
         padding: var(--space-1) var(--space-3) var(--space-1-5) var(--space-3);
-        pointer-events: auto; // opt back in — the anchor wrapper disables it
 
         &--loading {
             color: var(--accent-color);
-            // Opaque — same reasoning as --worked (commit 6e4497b): this row
-            // floats over the scrollable message list now, so a user
-            // scrolling up mid-stream saw history bleed through the old
-            // color-mix(...4%, transparent) background. Reagent P1 on a
+            // Opaque, still — kept deliberately after the row moved out of
+            // the scroll region. It no longer overlaps the message list, so
+            // the original bleed-through this fixed (commit 6e4497b: history
+            // showing through a color-mix(...4%, transparent) background
+            // while scrolled up mid-stream) can't recur — but the row now
+            // sits directly against the composer, and a translucent status
+            // row there would pick up the pane background rather than
+            // reading as its own band. Reagent P1 on a
             // later round: --main-bg-color is itself
             // `rgba(34, 34, 34, var(--window-opacity, 0.45))` — alpha-aware
             // by design, for window transparency — so it is NOT actually

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -4,19 +4,27 @@
 // Document container + status log (terminal-style). Wrapped in .agent-view so the cascade chain matches
 // the pre-split file (SPEC_AGENT_VIEW_SCSS_SPLIT_2026_04_24).
 .agent-view {
-    // Matches .agent-document::-webkit-scrollbar's width (app.scss) — shared
-    // here so .agent-working-row-anchor (_control-bar.scss) can inset itself
-    // by exactly this much and never paint over the scrollbar gutter, instead
-    // of fighting it with z-index. See that selector's own comment for the
-    // z-index-obscures-scrollbar bug this closes.
+    // Drives .agent-document::-webkit-scrollbar's width/height (app.scss).
+    // It had a second consumer until 2026-09-01: .agent-working-row-anchor
+    // inset itself by exactly this much so the floating working row could
+    // never paint over the scrollbar gutter. The row is no longer inside
+    // this box (SPEC_AGENT_WORKING_ROW_ABOVE_COMPOSER_2026_09_01.md), so
+    // nothing needs to dodge the gutter any more and this is now purely the
+    // scrollbar's own dimension.
     --agent-document-scrollbar-width: 14px;
 
-    // Wraps AgentDocumentView + the AgentWorkingRow anchor — takes over the
-    // flex-1 slot .agent-document used to occupy directly. .agent-document
-    // fills this box via position:absolute so AgentWorkingRow can float
-    // over its bottom edge instead of shrinking it as a normal-flow
-    // sibling — the scrollbar now reaches this box's true bottom edge.
-    // See docs/specs/SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md §3.2.
+    // Wraps AgentDocumentView — takes over the flex-1 slot .agent-document
+    // used to occupy directly. .agent-document fills this box via
+    // position:absolute.
+    //
+    // The absolute fill is a leftover requirement rather than a live one:
+    // it existed so AgentWorkingRow could float over this box's bottom edge
+    // without shrinking it, letting the scrollbar reach the true bottom
+    // (SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md §3.2).
+    // With the row moved out to normal flow above the composer, this box has
+    // exactly one child and nothing overlays it — the wrapper is kept because
+    // the padding/containment/stacking rules below hang off the inner element
+    // and unpicking that is a separate change with no user-visible payoff.
     .agent-document-scroll-region {
         position: relative;
         // Establishes a real stacking context (position + z-index together,

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -20,65 +20,42 @@
     .agent-document-scroll-region {
         position: relative;
         // Establishes a real stacking context (position + z-index together,
-        // per spec) for this box's three absolutely-positioned children —
-        // the .agent-working-row-backdrop, .agent-document, and
-        // .agent-working-row-anchor below. Without this, their relative
-        // paint order would depend on whatever stacking context happens to
-        // exist further up the ancestor tree, which isn't guaranteed to
-        // exist or behave predictably. With it, the three children's own
-        // z-index values (0/auto vs 2) are compared only against each
-        // other, isolated from anything outside this box — see
-        // docs/specs/SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md §5.
+        // per spec). This used to isolate three overlapping children — the
+        // working row's backdrop, .agent-document, and the working-row
+        // anchor — whose paint order relative to each other had to be
+        // predictable (SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md
+        // §5). Only .agent-document is left inside this box now that the
+        // working row moved out
+        // (SPEC_AGENT_WORKING_ROW_ABOVE_COMPOSER_2026_09_01.md), so there is
+        // no longer an intra-box ordering question. Kept anyway: it also
+        // isolates the scroll region's own painting from the rest of the
+        // pane, which the `contain` rules below are already trading on, and
+        // dropping it would let an ancestor's stacking context reorder this
+        // box against its siblings for no gain.
         z-index: 0;
         flex: 1;
         min-height: 0;
         overflow: hidden; // .agent-document inside owns the real scrolling
     }
 
-    // When AgentWorkingRow is visible, its color reaches this box's true
-    // bottom edge (.agent-working-row-backdrop above). The normal-flow
-    // rows between here and the composer that carry their own margin for
-    // standalone breathing room — AgentAuthPanel's two states
-    // (.agent-auth-panel-card during an active OAuth login,
-    // .agent-auth-notice after a failed one; both can co-occur with the
-    // working row, since AgentWorkingRow's own loading condition already
-    // covers launch/auth activity via showingLaunchActivity()),
-    // AgentQuestionPanel, and the disconnected banner — should sit flush
-    // against that color instead of leaving a gap, matching how the row
-    // already sits flush above the composer. Scoped to
-    // .agent-view--working-row-visible (agent-view.tsx, driven by the same
-    // workingRowVisible() memo that gates the row itself) so a panel
-    // appearing on its own, with no active working row above it, keeps
-    // its normal margin. Every OTHER row that can appear in this stack —
-    // AgentDecisionPanel, the retry bar, PendingMessagesPanel,
-    // PaneRow-based rows (AgentCredentialsRevokedChip, the
-    // failure-recovery pin), ActivityDock, InAppLoginPanel's own root
-    // (.pre-launch-auth-panel-waiting) — needs no rule here: confirmed via
-    // their own CSS that they carry a border (or nothing) instead of a
-    // margin in this direction, so they're already flush against whatever
-    // ends up next to them.
-    //
-    // ~ (general sibling), not + (adjacent): any of those border-only rows
-    // can legitimately render between .agent-document-scroll-region and
-    // the target panel (e.g. a disconnected stream with a queued message),
-    // and + only matches when the target is the LITERAL next element —
-    // reagent caught this fragility on round 1 for the bottom-margin rule
-    // below and on round 2 for this one.
-    &.agent-view--working-row-visible {
-        .agent-document-scroll-region ~ .agent-auth-panel-card,
-        .agent-document-scroll-region ~ .agent-auth-notice,
-        .agent-document-scroll-region ~ .agent-question-panel,
-        .agent-document-scroll-region ~ .agent-question-panel-minimized,
-        .agent-document-scroll-region ~ .agent-disconnected-banner {
-            margin-top: 0;
-        }
-    }
+    // A `.agent-view--working-row-visible` rule used to live here, zeroing
+    // the top margin of AgentAuthPanel / AgentQuestionPanel / the
+    // disconnected banner while the working row was visible. It existed
+    // because the row's color reached the scroll region's true bottom edge
+    // (via the since-removed .agent-working-row-backdrop) and those panels
+    // rendered immediately below it, so their own margin left a visible gap
+    // between the two. The row now sits below those panels entirely — right
+    // above the composer, per
+    // SPEC_AGENT_WORKING_ROW_ABOVE_COMPOSER_2026_09_01.md — so nothing
+    // renders flush beneath the row's color any more and the panels keep
+    // their ordinary standalone margin in every state. The class that gated
+    // it was removed from agent-view.tsx along with the rule; it had no
+    // other consumer.
 
-    // Same shape at the OTHER end: these panels' own bottom margin (the
-    // same shorthand that caused the top-edge gap above) leaves a gap
-    // before whatever comes next — unrelated to the working row, so
-    // unconditional (unlike the top-edge fix above): the composer strip is
-    // always there eventually, not something that only sometimes follows.
+    // Unrelated to the working row, and still needed: these panels' own
+    // bottom margin leaves a gap before whatever comes next. Unconditional —
+    // the composer strip is always there eventually, not something that only
+    // sometimes follows.
     // Uses :has() to target the panel's own margin from a "what comes
     // after me" condition, since CSS has no parent/previous-sibling
     // selector otherwise — already an accepted pattern in this codebase
@@ -146,13 +123,13 @@
         // for the agent pane specifically (both derive from the same
         // active block's term:zoom meta, §A.3), so they cancel exactly.
         padding-top: calc(var(--space-0-5) + var(--pane-tab-strip-height, 28px));
-        // Reserves exactly AgentWorkingRow's current rendered height (0 when
-        // hidden) so scrolling to true bottom leaves the last message above
-        // the floating row, not hidden underneath it. Set on
-        // .agent-document-scroll-region by agent-view.tsx's ResizeObserver;
-        // custom properties cascade through the DOM regardless of the
-        // AgentDocumentView/AgentDocumentVirtualList component boundary.
-        padding-bottom: calc(var(--space-0-5) + var(--agent-working-row-height, 0px));
+        // No working-row reservation here any more: this used to add
+        // AgentWorkingRow's measured height so scrolling to true bottom left
+        // the last message above the floating row rather than hidden under
+        // it. The row is a normal-flow sibling below the dock as of
+        // SPEC_AGENT_WORKING_ROW_ABOVE_COMPOSER_2026_09_01.md, so it no
+        // longer overlaps this box at all and there is nothing to reserve.
+        padding-bottom: var(--space-0-5);
         display: flex;
         flex-direction: column;
         gap: 4px;

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -116,20 +116,6 @@ export interface AgentDocumentVirtualListProps {
      * instead of TanStack's virtual items.
      */
     layoutView?: Accessor<LayoutView | null>;
-    /**
-     * AgentWorkingRow's current rendered height in px (0 when hidden) —
-     * agent-view.tsx measures it via ResizeObserver and uses the same value
-     * to size .agent-document's bottom padding (the row floats over this
-     * scroll container as an overlay; see
-     * docs/specs/SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md
-     * §3.2). Tracked by the stick-to-bottom effect below for the same
-     * reason nodes().length and layoutView().totalSize are: when this
-     * grows while pinned to bottom (a turn starts, tool-name text
-     * widens the row), .agent-document's effective content height grows
-     * too, and without re-pinning, the newly-taller overlay can end up
-     * covering the previously-visible tail of the message list.
-     */
-    workingRowHeight?: Accessor<number>;
     /** Ordinal-matched tool_use_id -> live dispatch, for this pane's
      *  Agent/Task/Workflow tool nodes. See `activity/dispatch-correlation.ts`. */
     dispatchMatches?: Accessor<Map<string, AgentDispatch>>;
@@ -555,20 +541,21 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
     // and stickToBottom itself never flips — the drop is invisible in state
     // inspection. See docs/specs/SPEC_AGENT_PANE_SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24.md §2.
     //
-    // Also tracks workingRowHeight (below) — reagent P1 on #2292: that same
-    // spec's §3.2 overlay (AgentWorkingRow floating over this scroll
-    // container's bottom edge, sized via .agent-document's padding-bottom)
-    // introduced an identical gap. When the row appears or grows while
-    // pinned to bottom (a turn starts, tool-name text widens it),
-    // .agent-document's effective content height changes without any
-    // node-count or layoutView change, so without this dependency the
-    // newly-taller overlay could end up covering the message that was
-    // previously visible at the bottom.
+    // This effect used to track a third dependency, workingRowHeight
+    // (reagent P1 on #2292), because that same spec's §3.2 overlay —
+    // AgentWorkingRow floating over this scroll container's bottom edge,
+    // sized via .agent-document's padding-bottom — changed the effective
+    // content height with no node-count or layoutView change, so a growing
+    // overlay could end up covering the message previously visible at the
+    // bottom. The row is a normal-flow sibling below this container as of
+    // SPEC_AGENT_WORKING_ROW_ABOVE_COMPOSER_2026_09_01.md, so it changes
+    // this container's *clientHeight* instead of its content height — which
+    // the clientHeight ResizeObserver below already re-pins on, and was
+    // written for precisely this family of normal-flow siblings.
     createEffect(() => {
         // Track length changes — Solid will re-run when nodes() emits.
         const _len = props.viewState.nodes().length;
         const _totalSize = props.layoutView?.()?.totalSize;
-        const _workingRowHeight = props.workingRowHeight?.();
         // Unconditional — a node-count drop (e.g. /clear) can collapse this
         // pane to non-overflowing while scrolled away reading history; see
         // syncOverflowState's own doc comment.
@@ -601,7 +588,7 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
     // §3.3's own "deferred as rare/transient" admission) shrinks THIS
     // container's clientHeight via pure CSS reflow — no scroll event fires
     // (it's a resize, not a scroll), and neither of the pin effect's tracked
-    // deps (nodes().length, layoutView().totalSize, workingRowHeight) change
+    // deps (nodes().length, layoutView().totalSize) change
     // either, so `stickToBottom` stays silently true while the view falls
     // short of the new, smaller max scroll position. Rather than adding a
     // tracked height signal per interposing panel (the whack-a-mole pattern
@@ -634,8 +621,8 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
     });
 
     // Content-resize-driven pin. The effect above only re-pins when one of
-    // three hand-picked signals changes (nodes().length, layoutView().totalSize,
-    // workingRowHeight) — any OTHER source of the content growing taller is
+    // two hand-picked signals changes (nodes().length,
+    // layoutView().totalSize) — any OTHER source of the content growing taller is
     // invisible to it, and the scrollbar visibly sits above true bottom until
     // some unrelated signal happens to change and the effect re-runs. The
     // clientHeight RO right above this one doesn't catch it either — it only
@@ -657,11 +644,6 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
     // libraries like use-stick-to-bottom rely on), so writing scrollTop
     // synchronously here never produces a visible flash. See
     // docs/specs/REPORT_AGENT_PANE_SCROLL_PIN_FLICKER_AUDIT_2026_07_30.md.
-    //
-    // workingRowHeight is NOT covered by this observer — it drives
-    // `.agent-document`'s own padding-bottom (scrollRef's box, not a child's),
-    // which changes scrollHeight without resizing either observed element.
-    // It stays covered by the effect above.
     onMount(() => {
         if (typeof ResizeObserver === "undefined") return;
         const ro = new ResizeObserver(() => {


### PR DESCRIPTION
## Summary

Two changes to the agent pane's bottom stack, both about saying each fact once, in the place the eye already is.

### 1. The `Working…` row hides once a tool is auto-backgrounded

Promotion into the ActivityDock — immediately for a declared `sleep`, otherwise after `TOOL_PROMOTION_MS` — is the point at which work stops being *"the pane is blocked on this"* and becomes *"this runs in the background, tracked over there, with its own live countdown."*

The row kept rendering straight through. Two rows for one fact, and the louder one asserted the opposite of what had just happened: `Working…` says the pane is busy waiting, when backgrounding the task is exactly what made it not busy.

`toolPromoted` already reached `AgentWorkingRow`, but it only suppressed the **label** (`AgentFooter.tsx`), never the row — the spinner and elapsed timer stayed. With the new gate and `sessionStats` cleared at turn submit, the row now hides outright rather than falling back to a stale `✓ Worked · Ns`.

**Deliberately narrow.** Only the plain "a promoted tool is running and nothing else is happening" case is suppressed. Everything the dock has no vocabulary for keeps the row:

| State | Why the dock can't express it |
|---|---|
| launch activity | the pane isn't up yet |
| `Interrupting` | "Stopping…" is about the turn, not the tool |
| `waitingReason` (rate limited) | no dock representation — and the one the user most needs to see |
| compacting / reconnecting | not tools |

Extracted as a pure predicate with its own tests rather than a closure inside `agent-view.tsx`, because that exception list *is* the interesting part: the failure mode here is silently swallowing one of those five states.

### 2. Order is now dock → working row → composer

Bottom-up, scope narrows: background tasks → what this turn is doing right now → where you type. Previously the turn's own status sat *furthest* from the composer.

## This one deletes rather than adds

The row used to float over `.agent-document-scroll-region` as an absolutely-positioned overlay (`SPEC_..._SCROLL_FOLLOW_AND_STATUS_OVERLAY_2026_07_24` §3.2) so the message list's scrollbar could run the box's full height. That needed a surprising amount of scaffolding — **all of which goes**, because a row that isn't inside the scroll region can't overlap its scrollbar or its content in the first place:

- `workingRowHeight` signal + ref-callback `ResizeObserver`
- the `--agent-working-row-height` custom property bridging two component boundaries
- `.agent-document`'s matching `padding-bottom` reservation
- that prop threaded through `AgentDocumentView` → `AgentDocumentVirtualList`
- …and its use as a third stick-to-bottom dependency (reagent P1 on #2292)
- `.agent-working-row-backdrop`, an element existing solely to color the scrollbar gutter the overlay had to stay inset from
- the anchor's scrollbar-width inset, `z-index: 2`, and the `pointer-events: none`/`auto` dance
- `.agent-view--working-row-visible` and its margin rule

`SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md` is superseded **in full**; the 07-24 spec only at §3.2 (its §2 scroll-follow analysis is untouched and still load-bearing).

Net **−315/+182**.

## Reviewer's real question: is scroll-follow still correct?

Yes, and it needs no replacement signal. As a normal-flow sibling the row changes the scroll region's **`clientHeight`**, not its content height — and `AgentDocumentVirtualList`'s `clientHeight` `ResizeObserver` already re-pins on exactly that. Its own comment names this family: *"the retry bar, AgentDecisionPanel, AgentQuestionPanel, or PendingMessagesPanel appearing/growing mid-turn — all normal-flow, flex-shrink:0 rows."* The working row joins it.

That observer was added specifically to end the per-panel-signal whack-a-mole; the overlay's tracked dependency was an instance of it. Removing it is a return to that design, not a regression waiting to happen.

## Verification

- `working-row-supersession.test.ts` — **9 tests**: the promotion case, the no-promotion case, all five keep-the-row exceptions, and two guards on reading optional `waitingReason` off a non-`Streaming` variant
- full `frontend/app/view/agent` suite — **1604 passing / 123 files**
- `npx tsc --noEmit` clean
- `vite build` clean (confirms the SCSS removals compile)

Spec: `docs/specs/SPEC_AGENT_WORKING_ROW_ABOVE_COMPOSER_2026_09_01.md`

<!-- agentmux:agent_id=agentx -->