### PR TITLE
Manoz@Area54: chore: release v0.55.32

### DIFF
--- a/.changesets/1788313802-docs-merge-the-top-level-specs-tree-into-docs-specs-cleanup--n0h7.md
+++ b/.changesets/1788313802-docs-merge-the-top-level-specs-tree-into-docs-specs-cleanup--n0h7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: merge the top-level specs/ tree into docs/specs/ (cleanup batch C)

--- a/.changesets/1788314332-fix-agent-hide-working-row-once-a-tool-is-promoted-to-the-do-6i96.md
+++ b/.changesets/1788314332-fix-agent-hide-working-row-once-a-tool-is-promoted-to-the-do-6i96.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): hide Working row once a tool is promoted to the dock; move it above the composer

--- a/.changesets/1788317206-docs-close-out-the-docs-cleanup-plan-with-batch-c-1d4m.md
+++ b/.changesets/1788317206-docs-close-out-the-docs-cleanup-plan-with-batch-c-1d4m.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: close out the docs cleanup plan with batch C

--- a/.changesets/1788318108-ci-gate-that-a-cited-docs-specs-path-actually-resolves-pbp0.md
+++ b/.changesets/1788318108-ci-gate-that-a-cited-docs-specs-path-actually-resolves-pbp0.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-ci: gate that a cited docs/specs path actually resolves

--- a/.changesets/1788319484-test-bashwrap-retry-any-nonzero-exit-in-the-a1-e2e-test-not--wy11.md
+++ b/.changesets/1788319484-test-bashwrap-retry-any-nonzero-exit-in-the-a1-e2e-test-not--wy11.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-test(bashwrap): retry any nonzero exit in the a1 e2e test, not just idle-kill

--- a/.changesets/1788330881-test-frontend-give-the-tool-renderer-parity-test-a-liveness--2uyz.md
+++ b/.changesets/1788330881-test-frontend-give-the-tool-renderer-parity-test-a-liveness--2uyz.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-test(frontend): give the tool-renderer parity test a liveness timeout (#2919)

--- a/.changesets/1788357580-fix-memory-agent-memory-rpc-handlers-never-adopted-2901-s-bl-51oi.md
+++ b/.changesets/1788357580-fix-memory-agent-memory-rpc-handlers-never-adopted-2901-s-bl-51oi.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(memory): agent:memory RPC handlers never adopted #2901's blank-workdir fix

--- a/.changesets/1788358164-feat-tabs-default-tab-names-are-tab-1-tab-2-not-tab1-tab2-qpuo.md
+++ b/.changesets/1788358164-feat-tabs-default-tab-names-are-tab-1-tab-2-not-tab1-tab2-qpuo.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(tabs): default tab names are "Tab 1", "Tab 2", not "tab1", "tab2"

--- a/.changesets/1788358346-fix-agent-retry-a-compaction-started-ping-missed-before-turn-89um.md
+++ b/.changesets/1788358346-fix-agent-retry-a-compaction-started-ping-missed-before-turn-89um.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): retry a compaction_started ping missed before turn-phase reconciliation

--- a/.changesets/1788359815-feat-armory-find-filter-and-sort-for-personal-memory-mirrori-x3n0.md
+++ b/.changesets/1788359815-feat-armory-find-filter-and-sort-for-personal-memory-mirrori-x3n0.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): find/filter and sort for Personal Memory, mirroring My Agents

--- a/.changesets/1788361865-fix-reactive-deliver-inter-agent-messages-to-subprocess-cont-6bqg.md
+++ b/.changesets/1788361865-fix-reactive-deliver-inter-agent-messages-to-subprocess-cont-6bqg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(reactive): deliver inter-agent messages to subprocess/container agents instead of dropping them on a PTY fallback

--- a/.changesets/1788364392-feat-armory-reactive-updates-across-the-armory-live-refreshi-37l2.md
+++ b/.changesets/1788364392-feat-armory-reactive-updates-across-the-armory-live-refreshi-37l2.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): reactive updates across the Armory (live-refreshing Personal Memory, Global Memory, ABF, MCP Servers, Skills)

--- a/.changesets/1788367281-fix-container-mount-the-bound-account-s-credentials-and-the--g96n.md
+++ b/.changesets/1788367281-fix-container-mount-the-bound-account-s-credentials-and-the--g96n.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(container): mount the bound account's credentials and the agent workspace into container agents

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.31"
+version = "0.55.32"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.31"
+version = "0.55.32"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.31"
+version = "0.55.32"
 dependencies = [
  "base64",
  "dirs",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.31"
+version = "0.55.32"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.31"
+version = "0.55.32"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.31"
+version = "0.55.32"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.31"
+version = "0.55.32"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,22 @@
 # AgentMux Version History
 
+## 0.55.32 — 2026-09-02
+
+- docs: merge the top-level specs/ tree into docs/specs/ (cleanup batch C)
+- fix(agent): hide Working row once a tool is promoted to the dock; move it above the composer
+- docs: close out the docs cleanup plan with batch C
+- ci: gate that a cited docs/specs path actually resolves
+- test(bashwrap): retry any nonzero exit in the a1 e2e test, not just idle-kill
+- test(frontend): give the tool-renderer parity test a liveness timeout (#2919)
+- fix(memory): agent:memory RPC handlers never adopted #2901's blank-workdir fix
+- feat(tabs): default tab names are "Tab 1", "Tab 2", not "tab1", "tab2"
+- fix(agent): retry a compaction_started ping missed before turn-phase reconciliation
+- feat(armory): find/filter and sort for Personal Memory, mirroring My Agents
+- fix(reactive): deliver inter-agent messages to subprocess/container agents instead of dropping them on a PTY fallback
+- feat(armory): reactive updates across the Armory (live-refreshing Personal Memory, Global Memory, ABF, MCP Servers, Skills)
+- fix(container): mount the bound account's credentials and the agent workspace into container agents
+
+
 ## 0.55.31 — 2026-09-01
 
 - fix(agent): agent.open looked for the CLI at a path that never existed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.31",
+  "version": "0.55.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.31",
+      "version": "0.55.32",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.31",
+  "version": "0.55.32",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Forced patch bump 0.55.31 -> 0.55.32 (overriding the computed minor bump — several changesets are feat-level, but shipping as patch per instruction).
- Consumes 13 pending changesets, all 5 version locations verified in agreement (package.json, Cargo.toml, Cargo.lock, package-lock.json, VERSION_HISTORY.md).
- No functional code changes — release-only commit.

## Test plan
- [x] `task release -- --as patch` ran clean, all 5 version locations verified by hand
- [x] `bash scripts/gen-docs-index.sh` re-run, no changes needed
- [ ] CI (windows-latest/ubuntu-latest tests, vitest, doc gates) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agentmux:agent_id=manoz -->