### PR TITLE
Manoz@Area54: fix(memory): agent:memory RPC handlers never adopted #2901's blank-workdir fix

### DIFF
--- a/.changesets/1788357580-fix-memory-agent-memory-rpc-handlers-never-adopted-2901-s-bl-51oi.md
+++ b/.changesets/1788357580-fix-memory-agent-memory-rpc-handlers-never-adopted-2901-s-bl-51oi.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(memory): agent:memory RPC handlers never adopted #2901's blank-workdir fix

--- a/agentmux-srv/src/server/native_memory_handlers.rs
+++ b/agentmux-srv/src/server/native_memory_handlers.rs
@@ -785,18 +785,22 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                     .map_err(|e| format!("agent:memory:list: store: {e}"))?
                     .ok_or_else(|| format!("agent:memory:list: agent {} not found", cmd.agent_id))?;
 
-                // No working directory → no memory path (avoid mapping to the shared
-                // ~/.claude/projects/memory/ directory — reagent P1 on PR #1588).
-                if agent.working_directory.is_empty() {
-                    return Ok(Some(serde_json::to_value(NativeMemoryListResult { files: vec![] }).map_err(|e| e.to_string())?));
-                }
-
-                let config_dir = wstore
-                    .agent_content_get(&agent.id, "env")
-                    .ok().flatten()
-                    .map(|c| parse_claude_config_dir(&c.content))
-                    .unwrap_or_default();
-                let memory_dir = memory_dir_for_cwd(&config_dir, &agent.working_directory);
+                // A blank working_directory is the DEFAULT state, not a
+                // reason to short-circuit: `agent.open` substitutes a real
+                // directory whenever this field is blank, so a blank row
+                // still describes an agent with real memories on disk. The
+                // old inline "blank → Ok(files: [])" here was a duplicate,
+                // un-synced copy of the exact blank-workdir bug
+                // SPEC_FIX_PERSONAL_MEMORY_EMPTY_WORKDIR_2026_09_01.md
+                // (#2901) already fixed once in `memory_dir_for_agent_by_id`
+                // itself — that fix never propagated to this handler (or to
+                // read_file/write_file/revert below), so it silently kept
+                // reporting "no memories" for every agent #2901 was
+                // supposed to have fixed. See
+                // SPEC_MEMORY_RPC_HANDLERS_BLANK_WORKDIR_2026_09_02.md.
+                let memory_dir = memory_dir_for_agent_by_id(&wstore, &agent).ok_or_else(|| {
+                    format!("agent:memory:list: agent {} has no resolvable memory directory", cmd.agent_id)
+                })?;
 
                 // Existing mirror metadata (no content) for this agent, keyed by
                 // filename — lets the loop below skip the expensive full-content
@@ -988,16 +992,13 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                     .map_err(|e| format!("agent:memory:read_file: store: {e}"))?
                     .ok_or_else(|| format!("agent:memory:read_file: agent {} not found", cmd.agent_id))?;
 
-                if agent.working_directory.is_empty() {
-                    return Err(format!("agent:memory:read_file: agent {} has no configured working directory", cmd.agent_id));
-                }
-
-                let config_dir = wstore
-                    .agent_content_get(&agent.id, "env")
-                    .ok().flatten()
-                    .map(|c| parse_claude_config_dir(&c.content))
-                    .unwrap_or_default();
-                let path = memory_dir_for_cwd(&config_dir, &agent.working_directory).join(&cmd.filename);
+                // See the identical comment on the list handler above — a
+                // blank working_directory is not "no memory dir".
+                let path = memory_dir_for_agent_by_id(&wstore, &agent)
+                    .ok_or_else(|| {
+                        format!("agent:memory:read_file: agent {} has no resolvable memory directory", cmd.agent_id)
+                    })?
+                    .join(&cmd.filename);
 
                 // Live FS is the freshest copy when present — Claude may have
                 // written moments ago, before this call's mirror upsert even
@@ -1098,16 +1099,11 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                     .map_err(|e| format!("agent:memory:write_file: store: {e}"))?
                     .ok_or_else(|| format!("agent:memory:write_file: agent {} not found", cmd.agent_id))?;
 
-                if agent.working_directory.is_empty() {
-                    return Err(format!("agent:memory:write_file: agent {} has no configured working directory", cmd.agent_id));
-                }
-
-                let config_dir = wstore
-                    .agent_content_get(&agent.id, "env")
-                    .ok().flatten()
-                    .map(|c| parse_claude_config_dir(&c.content))
-                    .unwrap_or_default();
-                let dir = memory_dir_for_cwd(&config_dir, &agent.working_directory);
+                // See the identical comment on the list handler above — a
+                // blank working_directory is not "no memory dir".
+                let dir = memory_dir_for_agent_by_id(&wstore, &agent).ok_or_else(|| {
+                    format!("agent:memory:write_file: agent {} has no resolvable memory directory", cmd.agent_id)
+                })?;
                 std::fs::create_dir_all(&dir)
                     .map_err(|e| format!("agent:memory:write_file: mkdir: {e}"))?;
 
@@ -1326,15 +1322,11 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                 // path as agent:memory:write_file (live file + mirror +
                 // version), not a rewrite of history — this is the
                 // git-revert-not-git-reset guarantee from the spec's §4.3.
-                if agent.working_directory.is_empty() {
-                    return Err(format!("agent:memory:revert: agent {} has no configured working directory", cmd.agent_id));
-                }
-                let config_dir = wstore
-                    .agent_content_get(&agent.id, "env")
-                    .ok().flatten()
-                    .map(|c| parse_claude_config_dir(&c.content))
-                    .unwrap_or_default();
-                let dir = memory_dir_for_cwd(&config_dir, &agent.working_directory);
+                // See the identical comment on the list handler above — a
+                // blank working_directory is not "no memory dir".
+                let dir = memory_dir_for_agent_by_id(&wstore, &agent).ok_or_else(|| {
+                    format!("agent:memory:revert: agent {} has no resolvable memory directory", cmd.agent_id)
+                })?;
                 std::fs::create_dir_all(&dir)
                     .map_err(|e| format!("agent:memory:revert: mkdir: {e}"))?;
 
@@ -1957,6 +1949,143 @@ mod tests {
         .await;
         assert_eq!(history.versions[0].source, "jekt");
         assert!(history.versions[0].source_detail.contains("network-claimed"));
+    }
+
+    /// The actual bug behind `SPEC_MEMORY_RPC_HANDLERS_BLANK_WORKDIR_2026_09_02.md`:
+    /// SPEC_FIX_PERSONAL_MEMORY_EMPTY_WORKDIR_2026_09_01.md (#2901) fixed blank
+    /// `working_directory` resolution inside `memory_dir_for_agent`/
+    /// `memory_dir_for_agent_by_id` themselves, but these four RPC handlers had
+    /// their OWN separate, un-synced `agent.working_directory.is_empty()` check
+    /// that never called either resolver — so the fix never actually reached
+    /// `agent:memory:write_file`, the handler live traffic (the Armory Personal
+    /// Memory grid, and the `MemoryWrite` MCP tool going through a *different*
+    /// path that DOES use the fixed resolver) hits. Live-tested against a running
+    /// v0.55.31 build: a `MemoryWrite` MCP call succeeded (App API path, already
+    /// fixed) while `agent:memory:write_file` for the exact same blank-workdir
+    /// agent definition failed outright with "has no configured working
+    /// directory" — this is the regression guard for that exact split.
+    #[tokio::test]
+    async fn write_file_resolves_a_blank_working_directory_instead_of_erroring() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let shared_id_store = Arc::new(Store::open_shared(tmp.path()).unwrap());
+        let config = tempfile::tempdir().unwrap();
+        let (engine, mut rx) = build_channel_state("agent-blankwd-write", "", config.path(), shared_id_store);
+
+        // Before the fix this errored with "has no configured working
+        // directory" — call_rpc itself asserts resp.error.is_empty().
+        call_rpc::<Option<serde_json::Value>>(
+            &engine,
+            &mut rx,
+            COMMAND_NATIVE_MEMORY_WRITE_FILE,
+            serde_json::json!({ "agent_id": "agent-blankwd-write", "filename": "MEMORY.md", "content": "hello from a blank-workdir agent" }),
+        )
+        .await;
+
+        let listed: NativeMemoryListResult = call_rpc(
+            &engine,
+            &mut rx,
+            COMMAND_NATIVE_MEMORY_LIST,
+            serde_json::json!({ "agent_id": "agent-blankwd-write" }),
+        )
+        .await;
+        assert_eq!(listed.files.len(), 1, "the write must be visible to list, not silently stranded");
+        assert_eq!(listed.files[0].filename, "MEMORY.md");
+
+        let read: NativeMemoryReadFileResult = call_rpc(
+            &engine,
+            &mut rx,
+            COMMAND_NATIVE_MEMORY_READ_FILE,
+            serde_json::json!({ "agent_id": "agent-blankwd-write", "filename": "MEMORY.md" }),
+        )
+        .await;
+        assert_eq!(read.content, "hello from a blank-workdir agent");
+
+        // It must have actually landed on disk at the SAME derived-default
+        // directory `agent.open` substitutes for this agent ("Test Agent") —
+        // not merely round-tripped through some other consistent-with-itself
+        // location. The sibling test below plants a file directly at this
+        // path and proves `list` finds it independently of this write path.
+        let default_dir = crate::backend::storage::agents::default_agent_working_dir("Test Agent");
+        let expected_path = memory_dir_for_cwd(&config.path().display().to_string(), &default_dir).join("MEMORY.md");
+        assert!(expected_path.is_file(), "expected the write to land at {expected_path:?}");
+    }
+
+    /// list's OLD behavior for a blank working_directory was to silently
+    /// return an empty file list rather than error — indistinguishable in
+    /// the Armory grid from "this agent genuinely has no memories" (the
+    /// exact trap SPEC_ARMORY_PERSONAL_MEMORY_AGENT_BLOCKS_2026_09_01.md's
+    /// four-state card design exists to avoid). This proves list now finds
+    /// files that were written directly to the derived-default directory —
+    /// i.e. files that existed on disk all along, that list was previously
+    /// silently failing to find, not files this test manufactures via
+    /// write_file (which now shares the same fixed resolver and would trivially
+    /// "work" even if list's OWN resolution were still broken).
+    #[tokio::test]
+    async fn list_finds_files_already_on_disk_at_the_derived_default_dir_for_a_blank_workdir_agent() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let shared_id_store = Arc::new(Store::open_shared(tmp.path()).unwrap());
+        let config = tempfile::tempdir().unwrap();
+
+        let default_dir = crate::backend::storage::agents::default_agent_working_dir("Test Agent");
+        let memory_dir = memory_dir_for_cwd(&config.path().display().to_string(), &default_dir);
+        std::fs::create_dir_all(&memory_dir).unwrap();
+        std::fs::write(memory_dir.join("PRE_EXISTING.md"), "written directly to disk, not via this RPC").unwrap();
+
+        let (engine, mut rx) = build_channel_state("agent-blankwd-preexisting", "", config.path(), shared_id_store);
+        let listed: NativeMemoryListResult = call_rpc(
+            &engine,
+            &mut rx,
+            COMMAND_NATIVE_MEMORY_LIST,
+            serde_json::json!({ "agent_id": "agent-blankwd-preexisting" }),
+        )
+        .await;
+        assert_eq!(
+            listed.files.len(),
+            1,
+            "list must find a file that genuinely exists on disk at the derived-default dir, not report empty"
+        );
+        assert_eq!(listed.files[0].filename, "PRE_EXISTING.md");
+    }
+
+    #[tokio::test]
+    async fn revert_resolves_a_blank_working_directory_instead_of_erroring() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let shared_id_store = Arc::new(Store::open_shared(tmp.path()).unwrap());
+        let config = tempfile::tempdir().unwrap();
+        let (engine, mut rx) = build_channel_state("agent-blankwd-revert", "", config.path(), shared_id_store);
+
+        call_rpc::<Option<serde_json::Value>>(
+            &engine, &mut rx, COMMAND_NATIVE_MEMORY_WRITE_FILE,
+            serde_json::json!({ "agent_id": "agent-blankwd-revert", "filename": "MEMORY.md", "content": "v1" }),
+        ).await;
+        let history: NativeMemoryHistoryResult = call_rpc(
+            &engine, &mut rx, COMMAND_NATIVE_MEMORY_HISTORY,
+            serde_json::json!({ "agent_id": "agent-blankwd-revert", "filename": "MEMORY.md" }),
+        ).await;
+        call_rpc::<Option<serde_json::Value>>(
+            &engine, &mut rx, COMMAND_NATIVE_MEMORY_WRITE_FILE,
+            serde_json::json!({ "agent_id": "agent-blankwd-revert", "filename": "MEMORY.md", "content": "v2" }),
+        ).await;
+
+        // Before the fix this errored with "has no configured working
+        // directory" — call_rpc itself asserts resp.error.is_empty().
+        call_rpc::<serde_json::Value>(
+            &engine, &mut rx, COMMAND_NATIVE_MEMORY_REVERT,
+            serde_json::json!({
+                "agent_id": "agent-blankwd-revert",
+                "filename": "MEMORY.md",
+                "target_version_id": history.versions[0].id,
+            }),
+        ).await;
+
+        let read: NativeMemoryReadFileResult = call_rpc(
+            &engine, &mut rx, COMMAND_NATIVE_MEMORY_READ_FILE,
+            serde_json::json!({ "agent_id": "agent-blankwd-revert", "filename": "MEMORY.md" }),
+        ).await;
+        assert_eq!(read.content, "v1", "revert must have restored v1's content on disk");
     }
 
     #[tokio::test]

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -329,7 +329,7 @@ partial list.
 | [`SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29`](SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29.md) | Spec: multi-tier discovery + remote API invocation over muxbus |
 | [`SPEC_WINDOW_NAME_API_HARDENING_2026_08_08`](SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md) | SPEC: Window-name App API hardening (phantom-id success + status codes) |
 
-### proposed (83)
+### proposed (84)
 
 | Spec | Title |
 |---|---|
@@ -374,6 +374,7 @@ partial list.
 | [`SPEC_MEDIA_PANE_V2_AGENT_WORKFLOW_GAPS_2026_07_28`](SPEC_MEDIA_PANE_V2_AGENT_WORKFLOW_GAPS_2026_07_28.md) | Spec: Media pane v2 — gaps found running a real agent video-editing workflow through it |
 | [`SPEC_MEDIA_PANE_V3_BROWSER_AND_CUSTOM_TRANSPORT_2026_07_29`](SPEC_MEDIA_PANE_V3_BROWSER_AND_CUSTOM_TRANSPORT_2026_07_29.md) | Spec: Media pane v3 — persistent browser + custom playback/scrub UI |
 | [`SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16`](SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16.md) | Memory-Pressure Supervision & Graceful Degradation (host / instance level) |
+| [`SPEC_MEMORY_RPC_HANDLERS_BLANK_WORKDIR_2026_09_02`](SPEC_MEMORY_RPC_HANDLERS_BLANK_WORKDIR_2026_09_02.md) | Spec: fix agent:memory:{list,read_file,write_file,revert} for a blank working_directory |
 | [`SPEC_MIGRATION_FRAMEWORK_2026_06_24`](SPEC_MIGRATION_FRAMEWORK_2026_06_24.md) | Migration Framework Spec |
 | [`SPEC_MODEL_EFFORT_CAPABILITY_VALIDATION_2026_07_02`](SPEC_MODEL_EFFORT_CAPABILITY_VALIDATION_2026_07_02.md) | SPEC — Per-model effort-capability validation for the composer strip |
 | [`SPEC_MUXBUS_CLOUD_RELAYED_LOGIN_CALLBACK_2026_08_15`](SPEC_MUXBUS_CLOUD_RELAYED_LOGIN_CALLBACK_2026_08_15.md) | SPEC: MuxBus cloud-relayed login callback (no loopback listener) |

--- a/docs/specs/SPEC_MEMORY_RPC_HANDLERS_BLANK_WORKDIR_2026_09_02.md
+++ b/docs/specs/SPEC_MEMORY_RPC_HANDLERS_BLANK_WORKDIR_2026_09_02.md
@@ -1,0 +1,111 @@
+# Spec: fix agent:memory:{list,read_file,write_file,revert} for a blank working_directory
+
+**Date:** 2026-09-02
+**Status:** Proposed
+**Motivated by:** a live smoke test of the Armory Personal Memory grid (PR #2917,
+v0.55.31) — asked to verify that writing a memory via the `MemoryWrite` MCP tool
+actually surfaces in the Armory UI.
+
+## What the test found
+
+Writing a memory via `MemoryWrite` (this session's own agent, definition id
+`43f2b0c6-...`, display name "Manoz") succeeded and the file existed on disk.
+The Armory Personal Memory grid, on the exact same build, showed "No memories
+yet" for that agent — both from the card's cached count and from a fresh
+`agent:memory:list` RPC call issued directly (bypassing the UI). Attempting a
+raw `agent:memory:write_file` RPC for the same agent failed outright with
+*"agent 43f2b0c6-... has no configured working directory."*
+
+## Root cause
+
+`SPEC_FIX_PERSONAL_MEMORY_EMPTY_WORKDIR_2026_09_01.md` (#2901) fixed exactly
+this class of bug — but only inside `memory_dir_for_agent` and
+`memory_dir_for_agent_by_id` (`native_memory_handlers.rs`), the resolvers used
+by the App API (`app_api/mod.rs`, what `MemoryWrite`/`MemoryList` MCP tools
+call) and by `bundle.rs`'s import/export.
+
+The four WebSocket RPC handlers that back the Armory UI —
+`agent:memory:list`, `read_file`, `write_file`, `revert` — never called either
+fixed resolver. Each had its **own, separate, un-synced** inline check:
+
+```rust
+if agent.working_directory.is_empty() {
+    return Ok(Some(... files: vec![] ...));      // list, read_file: silent empty
+    // or
+    return Err("... has no configured working directory");  // write_file, revert: hard error
+}
+```
+
+This is the exact pre-#2901 behavior (`list`'s short-circuit dates to PR
+#1588), sitting right next to the fixed code without ever calling it. The
+`memory_dir_for_agent_by_id` doc comment already (incorrectly) claimed *"Shared
+by those three handlers... so all five resolve identically"* — aspirational,
+not actual, prior to this fix.
+
+Consequence: **any agent whose definition has a blank `working_directory`**
+(the default state — `agent.open` substitutes a derived directory at spawn
+time rather than persisting it back to the definition row) shows "No memories
+yet" in Armory Personal Memory no matter how many real memory files it has.
+`list` never errors for this case, so it's indistinguishable in the UI from a
+genuinely-empty agent — the exact trap
+`SPEC_ARMORY_PERSONAL_MEMORY_AGENT_BLOCKS_2026_09_01.md`'s four-state card
+design exists to catch, just via a different root cause (silent
+success-with-empty, not #2901's HTTP 500) than the one it was built against.
+
+## Fix
+
+Repoint all four handlers at `memory_dir_for_agent_by_id(&wstore, &agent)` —
+the same resolver `bundle.rs` and `native_memory_drift.rs` already use —
+instead of their own inline `working_directory.is_empty()` check +
+`memory_dir_for_cwd` call. `memory_dir_for_agent_by_id` returning `None` (only
+possible if the agent has no name at all — a pathological case) is treated as
+an error, matching the existing "error must be visually distinct from empty"
+convention rather than silently reporting zero files.
+
+`history` and `diff` are unaffected — they resolve purely through
+`id_store`/`agent.id` (the SQLite version table), never touch
+`working_directory`, and were never part of this bug.
+
+## Tests
+
+Three new handler-level regression tests in `native_memory_handlers.rs`,
+each driving the real `WshRpcEngine` dispatch (not calling the resolver
+function directly — that path was already covered; the gap was the handlers
+bypassing it):
+
+- `write_file_resolves_a_blank_working_directory_instead_of_erroring` — a
+  blank-workdir `write_file` call now succeeds (previously errored), and the
+  written content round-trips through `list`/`read_file`.
+- `list_finds_files_already_on_disk_at_the_derived_default_dir_for_a_blank_workdir_agent`
+  — a file planted directly on disk at the derived-default directory (not
+  written through this RPC surface) is found by `list` — proves `list`'s own
+  resolution is fixed, not just piggybacking on `write_file` now using the
+  same (fixed) path.
+- `revert_resolves_a_blank_working_directory_instead_of_erroring` — same
+  shape for `revert`.
+
+All three take the module's existing `ENV_LOCK` (matching
+`blank_working_directory_resolves_to_the_same_default_agent_open_substitutes`,
+which exercises the same registry-lookup code path) to avoid racing other
+tests that mutate process-global env state.
+
+## How this was caught
+
+Live-tested against a running v0.55.31 build via CDP (`Runtime.evaluate`
+against the app's exposed `window.RpcApi`/`window.TabRpcClient`), not
+inferred from reading the code — the same "measure, don't just read" practice
+this session's operator notes (`~/.agentmux/shared/providers/claude/CLAUDE.md`
+§6) call out. Reading the code alone would very plausibly have missed this:
+`memory_dir_for_agent_by_id`'s own doc comment already claims the three
+handlers use it.
+
+## Non-goals
+
+- No change to `history`/`diff` — not part of this bug.
+- No change to the Armory grid UI itself (`native-memory-manager.tsx`,
+  `MemoryAgentCard.tsx`) — this is a backend fix; the four-state card design
+  from #2917 already handles the corrected behavior correctly once the
+  backend stops silently reporting empty.
+- No change to `memory_dir_for_agent`/`memory_dir_for_agent_by_id` themselves
+  — #2901 already fixed their internal logic; this PR only fixes their
+  *callers*.


### PR DESCRIPTION
## Summary

Live-tested Personal Memory end to end against a running v0.55.31 build (asked to verify a written memory actually surfaces in the Armory UI): a `MemoryWrite` MCP call succeeded and the file existed on disk, but the Armory grid showed "No memories yet" for that exact agent, and calling `agent:memory:write_file` directly for the same agent failed outright with *"has no configured working directory."*

**Root cause:** `SPEC_FIX_PERSONAL_MEMORY_EMPTY_WORKDIR_2026_09_01.md` (#2901) fixed blank-`working_directory` resolution inside `memory_dir_for_agent`/`memory_dir_for_agent_by_id` — but only the App API (what `MemoryWrite`/`MemoryList` MCP tools actually call) and `bundle.rs` use those resolvers. The four WebSocket RPC handlers backing the Armory UI itself — `list`/`read_file`/`write_file`/`revert` — had their own separate, never-updated inline `agent.working_directory.is_empty()` check: the exact pre-#2901 behavior (`list`'s dates to PR #1588), sitting right next to the fixed code without ever calling it. `memory_dir_for_agent_by_id`'s own doc comment already (incorrectly) claimed these handlers used it.

Since a blank `working_directory` is the *default* state (`agent.open` substitutes a derived directory at spawn time rather than persisting it back to the definition row), this meant Personal Memory silently showed "no memories" for any such agent's real files — indistinguishable from genuinely empty, since `list` never errored. Exactly the trap #2917's four-state card design exists to catch, via a different root cause than #2901 was built against.

## Fix

Repoint all four handlers at `memory_dir_for_agent_by_id`, the same resolver `bundle.rs` and `native_memory_drift.rs` already use. `history`/`diff` are unaffected — they resolve purely through `id_store`/`agent.id`, never touch `working_directory`.

## How this was found

Live CDP testing against the running build (`Runtime.evaluate` against the app's own exposed `window.RpcApi`), not inferred from reading the code — reading the code alone plausibly would have missed it, since `memory_dir_for_agent_by_id`'s own doc comment claims the handlers already use it.

## Test plan
- [x] Three new handler-level regression tests, driving the real `WshRpcEngine` dispatch (not the resolver function directly — that path was already covered elsewhere):
  - `write_file_resolves_a_blank_working_directory_instead_of_erroring`
  - `list_finds_files_already_on_disk_at_the_derived_default_dir_for_a_blank_workdir_agent` — proves `list`'s own resolution is fixed, not just piggybacking on `write_file` now sharing the same path
  - `revert_resolves_a_blank_working_directory_instead_of_erroring`
- [x] `cargo test -p agentmux-srv --bin agentmux-srv native_memory_handlers::tests` — 33/33 passing
- [x] `cargo test -p agentmux-srv --bin agentmux-srv server::app_api::bundle` — 55/55 passing (no regression in the callers that already used the fixed resolver)
- [x] `cargo build --release -p agentmux-srv` — clean, zero new warnings
- [x] Live re-verified: swapped the fixed binary into the actual v0.55.31 portable build and relaunched — no code-path regressions surfaced (the file-lock/relaunch friction encountered was OS/environment noise, not related to this diff)

See `docs/specs/SPEC_MEMORY_RPC_HANDLERS_BLANK_WORKDIR_2026_09_02.md`.

<!-- agentmux:agent_id=manoz -->