### PR TITLE
ci: gate that a cited docs/specs path actually resolves

### DIFF
--- a/.changesets/1788318108-ci-gate-that-a-cited-docs-specs-path-actually-resolves-pbp0.md
+++ b/.changesets/1788318108-ci-gate-that-a-cited-docs-specs-path-actually-resolves-pbp0.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+ci: gate that a cited docs/specs path actually resolves

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Specs index is current
         run: bash scripts/gen-docs-index.sh --check
 
+      - name: Spec citations resolve (changed files only)
+        run: bash scripts/check-spec-citations.sh
+
       # The three gates below already existed as Taskfile `check:*` tasks but
       # were wired into nothing — defined, documented, and never run. Each
       # encodes a regression that already happened once (see the spec/retro in

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -201,6 +201,15 @@ tasks:
             See docs/specs/PLAN_DOCS_CLEANUP_EXECUTION_2026_09_01.md batch E.
         cmd: bash scripts/check-doc-status.sh
 
+    check:spec-citations:
+        desc: >-
+            Gate — fails if a CHANGED file cites a `docs/specs/*.md` path that
+            does not exist. Scoped to the diff for the same reason as
+            check:doc-status: 89 files carry a dangling citation today, so a
+            repo-wide gate would fail every PR on somebody else's rot and be
+            switched off. See docs/specs/PLAN_DOCS_CLEANUP_EXECUTION_2026_09_01.md.
+        cmd: bash scripts/check-spec-citations.sh
+
     check:scrollbar-cursor:
         desc: >-
             Grep gate — fails if a scrollbar/os-scrollbar selector sets

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -205,9 +205,9 @@ tasks:
         desc: >-
             Gate — fails if a CHANGED file cites a `docs/specs/*.md` path that
             does not exist. Scoped to the diff for the same reason as
-            check:doc-status: 89 files carry a dangling citation today, so a
-            repo-wide gate would fail every PR on somebody else's rot and be
-            switched off. See docs/specs/PLAN_DOCS_CLEANUP_EXECUTION_2026_09_01.md.
+            check:doc-status: 90 dangling citations across 78 files exist
+            today, so a repo-wide gate would fail every PR on somebody else's
+            rot and be switched off. See docs/specs/PLAN_DOCS_CLEANUP_EXECUTION_2026_09_01.md.
         cmd: bash scripts/check-spec-citations.sh
 
     check:scrollbar-cursor:

--- a/scripts/check-spec-citations.sh
+++ b/scripts/check-spec-citations.sh
@@ -14,12 +14,19 @@
 # ever checked, so nobody knew, and each one sends the next reader hunting for a
 # document that is not there.
 #
-# SCOPED TO CHANGED FILES, for the same reason check-doc-status.sh is: 46
-# dangling citations exist today. A repo-wide gate would fail every PR on
-# somebody else's rot and be switched off within a day — the documented fate of
-# the three previous attempts at docs enforcement here. Applied to the diff it
-# is green for anyone who has not touched a citation, and it stops the count
-# growing.
+# SCOPED TO CHANGED FILES, for the same reason check-doc-status.sh is. Measured
+# 2026-09-01 with this script over every tracked .md/.rs/.ts/.tsx/.sh/.yml:
+#
+#     90 dangling citations, across 78 files, naming 49 distinct missing specs
+#
+# A repo-wide gate would fail every PR on somebody else's rot and be switched
+# off within a day — the documented fate of the three previous attempts at docs
+# enforcement here. Applied to the diff it is green for anyone who has not
+# touched a citation, and it stops 90 becoming 91.
+#
+# Those three numbers count different things and are easy to conflate: one file
+# can carry several dangling citations, and one missing spec can be cited from
+# many files. Quote the one you mean.
 #
 # Usage:
 #   bash scripts/check-spec-citations.sh          # changed vs origin/main

--- a/scripts/check-spec-citations.sh
+++ b/scripts/check-spec-citations.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# check-spec-citations.sh — CI gate: a cited spec path must resolve.
+#
+# docs/specs/PLAN_DOCS_CLEANUP_EXECUTION_2026_09_01.md §7 (why this exists)
+# docs/specs/README.md ("a broken pointer is worse than none")
+#
+# THE RULE: if a file names `docs/specs/<something>.md`, that file must exist.
+#
+# This repo cites specs from code comments constantly, which is a good habit —
+# it is often the only link between a design and its implementation. It is also
+# unmaintained: when the top-level specs/ tree was merged into docs/specs/
+# (batch C, PR #2920), 32 of 165 spec citations in source were ALREADY dangling,
+# 9 of them pointing at a path for a file that had moved months earlier. Nothing
+# ever checked, so nobody knew, and each one sends the next reader hunting for a
+# document that is not there.
+#
+# SCOPED TO CHANGED FILES, for the same reason check-doc-status.sh is: 46
+# dangling citations exist today. A repo-wide gate would fail every PR on
+# somebody else's rot and be switched off within a day — the documented fate of
+# the three previous attempts at docs enforcement here. Applied to the diff it
+# is green for anyone who has not touched a citation, and it stops the count
+# growing.
+#
+# Usage:
+#   bash scripts/check-spec-citations.sh          # changed vs origin/main
+#   bash scripts/check-spec-citations.sh FILE...  # explicit files (tests)
+
+set -uo pipefail
+
+fail=0
+
+# ── Which files to check ────────────────────────────────────────────────────
+if [ "$#" -gt 0 ]; then
+    files=("$@")
+else
+    base="${GITHUB_BASE_REF:-main}"
+    if git rev-parse --verify --quiet "origin/$base" >/dev/null 2>&1; then
+        ref="origin/$base"
+    elif git rev-parse --verify --quiet "$base" >/dev/null 2>&1; then
+        ref="$base"
+    else
+        echo "check-spec-citations: cannot resolve base ref '$base' — skipping."
+        exit 0
+    fi
+    # No pathspec: rename detection needs both sides of a move to pair them,
+    # and limiting the diff hides the deletions (the bug that made batch C's
+    # rename exemption a silent no-op). Pure renames are skipped for the same
+    # reason as in check-doc-status.sh — relocating a file asserts nothing.
+    mapfile -t files < <(
+        git diff --name-status --find-renames --diff-filter=d "$ref"...HEAD 2>/dev/null | awk '
+            $1 == "R100" { next }
+            $1 ~ /^R/    { print $3; next }
+            NF >= 2      { print $2 }
+        ' || true
+    )
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "check-spec-citations: nothing changed."
+    exit 0
+fi
+
+# ── Check each ──────────────────────────────────────────────────────────────
+checked=0
+bad=0
+for f in "${files[@]}"; do
+    [ -f "$f" ] || continue
+    case "$f" in
+        # Binary-ish and vendored trees have no citations worth reading, and
+        # scanning them is how a gate becomes slow enough to be resented.
+        *.png|*.jpg|*.jpeg|*.gif|*.ico|*.svg|*.pdf|*.zip|*.lock) continue ;;
+        node_modules/*|target/*|dist/*) continue ;;
+    esac
+    checked=$((checked + 1))
+
+    # A citation is a docs/specs path ending in .md. Globs are excluded: this
+    # file and its sibling gate both discuss `docs/specs/*.md` as a pattern,
+    # and failing on a pattern that was never meant to name one file is exactly
+    # the false positive that gets a gate disabled.
+    while IFS= read -r cite; do
+        [ -z "$cite" ] && continue
+        case "$cite" in *[\*\?\[]*) continue ;; esac
+        [ -e "$cite" ] && continue
+        echo "FAIL $f"
+        echo "     Cites a spec that does not exist: $cite"
+        bad=$((bad + 1))
+        fail=1
+    done < <(grep -oE 'docs/specs/[A-Za-z0-9_./-]+\.md' "$f" 2>/dev/null | sort -u)
+done
+
+if [ "$fail" -ne 0 ]; then
+    echo ""
+    echo "check-spec-citations: FAILED — $bad dangling citation(s)."
+    echo ""
+    echo "  If you MOVED a spec, repoint the citations to where it now lives."
+    echo "  If the spec never existed or is long gone, delete the path from the"
+    echo "  comment rather than leaving it: a pointer to nothing costs the next"
+    echo "  reader a search that cannot succeed, which is worse than no pointer"
+    echo "  at all (docs/specs/README.md). Do not invent a plausible-looking"
+    echo "  replacement path to satisfy this check."
+    exit 1
+fi
+
+echo "check-spec-citations: ok ($checked file(s) checked)"


### PR DESCRIPTION
## Summary

The follow-up promised on #2920. This repo cites specs from code comments constantly — often the only link between a design and its implementation — and **nothing has ever checked those links.**

The cost surfaced when the two spec trees were merged: **32 of 165 spec citations in source were already dangling**, 9 of them naming a path for a file that had moved months earlier. Nobody knew, because nothing looked. Each one sends the next reader hunting for a document that isn't there — the same cost as a wrong `Status:` line, and harder to notice.

## Scoped to changed files, and the measurement is why

Measured with this script over every tracked `.md/.rs/.ts/.tsx/.sh/.yml`:

> **90 dangling citations, across 78 files, naming 49 distinct missing specs**

A repo-wide gate would fail every PR on somebody else's rot and be switched off within a day — the documented fate of the three previous attempts at docs enforcement here. Applied to the diff it's green for anyone who hasn't touched a citation, and it stops 90 becoming 91.

Same philosophy as `check-doc-status.sh`: enforce claims made *in this diff*, don't demand a cleanup nobody signed up for.

*(An earlier revision of this PR quoted 46 and 89 in different places. Both were wrong — see the review thread; the three numbers above count different things and the script header now says which is which.)*

## Two deliberate refusals to be clever

Both aimed squarely at not getting disabled:

- **Glob patterns are skipped.** This script and its sibling both discuss `docs/specs/*.md` as a pattern. Failing on something never meant to name one file is exactly the false positive that kills a gate.
- **Pure renames are skipped**, same as `check-doc-status.sh` — relocating a file asserts nothing. The diff runs **without a pathspec**, because rename detection needs both sides of a move to pair them; limiting it hides the deletions and silently turns the exemption into a no-op. That's a bug this repo has now shipped once (#2920), so it's called out in the code.

The failure message says what to do, including the case people get wrong:

> If the spec never existed or is long gone, delete the path from the comment rather than leaving it… Do not invent a plausible-looking replacement path to satisfy this check.

## Verified

| Test | Expected | Got |
|---|---|---|
| File with a dangling citation | fail | **exit 1**, names the path |
| File with a resolving citation | pass | **exit 0** |
| File containing `docs/specs/*.md` glob | pass | **exit 0** |
| No files changed | pass | `nothing changed` |
| The gate running on its own PR | pass | **green** |

Wired into `ci-pr.yml` beside the existing doc gates, and exposed as `task check:spec-citations`.

<!-- agentmux:agent_id=agenty -->