### PR TITLE
Manoz@Area54: feat(tabs): default tab names are "Tab 1", "Tab 2", not "tab1", "tab2"

### DIFF
--- a/.changesets/1788358164-feat-tabs-default-tab-names-are-tab-1-tab-2-not-tab1-tab2-qpuo.md
+++ b/.changesets/1788358164-feat-tabs-default-tab-names-are-tab-1-tab-2-not-tab1-tab2-qpuo.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(tabs): default tab names are "Tab 1", "Tab 2", not "tab1", "tab2"

--- a/agentmux-srv/src/backend/storage/store/tests.rs
+++ b/agentmux-srv/src/backend/storage/store/tests.rs
@@ -234,8 +234,9 @@
 
                 let mut tab = Tab {
                     oid: "tab-tx".to_string(),
-                    // tabN naming convention per SPEC_TAB_GAPS_AND_NAMING_2026_04_25.
-                    name: "tab1".to_string(),
+                    // "Tab N" naming convention per SPEC_TAB_GAPS_AND_NAMING_2026_04_25
+                    // (revised from plain "tabN" 2026-09-02).
+                    name: "Tab 1".to_string(),
                     layoutstate: "ls-tx".to_string(),
                     meta: MetaMapType::new(),
                     ..Default::default()
@@ -257,7 +258,7 @@
         assert_eq!(ws.version, 2); // insert=v1, update=v2
 
         let tab = store.must_get::<Tab>("tab-tx").unwrap();
-        assert_eq!(tab.name, "tab1");
+        assert_eq!(tab.name, "Tab 1");
     }
 
     #[test]

--- a/agentmux-srv/src/backend/wcore/mod.rs
+++ b/agentmux-srv/src/backend/wcore/mod.rs
@@ -347,10 +347,10 @@ mod tests {
 
         let tabs = store.get_all::<Tab>().unwrap();
         assert_eq!(tabs.len(), 1);
-        // Tab should be named "tab1" (per SPEC_TAB_GAPS_AND_NAMING_2026_04_25 —
-        // auto-generated tabs use the `tabN` convention, not the older
-        // `Untitled1` name. The test was asserting against stale-spec naming).
-        assert_eq!(tabs[0].name, "tab1");
+        // Tab should be named "Tab 1" (per SPEC_TAB_GAPS_AND_NAMING_2026_04_25 —
+        // auto-generated tabs use the `Tab N` convention, not the older
+        // `Untitled1` name; revised from plain `tabN` 2026-09-02).
+        assert_eq!(tabs[0].name, "Tab 1");
     }
 
     #[test]

--- a/agentmux-srv/src/backend/wcore/tab.rs
+++ b/agentmux-srv/src/backend/wcore/tab.rs
@@ -25,12 +25,13 @@ pub fn create_tab_with_opts(
 ) -> Result<Tab, StoreError> {
     let mut ws = store.must_get::<Workspace>(ws_id)?;
 
-    // Auto-generate tab name if not provided. Plain "tabN" (per
-    // SPEC_TAB_GAPS_AND_NAMING_2026_04_25). Existing tabs named
-    // "Untitled1" / "T1" from older sessions are not migrated; this
-    // only affects newly-created tabs from this build forward.
+    // Auto-generate tab name if not provided. "Tab N" (originally plain
+    // "tabN" per SPEC_TAB_GAPS_AND_NAMING_2026_04_25, revised to "Tab N"
+    // 2026-09-02). Existing tabs named "Untitled1" / "T1" / "tab1" from
+    // older sessions are not migrated; this only affects newly-created
+    // tabs from this build forward.
     let name = if tab_name.is_empty() {
-        format!("tab{}", ws.tabids.len() + ws.pinnedtabids.len() + 1)
+        format!("Tab {}", ws.tabids.len() + ws.pinnedtabids.len() + 1)
     } else {
         tab_name.to_string()
     };

--- a/agentmux-srv/src/backend/wcore/tab.rs
+++ b/agentmux-srv/src/backend/wcore/tab.rs
@@ -10,7 +10,7 @@ use crate::backend::storage::StoreError;
 use crate::backend::obj::*;
 
 /// Create a new tab in a workspace.
-/// If `tab_name` is empty, auto-generates "Untitled1", "Untitled2", etc.
+/// If `tab_name` is empty, auto-generates "Tab 1", "Tab 2", etc.
 /// If `pinned` is true, the tab goes into `pinnedtabids` instead of `tabids`.
 pub fn create_tab(store: &Store, ws_id: &str) -> Result<Tab, StoreError> {
     create_tab_with_opts(store, ws_id, "", false)

--- a/agentmux-srv/src/backend/wcore/window.rs
+++ b/agentmux-srv/src/backend/wcore/window.rs
@@ -82,13 +82,13 @@ pub fn create_window_full(
             // Create tab
             let mut tab = Tab {
                 oid: Uuid::new_v4().to_string(),
-                // Plain "tabN" — same scheme used by `wcore/tab.rs:30`
+                // "Tab N" — same scheme used by `wcore/tab.rs:32`
                 // for tabs created via the user's "+" button. Earlier
-                // this used "T{N}" which was a stylistic mismatch.
-                // See SPEC_TAB_GAPS_AND_NAMING_2026_04_25 + the
-                // first-principles spec
-                // SPEC_TAB_BAR_FIRST_PRINCIPLES_2026_04_25.
-                name: format!("tab{}", ws.tabids.len() + ws.pinnedtabids.len() + 1),
+                // this used "T{N}" (a stylistic mismatch), then plain
+                // "tabN" (SPEC_TAB_GAPS_AND_NAMING_2026_04_25 + the
+                // first-principles spec SPEC_TAB_BAR_FIRST_PRINCIPLES_2026_04_25),
+                // revised to "Tab N" 2026-09-02.
+                name: format!("Tab {}", ws.tabids.len() + ws.pinnedtabids.len() + 1),
                 layoutstate: layout.oid.clone(),
                 blockids: vec![],
                 meta: MetaMapType::new(),

--- a/agentmux-srv/src/reducer/tab.rs
+++ b/agentmux-srv/src/reducer/tab.rs
@@ -1091,12 +1091,12 @@ mod tests {
         }
     }
 
-    /// codex P2 #622: empty name auto-generates `tabN`, mirroring
+    /// codex P2 #622: empty name auto-generates `Tab N`, mirroring
     /// `wcore::create_tab`'s default-naming behaviour. Without this,
     /// CreateWindow's "fresh workspace" path + TearOffBlock's new tab
     /// would land with blank titles — a user-visible regression.
     #[test]
-    fn create_tab_auto_generates_tabN_when_name_empty() {
+    fn create_tab_auto_generates_tab_n_when_name_empty() {
         let mut state = State::default();
         let ws_id = create_workspace(&mut state, "w");
         let events = update(

--- a/agentmux-srv/src/reducer/tab.rs
+++ b/agentmux-srv/src/reducer/tab.rs
@@ -27,14 +27,14 @@ pub(super) fn handle_create_tab(state: &mut State, workspace_id: String, name: S
             version: v,
         }];
     };
-    // codex P2 #622: auto-generate `tabN` when name is empty,
+    // codex P2 #622: auto-generate `Tab N` when name is empty,
     // matching `wcore::create_tab`'s default-naming behaviour. The
     // counter uses the reducer's tab_ids length + 1 (matching the
     // old SQLite-side count: tabids.len() + pinnedtabids.len() + 1
     // — pinnedtabids stays at zero in production since pinning
     // was removed in E.2c.3b, so reducer-only counting matches).
     let resolved_name = if name.is_empty() {
-        format!("tab{}", workspace_record.tab_ids.len() + 1)
+        format!("Tab {}", workspace_record.tab_ids.len() + 1)
     } else {
         name
     };
@@ -1109,12 +1109,12 @@ mod tests {
         );
         match &events[0] {
             Event::TabCreated { name, tab_id, .. } => {
-                assert_eq!(name, "tab1", "first tab in fresh workspace");
-                assert_eq!(state.tabs[tab_id].name, "tab1");
+                assert_eq!(name, "Tab 1", "first tab in fresh workspace");
+                assert_eq!(state.tabs[tab_id].name, "Tab 1");
             }
             other => panic!("expected TabCreated, got {:?}", other),
         }
-        // Second empty-name CreateTab → "tab2".
+        // Second empty-name CreateTab → "Tab 2".
         let events = update(
             &mut state,
             Command::CreateTab {
@@ -1124,7 +1124,7 @@ mod tests {
             &ctx(3),
         );
         match &events[0] {
-            Event::TabCreated { name, .. } => assert_eq!(name, "tab2"),
+            Event::TabCreated { name, .. } => assert_eq!(name, "Tab 2"),
             other => panic!("expected TabCreated, got {:?}", other),
         }
         // Explicit non-empty name passes through verbatim.

--- a/agentmux-srv/src/server/service/tab_lifecycle.rs
+++ b/agentmux-srv/src/server/service/tab_lifecycle.rs
@@ -36,9 +36,9 @@ pub(crate) async fn handle_create_tab(state: &AppState, call: &WebCallType) -> W
     let resolved_name = if tab_name.is_empty() {
         match store.get::<Workspace>(&ws_id) {
             Ok(Some(ws)) => {
-                format!("tab{}", ws.tabids.len() + ws.pinnedtabids.len() + 1)
+                format!("Tab {}", ws.tabids.len() + ws.pinnedtabids.len() + 1)
             }
-            _ => "tab1".to_string(),
+            _ => "Tab 1".to_string(),
         }
     } else {
         tab_name.clone()

--- a/agentmux-srv/src/server/service/tab_lifecycle.rs
+++ b/agentmux-srv/src/server/service/tab_lifecycle.rs
@@ -27,7 +27,7 @@ pub(crate) async fn handle_create_tab(state: &AppState, call: &WebCallType) -> W
     let tab_name: String = service::get_arg(args, 1).unwrap_or_default();
     let activate: bool = service::get_arg(args, 2).unwrap_or(true);
     // args[3] (`pinned`) intentionally ignored.
-    // Auto-generate a `tab{N}` name when the caller passed
+    // Auto-generate a `Tab {N}` name when the caller passed
     // empty so behaviour matches the prior wcore path. Counts
     // both `tabids` and any leftover `pinnedtabids` from
     // legacy data so the numbering doesn't collide with

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -329,7 +329,7 @@ partial list.
 | [`SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29`](SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29.md) | Spec: multi-tier discovery + remote API invocation over muxbus |
 | [`SPEC_WINDOW_NAME_API_HARDENING_2026_08_08`](SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md) | SPEC: Window-name App API hardening (phantom-id success + status codes) |
 
-### proposed (83)
+### proposed (84)
 
 | Spec | Title |
 |---|---|
@@ -352,6 +352,7 @@ partial list.
 | [`SPEC_COMPOSER_STRIP_DROP_CENTER_STATS_2026_08_31`](SPEC_COMPOSER_STRIP_DROP_CENTER_STATS_2026_08_31.md) | Spec: Drop the composer strip's centered token/elapsed stats |
 | [`SPEC_COMPOSER_STRIP_ROW_BASED_LAYOUT_2026_08_26`](SPEC_COMPOSER_STRIP_ROW_BASED_LAYOUT_2026_08_26.md) | SPEC: Composer Strip — Row-Based Layout (Rev 7) |
 | [`SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31`](SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md) | SPEC: A single content-resize contract for the agent pane |
+| [`SPEC_DEFAULT_TAB_NAME_TAB_N_2026_09_02`](SPEC_DEFAULT_TAB_NAME_TAB_N_2026_09_02.md) | Spec: default tab names — "Tab N", not "tabN" |
 | [`SPEC_DEFAULT_WIDGETS_REORDER_2026_08_25`](SPEC_DEFAULT_WIDGETS_REORDER_2026_08_25.md) | SPEC: Default fresh-start widgets — Agent, Swarm, Armory, Sysinfo |
 | [`SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27`](SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md) | SPEC — A repeatable process for Claude model catalog + CLI version upgrades |
 | [`SPEC_DOCS_CLEANUP_AUDIT_2026_08_22`](SPEC_DOCS_CLEANUP_AUDIT_2026_08_22.md) | SPEC — Docs cleanup audit: what's stale, duplicated, or mis-shelved |

--- a/docs/specs/SPEC_DEFAULT_TAB_NAME_TAB_N_2026_09_02.md
+++ b/docs/specs/SPEC_DEFAULT_TAB_NAME_TAB_N_2026_09_02.md
@@ -1,0 +1,61 @@
+# Spec: default tab names — "Tab N", not "tabN"
+
+**Date:** 2026-09-02
+**Status:** Proposed
+**Motivated by:** direct request — *"change the default name for the tabs at
+the top from tab1, tab2, to Tab 1, Tab 2, etc."*
+
+## Background
+
+`SPEC_TAB_GAPS_AND_NAMING_2026_04_25.md` deliberately unified two prior,
+inconsistent default names (`Untitled1`, `T1`) onto plain `tab1`/`tab2`/…
+That was itself a considered choice at the time, not an oversight — this spec
+is a **revision** of that decision (explicit operator request), not a
+correction of a bug.
+
+## Change
+
+All four sites that auto-generate a default tab name now produce `"Tab {N}"`
+(capital T, space, number) instead of `"tab{N}"`:
+
+- `agentmux-srv/src/backend/wcore/tab.rs` — `create_tab` (the "+" button path)
+- `agentmux-srv/src/backend/wcore/window.rs` — new-window tab bootstrap
+- `agentmux-srv/src/reducer/tab.rs` — `CreateTab` reducer (TearOffBlock /
+  fresh-workspace paths)
+- `agentmux-srv/src/server/service/tab_lifecycle.rs` — `handle_create_tab`
+  RPC (both the computed-count branch and the `"tab1"` degenerate fallback)
+
+These four sites already existed as separate, independently-maintained copies
+of the same one-line format string before this change (a duplication noted
+but not addressed here — same shape as the memory-dir-resolution duplication
+fixed in `SPEC_MEMORY_RPC_HANDLERS_BLANK_WORKDIR_2026_09_02.md`, flagged as a
+candidate for a shared helper if a fifth copy ever needs to change in sync
+with these four again).
+
+## Non-goals
+
+- **No migration of existing tabs.** A tab already named `tab1`/`tab2` (or the
+  even older `Untitled1`/`T1`) keeps its name; this only changes what a
+  *newly created* tab (empty name passed to `CreateTab`) gets assigned. Same
+  policy the original spec used for its own predecessor names.
+- **No change to user-renamed tabs.** The `tab_name.is_empty()` /
+  `name.is_empty()` branch is untouched — an explicit name always passes
+  through verbatim.
+- **No frontend change.** Naming is entirely backend-side (Rust); no
+  `defaultTabName()`-equivalent exists in the frontend to update.
+
+## Tests
+
+Five existing assertions across four files updated to expect `"Tab 1"` /
+`"Tab 2"` instead of `"tab1"`/`"tab2"`:
+
+- `agentmux-srv/src/backend/storage/store/tests.rs`
+- `agentmux-srv/src/backend/wcore/mod.rs`
+- `agentmux-srv/src/reducer/tab.rs` (two assertions: first and second
+  auto-generated tab in a fresh workspace)
+
+Full `cargo test -p agentmux-srv --bin agentmux-srv` (2920 tests) run clean
+after the change — confirms no other test/fixture depended on the literal
+`tab1`/`tab2` string beyond these five (several other `"tab1"` literals in
+the codebase are `tab_id`/identifier values, unrelated to the display name,
+and were left untouched).


### PR DESCRIPTION
## Summary

Direct request: change the default names for new tabs from `tab1`, `tab2`, … to `Tab 1`, `Tab 2`, ….

`SPEC_TAB_GAPS_AND_NAMING_2026_04_25.md` deliberately unified two prior inconsistent default names (`Untitled1`, `T1`) onto plain `tab1`/`tab2` — a considered choice at the time, not an oversight. This PR revises that choice on direct request.

## What changed

Four independently-maintained copies of the same one-line `format!("tab{}", …)` string, updated to `format!("Tab {}", …)`:

- `wcore::create_tab` — the "+" button path
- `wcore/window.rs` — new-window tab bootstrap
- `reducer/tab.rs` — the `CreateTab` reducer (TearOffBlock / fresh-workspace paths)
- `tab_lifecycle.rs::handle_create_tab` RPC handler — both its computed-count branch and its degenerate `"tab1"` fallback

(These four sites already existed as separate copies before this change — noted in the spec as a candidate for a shared helper if a fifth copy ever needs syncing with these four again, same shape as the duplication #2926 just fixed for memory-dir resolution. Not addressed here — kept this PR scoped to the rename that was actually asked for.)

## Non-goals
- **No migration** of already-existing tabs named `tab1`/`tab2` (or the even older `Untitled1`/`T1`) — same policy the original spec used for its own predecessors. Only newly-created tabs (empty name passed to `CreateTab`) get the new format.
- **No change to user-renamed tabs** — the empty-name branch is untouched.
- **No frontend change** — naming is entirely backend-side; no `defaultTabName()`-equivalent exists in the frontend.

## Test plan
- [x] Five test assertions across three files updated (`store/tests.rs`, `wcore/mod.rs`, `reducer/tab.rs` ×2) to expect `"Tab 1"`/`"Tab 2"`
- [x] Full `cargo test -p agentmux-srv --bin agentmux-srv` — **2920 passed, 0 failed** (confirms no other fixture depended on the literal string; several other `"tab1"` literals in the codebase are `tab_id` identifiers, unrelated to the display name, and correctly left untouched)
- [x] `cargo build -p agentmux-srv` — clean, no new warnings

See `docs/specs/SPEC_DEFAULT_TAB_NAME_TAB_N_2026_09_02.md`.

<!-- agentmux:agent_id=manoz -->