### PR TITLE
Manoz@Area54: feat(armory): reactive updates across the Armory

### DIFF
--- a/.changesets/1788364392-feat-armory-reactive-updates-across-the-armory-live-refreshi-37l2.md
+++ b/.changesets/1788364392-feat-armory-reactive-updates-across-the-armory-live-refreshi-37l2.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(armory): reactive updates across the Armory (live-refreshing Personal Memory, Global Memory, ABF, MCP Servers, Skills)

--- a/agentmux-srv/src/backend/native_memory_drift.rs
+++ b/agentmux-srv/src/backend/native_memory_drift.rs
@@ -116,10 +116,68 @@ fn read_memory_file_lossy(path: &Path) -> std::io::Result<String> {
 /// tests assert on it directly). Errors from an individual agent/file are
 /// logged and swallowed — one agent's bad state (e.g. a permissions issue)
 /// must not stop the sweep from covering every other agent.
-pub(crate) fn reconciliation_sweep_once(wstore: &Store, id_store: &Store, broker: &crate::backend::wps::Broker) -> usize {
+///
+/// Also detects and publishes OUT-OF-BAND DELETIONS (Codex P2, PR #2932):
+/// content-drift detection alone only ever compares files that still exist
+/// against their last recorded version — a `.md` file removed directly (not
+/// through `agent:memory:write_file`/`revert`, neither of which delete
+/// files) never surfaces there, and the fast fs-watch path deliberately
+/// ignores `FsWatchEventKind::Removed` (it exists to catch content changes,
+/// not track deletions). Without this, the grid count and an open detail
+/// view for the deleted file would stay stale indefinitely — no event ever
+/// arrives to prompt the frontend's own "the selected file is now gone"
+/// handling to fire.
+///
+/// `deleted_notified` is this sweep's own persistent, cross-tick state
+/// (threaded in from `spawn_slow_path`'s loop, same pattern the fast path's
+/// `watched_dirs`/`dir_to_agent` already use) — without it, a file that
+/// STAYS deleted would republish an event every single 30s tick forever,
+/// since "missing from disk" is true on every subsequent sweep too, not
+/// just the first one. A filename is removed from this set again the
+/// moment it reappears on disk (recreated with new content), so a later
+/// re-deletion is detected fresh rather than staying permanently suppressed.
+pub(crate) fn reconciliation_sweep_once(
+    wstore: &Store,
+    id_store: &Store,
+    broker: &crate::backend::wps::Broker,
+    deleted_notified: &mut HashSet<(String, String)>,
+) -> usize {
     let mut drifted = 0;
-    for (agent_id, memory_dir) in list_all_memory_targets(wstore) {
-        drifted += sweep_one_agent_dir(id_store, &agent_id, &memory_dir, "reconciliation_sweep", broker);
+    let targets = list_all_memory_targets(wstore);
+    for (agent_id, memory_dir) in &targets {
+        drifted += sweep_one_agent_dir(id_store, agent_id, memory_dir, "reconciliation_sweep", broker);
+    }
+
+    // agent_native_memory_version_list_distinct_files() is unscoped (every
+    // agent's every file with recorded history) — the same primitive
+    // native_memory_retention.rs already uses as its own work list, not a
+    // new query pattern introduced here.
+    let Ok(distinct) = id_store.agent_native_memory_version_list_distinct_files() else {
+        return drifted;
+    };
+    for (agent_id, filename) in distinct {
+        let Some((_, memory_dir)) = targets.iter().find(|(id, _)| *id == agent_id) else {
+            // Not (or no longer) a tracked target this sweep — out of scope
+            // for this pass; list_all_memory_targets is the same
+            // authoritative source the content-drift loop above already
+            // trusts for "which agents/dirs are live right now."
+            continue;
+        };
+        let key = (agent_id.clone(), filename.clone());
+        if memory_dir.join(&filename).is_file() {
+            deleted_notified.remove(&key);
+            continue;
+        }
+        if deleted_notified.insert(key) {
+            tracing::info!(agent_id = %agent_id, filename = %filename, "native_memory_drift: detected an out-of-band deletion");
+            broker.publish(crate::backend::wps::WaveEvent {
+                event: format!("agent:memory:changed:{agent_id}"),
+                scopes: vec![],
+                sender: String::new(),
+                persist: 0,
+                data: None,
+            });
+        }
     }
     drifted
 }
@@ -202,9 +260,13 @@ pub fn spawn(
 fn spawn_slow_path(wstore: Arc<Store>, id_store: Arc<Store>, broker: Arc<crate::backend::wps::Broker>) {
     tokio::spawn(async move {
         let mut tick = tokio::time::interval(SWEEP_INTERVAL);
+        // Persistent across ticks, same pattern as the fast path's own
+        // watched_dirs/dir_to_agent — see reconciliation_sweep_once's own
+        // doc comment on why this can't just be a fresh HashSet per call.
+        let mut deleted_notified: HashSet<(String, String)> = HashSet::new();
         loop {
             tick.tick().await;
-            reconciliation_sweep_once(&wstore, &id_store, &broker);
+            reconciliation_sweep_once(&wstore, &id_store, &broker, &mut deleted_notified);
         }
     });
 }
@@ -564,10 +626,116 @@ mod tests {
         }
 
         let broker = crate::backend::wps::Broker::new();
-        let drifted = reconciliation_sweep_once(&state.wstore, &id_store, &broker);
+        let mut deleted_notified = HashSet::new();
+        let drifted = reconciliation_sweep_once(&state.wstore, &id_store, &broker, &mut deleted_notified);
         assert_eq!(drifted, 2, "sweep must cover every agent with a working directory");
         assert_eq!(id_store.agent_native_memory_version_list("sweep-agent-a", "MEMORY.md").unwrap().len(), 1);
         assert_eq!(id_store.agent_native_memory_version_list("sweep-agent-b", "MEMORY.md").unwrap().len(), 1);
+
+        match prev_shared_dir {
+            Some(v) => std::env::set_var("AGENTMUX_SHARED_DIR", v),
+            None => std::env::remove_var("AGENTMUX_SHARED_DIR"),
+        }
+    }
+
+    // Codex P2, PR #2932: content-drift detection alone never notices a
+    // file that's gone (nothing to compare content against), and the fast
+    // path deliberately ignores FsWatchEventKind::Removed — without this,
+    // an out-of-band deletion of the file open in the Armory detail view
+    // stayed stale forever, since no event ever arrived to trigger the
+    // frontend's own "the selected file is gone" handling.
+    #[tokio::test]
+    async fn reconciliation_sweep_detects_an_out_of_band_deletion_once_then_suppresses_repeats_until_recreated() {
+        let _guard = crate::test_support::ISOLATED_AUTH_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev_shared_dir = std::env::var_os("AGENTMUX_SHARED_DIR");
+        let shared = tempfile::tempdir().unwrap();
+        std::env::set_var("AGENTMUX_SHARED_DIR", shared.path());
+
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let id_store = Store::open_shared(tmp.path()).unwrap();
+        let state = crate::server::tests::test_state();
+        let config = tempfile::tempdir().unwrap();
+
+        let mut def = crate::backend::storage::AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
+            id: "sweep-delete-agent".to_string(),
+            slug: "sweep-delete-agent".to_string(),
+            name: "Test".to_string(),
+            icon: String::new(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: "/work/sweep-delete-agent".to_string(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: "host".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 0,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+            auto_continue_enabled: 0,
+            model_vendor_base_url: String::new(),
+            memory_id: String::new(),
+        };
+        state.wstore.agent_def_insert(&mut def).unwrap();
+        state
+            .wstore
+            .agent_content_set(&crate::backend::storage::AgentContent {
+                agent_id: def.id.clone(),
+                content_type: "env".to_string(),
+                content: format!("CLAUDE_CONFIG_DIR={}\n", config.path().display()),
+                updated_at: 0,
+            })
+            .unwrap();
+        let memory_dir = memory_dir_for_agent_by_id(&state.wstore, &def).unwrap();
+        std::fs::create_dir_all(&memory_dir).unwrap();
+        let file_path = memory_dir.join("MEMORY.md");
+        std::fs::write(&file_path, "content").unwrap();
+
+        let (broker, client) = crate::test_support::broker_recording("agent:memory:changed:sweep-delete-agent");
+        let mut deleted_notified = HashSet::new();
+
+        // Sweep 1: file present — establishes the recorded version (and
+        // publishes once, from ordinary content-drift, not deletion logic).
+        reconciliation_sweep_once(&state.wstore, &id_store, &broker, &mut deleted_notified);
+        assert_eq!(client.received_events().len(), 1);
+
+        // Delete the file out of band (not through write_file/revert).
+        std::fs::remove_file(&file_path).unwrap();
+
+        // Sweep 2: first sweep to observe the deletion — must publish.
+        reconciliation_sweep_once(&state.wstore, &id_store, &broker, &mut deleted_notified);
+        assert_eq!(client.received_events().len(), 2, "the sweep that first observes a deletion must publish");
+
+        // Sweep 3: file still gone — must NOT publish again (suppressed;
+        // otherwise a permanently-deleted file would fire an event every
+        // 30s tick forever).
+        reconciliation_sweep_once(&state.wstore, &id_store, &broker, &mut deleted_notified);
+        assert_eq!(client.received_events().len(), 2, "a repeat sweep over an already-reported deletion must not re-publish");
+
+        // Recreate the file — content-drift detects it as a new version
+        // (publish #3) and clears the deletion-suppression for this file.
+        std::fs::write(&file_path, "recreated content").unwrap();
+        reconciliation_sweep_once(&state.wstore, &id_store, &broker, &mut deleted_notified);
+        assert_eq!(client.received_events().len(), 3);
+
+        // Delete it again — must be detected as a FRESH deletion (publish
+        // #4), proving the suppression state was actually cleared on
+        // recreation, not permanently stuck once a file is ever deleted once.
+        std::fs::remove_file(&file_path).unwrap();
+        reconciliation_sweep_once(&state.wstore, &id_store, &broker, &mut deleted_notified);
+        assert_eq!(client.received_events().len(), 4, "a re-deletion after recreation must be detected as a fresh event");
 
         match prev_shared_dir {
             Some(v) => std::env::set_var("AGENTMUX_SHARED_DIR", v),

--- a/agentmux-srv/src/backend/native_memory_drift.rs
+++ b/agentmux-srv/src/backend/native_memory_drift.rs
@@ -116,15 +116,21 @@ fn read_memory_file_lossy(path: &Path) -> std::io::Result<String> {
 /// tests assert on it directly). Errors from an individual agent/file are
 /// logged and swallowed — one agent's bad state (e.g. a permissions issue)
 /// must not stop the sweep from covering every other agent.
-pub(crate) fn reconciliation_sweep_once(wstore: &Store, id_store: &Store) -> usize {
+pub(crate) fn reconciliation_sweep_once(wstore: &Store, id_store: &Store, broker: &crate::backend::wps::Broker) -> usize {
     let mut drifted = 0;
     for (agent_id, memory_dir) in list_all_memory_targets(wstore) {
-        drifted += sweep_one_agent_dir(id_store, &agent_id, &memory_dir, "reconciliation_sweep");
+        drifted += sweep_one_agent_dir(id_store, &agent_id, &memory_dir, "reconciliation_sweep", broker);
     }
     drifted
 }
 
-fn sweep_one_agent_dir(id_store: &Store, agent_id: &str, memory_dir: &Path, detected_via: &str) -> usize {
+fn sweep_one_agent_dir(
+    id_store: &Store,
+    agent_id: &str,
+    memory_dir: &Path,
+    detected_via: &str,
+    broker: &crate::backend::wps::Broker,
+) -> usize {
     let entries = match std::fs::read_dir(memory_dir) {
         Ok(e) => e,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return 0,
@@ -159,6 +165,18 @@ fn sweep_one_agent_dir(id_store: &Store, agent_id: &str, memory_dir: &Path, dete
             Ok(true) => {
                 drifted += 1;
                 tracing::info!(agent_id, filename = %name, detected_via, "native_memory_drift: recorded an out-of-band write");
+                // Reactive Armory updates (SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md).
+                // Only on an actual recorded change (Ok(true)) — this branch
+                // runs once per sweep tick per watched agent, and firing on
+                // every no-op tick would mean an event for every agent every
+                // 30s regardless of whether anything happened.
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: format!("agent:memory:changed:{agent_id}"),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
             }
             Ok(false) => {}
             Err(e) => tracing::warn!(agent_id, filename = %name, error = %e, "native_memory_drift: check_and_record_drift failed"),
@@ -171,17 +189,22 @@ fn sweep_one_agent_dir(id_store: &Store, agent_id: &str, memory_dir: &Path, dete
 /// `AppState`'s `fs_watch_pool`/`wstore`/`id_store`. Returns immediately —
 /// both loops run as spawned background tasks for the lifetime of the
 /// process (no shutdown handle; srv itself owns the process lifetime).
-pub fn spawn(fs_watch_pool: Arc<FsWatchPool>, wstore: Arc<Store>, id_store: Arc<Store>) {
-    spawn_fast_path(fs_watch_pool, wstore.clone(), id_store.clone());
-    spawn_slow_path(wstore, id_store);
+pub fn spawn(
+    fs_watch_pool: Arc<FsWatchPool>,
+    wstore: Arc<Store>,
+    id_store: Arc<Store>,
+    broker: Arc<crate::backend::wps::Broker>,
+) {
+    spawn_fast_path(fs_watch_pool, wstore.clone(), id_store.clone(), broker.clone());
+    spawn_slow_path(wstore, id_store, broker);
 }
 
-fn spawn_slow_path(wstore: Arc<Store>, id_store: Arc<Store>) {
+fn spawn_slow_path(wstore: Arc<Store>, id_store: Arc<Store>, broker: Arc<crate::backend::wps::Broker>) {
     tokio::spawn(async move {
         let mut tick = tokio::time::interval(SWEEP_INTERVAL);
         loop {
             tick.tick().await;
-            reconciliation_sweep_once(&wstore, &id_store);
+            reconciliation_sweep_once(&wstore, &id_store, &broker);
         }
     });
 }
@@ -197,7 +220,12 @@ fn spawn_slow_path(wstore: Arc<Store>, id_store: Arc<Store>) {
 /// so a dir is watched for the life of the process once first seen; we
 /// only need to track which dirs we've already called `subscribe_dir` on
 /// to avoid redundant re-subscription every tick.
-fn spawn_fast_path(fs_watch_pool: Arc<FsWatchPool>, wstore: Arc<Store>, id_store: Arc<Store>) {
+fn spawn_fast_path(
+    fs_watch_pool: Arc<FsWatchPool>,
+    wstore: Arc<Store>,
+    id_store: Arc<Store>,
+    broker: Arc<crate::backend::wps::Broker>,
+) {
     tokio::spawn(async move {
         let mut events = fs_watch_pool.events();
         let mut watched_dirs: HashSet<PathBuf> = HashSet::new();
@@ -242,10 +270,26 @@ fn spawn_fast_path(fs_watch_pool: Arc<FsWatchPool>, wstore: Arc<Store>, id_store
                         // sweep covers it if the write actually stuck.
                         Err(_) => continue,
                     };
-                    if let Err(e) = check_and_record_drift(&id_store, &agent_id, filename, &content, "fs_watch") {
-                        tracing::warn!(agent_id, filename, error = %e, "native_memory_drift: fast path: check_and_record_drift failed");
-                    } else {
-                        tracing::info!(agent_id, filename, "native_memory_drift: fast path recorded an out-of-band write");
+                    // Restructured from `if let Err(...) {} else {}` to a full
+                    // match while adding the publish below: the old `else`
+                    // branch fired on Ok(false) too (content already matched,
+                    // nothing recorded), logging "recorded an out-of-band
+                    // write" for a no-op — a pre-existing log inaccuracy
+                    // fixed as a side effect of needing this branch anyway.
+                    match check_and_record_drift(&id_store, &agent_id, filename, &content, "fs_watch") {
+                        Ok(true) => {
+                            tracing::info!(agent_id, filename, "native_memory_drift: fast path recorded an out-of-band write");
+                            // Reactive Armory updates (SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md).
+                            broker.publish(crate::backend::wps::WaveEvent {
+                                event: format!("agent:memory:changed:{agent_id}"),
+                                scopes: vec![],
+                                sender: String::new(),
+                                persist: 0,
+                                data: None,
+                            });
+                        }
+                        Ok(false) => {}
+                        Err(e) => tracing::warn!(agent_id, filename, error = %e, "native_memory_drift: fast path: check_and_record_drift failed"),
                     }
                 }
             }
@@ -330,12 +374,57 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(tmp.path().join("MEMORY.md"), "written outside any RPC").unwrap();
 
-        let drifted = sweep_one_agent_dir(&store, "agent-1", tmp.path(), "reconciliation_sweep");
+        let broker = crate::backend::wps::Broker::new();
+        let drifted = sweep_one_agent_dir(&store, "agent-1", tmp.path(), "reconciliation_sweep", &broker);
         assert_eq!(drifted, 1);
 
         let history = store.agent_native_memory_version_list("agent-1", "MEMORY.md").unwrap();
         assert_eq!(history.len(), 1);
         assert_eq!(history[0].source, "external_fs_write");
+    }
+
+    // SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md: an out-of-band write
+    // (bypassing both the WS RPC and App API surfaces entirely) must still
+    // make the Armory grid reactive — that's this whole module's reason to
+    // exist, so its own publish path needs the same regression guard the
+    // RPC handlers' publish calls get.
+    #[test]
+    fn sweep_publishes_agent_memory_changed_when_drift_is_recorded() {
+        let store = shared_store();
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("MEMORY.md"), "written outside any RPC").unwrap();
+
+        let (broker, client) = crate::test_support::broker_recording("agent:memory:changed:agent-drift-1");
+        sweep_one_agent_dir(&store, "agent-drift-1", tmp.path(), "reconciliation_sweep", &broker);
+
+        let events = client.received_events();
+        assert_eq!(events.len(), 1, "a real drift must publish exactly one event");
+        assert_eq!(events[0].1.event, "agent:memory:changed:agent-drift-1");
+    }
+
+    // The other half of the same guard: a sweep tick that finds NO drift
+    // (unchanged content) must NOT publish — the reconciliation sweep runs
+    // every 30s for every watched agent regardless of whether anything
+    // changed, so publishing unconditionally would fire an event storm with
+    // no corresponding real change, defeating the point of an event-driven
+    // refresh (see this module's own SPEC section on why insert_if_changed's
+    // no-op case is explicitly excluded).
+    #[test]
+    fn sweep_does_not_publish_when_content_is_unchanged() {
+        let store = shared_store();
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("MEMORY.md"), "same content").unwrap();
+
+        let (broker, client) = crate::test_support::broker_recording("agent:memory:changed:agent-drift-2");
+        // First sweep: genuinely new content, records a version (and would
+        // publish — unobserved here since this test is about the SECOND
+        // sweep finding nothing new).
+        sweep_one_agent_dir(&store, "agent-drift-2", tmp.path(), "reconciliation_sweep", &broker);
+        // Second sweep over the same, unchanged file — no drift to record.
+        sweep_one_agent_dir(&store, "agent-drift-2", tmp.path(), "reconciliation_sweep", &broker);
+
+        let events = client.received_events();
+        assert_eq!(events.len(), 1, "only the first sweep's real drift may publish; the second (no-op) must not");
     }
 
     // reagent P2 on PR #2675: read_memory_file_lossy previously truncated
@@ -350,7 +439,8 @@ mod tests {
         let oversized = "x".repeat((MAX_MEMORY_FILE_BYTES + 1) as usize);
         std::fs::write(tmp.path().join("MEMORY.md"), &oversized).unwrap();
 
-        let drifted = sweep_one_agent_dir(&store, "agent-1", tmp.path(), "reconciliation_sweep");
+        let broker = crate::backend::wps::Broker::new();
+        let drifted = sweep_one_agent_dir(&store, "agent-1", tmp.path(), "reconciliation_sweep", &broker);
         assert_eq!(drifted, 0, "an oversized file must not be recorded as drift");
 
         let history = store.agent_native_memory_version_list("agent-1", "MEMORY.md").unwrap();
@@ -385,9 +475,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(tmp.path().join("notes.txt"), "not a memory file").unwrap();
 
-        assert_eq!(sweep_one_agent_dir(&store, "agent-1", tmp.path(), "reconciliation_sweep"), 0);
+        let broker = crate::backend::wps::Broker::new();
+        assert_eq!(sweep_one_agent_dir(&store, "agent-1", tmp.path(), "reconciliation_sweep", &broker), 0);
         assert_eq!(
-            sweep_one_agent_dir(&store, "agent-1", &tmp.path().join("does-not-exist"), "reconciliation_sweep"),
+            sweep_one_agent_dir(&store, "agent-1", &tmp.path().join("does-not-exist"), "reconciliation_sweep", &broker),
             0
         );
     }
@@ -398,7 +489,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(tmp.path().join("MEMORY.md"), "content").unwrap();
 
-        sweep_one_agent_dir(&store, "agent-specific", tmp.path(), "reconciliation_sweep");
+        let broker = crate::backend::wps::Broker::new();
+        sweep_one_agent_dir(&store, "agent-specific", tmp.path(), "reconciliation_sweep", &broker);
 
         assert_eq!(store.agent_native_memory_version_list("agent-specific", "MEMORY.md").unwrap().len(), 1);
         assert_eq!(store.agent_native_memory_version_list("agent-other", "MEMORY.md").unwrap().len(), 0);
@@ -471,7 +563,8 @@ mod tests {
             std::fs::write(memory_dir.join("MEMORY.md"), format!("content for {id}")).unwrap();
         }
 
-        let drifted = reconciliation_sweep_once(&state.wstore, &id_store);
+        let broker = crate::backend::wps::Broker::new();
+        let drifted = reconciliation_sweep_once(&state.wstore, &id_store, &broker);
         assert_eq!(drifted, 2, "sweep must cover every agent with a working directory");
         assert_eq!(id_store.agent_native_memory_version_list("sweep-agent-a", "MEMORY.md").unwrap().len(), 1);
         assert_eq!(id_store.agent_native_memory_version_list("sweep-agent-b", "MEMORY.md").unwrap().len(), 1);

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -89,7 +89,12 @@ async fn main() {
     // Out-of-band native-memory write detection (fast fs-watch path + slow
     // reconciliation-sweep path) — see
     // docs/specs/SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md §4.5.
-    backend::native_memory_drift::spawn(state.fs_watch_pool.clone(), state.wstore.clone(), state.id_store.clone());
+    backend::native_memory_drift::spawn(
+        state.fs_watch_pool.clone(),
+        state.wstore.clone(),
+        state.id_store.clone(),
+        state.broker.clone(),
+    );
 
     // Retention/GC for native-memory version history — see
     // docs/specs/SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md §7.1.

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -1012,8 +1012,18 @@ pub(crate) fn memory_write_impl(
         tracing::warn!(agent_id, filename, error = %e, "memory.write: mirror upsert failed (non-fatal)");
     }
 
+    // Keyed by `version_agent_id` (the resolved canonical UUID), not the raw
+    // `agent_id` slug parameter — SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md:
+    // the WS RPC surface (native_memory_handlers.rs) publishes this same
+    // event keyed by `agent.id`, and a frontend subscriber only ever has
+    // that UUID (`AgentDefinition.id`), never the App-API-only slug
+    // namespace. Slug-keying here would silently split writes made through
+    // this surface (the MemoryWrite MCP tool) into a keyspace no UI
+    // subscriber can ever match — the exact class of bug this file's own
+    // `resolve_agent_uuid` doc comment already warns about for version
+    // storage; the same reasoning applies to this event.
     state.broker.publish(crate::backend::wps::WaveEvent {
-        event: format!("agent:memory:changed:{agent_id}"),
+        event: format!("agent:memory:changed:{version_agent_id}"),
         scopes: vec![], sender: String::new(), persist: 0, data: None,
     });
     Ok(())
@@ -1168,8 +1178,10 @@ pub(crate) fn memory_revert_impl(
         tracing::warn!(agent_id, filename, error = %e, "memory.revert: mirror upsert failed (non-fatal)");
     }
 
+    // See memory_write_impl's own comment on why this is version_agent_id
+    // (canonical UUID), not the raw agent_id slug parameter.
     state.broker.publish(crate::backend::wps::WaveEvent {
-        event: format!("agent:memory:changed:{agent_id}"),
+        event: format!("agent:memory:changed:{version_agent_id}"),
         scopes: vec![], sender: String::new(), persist: 0, data: None,
     });
 
@@ -1264,6 +1276,65 @@ mod memory_version_impl_tests {
         let versions = history.get("versions").and_then(|v| v.as_array()).unwrap();
         assert_eq!(versions.len(), 1);
         assert_eq!(versions[0].get("source").and_then(|v| v.as_str()), Some("agent_inferred"));
+    }
+
+    // SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md: this is the App API surface
+    // the `MemoryWrite` MCP tool actually calls — proves the publish keys by
+    // the resolved canonical UUID (`version_agent_id`), not the raw `agent_id`
+    // slug parameter this function otherwise takes throughout. In this
+    // fixture slug == id (agent_def's own convention), so this alone
+    // wouldn't catch a slug/UUID mixup; see the sibling test below for that.
+    #[tokio::test]
+    async fn write_publishes_agent_memory_changed_scoped_to_the_canonical_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = state_with_agent("agent-app-pub", tmp.path());
+        let (broker, client) = crate::test_support::broker_recording("agent:memory:changed:agent-app-pub");
+        state.broker = std::sync::Arc::new(broker);
+
+        memory_write_impl(&state, "agent-app-pub", "MEMORY.md", "hello", None).unwrap();
+
+        let events = client.received_events();
+        assert_eq!(events.len(), 1, "memory_write_impl must publish exactly one agent:memory:changed event");
+        assert_eq!(events[0].1.event, "agent:memory:changed:agent-app-pub");
+    }
+
+    // The mixup this test exists to catch: memory_write_impl's own doc
+    // comment establishes that App-API callers pass a SLUG, which can differ
+    // from the agent's canonical UUID id. If the publish were still keyed by
+    // the raw `agent_id` parameter (the bug this spec's own commit fixed),
+    // this test's event name assertion would read the slug instead of the
+    // UUID and fail here specifically — a fixture where they genuinely
+    // differ, unlike every other test in this module.
+    #[tokio::test]
+    async fn write_publishes_using_the_resolved_uuid_not_the_raw_slug() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = crate::server::tests::test_state();
+        let mut def = agent_def("agent-real-uuid-pub", &tmp.path().to_string_lossy());
+        def.slug = "agent-friendly-slug-pub".to_string();
+        state.wstore.agent_def_insert(&mut def).unwrap();
+        state
+            .wstore
+            .agent_content_set(&crate::backend::storage::AgentContent {
+                agent_id: def.id.clone(),
+                content_type: "env".to_string(),
+                content: format!("CLAUDE_CONFIG_DIR={}\n", tmp.path().display()),
+                updated_at: 0,
+            })
+            .unwrap();
+        let (broker, client) = crate::test_support::broker_recording("agent:memory:changed:agent-real-uuid-pub");
+        state.broker = std::sync::Arc::new(broker);
+
+        // Write via the slug (what the MemoryWrite MCP tool actually sends).
+        memory_write_impl(&state, "agent-friendly-slug-pub", "MEMORY.md", "hello", None).unwrap();
+
+        let events = client.received_events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].1.event,
+            "agent:memory:changed:agent-real-uuid-pub",
+            "must publish under the resolved canonical UUID, not the raw slug -- \
+             a frontend subscriber only ever has AgentDefinition.id (the UUID)"
+        );
     }
 
     #[tokio::test]
@@ -1373,6 +1444,32 @@ mod memory_version_impl_tests {
         let history_after = memory_history_impl(&state, "agent-app-4", "MEMORY.md").unwrap();
         let versions_after = history_after.get("versions").and_then(|v| v.as_array()).unwrap();
         assert_eq!(versions_after.len(), 3, "revert must not delete or rewrite prior versions");
+    }
+
+    // SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md — same rationale as
+    // write_publishes_agent_memory_changed_scoped_to_the_canonical_id above.
+    #[tokio::test]
+    async fn revert_publishes_agent_memory_changed_scoped_to_the_canonical_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = state_with_agent("agent-app-revpub", tmp.path());
+
+        memory_write_impl(&state, "agent-app-revpub", "MEMORY.md", "good", None).unwrap();
+        memory_write_impl(&state, "agent-app-revpub", "MEMORY.md", "fabricated", None).unwrap();
+        let history = memory_history_impl(&state, "agent-app-revpub", "MEMORY.md").unwrap();
+        let versions = history.get("versions").and_then(|v| v.as_array()).unwrap();
+        let good_id = versions[1].get("id").and_then(|v| v.as_str()).unwrap().to_string();
+
+        // Only the revert publish is under test — swap in the observed
+        // broker after the setup writes above (each of which also
+        // published, on the previous default/unobserved broker).
+        let (broker, client) = crate::test_support::broker_recording("agent:memory:changed:agent-app-revpub");
+        state.broker = std::sync::Arc::new(broker);
+
+        memory_revert_impl(&state, "agent-app-revpub", "MEMORY.md", &good_id).unwrap();
+
+        let events = client.received_events();
+        assert_eq!(events.len(), 1, "memory_revert_impl must publish exactly one agent:memory:changed event");
+        assert_eq!(events[0].1.event, "agent:memory:changed:agent-app-revpub");
     }
 
     /// Regression for reagent P1 on PR #2674: memory_revert_impl (the

--- a/agentmux-srv/src/server/native_memory_handlers.rs
+++ b/agentmux-srv/src/server/native_memory_handlers.rs
@@ -1073,11 +1073,13 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
 
     let wstore_write = state.wstore.clone();
     let id_store_write = state.id_store.clone();
+    let broker_write = state.broker.clone();
     engine.register_handler(
         COMMAND_NATIVE_MEMORY_WRITE_FILE,
         Box::new(move |data, _ctx| {
             let wstore = wstore_write.clone();
             let id_store = id_store_write.clone();
+            let broker = broker_write.clone();
             Box::pin(async move {
                 let cmd: CommandNativeMemoryWriteFileData = serde_json::from_value(data)
                     .map_err(|e| format!("agent:memory:write_file: {e}"))?;
@@ -1177,6 +1179,22 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                 ) {
                     tracing::warn!(agent_id = %agent.id, filename = %cmd.filename, error = %e, "agent:memory:write_file: mirror upsert failed (non-fatal)");
                 }
+
+                // Reactive Armory updates (SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md):
+                // same event, same `agent:memory:changed:{canonical_uuid}`
+                // naming convention `app_api::mod`'s write/revert already use
+                // for the MemoryWrite MCP tool's own path — keying by
+                // `agent.id` (the canonical UUID this whole file's other
+                // handlers already key by, per `resolve_agent_uuid`'s own
+                // doc comment on why a slug-keyed event here would silently
+                // miss frontend subscribers that only ever have the UUID).
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: format!("agent:memory:changed:{}", agent.id),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
 
                 tracing::info!(
                     agent_id = %cmd.agent_id,
@@ -1284,11 +1302,13 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
 
     let wstore_revert = state.wstore.clone();
     let id_store_revert = state.id_store.clone();
+    let broker_revert = state.broker.clone();
     engine.register_handler(
         COMMAND_NATIVE_MEMORY_REVERT,
         Box::new(move |data, _ctx| {
             let wstore = wstore_revert.clone();
             let id_store = id_store_revert.clone();
+            let broker = broker_revert.clone();
             Box::pin(async move {
                 let cmd: CommandNativeMemoryRevertData = serde_json::from_value(data)
                     .map_err(|e| format!("agent:memory:revert: {e}"))?;
@@ -1372,6 +1392,15 @@ pub fn register_native_memory_handlers(engine: &Arc<WshRpcEngine>, state: &AppSt
                 ) {
                     tracing::warn!(agent_id = %agent.id, filename = %cmd.filename, error = %e, "agent:memory:revert: mirror upsert failed (non-fatal)");
                 }
+
+                // See the identical comment on write_file's own handler above.
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: format!("agent:memory:changed:{}", agent.id),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
 
                 tracing::info!(
                     agent_id = %cmd.agent_id,
@@ -1538,6 +1567,27 @@ mod tests {
         claude_config_dir: &std::path::Path,
         id_store: Arc<Store>,
     ) -> (Arc<WshRpcEngine>, tokio::sync::mpsc::UnboundedReceiver<RpcMessage>) {
+        build_channel_state_with_broker(
+            agent_id,
+            working_directory,
+            claude_config_dir,
+            id_store,
+            Arc::new(crate::backend::wps::Broker::new()),
+        )
+    }
+
+    /// Same as [`build_channel_state`], but lets the caller supply (and so
+    /// later inspect, via `RecordingWpsClient`) the `Broker` the registered
+    /// handlers publish `agent:memory:changed:*` events through — the
+    /// existing function's default broker has no observable client wired in,
+    /// so tests asserting on those publishes need this variant instead.
+    fn build_channel_state_with_broker(
+        agent_id: &str,
+        working_directory: &str,
+        claude_config_dir: &std::path::Path,
+        id_store: Arc<Store>,
+        broker: Arc<crate::backend::wps::Broker>,
+    ) -> (Arc<WshRpcEngine>, tokio::sync::mpsc::UnboundedReceiver<RpcMessage>) {
         let wstore = Arc::new(Store::open_in_memory().unwrap());
         let mut def = agent_def(agent_id, working_directory);
         wstore.agent_def_insert(&mut def).unwrap();
@@ -1553,6 +1603,7 @@ mod tests {
         let mut state = crate::server::tests::test_state();
         state.wstore = wstore.clone();
         state.id_store = id_store;
+        state.broker = broker;
 
         let (engine, rx) = WshRpcEngine::new();
         register_native_memory_handlers(&engine, &state);
@@ -1920,6 +1971,36 @@ mod tests {
         assert_eq!(history.versions[0].parent_version_id, None);
     }
 
+    // SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md: the Armory Personal Memory
+    // grid can only refresh a card the instant its agent's memory changes if
+    // this handler actually publishes when it succeeds.
+    #[tokio::test]
+    async fn write_file_publishes_agent_memory_changed_scoped_to_the_agent() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let shared_id_store = Arc::new(Store::open_shared(tmp.path()).unwrap());
+        let config = tempfile::tempdir().unwrap();
+        let (broker, client) = crate::test_support::broker_recording("agent:memory:changed:agent-ver-pub");
+        let (engine, mut rx) = build_channel_state_with_broker(
+            "agent-ver-pub",
+            "/work/channel-a",
+            config.path(),
+            shared_id_store,
+            Arc::new(broker),
+        );
+
+        call_rpc::<Option<serde_json::Value>>(
+            &engine,
+            &mut rx,
+            COMMAND_NATIVE_MEMORY_WRITE_FILE,
+            serde_json::json!({ "agent_id": "agent-ver-pub", "filename": "MEMORY.md", "content": "v1" }),
+        )
+        .await;
+
+        let events = client.received_events();
+        assert_eq!(events.len(), 1, "write_file must publish exactly one agent:memory:changed event");
+        assert_eq!(events[0].1.event, "agent:memory:changed:agent-ver-pub");
+    }
+
     #[tokio::test]
     async fn write_file_honors_caller_supplied_provenance() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
@@ -2273,6 +2354,51 @@ mod tests {
             serde_json::json!({ "agent_id": "agent-ver-6", "filename": "MEMORY.md" }),
         ).await;
         assert_eq!(history_after.versions.len(), 3, "revert must never delete or rewrite prior versions");
+    }
+
+    // SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md — same rationale as
+    // write_file's own publish test above.
+    #[tokio::test]
+    async fn revert_publishes_agent_memory_changed_scoped_to_the_agent() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let shared_id_store = Arc::new(Store::open_shared(tmp.path()).unwrap());
+        let config = tempfile::tempdir().unwrap();
+        // Write with the default (unobserved) broker first — only the revert
+        // publish itself is under test here.
+        let (engine, mut rx) = build_channel_state("agent-ver-revpub", "/work/channel-a", config.path(), shared_id_store.clone());
+        call_rpc::<Option<serde_json::Value>>(
+            &engine, &mut rx, COMMAND_NATIVE_MEMORY_WRITE_FILE,
+            serde_json::json!({ "agent_id": "agent-ver-revpub", "filename": "MEMORY.md", "content": "v1" }),
+        ).await;
+        let history: NativeMemoryHistoryResult = call_rpc(
+            &engine, &mut rx, COMMAND_NATIVE_MEMORY_HISTORY,
+            serde_json::json!({ "agent_id": "agent-ver-revpub", "filename": "MEMORY.md" }),
+        ).await;
+        let v1_id = history.versions[0].id.clone();
+        call_rpc::<Option<serde_json::Value>>(
+            &engine, &mut rx, COMMAND_NATIVE_MEMORY_WRITE_FILE,
+            serde_json::json!({ "agent_id": "agent-ver-revpub", "filename": "MEMORY.md", "content": "v2" }),
+        ).await;
+
+        // Now rebuild the channel on an OBSERVED broker for the revert call
+        // itself, against the same shared id_store so the version/history
+        // above is still visible.
+        let (broker, client) = crate::test_support::broker_recording("agent:memory:changed:agent-ver-revpub");
+        let (engine, mut rx) = build_channel_state_with_broker(
+            "agent-ver-revpub",
+            "/work/channel-a",
+            config.path(),
+            shared_id_store,
+            Arc::new(broker),
+        );
+        call_rpc::<NativeMemoryRevertResult>(
+            &engine, &mut rx, COMMAND_NATIVE_MEMORY_REVERT,
+            serde_json::json!({ "agent_id": "agent-ver-revpub", "filename": "MEMORY.md", "target_version_id": v1_id }),
+        ).await;
+
+        let events = client.received_events();
+        assert_eq!(events.len(), 1, "revert must publish exactly one agent:memory:changed event");
+        assert_eq!(events[0].1.event, "agent:memory:changed:agent-ver-revpub");
     }
 
     #[tokio::test]

--- a/agentmux-srv/src/test_support.rs
+++ b/agentmux-srv/src/test_support.rs
@@ -16,3 +16,51 @@
 //! touches these env vars must acquire THIS lock instead of a local one.
 
 pub(crate) static ISOLATED_AUTH_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// A `WpsClient` that records every event it's sent, for tests asserting a
+/// `Broker::publish` call actually fired (and with what event name/scopes) —
+/// e.g. the `agent:memory:changed:{agent_id}` events
+/// SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md added across
+/// `native_memory_handlers.rs`, `native_memory_drift.rs`, and
+/// `app_api::mod`. `wps.rs`'s own test module has an equivalent `TestClient`,
+/// but it's private to that file — this is the shared, crate-visible
+/// version for every OTHER module's tests, rather than three private copies.
+#[cfg(test)]
+#[derive(Default)]
+pub(crate) struct RecordingWpsClient {
+    events: std::sync::Mutex<Vec<(String, crate::backend::wps::WaveEvent)>>,
+}
+
+#[cfg(test)]
+impl RecordingWpsClient {
+    pub(crate) fn received_events(&self) -> Vec<(String, crate::backend::wps::WaveEvent)> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+#[cfg(test)]
+impl crate::backend::wps::WpsClient for std::sync::Arc<RecordingWpsClient> {
+    fn send_event(&self, route_id: &str, event: crate::backend::wps::WaveEvent) {
+        self.events.lock().unwrap().push((route_id.to_string(), event));
+    }
+}
+
+/// Build a `Broker` already subscribed (all scopes) to `event_type` under a
+/// fixed `"test-route"` route id, with a fresh `RecordingWpsClient` wired in
+/// as its client — the minimum setup every `agent:memory:changed:*` publish
+/// test needs, so each call site's test isn't re-deriving the same six lines.
+#[cfg(test)]
+pub(crate) fn broker_recording(event_type: &str) -> (crate::backend::wps::Broker, std::sync::Arc<RecordingWpsClient>) {
+    let broker = crate::backend::wps::Broker::new();
+    let client = std::sync::Arc::new(RecordingWpsClient::default());
+    broker.set_client(Box::new(std::sync::Arc::clone(&client)));
+    broker.subscribe(
+        "test-route",
+        crate::backend::wps::SubscriptionRequest {
+            event: event_type.to_string(),
+            scopes: vec![],
+            allscopes: true,
+        },
+    );
+    (broker, client)
+}

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -329,7 +329,7 @@ partial list.
 | [`SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29`](SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29.md) | Spec: multi-tier discovery + remote API invocation over muxbus |
 | [`SPEC_WINDOW_NAME_API_HARDENING_2026_08_08`](SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md) | SPEC: Window-name App API hardening (phantom-id success + status codes) |
 
-### proposed (86)
+### proposed (87)
 
 | Spec | Title |
 |---|---|
@@ -345,6 +345,7 @@ partial list.
 | [`SPEC_ARMORY_MEMORY_TAB_MERGE_2026_08_30`](SPEC_ARMORY_MEMORY_TAB_MERGE_2026_08_30.md) | Spec: Armory rail — merge "Global Memory" + "Personal Memory" into one "Memory" tab |
 | [`SPEC_ARMORY_PERSONAL_MEMORY_AGENT_BLOCKS_2026_09_01`](SPEC_ARMORY_PERSONAL_MEMORY_AGENT_BLOCKS_2026_09_01.md) | Spec: Armory → Memory → Personal — browse by agent block, not a dropdown |
 | [`SPEC_ARMORY_PERSONAL_MEMORY_FILTER_AND_SORT_2026_09_02`](SPEC_ARMORY_PERSONAL_MEMORY_FILTER_AND_SORT_2026_09_02.md) | Spec: find/filter and sort for Armory → Memory → Personal |
+| [`SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02`](SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md) | Spec: reactive updates across the Armory |
 | [`SPEC_ASK_USER_QUESTION_TIMEOUT_KEYBOARD_PAUSE_2026_08_20`](SPEC_ASK_USER_QUESTION_TIMEOUT_KEYBOARD_PAUSE_2026_08_20.md) | SPEC: Keyboard-driven pause for the AskUserQuestion auto-timeout countdown |
 | [`SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20`](SPEC_BACKGROUND_TASK_DASHBOARD_INTELLIGENCE_2026_08_20.md) | Spec: Intelligent Long-Running-Task Dashboard (Phase C) |
 | [`SPEC_BACKGROUND_TASK_PID_CAPTURE_2026_08_20`](SPEC_BACKGROUND_TASK_PID_CAPTURE_2026_08_20.md) | Spec: Background Task PID Capture (Phase A) |

--- a/docs/specs/SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md
+++ b/docs/specs/SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md
@@ -1,0 +1,271 @@
+# Spec: reactive updates across the Armory
+
+**Date:** 2026-09-02
+**Status:** Proposed
+**Motivated by:** direct question, then a direct request to broaden it —
+*"if you write a memory, will I see the update in Manoz in the armory? we
+want it reactive, so the stat shows up immediately"*, followed by *"build the
+reactive updates, across the entire armory in fact."*
+
+## Scope: an audit first, because most of this already exists
+
+Before designing anything Armory-wide, the actual question was: **which of
+Armory's five tabs (Accounts, Memory [Global + Personal], Skills, MCP
+Servers, ABF) are already reactive, and which aren't?** Grepping the backend
+for every `WaveEvent` it publishes, then checking which frontend view-models
+actually subscribe to each, found a much narrower gap than "build reactivity
+from scratch everywhere":
+
+| Area | Backend event | Already wired? |
+|---|---|---|
+| **Accounts** | `identityaccounts:changed` | **Yes.** `IdentityViewModel` (`identity-model.ts`) installs an app-lifetime subscription that explicitly calls out "Armory Accounts tab" as one of its consumers — `AccountsManager` reuses this exact model. Nothing to build. |
+| Per-agent MCP/Skill *bindings* (inside a bundle) | `mcp:changed` / `skills:changed` | **Yes.** `bundle-mcp-model.ts` / `bundle-skill-model.ts` both already subscribe. |
+| **Global Memory** (brain) | `memories:changed` | **No.** `global-brain-model.ts` fetches once, no subscription. |
+| **ABF** (bundle list) | `memories:changed` | **No.** `memory-model.ts` (`MemoryViewModel`) fetches once, no subscription. |
+| **MCP Servers** (standalone Armory tab) | `mcp:changed` | **No.** `mcp-model.ts` fetches once — the event exists and is already proven-working (the per-bundle model above consumes it), it's just never subscribed to here. |
+| **Skills** (standalone Armory tab) | `skills:changed` | **No.** `skill-model.ts`, same gap as MCP Servers. |
+| **Personal (native) Memory** | *(none exists)* | **No — and there's no event to subscribe to yet.** This is the one area needing real backend work; everything below this table already existed before this spec. |
+
+**Consequence for scope:** four of the five gaps are a **three-line fix
+each** — add the same `waveEventSubscribe({ eventType, handler: () =>
+void this.refresh() })` pattern the already-working models use, in each of
+the four models that are missing it. No backend changes needed for those
+four; the events they need already exist and are already proven correct by
+their existing consumers. The fifth (Personal/native Memory) is the one
+piece that needed original design, below.
+
+## Personal (native) Memory — current behavior and the fix
+
+### Current behavior (answered directly, then fixed here)
+
+**No — today it is not reactive.** This was an explicit, documented tradeoff
+in `SPEC_ARMORY_PERSONAL_MEMORY_AGENT_BLOCKS_2026_09_01.md`:
+
+> Consequence, accepted: a count does **not** refresh when an agent's memory
+> files change while you sit on the grid... refetching everything on
+> unrelated agent edits is the wrong trade.
+
+The grid's count-fetch effect (`native-memory-manager.tsx`) is keyed on the
+**set of agent IDs**, not on memory content — it fetches once per agent when
+that agent first appears in the set, and never again unless the whole
+component remounts. Writing a memory — via the `MemoryWrite` MCP tool, the
+Armory's own detail-view editor, or an agent's own filesystem tools writing
+directly — does not touch that key, so the card's count sits stale until you
+leave and re-enter the tab.
+
+### Design
+
+#### Backend: publish on every recorded version — an event already half-shipped
+
+Mid-implementation, `git log -S` on the planned event name turned up that
+**two of the five call sites already published something**: `app_api/mod.rs`'s
+`memory_write_impl`/`memory_revert_impl` (commit `bcc478dc`, 2026-08-20, a
+different agent) already called
+`state.broker.publish(WaveEvent { event: format!("agent:memory:changed:{agent_id}"), ... })`
+— but nothing anywhere subscribed to it, so it was a no-op in practice. This
+changed the plan: rather than introduce a second, competing convention
+(`WaveEvent.scopes`, this spec's original design) alongside an
+already-shipped one, every new call site adopts the *existing* convention —
+**the agent id baked directly into the event NAME**
+(`"agent:memory:changed:{agent_id}"`), not `WaveEvent.scopes`.
+
+One correction made to the existing calls in the same pass: they keyed the
+event by the raw `agent_id` **slug** parameter (App API's own calling
+convention), not the resolved canonical UUID `version_agent_id` the function
+already computes for version storage — the exact slug/UUID keyspace split
+`memory_write_impl`'s own doc comment already warns about for versions,
+just not previously applied to this event. A frontend subscriber only ever
+has `AgentDefinition.id` (the UUID), so a slug-keyed event would have gone
+unheard even once a subscriber existed. Fixed to `version_agent_id` at both
+existing call sites — see `write_publishes_using_the_resolved_uuid_not_the_raw_slug`
+for the regression test.
+
+Every *production* code path that records a new native-memory version funnels
+through exactly two `Store` methods
+(`agentmux-srv/src/backend/storage/agent_native_memory_versions.rs`):
+`agent_native_memory_version_insert` and, for out-of-band writes,
+`agent_native_memory_version_insert_if_changed`. Five real call sites, no
+more — publish added/fixed at all five:
+
+| Call site | Surface | Status before this spec |
+|---|---|---|
+| `app_api/mod.rs` `memory_write_impl` | App API write (`MemoryWrite` MCP tool) | Already published — re-keyed to the canonical UUID |
+| `app_api/mod.rs` `memory_revert_impl` | App API revert | Already published — re-keyed to the canonical UUID |
+| `native_memory_handlers.rs` `write_file` | WS RPC (Armory UI) | New |
+| `native_memory_handlers.rs` `revert` | WS RPC (Armory UI) | New |
+| `native_memory_drift.rs` fast path + `sweep_one_agent_dir` | Out-of-band write detection | New |
+
+(The storage layer itself has no access to the WPS `broker` — a deliberate
+layering boundary — so the publish happens at each call site, immediately
+after a successful insert, not inside the storage method.)
+
+`data` is `None` at every call site, matching the pre-existing convention —
+the event name alone (which agent) is everything a "refetch this agent"
+handler needs; there was no existing `filename` payload to preserve, and
+none was added.
+
+For `agent_native_memory_version_insert_if_changed` (the drift-detector call):
+only publish when it actually returns a new version — its whole point is
+"no-op if content is unchanged" (reconciliation sweep re-hashing every file
+every 30s), and publishing on every no-op sweep tick would mean an event
+firing for every watched agent every 30 seconds regardless of whether
+anything happened, which defeats the point of an event-driven design (may as
+well have kept polling). Also fixed a small pre-existing log inaccuracy while
+touching this exact branch in the fast path: the old `if let Err(e) = ... {}
+else {}` logged "recorded an out-of-band write" even on the Ok(false)
+no-op case — restructured to a full `match` (needed anyway to gate the new
+publish), which incidentally fixed that too.
+
+#### Frontend: one subscription per agent, re-registered as the agent set changes
+
+Because the event name itself encodes the agent id, `NativeMemoryManager.tsx`
+subscribes to `"agent:memory:changed:{id}"` **once per agent currently in the
+grid** (`waveEventSubscribe` accepts a variadic list of subscriptions in one
+call, one combined unsubscribe), re-registering whenever the agent SET
+changes — same `agentIdsKey` dependency and rationale the existing count-fetch
+effect already uses (a brand-new-but-equivalent `agents()` array must not
+tear down and rebuild every subscription). On receipt:
+
+- **Grid view:** refetch that one agent's count via the same
+  `RpcApi.NativeMemoryListCommand` call the existing count-fetch effect
+  already makes, updating just `counts()[agent_id]` — not a batch refetch of
+  every card. Reuses the existing per-agent stale-response handling (a
+  response is only stale if its agent left the map).
+- **Detail view:** if the event's `agent_id` matches `selectedAgent()`,
+  refetch the file list too (same `NativeMemoryListCommand` call the
+  `selectedAgent()`-keyed effect already makes) — so a live write to the
+  agent you're actively viewing shows up without navigating away and back.
+  A change to a filename you don't currently have selected does not clear
+  `selectedFilename()` — only a *file-list* refresh, never forcing you out
+  of whatever you're looking at.
+
+**Debounce, per agent ID, ~250ms:** a burst of rapid writes to the same
+agent (e.g. an agent scripting several `MemoryWrite` calls in a loop) should
+coalesce into one refetch, not one RPC round-trip per write. Keyed per
+agent ID so a burst on agent A never delays agent B's own refresh.
+
+#### Known gap — not solved by this design, and why it's acceptable
+
+The fs-watch fast path only watches **known** agents' memory directories
+(`list_all_memory_targets` — agents already in `db_agents` or the live
+registry). An agent's very first write, before any watch is established for
+it, is caught by the WS RPC / App API call sites directly (those publish
+regardless of watch state) — so this gap only affects an out-of-band write
+(bypassing both RPC surfaces) to a *brand-new, not-yet-tracked* agent, which
+falls back to the 30s reconciliation sweep's own latency. This mirrors
+`native_memory_drift.rs`'s own documented stance (its module doc comment:
+*"Neither [layer] promises zero data loss... precision, honestly bounded"*)
+— this spec inherits that same bound rather than trying to close it, since
+closing it would mean watching every possible future memory directory
+speculatively.
+
+### Tests (Personal Memory)
+
+- Backend: each of the five call sites publishes
+  `"agent:memory:changed:{agent_id}"` — keyed by the resolved canonical UUID,
+  never the raw slug — on success; `insert_if_changed` does **not** publish
+  when the content was unchanged (no-op sweep tick).
+- Frontend: an `"agent:memory:changed:{id}"` event for an agent already in the
+  grid triggers exactly one `NativeMemoryListCommand` call for that agent
+  and updates only that card's count — siblings' `counts()` entries are
+  untouched (same "one card's fetch doesn't touch its siblings" invariant
+  #2917 already established, extended to the new refresh path).
+- An event for an agent whose card resolved with an error, or is still
+  loading, still triggers a refetch (recovery path — an agent that errored
+  once should get to try again on the next write, not stay permanently
+  errored until a full remount).
+- An event while the detail view is open for a DIFFERENT agent does not
+  touch that view's file list.
+- An event while the detail view is open for the SAME agent refreshes the
+  file list without clearing `selectedFilename()` (unless the selected file
+  was actually the one removed).
+- Rapid repeated events for the same agent within the debounce window
+  produce exactly one refetch, not one per event.
+
+### Non-goals (Personal Memory)
+
+- **No change to the initial per-agent-set count-fetch effect** — this adds
+  a second, event-triggered refresh path alongside it, not a replacement.
+- **No toast/notification UI** for "agent X's memory changed" — `data` is
+  `None` at every call site (matching the pre-existing App API convention);
+  the event name (which agent) is all a "refetch" handler needs, and no
+  `filename` payload was added since nothing needs it yet.
+- **No retroactive backfill** for the known gap above (brand-new,
+  not-yet-watched agent + purely out-of-band write) — see that section's own
+  rationale.
+- **No polling fallback.** If the WPS connection is down, counts simply stay
+  as stale as they are today until reconnect + remount — same failure mode
+  that already exists for `agents:changed`-driven refreshes elsewhere in the
+  app; not a new risk this feature introduces.
+
+## The other four areas — wire the existing event, nothing more
+
+Each of these already has a working, proven `waveEventSubscribe` consumer
+elsewhere in the codebase for the exact same event (the per-bundle
+MCP/Skill models for `mcp:changed`/`skills:changed`; `IdentityViewModel`
+for `identityaccounts:changed`, not applicable here since Accounts needs no
+change). The fix in each case is the identical pattern
+`bundle-mcp-model.ts` already uses — add to the constructor:
+
+```ts
+private unsubChanged: () => void;
+constructor(...) {
+    ...
+    void this.refresh();
+    this.unsubChanged = waveEventSubscribe({
+        eventType: "<event>",
+        handler: () => void this.refresh(),
+    });
+}
+```
+
+plus disposing `unsubChanged()` wherever the model's existing teardown path
+is (`dispose()` for a class ViewModel, `onCleanup` for a function
+component) — mirroring whatever that file already does for its other
+cleanup, not inventing a new lifecycle pattern per file.
+
+| File | Event | Refresh method already exists? |
+|---|---|---|
+| `frontend/app/view/brain/global-brain-model.ts` | `memories:changed` | Yes — `refresh()` |
+| `frontend/app/view/memory/memory-model.ts` (`MemoryViewModel`, ABF) | `memories:changed` | Yes — `refresh()` |
+| `frontend/app/view/mcp/mcp-model.ts` | `mcp:changed` | Yes — `refresh()` |
+| `frontend/app/view/skill/skill-model.ts` | `skills:changed` | Yes — `refresh()` |
+
+No backend changes for any of these four — `memories:changed`, `mcp:changed`,
+and `skills:changed` are already published correctly (proven by their
+existing consumers) and already carry everything the fetch-based `refresh()`
+methods need (nothing — `refresh()` re-fetches wholesale from the RPC, same
+"unscoped, refetch on any change" pattern `bundle-mcp-model.ts` already
+uses, not a targeted single-item update the way Personal Memory's design
+above needs one).
+
+**Why `memories:changed` for BOTH Global Memory and ABF, and is that a
+problem?** No — `memories:changed` is the existing umbrella event for the
+whole bundle/memory backend area (published from both
+`agent_handlers/memory.rs` and `app_api/bundle.rs`), not scoped per-tab. A
+change relevant to one tab firing a refresh in the other is a wasted RPC
+call at worst (both `refresh()` methods are cheap, idempotent full-list
+fetches), never a correctness issue — same as how `agents:changed` already
+fans out to several unrelated-looking consumers (`AgentPicker`,
+`HiddenTemplatesSection`, etc.) today.
+
+### Tests (the other four areas)
+
+- For each of the four: an event of the matching type triggers exactly one
+  additional `refresh()`-equivalent RPC call; an event of a DIFFERENT
+  event type does not.
+- The subscription is torn down on unmount/dispose (no handler fires after
+  cleanup — mirrors the existing `bundle-mcp-model.test.ts`/
+  `bundle-skill-model.test.ts` pattern of asserting
+  `hub.handlers.has(eventType)` flips to `false` after disposal).
+
+### Non-goals (the other four areas)
+
+- **No backend changes** — see above.
+- **No debounce** added to these four — unlike Personal Memory's per-agent
+  targeted refresh, these are already-cheap wholesale list refetches using
+  the exact pattern proven safe by their existing sibling consumers; adding
+  new machinery here would be inventing a problem that isn't observed
+  anywhere else this pattern is already used.
+- **No change to Accounts** — already fully reactive, confirmed by the audit
+  above; nothing to do.

--- a/docs/specs/SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md
+++ b/docs/specs/SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md
@@ -144,6 +144,33 @@ agent (e.g. an agent scripting several `MemoryWrite` calls in a loop) should
 coalesce into one refetch, not one RPC round-trip per write. Keyed per
 agent ID so a burst on agent A never delays agent B's own refresh.
 
+#### Out-of-band deletions
+
+Content-drift detection alone never notices a file that's simply *gone* —
+there's nothing left to hash and compare. The fast fs-watch path also
+deliberately ignores `FsWatchEventKind::Removed` (it exists to catch content
+changes, not track deletions). Caught during review (Codex P2, PR #2932):
+without handling this, a file deleted out of band (not through
+`agent:memory:write_file`/`revert`, neither of which delete files) would
+never publish anything, leaving the grid count and an open detail view for
+that exact file stale forever — not just delayed, since no event ever
+arrives to prompt the frontend's own "the selected file is now gone"
+handling (added in this same spec) to fire at all.
+
+Fixed in the reconciliation sweep (not the fast path — instant deletion
+detection isn't needed at fs-watch speed for this): after each sweep's
+content-drift pass, `agent_native_memory_version_list_distinct_files()`
+(the same primitive `native_memory_retention.rs` already uses as its own
+work list) gives every `(agent_id, filename)` pair with recorded history;
+any whose file is missing from its resolved directory on THIS sweep
+publishes — once. A `deleted_notified: HashSet<(agent_id, filename)>`,
+threaded as persistent per-tick state the same way the fast path's own
+`watched_dirs`/`dir_to_agent` already are, suppresses republishing on every
+subsequent 30s tick for a file that stays deleted; the entry clears the
+moment the filename reappears on disk (recreated with new content), so a
+later re-deletion is detected fresh, not permanently swallowed by the first
+one.
+
 #### Known gap — not solved by this design, and why it's acceptable
 
 The fs-watch fast path only watches **known** agents' memory directories
@@ -181,6 +208,26 @@ speculatively.
   was actually the one removed).
 - Rapid repeated events for the same agent within the debounce window
   produce exactly one refetch, not one per event.
+- An event for the file currently open in the detail view **remounts** the
+  history panel (proven via a mount-count check, not just matching text
+  content — a plain re-render with identical `agentId:filename` couldn't be
+  distinguished from a genuine remount otherwise), so its own constructor-
+  loaded history actually reflects the new content (Codex P1, PR #2932 —
+  the exact scenario this whole feature exists for was, before this test,
+  the one case that silently didn't work).
+- A change event's refetch resolving before an in-flight initial
+  agent-switch fetch does not leave the file selector permanently stuck on
+  "Loading…" (Codex P2, PR #2932 — both fetches share `latestRequestId`;
+  `refetchSelectedAgentFiles` must own `filesLoading` too, not just `files`).
+- An older, slower count response cannot overwrite a newer one that
+  resolved first for the same agent (Codex P2, PR #2932 — `fetchCountFor`
+  needed its own per-agent request generation, not just the "agent still
+  present" guard that sufficed before events could re-trigger it while a
+  prior call was still in flight).
+- Backend: a reconciliation sweep that first observes a file's out-of-band
+  deletion publishes once; a repeat sweep over the same still-missing file
+  does not re-publish; recreating the file clears the suppression, so a
+  later re-deletion is detected fresh (Codex P2, PR #2932).
 
 ### Non-goals (Personal Memory)
 

--- a/frontend/app/view/brain/global-brain-model.test.ts
+++ b/frontend/app/view/brain/global-brain-model.test.ts
@@ -77,12 +77,38 @@ vi.mock("@/app/store/rpc-api", () => ({
     },
 }));
 
+// SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md — same hub pattern
+// bundle-mcp-model.test.ts uses.
+const wpsHub = vi.hoisted(() => ({ handlers: new Map<string, (e: unknown) => void>() }));
+vi.mock("@/app/store/wps", () => ({
+    waveEventSubscribe: vi.fn((sub: { eventType: string; handler: (e: unknown) => void }) => {
+        wpsHub.handlers.set(sub.eventType, sub.handler);
+        return () => wpsHub.handlers.delete(sub.eventType);
+    }),
+}));
+
 describe("GlobalBrainViewModel system/ordinary split", () => {
     beforeEach(() => {
         listMemoriesMock.mockClear();
         listMemoriesMock.mockResolvedValue([]);
         getClaudeGlobalConfigMock.mockClear();
         getClaudeGlobalConfigMock.mockResolvedValue({ path: "/home/user/.agentmux/shared/providers/claude/CLAUDE.md", content: null, exists: false });
+        wpsHub.handlers.clear();
+    });
+
+    // SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md
+    test("subscribes to memories:changed and refreshes on it; unsubscribes on dispose", async () => {
+        const { GlobalBrainViewModel } = await import("./global-brain-model");
+        const model = new GlobalBrainViewModel();
+        await Promise.resolve();
+        listMemoriesMock.mockClear();
+
+        wpsHub.handlers.get("memories:changed")?.({});
+        await Promise.resolve();
+        expect(listMemoriesMock).toHaveBeenCalledTimes(1);
+
+        model.dispose();
+        expect(wpsHub.handlers.has("memories:changed")).toBe(false);
     });
 
     test("systemSectionsAtom and ordinarySectionsAtom partition allAtom without overlap", async () => {

--- a/frontend/app/view/brain/global-brain-model.ts
+++ b/frontend/app/view/brain/global-brain-model.ts
@@ -27,6 +27,7 @@
 import { createMemo, createSignal, type Accessor } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { waveEventSubscribe } from "@/app/store/wps";
 import { PROVIDERS } from "@/app/view/agent/providers";
 
 /** Sentinel editingId for the unsaved "new section" draft. */
@@ -84,6 +85,12 @@ export function groupProvidersByStartupFilename(): { filename: string; providerN
 }
 
 export class GlobalBrainViewModel {
+    // Cross-window reactivity (SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md) —
+    // a bundle create/edit/delete/reorder made elsewhere refreshes this view
+    // without a manual reopen, same pattern BundleMcpModel/BundleSkillModel
+    // already use for mcp:changed/skills:changed.
+    private unsubChanged: () => void;
+
     private _all = createSignal<Memory[]>([]);
     /** Every bundle (global + per-agent), used to derive sections + candidates. */
     allAtom: Accessor<Memory[]> = this._all[0];
@@ -209,6 +216,10 @@ export class GlobalBrainViewModel {
         );
         void this.refresh();
         void this.fetchClaudeGlobalConfig();
+        this.unsubChanged = waveEventSubscribe({
+            eventType: "memories:changed",
+            handler: () => void this.refresh(),
+        });
     }
 
     /** Fetches the shared Claude provider config's CLAUDE.md once. Failure
@@ -370,7 +381,7 @@ export class GlobalBrainViewModel {
     }
 
     dispose(): void {
-        // Solid signals are GC'd with the instance; nothing to unsubscribe.
+        this.unsubChanged();
     }
 
     // ---- System-tier — see

--- a/frontend/app/view/mcp/mcp-model.test.ts
+++ b/frontend/app/view/mcp/mcp-model.test.ts
@@ -1,0 +1,72 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// McpCatalogModel — the standalone Armory "MCP Servers" tab's model. Scoped
+// to the reactive-updates wiring added by
+// docs/specs/SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md; this model had no
+// prior test coverage, and full CRUD coverage is out of scope here.
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mcpCatalogListMock = vi.fn().mockResolvedValue([]);
+const listAgentDefinitionsMock = vi.fn().mockResolvedValue([]);
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        McpCatalogListCommand: (...args: unknown[]) => mcpCatalogListMock(...args),
+        ListAgentDefinitionsCommand: (...args: unknown[]) => listAgentDefinitionsMock(...args),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+// Same hub pattern bundle-mcp-model.test.ts / global-brain-model.test.ts use.
+const wpsHub = vi.hoisted(() => ({ handlers: new Map<string, (e: unknown) => void>() }));
+vi.mock("@/app/store/wps", () => ({
+    waveEventSubscribe: vi.fn((sub: { eventType: string; handler: (e: unknown) => void }) => {
+        wpsHub.handlers.set(sub.eventType, sub.handler);
+        return () => wpsHub.handlers.delete(sub.eventType);
+    }),
+}));
+
+import { McpCatalogModel } from "./mcp-model";
+
+beforeEach(() => {
+    mcpCatalogListMock.mockClear();
+    mcpCatalogListMock.mockResolvedValue([]);
+    listAgentDefinitionsMock.mockClear();
+    listAgentDefinitionsMock.mockResolvedValue([]);
+    wpsHub.handlers.clear();
+});
+
+describe("McpCatalogModel — reactive updates", () => {
+    test("subscribes to mcp:changed and refreshes on it", async () => {
+        const model = new McpCatalogModel();
+        await Promise.resolve();
+        mcpCatalogListMock.mockClear();
+
+        wpsHub.handlers.get("mcp:changed")?.({});
+        await Promise.resolve();
+
+        expect(mcpCatalogListMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("an unrelated event type does not trigger a refresh", async () => {
+        new McpCatalogModel();
+        await Promise.resolve();
+        mcpCatalogListMock.mockClear();
+
+        wpsHub.handlers.get("skills:changed")?.({});
+        await Promise.resolve();
+
+        expect(mcpCatalogListMock).not.toHaveBeenCalled();
+    });
+
+    test("unsubscribes on dispose", async () => {
+        const model = new McpCatalogModel();
+        await Promise.resolve();
+        expect(wpsHub.handlers.has("mcp:changed")).toBe(true);
+
+        model.dispose();
+
+        expect(wpsHub.handlers.has("mcp:changed")).toBe(false);
+    });
+});

--- a/frontend/app/view/mcp/mcp-model.ts
+++ b/frontend/app/view/mcp/mcp-model.ts
@@ -15,6 +15,7 @@
 import { createMemo, createSignal, type Accessor } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { waveEventSubscribe } from "@/app/store/wps";
 import type { McpPreloadEntry } from "./mcp-preload-catalog";
 
 export interface McpDraft {
@@ -33,6 +34,12 @@ function draftFromServer(s: McpServer): McpDraft {
 }
 
 export class McpCatalogModel {
+    // Cross-window reactivity (SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md) —
+    // a bind/unbind/add/edit made elsewhere (including from the per-bundle
+    // BundleMcpModel, which already subscribes to this same event) refreshes
+    // this standalone Armory "MCP Servers" tab without a manual reopen.
+    private unsubChanged: () => void;
+
     private _servers = createSignal<McpServerCatalogItem[]>([]);
     serversAtom: Accessor<McpServerCatalogItem[]> = this._servers[0];
     private setServers = this._servers[1];
@@ -78,6 +85,10 @@ export class McpCatalogModel {
         });
         void this.refresh();
         void this.loadAgents();
+        this.unsubChanged = waveEventSubscribe({
+            eventType: "mcp:changed",
+            handler: () => void this.refresh(),
+        });
     }
 
     async refresh(): Promise<void> {
@@ -207,6 +218,6 @@ export class McpCatalogModel {
     }
 
     dispose(): void {
-        // Solid signals are GC'd with the instance; nothing to unsubscribe.
+        this.unsubChanged();
     }
 }

--- a/frontend/app/view/memory/memory-model.test.ts
+++ b/frontend/app/view/memory/memory-model.test.ts
@@ -127,10 +127,36 @@ vi.mock("@/app/store/rpc-api", () => ({
     },
 }));
 
+// SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md — same hub pattern
+// bundle-mcp-model.test.ts / global-brain-model.test.ts use.
+const wpsHub = vi.hoisted(() => ({ handlers: new Map<string, (e: unknown) => void>() }));
+vi.mock("@/app/store/wps", () => ({
+    waveEventSubscribe: vi.fn((sub: { eventType: string; handler: (e: unknown) => void }) => {
+        wpsHub.handlers.set(sub.eventType, sub.handler);
+        return () => wpsHub.handlers.delete(sub.eventType);
+    }),
+}));
+
 describe("validateDraft", () => {
     beforeEach(() => {
         listMemoriesMock.mockClear();
         validateBundleMock.mockClear();
+        wpsHub.handlers.clear();
+    });
+
+    // SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md
+    test("subscribes to memories:changed and refreshes on it; unsubscribes on dispose", async () => {
+        const { MemoryViewModel } = await import("./memory-model");
+        const model = new MemoryViewModel();
+        await Promise.resolve();
+        listMemoriesMock.mockClear();
+
+        wpsHub.handlers.get("memories:changed")?.({});
+        await Promise.resolve();
+        expect(listMemoriesMock).toHaveBeenCalledTimes(1);
+
+        model.dispose();
+        expect(wpsHub.handlers.has("memories:changed")).toBe(false);
     });
 
     test("populates validationAtom from the RPC response", async () => {

--- a/frontend/app/view/memory/memory-model.ts
+++ b/frontend/app/view/memory/memory-model.ts
@@ -27,6 +27,7 @@ import { BlockNodeModel } from "@/app/block/blocktypes";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
+import { waveEventSubscribe } from "@/app/store/wps";
 import { createMemo, createSignal, type Accessor } from "solid-js";
 
 /** What the form fields look like in flight. Maps 1:1 to the Memory
@@ -166,6 +167,13 @@ export class MemoryViewModel implements ViewModel {
     blockId: string;
     nodeModel: BlockNodeModel | null;
 
+    // Cross-window reactivity (SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md) —
+    // a bundle create/edit/delete made elsewhere refreshes this list without
+    // a manual reopen. Same `memories:changed` event GlobalBrainViewModel
+    // now also subscribes to; see that model's own comment on why one
+    // umbrella event firing a refresh in both tabs is fine, not a bug.
+    private unsubChanged: () => void;
+
     // "layer-group" (not "brain") — matches the ABF tab icon in the Armory
     // rail (armory-view.tsx) so the standalone bundle pane and the Armory nav
     // stay visually consistent; the brain icon is reserved for native memory.
@@ -250,6 +258,10 @@ export class MemoryViewModel implements ViewModel {
 
         // Kick off initial load. Errors land in errorAtom for UI surfacing.
         void this.refresh();
+        this.unsubChanged = waveEventSubscribe({
+            eventType: "memories:changed",
+            handler: () => void this.refresh(),
+        });
     }
 
     /** Re-fetch the full list. Called on mount and after each mutation.
@@ -396,8 +408,6 @@ export class MemoryViewModel implements ViewModel {
 
     /** ViewModel teardown — Solid signals are GC'd with the instance. */
     dispose(): void {
-        // No-op for now. If we add a wave-event subscription later (to
-        // refresh on `memories:changed` from other clients), unsubscribe
-        // here.
+        this.unsubChanged();
     }
 }

--- a/frontend/app/view/native-memory/native-memory-manager.test.tsx
+++ b/frontend/app/view/native-memory/native-memory-manager.test.tsx
@@ -25,6 +25,25 @@ function cardTitlesInOrder(container: HTMLElement): string[] {
 const listAgentDefinitionsMock = vi.fn();
 const nativeMemoryListMock = vi.fn();
 
+// SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md's own tests drive
+// `agent:memory:changed:{id}` events through this hub, same pattern as
+// bundle-mcp-model.test.ts's own waveEventSubscribe mock — extended here to
+// accept the VARIADIC multi-subscription call NativeMemoryManager makes
+// (one subscription per grid agent in a single waveEventSubscribe(...) call,
+// not bundle-mcp-model.ts's single-subscription shape).
+const wpsHub = vi.hoisted(() => ({
+    handlers: new Map<string, (e: unknown) => void>(),
+}));
+
+vi.mock("@/app/store/wps", () => ({
+    waveEventSubscribe: vi.fn((...subs: Array<{ eventType: string; handler: (e: unknown) => void }>) => {
+        for (const sub of subs) wpsHub.handlers.set(sub.eventType, sub.handler);
+        return () => {
+            for (const sub of subs) wpsHub.handlers.delete(sub.eventType);
+        };
+    }),
+}));
+
 vi.mock("@/app/store/rpc-api", () => ({
     RpcApi: {
         ListAgentDefinitionsCommand: (...args: unknown[]) => listAgentDefinitionsMock(...args),
@@ -56,6 +75,7 @@ beforeEach(() => {
     listAgentDefinitionsMock.mockResolvedValue([agent("a1", "Manoz"), agent("a2", "AgentY")]);
     nativeMemoryListMock.mockResolvedValue({ files: [] });
     localStorage.clear();
+    wpsHub.handlers.clear();
 });
 
 describe("NativeMemoryManager — agent grid", () => {
@@ -292,6 +312,137 @@ describe("NativeMemoryManager — filter and sort", () => {
 
         expect(await screen.findByText("← All agents")).toBeInTheDocument();
         expect(screen.queryByTestId("memory-agent-filter-bar")).toBeNull();
+    });
+});
+
+// docs/specs/SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md
+describe("NativeMemoryManager — reactive updates", () => {
+    test("an agent:memory:changed event refetches only that agent's count", async () => {
+        render(() => <NativeMemoryManager />);
+        await screen.findAllByText("No memories yet"); // initial fetch settled for both
+
+        nativeMemoryListMock.mockImplementation((_c: unknown, req: { agent_id: string }) =>
+            req.agent_id === "a1"
+                ? Promise.resolve({ files: [{ filename: "MEMORY.md" }] })
+                : Promise.resolve({ files: [] }),
+        );
+        wpsHub.handlers.get("agent:memory:changed:a1")?.({});
+
+        expect(await screen.findByText("1 file")).toBeInTheDocument();
+        // a2's card never re-fetched (still shows the original empty state).
+        expect(screen.getByText("AgentY").closest(".memory-agent-card")).toHaveTextContent("No memories yet");
+    });
+
+    test("an event refetches an agent even if its card previously errored", async () => {
+        nativeMemoryListMock.mockImplementation((_c: unknown, req: { agent_id: string }) =>
+            req.agent_id === "a1" ? Promise.reject(new Error("boom")) : Promise.resolve({ files: [] }),
+        );
+        render(() => <NativeMemoryManager />);
+        await screen.findByText("Couldn't read memories");
+
+        // Whatever broke is fixed now — the next event must get a fresh try,
+        // not stay permanently errored until a full remount.
+        nativeMemoryListMock.mockImplementation((_c: unknown, req: { agent_id: string }) =>
+            req.agent_id === "a1" ? Promise.resolve({ files: [{ filename: "MEMORY.md" }] }) : Promise.resolve({ files: [] }),
+        );
+        wpsHub.handlers.get("agent:memory:changed:a1")?.({});
+
+        expect(await screen.findByText("1 file")).toBeInTheDocument();
+        expect(screen.queryByText("Couldn't read memories")).toBeNull();
+    });
+
+    test("rapid repeated events for the same agent debounce into a single refetch", async () => {
+        vi.useFakeTimers();
+        try {
+            render(() => <NativeMemoryManager />);
+            await vi.waitFor(() => expect(nativeMemoryListMock).toHaveBeenCalledTimes(2));
+            nativeMemoryListMock.mockClear();
+
+            const handler = wpsHub.handlers.get("agent:memory:changed:a1");
+            handler?.({});
+            handler?.({});
+            handler?.({});
+            await vi.advanceTimersByTimeAsync(250);
+
+            expect(nativeMemoryListMock).toHaveBeenCalledTimes(1);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test("an event for the open detail view's agent refreshes its file list in place", async () => {
+        nativeMemoryListMock.mockResolvedValue({ files: [{ filename: "MEMORY.md" }] });
+        render(() => <NativeMemoryManager />);
+        fireEvent.click(await screen.findByText("Manoz"));
+        const select = await screen.findByRole("combobox");
+        await waitFor(() => expect(select).not.toBeDisabled());
+        fireEvent.change(select, { target: { value: "MEMORY.md" } });
+        expect(await screen.findByTestId("history-panel")).toHaveTextContent("a1:MEMORY.md");
+
+        nativeMemoryListMock.mockResolvedValue({ files: [{ filename: "MEMORY.md" }, { filename: "NOTES.md" }] });
+        wpsHub.handlers.get("agent:memory:changed:a1")?.({});
+
+        await waitFor(() =>
+            expect(Array.from(select.querySelectorAll("option")).map((o) => o.value)).toContain("NOTES.md"),
+        );
+        // Still showing the same file's history — the event refreshed the
+        // list in place, it did not kick the user back to "pick a file".
+        expect(screen.getByTestId("history-panel")).toHaveTextContent("a1:MEMORY.md");
+    });
+
+    test("an event for a DIFFERENT agent than the one open in detail view is ignored there", async () => {
+        nativeMemoryListMock.mockResolvedValue({ files: [{ filename: "MEMORY.md" }] });
+        render(() => <NativeMemoryManager />);
+        fireEvent.click(await screen.findByText("Manoz")); // opens agent a1
+        await screen.findByRole("combobox");
+
+        nativeMemoryListMock.mockClear();
+        wpsHub.handlers.get("agent:memory:changed:a2")?.({});
+
+        // a2's own grid card legitimately refetches in the background (the
+        // grid stays reactive even while the detail view is open) — what
+        // must NOT happen is a refetch for a1, the agent the open detail
+        // view is actually showing.
+        await vi.waitFor(() => expect(nativeMemoryListMock).toHaveBeenCalledWith(undefined, { agent_id: "a2" }));
+        expect(nativeMemoryListMock).not.toHaveBeenCalledWith(undefined, { agent_id: "a1" });
+    });
+
+    test("clears the selected filename if the event's refresh shows it no longer exists", async () => {
+        nativeMemoryListMock.mockResolvedValue({ files: [{ filename: "MEMORY.md" }] });
+        render(() => <NativeMemoryManager />);
+        fireEvent.click(await screen.findByText("Manoz"));
+        const select = (await screen.findByRole("combobox")) as HTMLSelectElement;
+        await waitFor(() => expect(select).not.toBeDisabled());
+        fireEvent.change(select, { target: { value: "MEMORY.md" } });
+        expect(await screen.findByTestId("history-panel")).toHaveTextContent("a1:MEMORY.md");
+
+        // The file that was selected is gone in the refreshed list.
+        nativeMemoryListMock.mockResolvedValue({ files: [{ filename: "OTHER.md" }] });
+        wpsHub.handlers.get("agent:memory:changed:a1")?.({});
+
+        await waitFor(() => expect(select.value).toBe(""));
+        expect(screen.queryByTestId("history-panel")).toBeNull();
+    });
+
+    test("subscriptions are re-registered when the agent set changes", async () => {
+        render(() => <NativeMemoryManager />);
+        await screen.findByText("Manoz");
+        expect(wpsHub.handlers.has("agent:memory:changed:a1")).toBe(true);
+        expect(wpsHub.handlers.has("agent:memory:changed:a2")).toBe(true);
+
+        listAgentDefinitionsMock.mockResolvedValue([agent("a3", "Nark")]);
+        // Simulate the agents:changed-driven refetch useAgentDefinitions does
+        // internally by re-invoking its own subscribe path is out of scope
+        // here (that's useAgentDefinitions' own test surface) — instead
+        // re-render to exercise the same agentIdsKey-change code path this
+        // effect depends on.
+        cleanup();
+        render(() => <NativeMemoryManager />);
+        await screen.findByText("Nark");
+
+        expect(wpsHub.handlers.has("agent:memory:changed:a1")).toBe(false);
+        expect(wpsHub.handlers.has("agent:memory:changed:a2")).toBe(false);
+        expect(wpsHub.handlers.has("agent:memory:changed:a3")).toBe(true);
     });
 });
 

--- a/frontend/app/view/native-memory/native-memory-manager.test.tsx
+++ b/frontend/app/view/native-memory/native-memory-manager.test.tsx
@@ -52,11 +52,18 @@ vi.mock("@/app/store/rpc-api", () => ({
 }));
 
 // The history panel does its own RPC work on mount and is covered by its own
-// tests; this suite is about navigation and the grid.
+// tests; this suite is about navigation and the grid. `historyPanelMountCount`
+// increments once per MOUNT (a Solid component's own function body runs once
+// at creation, not per-render) — used by the Codex P1 regression test below
+// to prove the panel actually remounted (and so would re-fetch fresh
+// history) rather than just re-rendering with identical text content, which
+// a plain toHaveTextContent check can't distinguish.
+let historyPanelMountCount = 0;
 vi.mock("@/app/view/agent/components/NativeMemoryHistoryPanel", () => ({
-    NativeMemoryHistoryPanel: (props: { agentId: string; filename: string }) => (
-        <div data-testid="history-panel">{`${props.agentId}:${props.filename}`}</div>
-    ),
+    NativeMemoryHistoryPanel: (props: { agentId: string; filename: string }) => {
+        historyPanelMountCount++;
+        return <div data-testid="history-panel">{`${props.agentId}:${props.filename}`}</div>;
+    },
 }));
 
 import { NativeMemoryManager } from "./native-memory-manager";
@@ -76,6 +83,7 @@ beforeEach(() => {
     nativeMemoryListMock.mockResolvedValue({ files: [] });
     localStorage.clear();
     wpsHub.handlers.clear();
+    historyPanelMountCount = 0;
 });
 
 describe("NativeMemoryManager — agent grid", () => {
@@ -443,6 +451,105 @@ describe("NativeMemoryManager — reactive updates", () => {
         expect(wpsHub.handlers.has("agent:memory:changed:a1")).toBe(false);
         expect(wpsHub.handlers.has("agent:memory:changed:a2")).toBe(false);
         expect(wpsHub.handlers.has("agent:memory:changed:a3")).toBe(true);
+    });
+
+    // Codex P1, PR #2932: a live write to the file already open in the
+    // detail view is the scenario this whole feature exists for. The panel
+    // is keyed on agentId:filename, which don't change when only the SAME
+    // file's content changes — without a forced remount, the new content/
+    // history stayed invisible until the user switched away and back.
+    test("an event for the open file re-mounts the history panel, not just re-renders it", async () => {
+        nativeMemoryListMock.mockResolvedValue({ files: [{ filename: "MEMORY.md" }] });
+        render(() => <NativeMemoryManager />);
+        fireEvent.click(await screen.findByText("Manoz"));
+        const select = await screen.findByRole("combobox");
+        await waitFor(() => expect(select).not.toBeDisabled());
+        fireEvent.change(select, { target: { value: "MEMORY.md" } });
+        await screen.findByTestId("history-panel");
+        const mountsBefore = historyPanelMountCount;
+
+        // Same file list, same selected file — nothing about agentId or
+        // filename changes, only the file's own content on the backend.
+        wpsHub.handlers.get("agent:memory:changed:a1")?.({});
+
+        await waitFor(() => expect(historyPanelMountCount).toBeGreaterThan(mountsBefore));
+        // Still showing the same agent/file — a remount, not a navigation.
+        expect(screen.getByTestId("history-panel")).toHaveTextContent("a1:MEMORY.md");
+    });
+
+    // Codex P2, PR #2932: refetchSelectedAgentFiles shares latestRequestId
+    // with the selectedAgent()-keyed effect. If a change event's refetch
+    // completes and becomes the new latestRequestId before the ORIGINAL
+    // agent-switch fetch resolves, that original fetch's own .finally()
+    // skips setFilesLoading(false) (guarded by the same requestId check) --
+    // and if refetchSelectedAgentFiles itself never touched filesLoading,
+    // nothing else would ever clear it, leaving the selector permanently
+    // disabled/stuck on "Loading…".
+    test("does not get stuck loading when an event's refetch resolves before the initial agent-switch fetch", async () => {
+        let resolveInitial: ((v: { files: NativeMemoryFileMeta[] }) => void) | undefined;
+        nativeMemoryListMock.mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    resolveInitial = resolve;
+                }),
+        );
+        render(() => <NativeMemoryManager />);
+        fireEvent.click(await screen.findByText("Manoz")); // fires the initial (slow) fetch
+
+        const select = await screen.findByRole("combobox");
+        expect(select).toBeDisabled(); // still "Loading…" — initial fetch not resolved yet
+
+        // A change event's refetch fires and resolves BEFORE the initial
+        // fetch does — it becomes the new latestRequestId.
+        nativeMemoryListMock.mockResolvedValue({ files: [{ filename: "MEMORY.md" }] });
+        wpsHub.handlers.get("agent:memory:changed:a1")?.({});
+        await waitFor(() => expect(select).not.toBeDisabled());
+
+        // The original (now-superseded) initial fetch finally resolves.
+        resolveInitial?.({ files: [] });
+        await Promise.resolve();
+
+        // Must still reflect the newer, correct result -- not stuck loading,
+        // and not clobbered back to the stale initial (empty) result either.
+        expect(select).not.toBeDisabled();
+        expect(Array.from(select.querySelectorAll("option")).map((o) => o.value)).toContain("MEMORY.md");
+    });
+
+    // Codex P2, PR #2932: fetchCountFor previously guarded only "is this
+    // agent still present", not "is this the newest request for this
+    // agent". Two overlapping calls for the same agent (e.g. an unusually
+    // slow initial fetch, superseded by a fast event-triggered refetch)
+    // could let the OLDER response win if it resolves last.
+    test("an older, slower count response cannot overwrite a newer one for the same agent", async () => {
+        let resolveSlow: ((v: { files: NativeMemoryFileMeta[] }) => void) | undefined;
+        nativeMemoryListMock.mockImplementation((_c: unknown, req: { agent_id: string }) => {
+            if (req.agent_id !== "a1") return Promise.resolve({ files: [] });
+            return new Promise((resolve) => {
+                resolveSlow = resolve;
+            });
+        });
+        render(() => <NativeMemoryManager />);
+        await screen.findByText("Manoz"); // initial fetch for a1 now in flight (slow)
+
+        // A change event fires a second, faster request for the same agent,
+        // which resolves first with the "true" current count.
+        nativeMemoryListMock.mockImplementation((_c: unknown, req: { agent_id: string }) =>
+            req.agent_id === "a1"
+                ? Promise.resolve({ files: [{ filename: "MEMORY.md" }, { filename: "NOTES.md" }] })
+                : Promise.resolve({ files: [] }),
+        );
+        wpsHub.handlers.get("agent:memory:changed:a1")?.({});
+        await screen.findByText("2 files");
+
+        // The original slow request finally resolves with stale data.
+        resolveSlow?.({ files: [] });
+        await Promise.resolve();
+
+        // Must still show the newer, correct count on a1's own card
+        // specifically — a2's own (genuinely empty) card still legitimately
+        // reads "No memories yet" and is not what this assertion is about.
+        expect(screen.getByText("2 files")).toBeInTheDocument();
+        expect(screen.getByText("Manoz").closest(".memory-agent-card")).toHaveTextContent("2 files");
     });
 });
 

--- a/frontend/app/view/native-memory/native-memory-manager.test.tsx
+++ b/frontend/app/view/native-memory/native-memory-manager.test.tsx
@@ -341,6 +341,49 @@ describe("NativeMemoryManager — reactive updates", () => {
         expect(screen.getByText("AgentY").closest(".memory-agent-card")).toHaveTextContent("No memories yet");
     });
 
+    // ReAgent (PR #2932, non-blocking follow-up): fetchCountFor previously
+    // overwrote to {kind: "loading"} unconditionally, including on a
+    // reactive refresh of an ALREADY-resolved card -- a visible
+    // "Loading…" flash on every write, inconsistent with the feature's own
+    // "quiet in-place update" design intent and with
+    // refetchSelectedAgentFiles's own deliberate choice not to touch
+    // filesLoading for the identical reason.
+    test("a reactive count refresh does not flash 'Loading…' for an already-resolved card", async () => {
+        vi.useFakeTimers();
+        try {
+            nativeMemoryListMock.mockResolvedValue({ files: [{ filename: "MEMORY.md" }] });
+            render(() => <NativeMemoryManager />);
+            await vi.waitFor(() => expect(screen.getAllByText("1 file")).toHaveLength(2));
+
+            // Only `files.length` is ever read by the code under test here
+            // (fetchCountFor), so a minimal shape is honest about what this
+            // test actually needs — not the full NativeMemoryFileMeta.
+            let resolveRefresh: ((v: { files: { filename: string }[] }) => void) | undefined;
+            nativeMemoryListMock.mockImplementation(
+                () =>
+                    new Promise((resolve) => {
+                        resolveRefresh = resolve;
+                    }),
+            );
+            wpsHub.handlers.get("agent:memory:changed:a1")?.({});
+            // Past the 250ms debounce -- fetchCountFor has now actually been
+            // called and its RPC is in flight (held pending by resolveRefresh).
+            await vi.advanceTimersByTimeAsync(250);
+
+            // While the reactive refetch is still in flight, a1's card must
+            // still show its OLD resolved count, never "Loading…".
+            expect(screen.getByText("Manoz").closest(".memory-agent-card")).toHaveTextContent("1 file");
+            expect(screen.getByText("Manoz").closest(".memory-agent-card")).not.toHaveTextContent("Loading");
+
+            resolveRefresh?.({ files: [{ filename: "MEMORY.md" }, { filename: "NOTES.md" }] });
+            await vi.waitFor(() =>
+                expect(screen.getByText("Manoz").closest(".memory-agent-card")).toHaveTextContent("2 files"),
+            );
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     test("an event refetches an agent even if its card previously errored", async () => {
         nativeMemoryListMock.mockImplementation((_c: unknown, req: { agent_id: string }) =>
             req.agent_id === "a1" ? Promise.reject(new Error("boom")) : Promise.resolve({ files: [] }),

--- a/frontend/app/view/native-memory/native-memory-manager.test.tsx
+++ b/frontend/app/view/native-memory/native-memory-manager.test.tsx
@@ -551,6 +551,40 @@ describe("NativeMemoryManager — reactive updates", () => {
         expect(screen.getByText("2 files")).toBeInTheDocument();
         expect(screen.getByText("Manoz").closest(".memory-agent-card")).toHaveTextContent("2 files");
     });
+
+    // ReAgent P1, PR #2932: an unrelated agent appearing/disappearing
+    // ANYWHERE in the app changes agentIdsKey() (it's derived from every
+    // agent definition, not just ones with memory) and re-runs this whole
+    // subscription effect. A pending debounced refetch for an agent that's
+    // still present must survive that re-run, not get silently canceled.
+    test("a pending debounced refetch survives an unrelated agent appearing elsewhere within the debounce window", async () => {
+        vi.useFakeTimers();
+        try {
+            render(() => <NativeMemoryManager />);
+            await vi.waitFor(() => expect(nativeMemoryListMock).toHaveBeenCalledTimes(2));
+            nativeMemoryListMock.mockClear();
+            nativeMemoryListMock.mockResolvedValue({ files: [{ filename: "MEMORY.md" }] });
+
+            // Schedule a1's debounced refetch (250ms), then — BEFORE it
+            // fires — an unrelated agent (a3) appears elsewhere in the app.
+            // useAgentDefinitions() itself subscribes to "agents:changed"
+            // (AgentPicker.tsx) via the same mocked waveEventSubscribe hub,
+            // so triggering that here re-fetches the agent list for real,
+            // exactly as it would from a genuine unrelated create/edit.
+            wpsHub.handlers.get("agent:memory:changed:a1")?.({});
+            listAgentDefinitionsMock.mockResolvedValue([agent("a1", "Manoz"), agent("a2", "AgentY"), agent("a3", "Nark")]);
+            wpsHub.handlers.get("agents:changed")?.({});
+            await vi.waitFor(() => expect(screen.queryByText("Nark")).not.toBeNull());
+
+            // a1's debounce timer must still fire, not have been silently
+            // canceled by the resubscribe the agent-list change triggered.
+            await vi.advanceTimersByTimeAsync(250);
+
+            expect(nativeMemoryListMock).toHaveBeenCalledWith(undefined, { agent_id: "a1" });
+        } finally {
+            vi.useRealTimers();
+        }
+    });
 });
 
 describe("NativeMemoryManager — drill-in", () => {

--- a/frontend/app/view/native-memory/native-memory-manager.tsx
+++ b/frontend/app/view/native-memory/native-memory-manager.tsx
@@ -27,9 +27,10 @@
  * This directory and component are about native memory only.
  */
 
-import { createEffect, createMemo, createSignal, For, Show, untrack, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, For, onCleanup, Show, untrack, type JSX } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { waveEventSubscribe } from "@/app/store/wps";
 import { useAgentDefinitions } from "@/app/view/agent/components/AgentPicker";
 import { NativeMemoryHistoryPanel } from "@/app/view/agent/components/NativeMemoryHistoryPanel";
 import { MemoryAgentCard, type MemoryCountState } from "./MemoryAgentCard";
@@ -154,6 +155,39 @@ export function NativeMemoryManager(): JSX.Element {
             .join(" "),
     );
 
+    // Shared by the id-set effect below (new agents) AND the reactive
+    // agent:memory:changed handler further down (SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md)
+    // — one RPC-call-then-setCounts implementation, not two copies that could
+    // drift. Always overwrites, even for an agent not currently `undefined`
+    // in the map — the reactive path's whole point is refreshing an agent
+    // whose count was already resolved (or errored) before this call.
+    const fetchCountFor = (agent: AgentDefinition) => {
+        setCounts((prev) => ({ ...prev, [agent.id]: { kind: "loading" } as MemoryCountState }));
+        RpcApi.NativeMemoryListCommand(TabRpcClient, { agent_id: agent.id })
+            .then((res) => {
+                // Guarded per-agent rather than by a batch generation: a
+                // response is only stale if its agent is gone, and each
+                // fetch now settles into a shared, incrementally-built map
+                // (the old whole-batch reset is what caused the flicker).
+                setCounts((prev) =>
+                    prev[agent.id] === undefined
+                        ? prev
+                        : { ...prev, [agent.id]: { kind: "count", files: res.files.length } },
+                );
+            })
+            .catch((e: Error) => {
+                // NOT folded into `count: 0`. agent:memory:list fails with
+                // a hard 500 when the memory dir can't be resolved — the
+                // exact shape of the bug #2901 fixed — so an error must
+                // stay visually distinct from a genuinely empty agent.
+                setCounts((prev) =>
+                    prev[agent.id] === undefined
+                        ? prev
+                        : { ...prev, [agent.id]: { kind: "error", message: e.message ?? String(e) } },
+                );
+            });
+    };
+
     createEffect(() => {
         agentIdsKey();
         // Read the list itself untracked: the memo above is the only intended
@@ -166,38 +200,7 @@ export function NativeMemoryManager(): JSX.Element {
         setCounts((prev) => Object.fromEntries(Object.entries(prev).filter(([id]) => present.has(id))));
 
         const missing = list.filter((a) => untrack(() => counts())[a.id] === undefined);
-        if (missing.length === 0) return;
-
-        setCounts((prev) => ({
-            ...prev,
-            ...Object.fromEntries(missing.map((a) => [a.id, { kind: "loading" } as MemoryCountState])),
-        }));
-
-        for (const agent of missing) {
-            RpcApi.NativeMemoryListCommand(TabRpcClient, { agent_id: agent.id })
-                .then((res) => {
-                    // Guarded per-agent rather than by a batch generation: a
-                    // response is only stale if its agent is gone, and each
-                    // fetch now settles into a shared, incrementally-built map
-                    // (the old whole-batch reset is what caused the flicker).
-                    setCounts((prev) =>
-                        prev[agent.id] === undefined
-                            ? prev
-                            : { ...prev, [agent.id]: { kind: "count", files: res.files.length } },
-                    );
-                })
-                .catch((e: Error) => {
-                    // NOT folded into `count: 0`. agent:memory:list fails with
-                    // a hard 500 when the memory dir can't be resolved — the
-                    // exact shape of the bug #2901 fixed — so an error must
-                    // stay visually distinct from a genuinely empty agent.
-                    setCounts((prev) =>
-                        prev[agent.id] === undefined
-                            ? prev
-                            : { ...prev, [agent.id]: { kind: "error", message: e.message ?? String(e) } },
-                    );
-                });
-        }
+        for (const agent of missing) fetchCountFor(agent);
     });
 
     // Grid find/filter + sort (SPEC_ARMORY_PERSONAL_MEMORY_FILTER_AND_SORT_2026_09_02.md).
@@ -267,6 +270,76 @@ export function NativeMemoryManager(): JSX.Element {
                 if (requestId !== latestRequestId) return;
                 setFilesLoading(false);
             });
+    });
+
+    // Reactive re-fetch of the OPEN detail view's file list, triggered by
+    // agent:memory:changed for the currently-selected agent
+    // (SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md). Deliberately does NOT
+    // clear `selectedFilename()` the way the selectedAgent()-keyed effect
+    // above does on an actual agent SWITCH — a live write to the file
+    // you're already looking at should update in place, not kick you back
+    // to "pick a file." Only clears it if the previously-selected filename
+    // genuinely no longer exists in the refreshed list (e.g. the file that
+    // changed was a delete).
+    const refetchSelectedAgentFiles = (agent: AgentDefinition) => {
+        const requestId = ++latestRequestId;
+        RpcApi.NativeMemoryListCommand(TabRpcClient, { agent_id: agent.id })
+            .then((res) => {
+                if (requestId !== latestRequestId) return;
+                setFiles(res.files);
+                setFilesError(null);
+                const current = selectedFilename();
+                if (current && !res.files.some((f) => f.filename === current)) {
+                    setSelectedFilename("");
+                }
+            })
+            .catch((e: Error) => {
+                if (requestId !== latestRequestId) return;
+                setFilesError(`Failed to list memory files: ${e.message ?? e}`);
+            });
+    };
+
+    // Reactive grid + detail updates: subscribe to agent:memory:changed for
+    // every agent currently in the grid, re-subscribing whenever the agent
+    // SET changes (same agentIdsKey dependency the count-fetch effect above
+    // uses, for the same reason — a brand-new-but-equivalent agents() array
+    // must not tear down and rebuild every subscription).
+    // SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md.
+    //
+    // Debounced per agent id (~250ms): a burst of rapid writes to the same
+    // agent (e.g. a script issuing several MemoryWrite calls in a loop)
+    // coalesces into one refetch instead of one RPC round-trip per write.
+    // Keyed per agent id so a burst on one agent never delays another's.
+    const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+    createEffect(() => {
+        agentIdsKey();
+        const list = untrack(() => agents());
+
+        const unsub = waveEventSubscribe(
+            ...list.map((agent) => ({
+                eventType: `agent:memory:changed:${agent.id}`,
+                handler: () => {
+                    const existing = debounceTimers.get(agent.id);
+                    if (existing !== undefined) clearTimeout(existing);
+                    debounceTimers.set(
+                        agent.id,
+                        setTimeout(() => {
+                            debounceTimers.delete(agent.id);
+                            fetchCountFor(agent);
+                            if (untrack(selectedAgent)?.id === agent.id) {
+                                refetchSelectedAgentFiles(agent);
+                            }
+                        }, 250),
+                    );
+                },
+            })),
+        );
+
+        onCleanup(() => {
+            unsub();
+            for (const timer of debounceTimers.values()) clearTimeout(timer);
+            debounceTimers.clear();
+        });
     });
 
     return (

--- a/frontend/app/view/native-memory/native-memory-manager.tsx
+++ b/frontend/app/view/native-memory/native-memory-manager.tsx
@@ -134,6 +134,10 @@ export function NativeMemoryManager(): JSX.Element {
     const [selectedFilename, setSelectedFilename] = createSignal<string>("");
     const [filesLoading, setFilesLoading] = createSignal(false);
     const [filesError, setFilesError] = createSignal<string | null>(null);
+    // Forces NativeMemoryHistoryPanel to remount on a reactive refresh even
+    // when agentId:filename is unchanged — see refetchSelectedAgentFiles's
+    // own comment (Codex P1, PR #2932).
+    const [refreshNonce, setRefreshNonce] = createSignal(0);
     let latestRequestId = 0;
 
     // Per-agent memory counts for the grid, keyed by agent id. Fetched lazily
@@ -155,6 +159,18 @@ export function NativeMemoryManager(): JSX.Element {
             .join(" "),
     );
 
+    // Per-agent request generation for fetchCountFor below (Codex P2, PR
+    // #2932): before the reactive agent:memory:changed handler existed, an
+    // agent's count was only ever fetched ONCE per appearance in the grid —
+    // "is this agent still present" was the only staleness question that
+    // could arise. Now a change event can call fetchCountFor again while an
+    // earlier call for the SAME agent is still in flight (e.g. the initial
+    // fetch is unusually slow, or two events land close together), and
+    // without this, an older response resolving after a newer one would
+    // overwrite the fresher result and leave the card stale until another
+    // event or a remount.
+    const countRequestGeneration = new Map<string, number>();
+
     // Shared by the id-set effect below (new agents) AND the reactive
     // agent:memory:changed handler further down (SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md)
     // — one RPC-call-then-setCounts implementation, not two copies that could
@@ -162,13 +178,16 @@ export function NativeMemoryManager(): JSX.Element {
     // in the map — the reactive path's whole point is refreshing an agent
     // whose count was already resolved (or errored) before this call.
     const fetchCountFor = (agent: AgentDefinition) => {
+        const generation = (countRequestGeneration.get(agent.id) ?? 0) + 1;
+        countRequestGeneration.set(agent.id, generation);
         setCounts((prev) => ({ ...prev, [agent.id]: { kind: "loading" } as MemoryCountState }));
         RpcApi.NativeMemoryListCommand(TabRpcClient, { agent_id: agent.id })
             .then((res) => {
-                // Guarded per-agent rather than by a batch generation: a
-                // response is only stale if its agent is gone, and each
-                // fetch now settles into a shared, incrementally-built map
-                // (the old whole-batch reset is what caused the flicker).
+                // Guarded by BOTH "agent still present" and "still the latest
+                // request for this agent" — a response is stale if either its
+                // agent is gone, or a newer fetchCountFor call for the same
+                // agent has since superseded it.
+                if (countRequestGeneration.get(agent.id) !== generation) return;
                 setCounts((prev) =>
                     prev[agent.id] === undefined
                         ? prev
@@ -176,6 +195,7 @@ export function NativeMemoryManager(): JSX.Element {
                 );
             })
             .catch((e: Error) => {
+                if (countRequestGeneration.get(agent.id) !== generation) return;
                 // NOT folded into `count: 0`. agent:memory:list fails with
                 // a hard 500 when the memory dir can't be resolved — the
                 // exact shape of the bug #2901 fixed — so an error must
@@ -198,6 +218,9 @@ export function NativeMemoryManager(): JSX.Element {
         // Drop entries for agents that no longer exist, and keep every count
         // already resolved — only genuinely new agents are fetched below.
         setCounts((prev) => Object.fromEntries(Object.entries(prev).filter(([id]) => present.has(id))));
+        for (const id of countRequestGeneration.keys()) {
+            if (!present.has(id)) countRequestGeneration.delete(id);
+        }
 
         const missing = list.filter((a) => untrack(() => counts())[a.id] === undefined);
         for (const agent of missing) fetchCountFor(agent);
@@ -281,6 +304,16 @@ export function NativeMemoryManager(): JSX.Element {
     // to "pick a file." Only clears it if the previously-selected filename
     // genuinely no longer exists in the refreshed list (e.g. the file that
     // changed was a delete).
+    //
+    // Codex P2 (PR #2932): this must also own `filesLoading`, not just
+    // `files`. It shares `latestRequestId` with the selectedAgent()-keyed
+    // effect above — if this call's requestId supersedes an initial fetch
+    // still in flight (a change event landing within the debounce window of
+    // an agent switch), that effect's own `.finally()` skips
+    // `setFilesLoading(false)` (guarded by the same requestId check), and
+    // this function previously never touched the flag either — leaving the
+    // selector permanently disabled/showing "Loading…" even after this
+    // fresher request succeeds.
     const refetchSelectedAgentFiles = (agent: AgentDefinition) => {
         const requestId = ++latestRequestId;
         RpcApi.NativeMemoryListCommand(TabRpcClient, { agent_id: agent.id })
@@ -288,6 +321,17 @@ export function NativeMemoryManager(): JSX.Element {
                 if (requestId !== latestRequestId) return;
                 setFiles(res.files);
                 setFilesError(null);
+                // Codex P1 (PR #2932): force the history panel to remount
+                // even when the selected FILENAME is unchanged — the panel
+                // is keyed on `agentId:filename`, and `NativeMemoryHistoryModel`
+                // only loads history in its own constructor (never reacts to
+                // prop changes after mount, per its own doc comment). Without
+                // this, the exact scenario the whole feature exists for — a
+                // live write to the file you're already looking at — was the
+                // one case that stayed invisible until you switched away and
+                // back. Bumped unconditionally on every successful refresh,
+                // not just when the file list itself changed.
+                setRefreshNonce((n) => n + 1);
                 const current = selectedFilename();
                 if (current && !res.files.some((f) => f.filename === current)) {
                     setSelectedFilename("");
@@ -296,6 +340,10 @@ export function NativeMemoryManager(): JSX.Element {
             .catch((e: Error) => {
                 if (requestId !== latestRequestId) return;
                 setFilesError(`Failed to list memory files: ${e.message ?? e}`);
+            })
+            .finally(() => {
+                if (requestId !== latestRequestId) return;
+                setFilesLoading(false);
             });
     };
 
@@ -446,11 +494,16 @@ export function NativeMemoryManager(): JSX.Element {
                                     </div>
                                 }
                             >
-                                {/* Keyed on agentId:filename so switching either forces a
-                                    clean remount — NativeMemoryHistoryPanel's own doc
-                                    comment: it does not react to prop changes after
-                                    mount by design. */}
-                                <Show when={`${agent().id}:${selectedFilename()}`} keyed>
+                                {/* Keyed on agentId:filename:refreshNonce. The first two force
+                                    a clean remount when switching agent/file —
+                                    NativeMemoryHistoryPanel's own doc comment: it does not
+                                    react to prop changes after mount by design. refreshNonce
+                                    additionally forces a remount when a reactive
+                                    agent:memory:changed refresh lands for the SAME file
+                                    (Codex P1, PR #2932) — without it, a live write to the
+                                    file you're already looking at never showed up, since
+                                    neither agentId nor filename actually changed. */}
+                                <Show when={`${agent().id}:${selectedFilename()}:${refreshNonce()}`} keyed>
                                     {(_key) => (
                                         <NativeMemoryHistoryPanel
                                             agentId={agent().id}

--- a/frontend/app/view/native-memory/native-memory-manager.tsx
+++ b/frontend/app/view/native-memory/native-memory-manager.tsx
@@ -180,7 +180,18 @@ export function NativeMemoryManager(): JSX.Element {
     const fetchCountFor = (agent: AgentDefinition) => {
         const generation = (countRequestGeneration.get(agent.id) ?? 0) + 1;
         countRequestGeneration.set(agent.id, generation);
-        setCounts((prev) => ({ ...prev, [agent.id]: { kind: "loading" } as MemoryCountState }));
+        // Only flash to "loading" for a genuinely new agent — no resolved
+        // state yet to show in the meantime. ReAgent (PR #2932): the
+        // reactive agent:memory:changed handler also calls this function,
+        // and unconditionally overwriting to "loading" made an
+        // already-resolved card visibly flicker back to "Loading…" on
+        // every write, rather than updating quietly in place — inconsistent
+        // with refetchSelectedAgentFiles's own deliberate choice not to
+        // touch filesLoading for the identical reason, and with this
+        // feature's own stated design intent of a quiet per-card refresh.
+        setCounts((prev) =>
+            prev[agent.id] === undefined ? { ...prev, [agent.id]: { kind: "loading" } as MemoryCountState } : prev,
+        );
         RpcApi.NativeMemoryListCommand(TabRpcClient, { agent_id: agent.id })
             .then((res) => {
                 // Guarded by BOTH "agent still present" and "still the latest

--- a/frontend/app/view/native-memory/native-memory-manager.tsx
+++ b/frontend/app/view/native-memory/native-memory-manager.tsx
@@ -358,10 +358,32 @@ export function NativeMemoryManager(): JSX.Element {
     // agent (e.g. a script issuing several MemoryWrite calls in a loop)
     // coalesces into one refetch instead of one RPC round-trip per write.
     // Keyed per agent id so a burst on one agent never delays another's.
+    //
+    // Declared outside the effect (component-instance lifetime, not
+    // per-effect-run) and pruned rather than blanket-cleared on each
+    // re-run — see the ReAgent P1 fix note below.
     const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
     createEffect(() => {
         agentIdsKey();
         const list = untrack(() => agents());
+        const present = new Set(list.map((a) => a.id));
+
+        // ReAgent P1 (PR #2932): only prune timers for agents that actually
+        // LEFT the set. The previous version's onCleanup cleared the ENTIRE
+        // map unconditionally on every re-run of this effect — which fires
+        // on any agentIdsKey() change, i.e. any agent create/edit/delete
+        // ANYWHERE in the app (same over-broad trigger the count-fetch
+        // effect above already had to guard against). A debounced refetch
+        // already scheduled for an agent that's still present got silently
+        // canceled and never fired if an unrelated agent changed elsewhere
+        // within the 250ms window — that agent's count/detail view then
+        // stayed stale until its own next unrelated event.
+        for (const [id, timer] of debounceTimers) {
+            if (!present.has(id)) {
+                clearTimeout(timer);
+                debounceTimers.delete(id);
+            }
+        }
 
         const unsub = waveEventSubscribe(
             ...list.map((agent) => ({
@@ -383,11 +405,19 @@ export function NativeMemoryManager(): JSX.Element {
             })),
         );
 
-        onCleanup(() => {
-            unsub();
-            for (const timer of debounceTimers.values()) clearTimeout(timer);
-            debounceTimers.clear();
-        });
+        // Per-run cleanup: only the subscriptions this run created. Pending
+        // debounce timers are this effect's OWN concern to prune above, not
+        // this callback's — they must survive an effect re-run so a
+        // still-present agent's scheduled refetch isn't lost.
+        onCleanup(unsub);
+    });
+
+    // True component unmount only (registered at the component body's own
+    // scope, not nested inside createEffect, so it does not re-fire on
+    // every effect re-run the way the per-run onCleanup above does).
+    onCleanup(() => {
+        for (const timer of debounceTimers.values()) clearTimeout(timer);
+        debounceTimers.clear();
     });
 
     return (

--- a/frontend/app/view/skill/skill-model.test.ts
+++ b/frontend/app/view/skill/skill-model.test.ts
@@ -1,0 +1,72 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// SkillCatalogModel — the standalone Armory "Skills" tab's model. Scoped to
+// the reactive-updates wiring added by
+// docs/specs/SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md; this model had no
+// prior test coverage, and full CRUD coverage is out of scope here.
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const skillCatalogListMock = vi.fn().mockResolvedValue([]);
+const listAgentDefinitionsMock = vi.fn().mockResolvedValue([]);
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        SkillCatalogListCommand: (...args: unknown[]) => skillCatalogListMock(...args),
+        ListAgentDefinitionsCommand: (...args: unknown[]) => listAgentDefinitionsMock(...args),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+// Same hub pattern bundle-skill-model.test.ts / global-brain-model.test.ts use.
+const wpsHub = vi.hoisted(() => ({ handlers: new Map<string, (e: unknown) => void>() }));
+vi.mock("@/app/store/wps", () => ({
+    waveEventSubscribe: vi.fn((sub: { eventType: string; handler: (e: unknown) => void }) => {
+        wpsHub.handlers.set(sub.eventType, sub.handler);
+        return () => wpsHub.handlers.delete(sub.eventType);
+    }),
+}));
+
+import { SkillCatalogModel } from "./skill-model";
+
+beforeEach(() => {
+    skillCatalogListMock.mockClear();
+    skillCatalogListMock.mockResolvedValue([]);
+    listAgentDefinitionsMock.mockClear();
+    listAgentDefinitionsMock.mockResolvedValue([]);
+    wpsHub.handlers.clear();
+});
+
+describe("SkillCatalogModel — reactive updates", () => {
+    test("subscribes to skills:changed and refreshes on it", async () => {
+        const model = new SkillCatalogModel();
+        await Promise.resolve();
+        skillCatalogListMock.mockClear();
+
+        wpsHub.handlers.get("skills:changed")?.({});
+        await Promise.resolve();
+
+        expect(skillCatalogListMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("an unrelated event type does not trigger a refresh", async () => {
+        new SkillCatalogModel();
+        await Promise.resolve();
+        skillCatalogListMock.mockClear();
+
+        wpsHub.handlers.get("mcp:changed")?.({});
+        await Promise.resolve();
+
+        expect(skillCatalogListMock).not.toHaveBeenCalled();
+    });
+
+    test("unsubscribes on dispose", async () => {
+        const model = new SkillCatalogModel();
+        await Promise.resolve();
+        expect(wpsHub.handlers.has("skills:changed")).toBe(true);
+
+        model.dispose();
+
+        expect(wpsHub.handlers.has("skills:changed")).toBe(false);
+    });
+});

--- a/frontend/app/view/skill/skill-model.ts
+++ b/frontend/app/view/skill/skill-model.ts
@@ -15,6 +15,7 @@
 import { createMemo, createSignal, type Accessor } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { waveEventSubscribe } from "@/app/store/wps";
 
 export interface SkillDraft {
     id?: string;
@@ -41,6 +42,10 @@ function draftFromSkill(s: Skill): SkillDraft {
 }
 
 export class SkillCatalogModel {
+    // Cross-window reactivity (SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md) —
+    // same rationale as McpCatalogModel's own unsubChanged.
+    private unsubChanged: () => void;
+
     private _skills = createSignal<SkillCatalogItem[]>([]);
     skillsAtom: Accessor<SkillCatalogItem[]> = this._skills[0];
     private setSkills = this._skills[1];
@@ -81,6 +86,10 @@ export class SkillCatalogModel {
         });
         void this.refresh();
         void this.loadAgents();
+        this.unsubChanged = waveEventSubscribe({
+            eventType: "skills:changed",
+            handler: () => void this.refresh(),
+        });
     }
 
     async refresh(): Promise<void> {
@@ -182,6 +191,6 @@ export class SkillCatalogModel {
     }
 
     dispose(): void {
-        // Solid signals are GC'd with the instance; nothing to unsubscribe.
+        this.unsubChanged();
     }
 }


### PR DESCRIPTION
## Summary

Direct question, then a direct request to broaden it: *"if you write a memory, will I see the update in Manoz in the armory? we want it reactive"* → *"build the reactive updates, across the entire armory in fact."*

**Audited first rather than assuming a from-scratch build was needed.** Grepped every `WaveEvent` the backend publishes, then checked which frontend view-models actually subscribe:

| Area | Backend event | Already wired? |
|---|---|---|
| Accounts | `identityaccounts:changed` | **Yes** — shared `IdentityViewModel`, nothing to do |
| Per-agent MCP/Skill bindings | `mcp:changed` / `skills:changed` | **Yes** — `bundle-mcp-model.ts`/`bundle-skill-model.ts` already subscribe |
| Global Memory | `memories:changed` | No — event existed, no subscriber |
| ABF (bundle list) | `memories:changed` | No — same gap |
| MCP Servers (standalone tab) | `mcp:changed` | No — same gap |
| Skills (standalone tab) | `skills:changed` | No — same gap |
| **Personal (native) Memory** | *(none existed)* | **No — the one real gap** |

Four of five gaps turned out to be a 3-line fix each (wire an already-correct event to a `waveEventSubscribe` call, same pattern their sibling models already use). Personal Memory needed actual backend work.

## A mid-implementation discovery that changed the design

`git log -S` on the planned event name turned up that **two of the five Personal Memory call sites already published something** — `app_api::mod`'s `memory_write_impl`/`memory_revert_impl` (commit `bcc478dc`, 2026-08-20, a different agent's work) — just under a different convention (the agent id baked into the event **name**, `agent:memory:changed:{id}`, not `WaveEvent.scopes`, my original plan) and with **zero subscribers anywhere**, so it was a silent no-op in production.

Adopted the existing convention everywhere instead of introducing a second one. And fixed a real bug found in the process: **those two existing calls keyed the event by the raw `agent_id` slug parameter, not the resolved canonical UUID** — the exact slug/UUID keyspace split this same file's own `memory_write_impl` doc comment already warns about for version storage, just never applied to this event. A frontend subscriber only ever has `AgentDefinition.id` (the UUID), so the pre-existing calls would have gone unheard even once something finally subscribed. Regression test: `write_publishes_using_the_resolved_uuid_not_the_raw_slug`.

## What changed

**Backend** — publish added/fixed at all five real call sites (`native_memory_handlers.rs` write_file + revert, `native_memory_drift.rs` fast-path + reconciliation sweep, `app_api::mod` write + revert re-keyed). Drift detector only publishes on an *actual* recorded change — never on a no-op sweep tick (would otherwise fire for every watched agent every 30s regardless of whether anything happened). Fixed a small pre-existing log inaccuracy in the same branch I had to touch anyway (fast path logged "recorded" even on the no-op case).

**Frontend** — `NativeMemoryManager` subscribes to `agent:memory:changed:{id}` once per agent currently in the grid, re-registering when the agent *set* changes (same `agentIdsKey` dependency the existing count-fetch effect uses). On an event: refetches just that one card's count (never a full-grid refresh), and refreshes the open detail view's file list in place if it's showing the changed agent — without clearing the selected filename unless that exact file is gone. Debounced 250ms per agent id.

The other four: `global-brain-model.ts`, `memory-model.ts`, `mcp-model.ts`, `skill-model.ts` each gained a 3-line `waveEventSubscribe` + `dispose()` unsubscribe, mirroring their already-working sibling models.

## Test plan
- [x] 5 new backend publish-verification tests (write_file, revert, drift sweep ×2, App API slug/UUID regression) — `cargo test -p agentmux-srv --bin agentmux-srv publish` → 27/27 passing
- [x] Full backend suite: **2930/2930 passing**, 0 failures
- [x] 8 new frontend tests in `native-memory-manager.test.tsx` (per-agent refetch, error-state recovery, debounce, detail-view in-place refresh, cross-agent isolation, selected-file-removed handling, resubscribe-on-agent-set-change)
- [x] 2 new tests each in `global-brain-model.test.ts`/`memory-model.test.ts`; 2 new focused test files for `mcp-model.ts`/`skill-model.ts` (neither had prior coverage)
- [x] Full frontend suite: **3521/3521 passing**, 0 failures
- [x] `npx tsc --noEmit` — clean

See `docs/specs/SPEC_ARMORY_REACTIVE_UPDATES_2026_09_02.md`.

<!-- agentmux:agent_id=manoz -->