### PR TITLE
test(frontend): give the tool-renderer parity test a liveness timeout

### DIFF
--- a/.changesets/1788330881-test-frontend-give-the-tool-renderer-parity-test-a-liveness--2uyz.md
+++ b/.changesets/1788330881-test-frontend-give-the-tool-renderer-parity-test-a-liveness--2uyz.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+test(frontend): give the tool-renderer parity test a liveness timeout (#2919)

--- a/frontend/app/view/agent/components/tool-renderers/registry.test.ts
+++ b/frontend/app/view/agent/components/tool-renderers/registry.test.ts
@@ -90,6 +90,29 @@ describe("tool-renderer registry — matchers", () => {
 });
 
 describe("tool-renderer registry — built-ins (parity)", () => {
+    /**
+     * Liveness bound, NOT a performance assertion — see the timeout argument
+     * at the end of this `it`.
+     *
+     * This test flaked twice on 2026-08-31/09-01, failing at exactly 5005ms
+     * (vitest's default per-test timeout) on branches that couldn't have
+     * caused it. It is not marginally slow, it is a genuine outlier: measured
+     * across a full local run of 3500 tests it takes **4.32s**, while the
+     * next-slowest test in the entire suite is 2.02s and only four tests
+     * exceed 1s at all. So on an idle machine it already sits 86% of the way
+     * to the ceiling; a loaded CI runner tips it over.
+     *
+     * The cost is the `await import("../ToolOverlayLog")` below, which drags
+     * the whole renderer tree through vitest's transform. That import IS the
+     * thing under test (the registrations are its module side effect), so it
+     * can't be stubbed away without deleting the coverage.
+     *
+     * Deliberately a per-test timeout rather than a global `testTimeout` bump
+     * in vitest.config.ts: the distribution above shows this is one unusually
+     * expensive test, not a suite-wide margin problem. Raising the default for
+     * all 3500 would slow the detection of genuine hangs everywhere to fix a
+     * problem that exists in exactly one place. Issue #2919.
+     */
     it("registers all built-in renderers and routes every kind through the registry", async () => {
         // Importing ToolOverlayLog runs the built-in registrations (module side
         // effect). Assert the built-ins are present and resolution is total.
@@ -114,5 +137,9 @@ describe("tool-renderer registry — built-ins (parity)", () => {
         }
         // An unknown provider tool (no built-in kind) still resolves (catch-all).
         expect(resolveToolRenderer(tool({ tool: "Other", toolName: "WebSearch" }))).not.toBeNull();
-    });
+        // 30s, ~7× the 4.32s measured worst case. Costs nothing on the happy
+        // path; if this test ever genuinely takes 30s something is wedged and
+        // the failure is real. Same reasoning as IO_TIMEOUT in
+        // agentmux-srv/tests/subprocess_io.rs (issue #2863 / PR #2911).
+    }, 30_000);
 });


### PR DESCRIPTION
Fixes #2919.

## Problem

`registry.test.ts > built-ins (parity)` failed twice at exactly **5005ms** — vitest's default per-test timeout — on branches that could not have caused it, blocking unrelated PRs. Same bug class as #2863 in the Rust suite.

## Measured, not guessed

Across a full local run of all 3500 tests:

| duration | test |
|---:|---|
| **4.32s** | **`registry.test.ts` > built-ins (parity)** ← this one |
| 2.02s | `AgentShellSubblock.test.tsx` > zoom seed race |
| 2.00s | `login.test.ts` > stale cancellation flag |
| 1.06s | `SystemToolInstallInline.test.tsx` |

Only **4 of 3500** tests exceed 1s at all, and none other approaches 5s.

So this isn't marginally slow — it's a 2× outlier already sitting **86% of the way to the ceiling on an idle machine**. A loaded CI runner tips it over.

## Why not just make it faster

The cost is `await import("../ToolOverlayLog")`, which pulls the whole renderer tree through vitest's transform. That import **is the thing under test** — the built-in registrations are its module side effect — so it can't be stubbed out without deleting the coverage. The test asserts registration is total and resolution never falls through; it makes no claim about speed and simply needs to finish.

## Why per-test and not a global `testTimeout`

The distribution above shows one unusually expensive test, not a suite-wide margin problem. Raising the default for all 3500 tests would slow the detection of genuine hangs everywhere in order to fix something that exists in exactly one place.

30s is ~7× the measured worst case: free on the happy path, and if it ever does take 30s something is genuinely wedged and the failure is real. Same reasoning as `IO_TIMEOUT` in `agentmux-srv/tests/subprocess_io.rs` (#2863 / PR #2911).

## Verification

- Target file: 10 passed
- Full suite before the change: 3497 passed / 3 skipped (the run the measurements come from)

<!-- agentmux:agent_id=agentx -->