### PR TITLE
Manoz@Area54: fix(subagent): ISO-8601 timestamp parse + Activity Dock settle race

### DIFF
--- a/.changesets/1788398766-fix-agent-activity-dock-settle-waits-for-the-real-dock-data--8iul.md
+++ b/.changesets/1788398766-fix-agent-activity-dock-settle-waits-for-the-real-dock-data--8iul.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): Activity Dock settle waits for the real dock-data refresh, not a fixed 250ms guess

--- a/.changesets/1788421322-fix-subagent-parse-iso-8601-event-timestamps-so-replayed-sub-03aj.md
+++ b/.changesets/1788421322-fix-subagent-parse-iso-8601-event-timestamps-so-replayed-sub-03aj.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(subagent): parse ISO-8601 event timestamps so replayed subagents stop flashing in the Activity Dock

--- a/agentmux-srv/src/backend/subagent_watcher/jsonl.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/jsonl.rs
@@ -141,6 +141,20 @@ impl SubagentWatcher {
                     _ => SubAgentStatus::Active,
                 }
             };
+            // Real spawn time for a REPLAYED file, not replay time. The
+            // events were just parsed from a transcript that may be months
+            // old; stamping `now_millis()` made every backfilled subagent
+            // claim to have started at pane-open, which both misreported
+            // elapsed time and corrupted the dock's newest-first ordering.
+            // Falls back to `now_millis()` only when the file yielded no
+            // parseable event at all (a genuinely new/empty transcript,
+            // where "now" is the honest answer). See
+            // docs/retro/retro-activitydock-appears-on-agent-pane-load-2026-09-02.md.
+            let initial_spawned_at = new_events
+                .iter()
+                .map(|e| e.timestamp)
+                .min()
+                .unwrap_or_else(now_millis);
             let state = session.subagents.entry(agent_id.clone()).or_insert_with(|| {
                 SubagentState {
                     info: SubAgent {
@@ -150,8 +164,8 @@ impl SubagentWatcher {
                         parent_agent: parent_agent.to_string(),
                         parent_block_id: parent_block_id.to_string(),
                         session_id: session_id.clone(),
-                        spawned_at: now_millis(),
-                        last_event_at: now_millis(),
+                        spawned_at: initial_spawned_at,
+                        last_event_at: initial_spawned_at,
                         status: initial_status,
                         event_count: 0,
                         model: None,

--- a/agentmux-srv/src/backend/subagent_watcher/parse.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/parse.rs
@@ -150,7 +150,7 @@ pub(super) fn read_jsonl_from_offset(
 
         let timestamp = value
             .get("timestamp")
-            .and_then(|v| v.as_u64())
+            .and_then(parse_event_timestamp)
             .unwrap_or_else(now_millis);
 
         let event_type = parse_event_type(&value);
@@ -329,6 +329,43 @@ pub(super) fn parse_event_type(value: &serde_json::Value) -> Option<SubagentEven
 /// Modification time of `path`, or `UNIX_EPOCH` if it can't be read (a
 /// vanished/permission-denied file sorts oldest — excluded first by
 /// `scan_subagents_dir`'s recency cap rather than crashing the scan).
+/// Epoch-millis for a subagent JSONL line's `timestamp` field, tolerant of
+/// BOTH shapes that occur in real transcripts.
+///
+/// Claude Code writes an ISO-8601 STRING (`"2026-07-03T08:09:20.743Z"`), but
+/// this was read with a bare `as_u64()`, which returns `None` for a string
+/// and silently fell through to `now_millis()`. Every replayed historical
+/// event therefore claimed to have happened *at replay time*.
+///
+/// That is not a cosmetic timestamp bug: `last_event_at` becomes
+/// `subagentToActivity`'s `endedAt` (activity/subagent-adapter.ts), and the
+/// Activity Dock keeps a terminal row only while
+/// `now - endedAt < RETENTION_MS[status]`. With `endedAt ≈ now`, every
+/// long-dead subagent replayed on pane (re)open passed that window and
+/// rendered as a live-looking dock row, then vanished a few seconds later
+/// when it aged out — the "dock flashes on load, then disappears" report.
+/// With real historical timestamps these rows are filtered out immediately
+/// and never paint at all.
+///
+/// Numeric epoch-millis are still accepted unchanged (other providers, and
+/// any future writer that emits a number). An unparseable value returns
+/// `None` so the caller keeps its existing `now_millis()` fallback — a
+/// genuinely-live event with a malformed timestamp is better dated "now"
+/// than dropped to the epoch.
+///
+/// See docs/retro/retro-activitydock-appears-on-agent-pane-load-2026-09-02.md.
+pub(super) fn parse_event_timestamp(v: &serde_json::Value) -> Option<u64> {
+    if let Some(n) = v.as_u64() {
+        return Some(n);
+    }
+    let s = v.as_str()?;
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.timestamp_millis())
+        .filter(|ms| *ms >= 0)
+        .map(|ms| ms as u64)
+}
+
 pub(super) fn file_mtime(path: &Path) -> std::time::SystemTime {
     std::fs::metadata(path)
         .and_then(|m| m.modified())

--- a/agentmux-srv/src/backend/subagent_watcher/parse.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/parse.rs
@@ -326,9 +326,6 @@ pub(super) fn parse_event_type(value: &serde_json::Value) -> Option<SubagentEven
     }
 }
 
-/// Modification time of `path`, or `UNIX_EPOCH` if it can't be read (a
-/// vanished/permission-denied file sorts oldest — excluded first by
-/// `scan_subagents_dir`'s recency cap rather than crashing the scan).
 /// Epoch-millis for a subagent JSONL line's `timestamp` field, tolerant of
 /// BOTH shapes that occur in real transcripts.
 ///
@@ -366,6 +363,9 @@ pub(super) fn parse_event_timestamp(v: &serde_json::Value) -> Option<u64> {
         .map(|ms| ms as u64)
 }
 
+/// Modification time of `path`, or `UNIX_EPOCH` if it can't be read (a
+/// vanished/permission-denied file sorts oldest — excluded first by
+/// `scan_subagents_dir`'s recency cap rather than crashing the scan).
 pub(super) fn file_mtime(path: &Path) -> std::time::SystemTime {
     std::fs::metadata(path)
         .and_then(|m| m.modified())

--- a/agentmux-srv/src/backend/subagent_watcher/parse.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/parse.rs
@@ -540,7 +540,7 @@ pub fn derive_claude_config_dir(agent_id: &str) -> Option<PathBuf> {
 /// agent forever (confirmed live: repeated "config dir does not exist yet"
 /// over 38+ minutes and multiple re-registrations, for an agent that had, in
 /// fact, already spawned subagents — just under the real shared path). See
-/// docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md.
+/// docs/specs/archive/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md.
 pub fn resolve_claude_config_dir(
     meta: &crate::backend::obj::MetaMapType,
     agent_id: &str,

--- a/agentmux-srv/src/backend/subagent_watcher/scan.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/scan.rs
@@ -18,6 +18,16 @@ use super::SubagentWatcher;
 use crate::backend::eventbus::{WSEventType, WS_EVENT_RPC};
 use crate::backend::wps;
 
+/// How many times `reconcile_stale_subagents` retries when the parent
+/// block's controller isn't registered yet, before giving up and leaving
+/// the entries as-is. See that function's own doc comment (2026-09-02
+/// update) for why a single 2s attempt proved too short in practice —
+/// `MAX_RECONCILE_RETRIES * RECONCILE_RETRY_INTERVAL_MS` (~15s) is a
+/// realistic bound for a real controller to finish spawning under load,
+/// while still failing open rather than chasing a block forever.
+const MAX_RECONCILE_RETRIES: u32 = 5;
+const RECONCILE_RETRY_INTERVAL_MS: u64 = 3_000;
+
 /// Publish a `wps::EVENT_SUBAGENT_BACKFILL_STATUS` ping, scoped to this
 /// pane's own block id. No-op if `self.broker` was never wired (tests, or a
 /// `SubagentWatcher` built via bare `new()`) -- see the `broker` field's own
@@ -158,29 +168,46 @@ impl SubagentWatcher {
     /// `CONTROLLER_REGISTRY`. Left unresolved, an entry hitting that race
     /// stayed `Active`-looking forever, since nothing else ever revisits it
     /// (see `SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md`
-    /// §2, mechanism 4). Fixed by treating `None` as "retry once, don't
-    /// give up silently" (`retry_reconcile_once`) instead of a terminal
-    /// no-op — still conservative (a genuine `Some(true)` never retries;
-    /// only the single ambiguous case does, and only once).
+    /// §2, mechanism 4). Fixed by treating `None` as "retry, don't give up
+    /// silently" (`retry_reconcile_once`) instead of a terminal no-op —
+    /// still conservative (a genuine `Some(true)` never retries; only the
+    /// ambiguous case does, and only up to `MAX_RECONCILE_RETRIES` times).
+    ///
+    /// 2026-09-02 (docs/retro/retro-activitydock-appears-on-agent-pane-load-2026-09-02.md):
+    /// the original version of this fix allowed exactly ONE 2s retry before
+    /// giving up permanently. Confirmed live on a real agent whose CLI
+    /// controller never registered at all (an expired provider login — the
+    /// process either never spawns or spawns and exits before reaching
+    /// `register_controller`): the single 2s retry window is frequently too
+    /// short to distinguish "controller is still starting up, wait" from
+    /// "controller is never coming" — for the FORMER case this left the
+    /// pane's Activity Dock showing genuinely-dead subagents as `Active`
+    /// indefinitely (no live turn-end ever fires to retry later either),
+    /// and for the LATTER case a couple of seconds is too optimistic a
+    /// bound for how long a real controller can legitimately take to spawn
+    /// and register under load. Extended to a bounded retry loop
+    /// (`MAX_RECONCILE_RETRIES` attempts, `RECONCILE_RETRY_INTERVAL_MS`
+    /// apart) — still fails open in bounded time (~`MAX_RECONCILE_RETRIES *
+    /// RECONCILE_RETRY_INTERVAL_MS`), just with a realistic window instead
+    /// of a single throw-away check.
+    ///
     /// Called from two places as of SPEC_SUBAGENT_LIVE_RECONCILIATION_AND_
     /// RETIRE_2026_07_20 Phase A: `scan_session_subagents` (reopen/backfill,
     /// unchanged) and `blockcontroller::persistent`'s turn-end hook (live —
     /// closes docs/specs/SPEC_SUBAGENT_LIFECYCLE_RECONCILIATION_2026_07_12.md
     /// Open Question 1, which deliberately deferred real-time wiring).
     /// `pub(crate)` so the live call site (a different module) can reach it.
-    /// Thin entry point — always allows the one `None`-case retry described
-    /// above. The retry itself calls `reconcile_stale_subagents_impl`
-    /// directly with `allow_retry: false`, so a still-`None` second attempt
-    /// gives up rather than chaining into an unbounded retry loop.
+    /// Thin entry point — always starts the retry budget at
+    /// `MAX_RECONCILE_RETRIES`.
     pub(crate) fn reconcile_stale_subagents(&self, parent_block_id: &str, session_id: &str) {
-        self.reconcile_stale_subagents_impl(parent_block_id, session_id, true);
+        self.reconcile_stale_subagents_impl(parent_block_id, session_id, MAX_RECONCILE_RETRIES);
     }
 
     // pub(super), not private — `tests.rs` (a sibling module, not a
     // descendant of `scan`) needs to call this directly with
-    // `allow_retry: false` to test the exhausted-retry path without
+    // `retries_remaining: 0` to test the exhausted-retry path without
     // depending on a real spawned watcher's tokio::spawn actually firing.
-    pub(super) fn reconcile_stale_subagents_impl(&self, parent_block_id: &str, session_id: &str, allow_retry: bool) {
+    pub(super) fn reconcile_stale_subagents_impl(&self, parent_block_id: &str, session_id: &str, retries_remaining: u32) {
         let turn_active = crate::backend::blockcontroller::get_block_controller_status(parent_block_id)
             .map(|s| s.turn_active);
         match turn_active {
@@ -192,20 +219,21 @@ impl SubagentWatcher {
                 );
                 return;
             }
-            None if allow_retry => {
+            None if retries_remaining > 0 => {
                 tracing::info!(
                     parent_block_id = %parent_block_id,
                     session_id = %session_id,
-                    "reconcile_stale_subagents: controller not yet registered — retrying once, not skipping silently"
+                    retries_remaining,
+                    "reconcile_stale_subagents: controller not yet registered — retrying, not giving up silently"
                 );
-                self.retry_reconcile_once(parent_block_id, session_id);
+                self.retry_reconcile_once(parent_block_id, session_id, retries_remaining - 1);
                 return;
             }
             None => {
                 tracing::info!(
                     parent_block_id = %parent_block_id,
                     session_id = %session_id,
-                    "reconcile_stale_subagents: controller still not registered after retry — giving up (bounded to one retry)"
+                    "reconcile_stale_subagents: controller still not registered after all retries — giving up (bounded)"
                 );
                 return;
             }
@@ -341,31 +369,28 @@ impl SubagentWatcher {
         }
     }
 
-    /// Bounded one-shot retry for `reconcile_stale_subagents`'s `None`
+    /// Bounded retry for `reconcile_stale_subagents`'s `None`
     /// (controller-not-yet-registered) case — see that function's doc
-    /// comment. Exactly one retry, not a loop: if the controller genuinely
-    /// never registers (e.g. the block was deleted in the meantime), a
-    /// single delayed re-check is enough to stop treating "unknown" as a
-    /// permanent no-op without risking an unbounded retry chain chasing a
-    /// block that's never coming back. 2s is long enough to clear the
-    /// observed registration race without meaningfully delaying the
-    /// correction a user would notice.
+    /// comment for why a single 2s attempt was too short in practice.
+    /// `retries_remaining` counts DOWN — the loop terminates because each
+    /// hop passes a strictly smaller budget, never because of a separate
+    /// flag; a block whose controller genuinely never registers (e.g. it
+    /// was deleted, or its provider login never resolves) still gets a
+    /// bounded, not unbounded, chase.
     ///
     /// Mirrors `trigger_eager_naming`'s `self_ref` upgrade-to-`Arc` pattern
     /// for spawning a task that outlives this sync call; silently no-ops
     /// for a bare `new()` watcher (most unit tests), same "untracked ->
     /// safe no-op" convention as that method.
-    fn retry_reconcile_once(&self, parent_block_id: &str, session_id: &str) {
+    fn retry_reconcile_once(&self, parent_block_id: &str, session_id: &str, retries_remaining: u32) {
         let Some(watcher) = self.self_ref.lock().unwrap().as_ref().and_then(|w| w.upgrade()) else {
             return;
         };
         let parent_block_id = parent_block_id.to_string();
         let session_id = session_id.to_string();
         tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-            // allow_retry: false — this IS the one retry; a second `None`
-            // here gives up rather than spawning another.
-            watcher.reconcile_stale_subagents_impl(&parent_block_id, &session_id, false);
+            tokio::time::sleep(std::time::Duration::from_millis(RECONCILE_RETRY_INTERVAL_MS)).await;
+            watcher.reconcile_stale_subagents_impl(&parent_block_id, &session_id, retries_remaining);
         });
     }
 

--- a/agentmux-srv/src/backend/subagent_watcher/tests.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/tests.rs
@@ -1626,15 +1626,14 @@ fn reconcile_stale_subagents_leaves_active_alone_when_no_controller_is_registere
     // No register_stub_controller call — block id is guaranteed unique
     // (per-test suffix) so get_block_controller_status returns None. The
     // public entry point's synchronous behavior is unchanged by the
-    // None-retry fix: it queues a bounded one-shot retry
-    // (`retry_reconcile_once`) rather than leaving the entry untouched
-    // forever, but that retry itself silently no-ops here because
-    // `fixture_watcher()` is built via bare `new()` (no `self_ref` to
-    // upgrade to a real `Arc` — see `retry_reconcile_once`'s doc comment,
-    // same "untracked -> safe no-op" convention `trigger_eager_naming`
-    // uses). So immediately after this call, nothing has changed yet —
-    // covered directly (not via a real spawned retry) by the
-    // `_impl(..., allow_retry: false)` tests below.
+    // None-retry fix: it queues a bounded retry (`retry_reconcile_once`)
+    // rather than leaving the entry untouched forever, but that retry
+    // itself silently no-ops here because `fixture_watcher()` is built via
+    // bare `new()` (no `self_ref` to upgrade to a real `Arc` — see
+    // `retry_reconcile_once`'s doc comment, same "untracked -> safe no-op"
+    // convention `trigger_eager_naming` uses). So immediately after this
+    // call, nothing has changed yet — covered directly (not via a real
+    // spawned retry) by the `_impl(..., retries_remaining: 0)` tests below.
     let block_id = format!("recon-unregistered-{}", now_millis());
 
     let watcher = fixture_watcher();
@@ -1655,10 +1654,11 @@ fn reconcile_stale_subagents_leaves_active_alone_when_no_controller_is_registere
 
 #[test]
 fn reconcile_stale_subagents_impl_with_retry_exhausted_leaves_active_alone_when_no_controller_is_registered() {
-    // The bounded-retry fix's terminal case: a second attempt (allow_retry:
-    // false, as the real tokio::spawn'd retry calls it) with the controller
-    // STILL unregistered must give up, not chain into another retry or
-    // panic. See SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md §3.2.
+    // The bounded-retry fix's terminal case: a call with `retries_remaining:
+    // 0` (as the real tokio::spawn'd retry chain eventually reaches) and
+    // the controller STILL unregistered must give up, not chain into
+    // another retry or panic. See
+    // SPEC_SWARM_DISPATCH_ATTRIBUTION_AND_LIFECYCLE_2026_08_19.md §3.2.
     let block_id = format!("recon-unregistered-exhausted-{}", now_millis());
 
     let watcher = fixture_watcher();
@@ -1671,10 +1671,42 @@ fn reconcile_stale_subagents_impl_with_retry_exhausted_leaves_active_alone_when_
         sessions.insert("s1".to_string(), s1);
     }
 
-    watcher.reconcile_stale_subagents_impl(&block_id, "s1", false);
+    watcher.reconcile_stale_subagents_impl(&block_id, "s1", 0);
 
     let info = watcher.get_info("sub-a").expect("sub-a should still exist");
-    assert_eq!(info.status, SubAgentStatus::Active, "unregistered + retry exhausted must still not guess");
+    assert_eq!(info.status, SubAgentStatus::Active, "unregistered + retries exhausted must still not guess");
+}
+
+#[test]
+fn reconcile_stale_subagents_impl_retries_again_when_controller_is_still_unregistered_but_budget_remains() {
+    // 2026-09-02 fix: a `None` read with retries_remaining > 0 must queue
+    // ANOTHER retry (decrementing the budget), not give up on the first
+    // unregistered read the way the old allow_retry:bool version did.
+    // Confirmed by checking the entry is untouched (still Active, not yet
+    // reconciled) after a call that still has retries left — the real
+    // assertion that matters (does it eventually give up vs. loop forever)
+    // is covered by the exhausted-vs-registers-before-retry tests either
+    // side of this one; this test isolates the "still retrying, not done
+    // yet" middle state.
+    let block_id = format!("recon-unregistered-midbudget-{}", now_millis());
+
+    let watcher = fixture_watcher();
+    {
+        let mut sessions = watcher.sessions.lock().unwrap();
+        let mut s1 = SessionWatch { subagents: HashMap::new() };
+        let mut state = fixture_state("parent-1", "sub-a", "s1");
+        state.info.parent_block_id = block_id.clone();
+        s1.subagents.insert("sub-a".to_string(), state);
+        sessions.insert("s1".to_string(), s1);
+    }
+
+    // fixture_watcher() has no self_ref, so the queued retry silently
+    // no-ops (same convention as the exhausted-case test above) — this
+    // call itself must not touch the entry regardless of retry budget.
+    watcher.reconcile_stale_subagents_impl(&block_id, "s1", 3);
+
+    let info = watcher.get_info("sub-a").expect("sub-a should still exist");
+    assert_eq!(info.status, SubAgentStatus::Active, "still unregistered with budget remaining must not reconcile yet");
 }
 
 #[test]
@@ -1696,7 +1728,7 @@ fn reconcile_stale_subagents_impl_reconciles_normally_once_the_controller_regist
         sessions.insert("s1".to_string(), s1);
     }
 
-    watcher.reconcile_stale_subagents_impl(&block_id, "s1", false);
+    watcher.reconcile_stale_subagents_impl(&block_id, "s1", 0);
 
     let info = watcher.get_info("sub-a").expect("sub-a should still exist");
     assert_eq!(info.status, SubAgentStatus::Abandoned);
@@ -2289,4 +2321,51 @@ fn a_live_observation_does_not_resurrect_a_completed_subagent() {
     );
 
     std::fs::remove_dir_all(&dir).ok();
+}
+
+// ── parse_event_timestamp ────────────────────────────────────────────────
+// docs/retro/retro-activitydock-appears-on-agent-pane-load-2026-09-02.md:
+// Claude Code writes `timestamp` as an ISO-8601 STRING, but this was read
+// with a bare `as_u64()` (which returns None for a string) and silently
+// fell back to `now_millis()`. Every replayed historical subagent therefore
+// reported `last_event_at ≈ now`, which becomes the dock row's `endedAt`,
+// which kept it inside `RETENTION_MS.stopped` — so long-dead subagents
+// rendered as dock rows on every pane (re)open and vanished ~3.4s later.
+// Confirmed live: 19 of Lzop's subagents all reported spawned_at ==
+// last_event_at == pane-open time, from a transcript dated two months
+// earlier.
+
+#[test]
+fn parse_event_timestamp_reads_an_iso8601_string_as_real_epoch_millis() {
+    // The exact shape observed in a real subagent JSONL.
+    let v = serde_json::json!("2026-07-03T08:09:20.743Z");
+    let got = parse_event_timestamp(&v).expect("an ISO-8601 string must parse");
+    assert_eq!(got, 1783066160743, "must be the transcript's real time, not now");
+}
+
+#[test]
+fn parse_event_timestamp_still_accepts_numeric_epoch_millis() {
+    let v = serde_json::json!(1783066160743u64);
+    assert_eq!(parse_event_timestamp(&v), Some(1783066160743));
+}
+
+#[test]
+fn parse_event_timestamp_returns_none_for_unparseable_values_so_the_caller_can_fall_back() {
+    assert_eq!(parse_event_timestamp(&serde_json::json!("not-a-date")), None);
+    assert_eq!(parse_event_timestamp(&serde_json::json!(null)), None);
+    assert_eq!(parse_event_timestamp(&serde_json::json!({})), None);
+}
+
+#[test]
+fn parse_event_timestamp_does_not_return_now_for_a_historical_string() {
+    // The actual regression guard: whatever this returns, it must NOT be
+    // "roughly now" for a two-month-old transcript timestamp. This is the
+    // property the dock's retention filter depends on.
+    let v = serde_json::json!("2026-07-03T08:09:20.743Z");
+    let got = parse_event_timestamp(&v).expect("must parse");
+    let now = now_millis();
+    assert!(
+        now.saturating_sub(got) > 24 * 60 * 60 * 1000,
+        "a historical timestamp must read as historical (got {got}, now {now})"
+    );
 }

--- a/docs/retro/retro-activitydock-appears-on-agent-pane-load-2026-09-02.md
+++ b/docs/retro/retro-activitydock-appears-on-agent-pane-load-2026-09-02.md
@@ -5,10 +5,56 @@
 sure the agent pane loaded smooth... but now when the agent pane loads, I
 see the long-running tasks dock." Confirmed on follow-up: a flash lasting a
 couple of milliseconds to a few seconds, self-corrects.
-**Status:** Implemented — root cause identified with direct evidence (live
-trace + prior project history), fix shipped in PR #2937. Not a regression
-of any single commit — it's the previously-documented, explicitly-still-open
-structural gap in this feature area surfacing again on a heavy agent (Lzop).
+**Status:** Implemented — root cause found and fixed; confirmed resolved by
+the repo owner on a rebuilt dev instance. The fix is a backend timestamp-parsing
+bug (see "RESOLVED" below), NOT the structural paint-gate gap this retro
+originally concluded.
+
+---
+
+## RESOLVED — actual root cause (2026-09-03)
+
+The TL;DR below was written before the root cause was found, and its
+conclusion ("the never-built paint gate from the 08-27 report") is **wrong**.
+Kept as written because the elimination trail is the useful part, but read
+this section first.
+
+**Root cause: `parse.rs` read each subagent event's `timestamp` with a bare
+`as_u64()`.** Claude Code writes that field as an ISO-8601 *string*
+(`"2026-07-03T08:09:20.743Z"`); `as_u64()` returns `None` for a string, so it
+silently fell through to `now_millis()`. Every replayed historical event
+claimed to have happened at replay time.
+
+`last_event_at` becomes the dock row's `endedAt`
+(`activity/subagent-adapter.ts`), and the dock keeps a terminal row only
+while `now - endedAt < RETENTION_MS[status]`. With `endedAt ≈ now`, every
+long-dead subagent passed that window, rendered, then aged out.
+
+**Measured, not inferred:**
+- `ListActive` on the live instance returned all 19 of Lzop's subagents with
+  `spawned_at == last_event_at ==` exactly 127.6s ago — identical across all
+  19, matching pane-open time, from a transcript dated two months earlier.
+- Dock trace: appeared `07:22:15.005`, gone `07:22:18.362` = **3.357s**.
+  `RETENTION_MS.stopped` (3000) + `EXIT_FLASH_MS` (400) = **3400ms**.
+- After the fix, the same query returns **58.2 / 58.3 / 62.0 / 67.5 days**,
+  differing per subagent. Rows now fail the retention filter and never paint.
+  Confirmed visually by the repo owner.
+
+**Fixes (all in `agentmux-srv/src/backend/subagent_watcher/`):**
+1. `parse.rs` — `parse_event_timestamp` accepts ISO-8601 strings *and*
+   numeric epoch millis. **This is the actual fix.**
+2. `jsonl.rs` — `spawned_at` derives from the earliest real event instead of
+   replay time (elapsed display + newest-first ordering correctness).
+3. `scan.rs` — `reconcile_stale_subagents` retries on a bounded budget
+   instead of giving up after one 2s check. Complementary, not the fix: if
+   reconcile fails the subagents stay `active` → `RETENTION_MS.running` is
+   `Infinity` → shown forever regardless of timestamps.
+
+**Note on PR #2937** (the frontend backfill-gate change, same branch): it
+fixes a genuine settle race and its tests are real, but it did **not** fix
+this symptom, and I twice reported it as a likely fix before confirming. The
+flash was a *data* bug the whole time — one `ListActive` query would have
+shown it immediately.
 
 ---
 

--- a/docs/retro/retro-activitydock-appears-on-agent-pane-load-2026-09-02.md
+++ b/docs/retro/retro-activitydock-appears-on-agent-pane-load-2026-09-02.md
@@ -5,10 +5,10 @@
 sure the agent pane loaded smooth... but now when the agent pane loads, I
 see the long-running tasks dock." Confirmed on follow-up: a flash lasting a
 couple of milliseconds to a few seconds, self-corrects.
-**Status:** Root cause identified with direct evidence (live trace + prior
-project history). Not a regression of any single commit — it's the
-previously-documented, explicitly-still-open structural gap in this feature
-area surfacing again on a heavy agent (Lzop).
+**Status:** Implemented — root cause identified with direct evidence (live
+trace + prior project history), fix shipped in PR #2937. Not a regression
+of any single commit — it's the previously-documented, explicitly-still-open
+structural gap in this feature area surfacing again on a heavy agent (Lzop).
 
 ---
 

--- a/docs/retro/retro-activitydock-appears-on-agent-pane-load-2026-09-02.md
+++ b/docs/retro/retro-activitydock-appears-on-agent-pane-load-2026-09-02.md
@@ -1,0 +1,150 @@
+# Retro: ActivityDock flashes stale subagent rows on agent pane load (again)
+
+**Date:** 2026-09-02
+**Reported by:** repo owner, live session — "we had a lot of work that made
+sure the agent pane loaded smooth... but now when the agent pane loads, I
+see the long-running tasks dock." Confirmed on follow-up: a flash lasting a
+couple of milliseconds to a few seconds, self-corrects.
+**Status:** Root cause identified with direct evidence (live trace + prior
+project history). Not a regression of any single commit — it's the
+previously-documented, explicitly-still-open structural gap in this feature
+area surfacing again on a heavy agent (Lzop).
+
+---
+
+## TL;DR
+
+This bug (or a close relative of it) has been reported and partially fixed
+**four times before** across 2026-08-22 through 2026-08-27
+(`retro-activity-dock-stale-shell-flash-on-load-2026-08-22.md`,
+`REPORT_AGENT_PANE_REOPEN_SUBAGENT_STORM_2026_08_23.md`,
+`retro-activity-dock-flicker-survives-debounce-fix-2026-08-24.md`,
+`REPORT_AGENT_PANE_LOAD_RENDER_ARCHITECTURE_2026_08_27.md`). Each fix
+closed one specific, measured mechanism. The last of those four reports
+(2026-08-27) explicitly diagnosed **why the whole family keeps recurring**
+and proposed the actual structural fix — a single pane-scoped "paint gate"
+that nothing renders until every async data source has registered as ready.
+That fix (§4 of the 08-27 report) was **never built** — marked open then,
+still open now (no commit since `c58ce9f1` touches it). Today's flash on
+Lzop is that same open gap, not new breakage.
+
+## Live evidence
+
+A `MutationObserver` installed via CDP against Lzop's actual running pane
+(`local-main-b28b7a-8505b7b7`, block `f5c69569-…`) caught the flash directly
+on a reopen the repo owner triggered:
+
+```
+t=9510130ms  ADDED    "■ a2e5b60979142ecb3 [0:00] ↳ 52 events
+                       ■ magical-enchanting-diffie [0:00] ↳ 7 events
+                       ■ magical-enchanting-diffie [0:00] ↳ 28 events
+                       ▸ 16 more (16 subagents)"
+t=9513507ms  REMOVED
+```
+
+~20 subagents render as live dock rows, then all disappear ~3.4s later.
+This is **not** the orphaned-Bash-tool-call theory from the first pass of
+this retro (that data is real and does sit in Lzop's history, but the
+settled document state correctly clamps it out — confirmed separately, see
+"What this is NOT" below). It's the subagent source,
+`frontend/app/view/agent/activity/subagent-source.ts`'s `allSubagentsAtom`,
+fed by `subagent.ListActive`.
+
+## Why this exact shape, on this exact agent
+
+Straight from `REPORT_AGENT_PANE_LOAD_RENDER_ARCHITECTURE_2026_08_27.md`
+§2-3, still accurate today:
+
+1. On every pane reopen, the backend cold-replays the agent's historical
+   `agent-*.jsonl` subagent files (`scan_subagents_dir`, capped at
+   `BACKFILL_MAX_FILES = 200`) to reconstruct "what subagents does this
+   agent know about." Each replayed file broadcasts `subagent:spawned`.
+2. **PR #2837 (v0.55.28, shipped, still in place)** fixed the worst part of
+   this: a replay whose parent turn has already ended is now born
+   `Abandoned` instead of `Active`, removing the specific "assert 200 fake-
+   active subagents, then retract them 314ms later" transient the 08-27
+   report measured.
+3. What was **never fixed** (08-27 report §4, marked open, unstarted): there
+   is still no single, deterministic "this pane's data is fully settled,
+   render now" barrier. What exists instead is four independent, timing-
+   based approximations — `createDebouncedRefresh` (100ms/1000ms),
+   `useSubagentBackfillGate` (250ms buffer + 20s safety net),
+   `createBackfillAwareTrigger` (20s lost-event fallback), and
+   `shellStatusCorrection` (no timeout at all, races the exit-chunk ring).
+   None of them *guarantee* zero flicker — they reduce its probability for
+   the burst shapes they were tuned against.
+4. The report's own §3 called out explicitly which agents this hits hardest:
+   *"a lightly-used agent's reopen has few or zero backfill events... The
+   repo owner's own long-running agents... are exactly the case where 150+
+   backend events compress into 2-3 real, visibly-different frontend
+   snapshots."* Lzop — 72,260 lines of transcript, extensive subagent
+   history (matching the "16-20 subagents" in the live capture) — is
+   precisely that worst case. A lighter agent's pane would likely show
+   nothing at all, which is consistent with why this wasn't caught again
+   until now.
+
+So: **the backend no longer lies about subagent status (fixed), but the
+frontend still has no hard guarantee it won't sample and render mid-burst
+(never fixed)** — for a heavy-enough agent, that residual timing gap is
+still wide enough to paint and unpaint a real (if momentary) intermediate
+state.
+
+## What this is NOT
+
+- **Not the orphaned-tool-call theory this retro originally proposed.**
+  Lzop's transcript genuinely contains 5 permanently-`"running"` orphaned
+  Bash `tool_use` calls (real debris from a "someone just killed the
+  instance" incident on v0.49.13, weeks old) — but live CDP inspection of
+  the settled pane confirmed `clampToSessionScope` correctly excludes them
+  (`dockCount: 0`, correct "NEW SESSION STARTED" banner shown). That code
+  path is fine. Left as a documented dead end so it isn't re-investigated.
+- **Not a regression from PR #2932** (this session's own Armory reactive-
+  updates work) or from PR #2930/#2933 (the subprocess/container turn and
+  credential-mounting fixes merged just before it) — none of those touch
+  `subagent_watcher/`, `subagent-source.ts`, or any of the four mechanisms
+  in the table above. That line of investigation (the first pass of this
+  retro) is superseded.
+- **Not something PR #2837 failed to fix.** Its own scope (stop asserting
+  false-`Active` state on replay) is intact and working — verified no
+  commit has touched `jsonl.rs`/`scan.rs`'s relevant functions since.
+
+## What would actually close this
+
+Exactly what `REPORT_AGENT_PANE_LOAD_RENDER_ARCHITECTURE_2026_08_27.md` §4
+already specified and scoped, still unbuilt:
+
+> **A participant-registered paint gate.** Each async source that can
+> change first-paint content registers a token at mount
+> (`"history-replay"`, `"subagent-backfill"`, `"shell-status"`,
+> `"background-registry"`). The pane paints when the token set empties, or
+> when one shared deadline expires. Adding a new async surface means
+> registering a token, not discovering `ready()` and wiring in a fifth
+> ad-hoc gate.
+
+This is a real, moderately-sized frontend change (a new pane-scoped
+readiness registry consumed by `block.tsx`'s `ready()`/BrainSpinner, plus
+updating the ~4 existing mechanisms to register/deregister tokens instead
+of independently guessing timing), not a quick patch. Given it's already
+fully designed and scoped in an existing report, the right next step is
+implementing §4 as specified there — not inventing a new approach.
+
+## Sources
+
+- `docs/reports/REPORT_AGENT_PANE_LOAD_RENDER_ARCHITECTURE_2026_08_27.md` —
+  the direct answer to "how did it come back": §4 was always still open.
+- `docs/retro/retro-activity-dock-stale-shell-flash-on-load-2026-08-22.md`,
+  `docs/reports/REPORT_AGENT_PANE_REOPEN_SUBAGENT_STORM_2026_08_23.md`,
+  `docs/retro/retro-activity-dock-flicker-survives-debounce-fix-2026-08-24.md`
+  — the three earlier fixes in this family, all still intact, none of them
+  claiming to fully close the flicker class.
+- `frontend/app/view/agent/activity/subagent-source.ts`,
+  `hooks/useSubagentBackfillGate.ts`, `activity/backfill-tracker.ts`,
+  `activity/debounced-refresh.ts` — the four still-live, still-approximate
+  mechanisms.
+- `agentmux-srv/src/backend/subagent_watcher/{jsonl,scan}.rs` — confirmed
+  PR #2837's fix (`c58ce9f1`) is the latest change, still in place.
+- Live trace this session: CDP `MutationObserver` against
+  `ws://127.0.0.1:60304/devtools/page/…` (Lzop's actual running pane,
+  channel `local-main-b28b7a-8505b7b7`, block
+  `f5c69569-5763-4319-a114-07864ecd06d9`), captured on a reopen the repo
+  owner triggered directly.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -330,7 +330,7 @@ partial list.
 | [`SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29`](SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29.md) | Spec: multi-tier discovery + remote API invocation over muxbus |
 | [`SPEC_WINDOW_NAME_API_HARDENING_2026_08_08`](SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md) | SPEC: Window-name App API hardening (phantom-id success + status codes) |
 
-### proposed (87)
+### proposed (88)
 
 | Spec | Title |
 |---|---|
@@ -382,6 +382,7 @@ partial list.
 | [`SPEC_MIGRATION_FRAMEWORK_2026_06_24`](SPEC_MIGRATION_FRAMEWORK_2026_06_24.md) | Migration Framework Spec |
 | [`SPEC_MODEL_EFFORT_CAPABILITY_VALIDATION_2026_07_02`](SPEC_MODEL_EFFORT_CAPABILITY_VALIDATION_2026_07_02.md) | SPEC — Per-model effort-capability validation for the composer strip |
 | [`SPEC_MUXBUS_CLOUD_RELAYED_LOGIN_CALLBACK_2026_08_15`](SPEC_MUXBUS_CLOUD_RELAYED_LOGIN_CALLBACK_2026_08_15.md) | SPEC: MuxBus cloud-relayed login callback (no loopback listener) |
+| [`SPEC_MUXSPECT_CROSS_TIER_INSTANCE_INSPECTION_2026_09_02`](SPEC_MUXSPECT_CROSS_TIER_INSTANCE_INSPECTION_2026_09_02.md) | muxspect Phase 2: cross-tier instance inspection (same-host channels + LAN) |
 | [`SPEC_PANE_MINIMIZE_AND_TOOLCALL_FAILCOLLAPSE_2026_06_21`](SPEC_PANE_MINIMIZE_AND_TOOLCALL_FAILCOLLAPSE_2026_06_21.md) | SPEC — Pane Minimize Button + Failed Tool Call Immediate Collapse |
 | [`SPEC_PANE_MINIMIZE_COLUMN_DISSOLVE_2026_06_27`](SPEC_PANE_MINIMIZE_COLUMN_DISSOLVE_2026_06_27.md) | SPEC — Pane Minimize: Column Dissolve on Full-Column Collapse |
 | [`SPEC_PANE_MINIMIZE_REFINEMENTS_2026_06_24`](SPEC_PANE_MINIMIZE_REFINEMENTS_2026_06_24.md) | SPEC — Pane Minimize Refinements |

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -330,7 +330,7 @@ partial list.
 | [`SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29`](SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29.md) | Spec: multi-tier discovery + remote API invocation over muxbus |
 | [`SPEC_WINDOW_NAME_API_HARDENING_2026_08_08`](SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md) | SPEC: Window-name App API hardening (phantom-id success + status codes) |
 
-### proposed (88)
+### proposed (89)
 
 | Spec | Title |
 |---|---|

--- a/docs/specs/SPEC_MUXSPECT_CROSS_TIER_INSTANCE_INSPECTION_2026_09_02.md
+++ b/docs/specs/SPEC_MUXSPECT_CROSS_TIER_INSTANCE_INSPECTION_2026_09_02.md
@@ -1,0 +1,334 @@
+# muxspect Phase 2: cross-tier instance inspection (same-host channels + LAN)
+
+**Status:** proposed
+**Date:** 2026-09-02
+**Author:** Manoz@Area54
+**Motivating incident:** live-debugging a `task dev` build on branch
+`manoz/fix-activity-dock-subagent-backfill-flash` required inspecting a
+*second*, freshly-launched AgentMux instance's live state (agent Lzop's
+subagent backfill/reconciliation). `muxspect` — the tool built exactly for
+this — could not reach it (Phase 1, current-instance-only). The workaround
+was manual: `netstat` to find the second instance's CDP port, a hand-rolled
+CDP `MutationObserver` script, and `grep`-ing that instance's raw srv log
+file for `reconcile_stale_subagents` lines. That workaround found the real
+bug (§"Motivating incident" detail below), but it took a dozen ad-hoc steps
+a purpose-built tool should collapse into one command.
+
+---
+
+## 0. This is a planned extension, not a new idea — read this first
+
+`docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md` §7 already
+named "Phase 2: cross-instance query" as the next step after Phase 1 shipped.
+`docs/reports/REPORT_MUXSPECT_MUXLOG_CROSS_CHANNEL_INSPECTION_2026_08_22.md`
+§3 point 3 already proposed the specific missing primitive this spec builds
+(a real "list live instances" command cross-referencing actual processes
+against disk). `docs/specs/SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md`
+already built and shipped the *transport, trust, and consent* pattern this
+spec reuses (jekt-riding request/response, per-agent visibility setting,
+TOFU-pinned LAN identity) — for transcripts specifically — and its own
+Non-goals section left the door open in so many words: *"A future second
+remote-read need should get its own narrow protocol rather than generalizing
+this one prematurely."* This spec is that second need.
+
+**Nothing here invents a new trust or transport model.** Every mechanism
+below is an application of infrastructure that already exists, is reviewed,
+and is (mostly) already shipped. The new work is: a same-host instance
+registry (doesn't exist yet, in any form), a generalized forward path for
+muxspect's existing read routes (today only `describe`/`transcript` forward
+cross-channel; nothing forwards to LAN except one narrow agent-lookup), and
+one new jekt content type for the LAN hop, built the same way
+`transcript_request` was.
+
+---
+
+## 1. Scope
+
+### In scope
+- **Phase 2a — same-host, cross-channel.** A `muxspect instances` command
+  listing every live AgentMux channel/instance on this machine (channel
+  name, version, PID, port, agent count, uptime) — ground-truthed against
+  actual running processes, not just disk contents. Generalize the existing
+  single-purpose cross-channel forward (used today only by `describe` and
+  the transcript route) into a general-purpose forward any read-only
+  muxspect route can use, addressed by channel name.
+- **Phase 2b — LAN.** A new `muxspect_request`/`muxspect_response` jekt
+  content-type pair, riding the same signed jekt envelope and LAN Ed25519
+  identity (TOFU-pinned) the existing `transcript_request` pair uses,
+  carrying `{route, params}` and returning the same JSON shape the local
+  HTTP handler would produce. Gated by the same visibility-setting +
+  trust-grant infrastructure already built for transcripts (§4.3 — this is
+  the one point needing explicit confirmation, not a default I'm assuming).
+
+### Out of scope (explicitly, matching this codebase's own established sequencing)
+- **WAN.** Every prior phase in this family (transcript visibility, jekt
+  trust hardening) sequenced LAN before WAN and left WAN for a dedicated
+  follow-up once LAN ships and settles. Same here.
+- **Any mutating route.** `muxspect dock/clear` is the one mutating route
+  muxspect exposes today. It stays local-instance-only in this spec — no
+  remote tier gets write access to another instance's live state. If a
+  genuine need for remote dock-clear shows up later, it gets its own spec
+  and its own (almost certainly stricter) trust rule, the same way this
+  spec is treating instance inspection as its own narrow thing rather than
+  folding it into transcript visibility.
+- **A general remote-RPC framework.** `SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29.md`
+  §4 already scoped that as a separate, much larger, explicitly-sequenced-last
+  piece of work (gated on WAN per-agent authorization actually being
+  enforced, which it isn't yet). This spec's `muxspect_request` is
+  deliberately narrow — one route name + one params object, allowlisted to
+  muxspect's own existing read handlers — not a general verb space.
+- **Agent-less-channel visibility on the LAN tier.** Phase 2a's same-host
+  registry closes the "channel with no registered agents is invisible"
+  gap locally (§3.1). Doing the same over LAN is a natural follow-on but
+  adds discovery-protocol surface (`lan_discovery.rs` TXT records would
+  need a new field) this spec doesn't touch — LAN in this spec only reaches
+  a channel that already has ≥1 registered agent, same limitation
+  `muxspect find`'s LAN tier has today.
+
+---
+
+## 2. Phase 2a: same-host instance registry
+
+### 2.1 The gap, precisely
+
+Two things exist today and neither is "list every live instance":
+
+- `agentmux-launcher/src/other_instances.rs`'s `enumerate_sibling_instances()`
+  walks `<channels_root>/*/versions/*/` and probes each sibling's
+  single-instance pipe for liveness — but this is launcher-internal,
+  diagnostic-log-only (`log_older_running_instances()`), never exposed to
+  any RPC caller.
+- The shared reactive registry (`agentmux-srv/src/backend/reactive/registry.rs`,
+  `~/.agentmux/shared/agents/reactive/<agent>/<channel>.json`) is
+  **agent-keyed**: a channel with zero registered agents (all shell/terminal
+  panes, no agent CLI) has no entry and is invisible to every
+  `muxspect find`/`conversations`/`verify-sender` cross-channel tier today.
+
+### 2.2 Design: instance-level heartbeat, same pattern as the agent registry
+
+Add `~/.agentmux/shared/instances/<channel>.json`, one file per running srv
+instance, written on startup and refreshed on a short interval (reuse
+whatever interval the existing memory-heartbeat logging already uses as a
+starting point — this needs an actual number chosen during implementation,
+not guessed here). Shape:
+
+```json
+{
+  "channel": "manoz-fix-activity-dock-subagent-backfill-flash",
+  "version": "0.55.32",
+  "pid": 13120,
+  "local_url": "http://127.0.0.1:60304",
+  "auth_key": "...",
+  "started_at": 1788399530000,
+  "updated_at": 1788399605000,
+  "agent_count": 1
+}
+```
+
+This is the exact same "well-known directory + per-owner JSON file, `pid`/
+`updated_at` freshness, `auth_key` embedded for forwarding" shape the agent
+registry already uses (`registry.rs:22-62`) — same eviction logic
+(`cleanup_stale_shared`'s `pid_alive()` check) reused, not reinvented.
+`agent_count` is read from the existing `ProcessBroker`/agent-registration
+count at write time — cheap, already computed for other purposes.
+
+**Why a new file instead of extending the agent registry to allow zero-agent
+entries:** the agent registry's file-per-`(agent, channel)` shape means an
+agent-less channel has literally nothing to key a file on without changing
+that shape for every existing reader. A parallel, channel-keyed file is the
+smaller, more legible change, and cheap to reconcile (each is a straight
+`pid`-liveness check).
+
+### 2.3 New route + CLI command
+
+- `GET /api/v1/muxspect/instances` (`muxspect_handlers.rs`, new handler,
+  same auth middleware as every other route in the file) — reads
+  `~/.agentmux/shared/instances/*.json`, does the same `pid_alive()` sweep
+  the agent registry does (evict stale entries, don't just trust the file),
+  returns the live set.
+- `muxspect instances` (`muxspect.mjs`, new subcommand, same
+  `apiGet`/render pattern as `muxspect list`) — table: channel, version,
+  pid, agents, uptime.
+
+### 2.4 Generalizing the forward path
+
+Today, exactly two routes (`describe`, the transcript route) forward a
+request to a specific OTHER channel, and only when reached via `find`'s own
+match logic — there's no way to say "run `dock` against channel X"
+directly. Add an optional `?channel=<name>` param, handled once, centrally
+(not per-route): if present, resolve `<name>` in the new instance registry,
+forward the request verbatim to that instance's `local_url` with its
+`auth_key` (same bounded-timeout forward pattern already in
+`muxspect_handlers.rs:931`'s `CROSS_CHANNEL_PREVIEW_TIMEOUT_MS`), return its
+response. This makes `list`, `describe`, `dock`, `background-tasks`,
+`verify-sender`, `layout` all immediately cross-channel-capable with one
+shared code path, instead of each route needing its own forward logic the
+way `describe`/transcript do today.
+
+`dock/clear` explicitly does NOT get this treatment (§1, out of scope).
+
+### 2.5 Trust for Phase 2a
+
+**None needed beyond what already exists.** Same host, same OS user, same
+`~/.agentmux/shared/` directory every other cross-channel mechanism in this
+codebase already trusts implicitly (the agent registry's `auth_key` embedding
+already assumes this). No jekt tier is involved — this is a same-machine,
+same-privilege-level RPC (`agentmux-mcp`, the CLI, and every existing
+cross-channel forward already work this way). No new CLAUDE.md jekt-rules
+change needed.
+
+---
+
+## 3. Phase 2b: LAN
+
+### 3.1 Design: `muxspect_request` / `muxspect_response`, riding the jekt envelope
+
+Directly mirrors `transcript_request`/`transcript_response`
+(`SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md`,
+`agentmux-common::transcript_request`): a new payload type carried inside
+the *same* signed jekt envelope (no new crypto — reuses per-agent LAN
+Ed25519 signing + `db_lan_peer_pubkey_pins` TOFU pinning exactly as-is).
+
+```
+MuxspectRequest  { route: String, params: JsonValue }
+MuxspectResponse { status: "ok" | "denied" | "error", body: JsonValue | null, reason: String | null }
+```
+
+`route` is allowlisted server-side to muxspect's own existing read-handler
+names (`list`, `describe`, `find`, `dock`, `background-tasks`,
+`verify-sender`, `conversations`, `layout`) — never a free-form path, never
+`dock/clear`. This allowlist is the entire "RPC verb space" this spec adds;
+it is not a general method registry the way
+`SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29.md` §4
+scoped its (still-unbuilt, deliberately-deferred) general RPC layer to be.
+
+The responding agent's own srv resolves the request against ITS OWN local
+muxspect handlers (i.e. the receiving side literally calls the same
+handler function `handle_muxspect_dock` etc. would call for a local HTTP
+request) and returns the result inline in `MuxspectResponse`, rather than
+the requester making a second hop — this avoids opening any new inbound
+HTTP surface on the LAN beyond what jekt delivery already requires.
+
+### 3.2 Discovery — no changes needed
+
+`lan_discovery.rs`'s existing mDNS/UDP-broadcast discovery + the
+`GET /agentmux/reactive/agent` agent-presence lookup already answers "which
+LAN peer hosts agent X" and already carries that peer's LAN public key.
+Nothing here needs a new discovery mechanism — `muxspect_request` just needs
+an agent name to route through, exactly like `transcript_request` does.
+
+### 3.3 The one real design question: what gates disclosure?
+
+This needs explicit confirmation before implementation, not a default
+assumed here. Two options:
+
+**Option A — reuse `conversation_visibility` as-is.** The existing setting
+(`private` / `trusted_peers` / `ask`) and its `db_conversation_trust_grants`
+table already implement exactly the question this spec needs answered:
+"should this agent disclose internal state to that peer?" `muxspect dock`/
+`describe`/`background-tasks` are less sensitive than a full transcript
+(structured metadata — process status, retry counts, activity summaries —
+not conversation content) but are still real information disclosure (e.g.
+`dock` reveals what an agent is actively doing right now). Reusing the same
+setting keeps the user's mental model to one dial ("who can see into this
+agent") instead of two.
+
+**Option B — a new, separate `remote_inspection_visibility` setting.**
+Keeps "can read my conversation" and "can query my process/activity state"
+as independently tunable — a user might reasonably want peers to see "is
+this agent alive and what's it doing" (operationally useful for fleet
+management) without granting transcript access, or vice versa.
+
+**Recommendation: Option B**, on the same three-state shape
+(`private`/`trusted_peers`/`ask`) and the same `db_conversation_trust_grants`-
+shaped table (parameterized by request kind rather than a second table), for
+exactly the reason a fleet operator plausibly wants those two dials
+independent — but this is a judgment call about user-facing behavior, not a
+technical constraint, and should be confirmed with the repo owner before
+implementation the same way `transcript_request`'s own tier rule needed
+explicit confirmation (§3.4).
+
+### 3.4 Tier rule — needs repo-owner sign-off, same as transcript_request did
+
+Per `CLAUDE.md`'s jekt security rules: *"Any change to CLAUDE.md's jekt
+rules table requires explicit, live repo-owner confirmation before it's
+real"* — this isn't optional process, it's the documented lesson from the
+PR #2536 incident. Proposed rule, symmetric to
+`SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md`:
+
+- `muxspect_request` is always forced `TIER=sensitive` (it's a
+  disclosure-shaped question, same reasoning as transcript_request).
+- `ESCALATE=required` is NOT relaxed by a verified sender when the
+  responding agent's own visibility setting (§3.3) is `ask`, or
+  `trusted_peers` with a requester not on the allowlist — identity proof
+  answers *who's asking*, not *whether this should be shown*, same
+  rationale as the transcript rule.
+- For `private` or `trusted_peers`-with-allowlisted-requester, auto-resolve
+  per that mode's existing design intent (deny / approve respectively),
+  same as transcript_request.
+
+This should ship as its own dedicated
+`SPEC_JEKT_MUXSPECT_REQUEST_TIER_RULES_2026_09_XX.md`, written and confirmed
+the same way the transcript one was, not folded silently into this spec's
+own authority.
+
+### 3.5 What Phase 2b deliberately does NOT build
+
+- No `muxspect conversation-requests`-style approve/deny CLI beyond what's
+  strictly needed for `ask` mode — reuse whatever Phase B/C's own deferred
+  UI work lands as, don't build a second one.
+- No caching/offline answer — a LAN peer that's unreachable just times out
+  (bounded, same posture as the existing `remote_fetch_required: true`
+  liveness-only LAN tier `find`/`conversations` already have).
+- No new mDNS/broadcast TXT fields — this rides jekt, not a new discovery
+  payload.
+
+---
+
+## 4. Non-goals recap (mirrors the discipline of every prior spec in this family)
+
+- Not a general remote-RPC framework (§1, §3.1).
+- Not WAN (§1).
+- Not a mutation path of any kind on any remote tier (§1, §2.4, §3.1).
+- Not a new discovery mechanism for LAN (§3.2) or same-host (§2.2 reuses the
+  established registry-file pattern, doesn't invent a new one).
+- Not a redesign of the tier vocabulary, transport, or LAN identity/pinning
+  model — all reused verbatim from already-shipped work.
+
+## 5. Rollout sequencing
+
+1. **2a first, alone.** No trust-model risk, immediately useful (closes the
+   exact gap this session's live-debugging hit), and the generalized forward
+   path built here is a prerequisite building block for 2b's response side
+   anyway (the responding agent's own srv needs to be able to answer any
+   allowlisted route locally regardless of which transport the request
+   arrived over).
+2. **2b's tier-rule spec, written and confirmed, before any 2b code.**
+   Matches how `transcript_request`'s rule was handled — spec and
+   confirmation first, implementation second, not concurrently.
+3. **2b implementation**, once 1 and 2 are settled.
+
+## 6. Testing
+
+- 2a: `muxspect instances` against a real second `task dev` instance
+  (exactly this session's own motivating scenario) — assert it lists both
+  channels with correct pid/agent-count, and that a killed instance's stale
+  file gets evicted (mirror the agent registry's own
+  `cleanup_stale_shared` test pattern).
+- 2a forward path: `muxspect dock --channel=<other>` against a real second
+  instance with a genuinely different dock state than the caller's own —
+  assert the correct instance's data comes back, not the caller's own.
+- 2b: reuse the transcript_request test harness's shape
+  (`SPEC_MUXSPECT_PHASE_B_POLICY_AND_TIER_ENFORCEMENT_2026_08_22.md`'s own
+  tests are the template) — one test per visibility mode × allowlist state,
+  plus a TOFU-pin mismatch test (a second key claiming an already-pinned
+  agent name must be rejected, not silently accepted as a rotation).
+
+## 7. Open questions for the repo owner
+
+1. Option A vs. B in §3.3 — one shared visibility dial or two independent
+   ones?
+2. Confirm the §3.4 tier rule before it's written up as its own dedicated
+   spec (per CLAUDE.md's own process requirement for jekt-rules changes).
+3. Heartbeat refresh interval for §2.2 — not chosen here; needs an actual
+   number picked against real overhead during implementation.

--- a/frontend/app/view/agent/activity/dispatch-source.test.ts
+++ b/frontend/app/view/agent/activity/dispatch-source.test.ts
@@ -21,7 +21,7 @@ vi.mock("@/app/store/wps", () => ({
 
 const callBackendServiceSpy = vi.spyOn(wos, "callBackendService").mockResolvedValue([]);
 
-import { msUntilNextQuietWindowRefresh } from "./dispatch-source";
+import { allDispatchesAtom, msUntilNextQuietWindowRefresh, refreshDispatchesNow } from "./dispatch-source";
 
 function mkDispatch(overrides: Partial<AgentDispatch> & Pick<AgentDispatch, "dispatch_id">): AgentDispatch {
     return {
@@ -83,6 +83,28 @@ describe("msUntilNextQuietWindowRefresh", () => {
 // dispatch:updated event (up to ~200 in a real trace). These events must
 // now collapse into a single call once the burst goes quiet. Mirrors
 // subagent-source.test.ts's own coalescing tests for its sibling singleton.
+// docs/retro/retro-activitydock-appears-on-agent-pane-load-2026-09-02.md —
+// mirrors subagent-source.test.ts's identical coverage for the sibling
+// singleton.
+describe("dispatch-source — refreshDispatchesNow", () => {
+    async function flushMicrotasks(): Promise<void> {
+        await Promise.resolve();
+        await Promise.resolve();
+    }
+
+    it("bypasses the debounce entirely and resolves once ListDispatches has actually landed", async () => {
+        await flushMicrotasks();
+        callBackendServiceSpy.mockClear();
+        callBackendServiceSpy.mockResolvedValueOnce([mkDispatch({ dispatch_id: "d1" })]);
+
+        await refreshDispatchesNow();
+
+        expect(callBackendServiceSpy).toHaveBeenCalledTimes(1);
+        expect(callBackendServiceSpy).toHaveBeenCalledWith("subagent", "ListDispatches", []);
+        expect(allDispatchesAtom().find((d) => d.dispatch_id === "d1")).toBeDefined();
+    });
+});
+
 describe("dispatch-source — refresh coalescing", () => {
     beforeEach(() => vi.useFakeTimers());
     afterEach(() => vi.useRealTimers());

--- a/frontend/app/view/agent/activity/dispatch-source.ts
+++ b/frontend/app/view/agent/activity/dispatch-source.ts
@@ -112,3 +112,12 @@ waveEventSubscribe({ eventType: "dispatch:updated", handler: () => trigger() });
 /** Every tracked dispatch (Solo or Workflow) currently known, across the
  *  whole app. Callers filter by `parent_block_id` for their own pane. */
 export const allDispatchesAtom: Accessor<AgentDispatch[]> = allDispatches;
+
+/**
+ * Force an immediate (non-debounced) refresh and resolve once it has
+ * actually landed. Mirrors `subagent-source.ts`'s `refreshSubagentsNow` —
+ * same rationale, same caller (`useSubagentBackfillGate.ts`).
+ */
+export function refreshDispatchesNow(): Promise<void> {
+    return refresh();
+}

--- a/frontend/app/view/agent/activity/subagent-source.test.ts
+++ b/frontend/app/view/agent/activity/subagent-source.test.ts
@@ -37,7 +37,7 @@ vi.mock("@/app/store/wps", () => ({
 
 const callBackendServiceSpy = vi.spyOn(wos, "callBackendService").mockResolvedValue([]);
 
-import { allSubagentsAtom } from "./subagent-source";
+import { allSubagentsAtom, refreshSubagentsNow } from "./subagent-source";
 
 function mkSubagent(overrides: Partial<ActiveSubagent> & Pick<ActiveSubagent, "agent_id">): ActiveSubagent {
     return {
@@ -73,6 +73,23 @@ async function flushMicrotasks(): Promise<void> {
 // unchanged alongside them.
 beforeEach(() => vi.useFakeTimers());
 afterEach(() => vi.useRealTimers());
+
+// docs/retro/retro-activitydock-appears-on-agent-pane-load-2026-09-02.md:
+// `useSubagentBackfillGate` needs to know when the dock's OWN data has
+// actually caught up with a settled backfill, not guess a fixed duration.
+describe("subagent-source — refreshSubagentsNow", () => {
+    it("bypasses the debounce entirely and resolves once ListActive has actually landed", async () => {
+        await flushMicrotasks();
+        callBackendServiceSpy.mockClear();
+        callBackendServiceSpy.mockResolvedValueOnce([mkSubagent({ agent_id: "a1" })]);
+
+        await refreshSubagentsNow();
+
+        expect(callBackendServiceSpy).toHaveBeenCalledTimes(1);
+        expect(callBackendServiceSpy).toHaveBeenCalledWith("subagent", "ListActive", []);
+        expect(allSubagentsAtom().find((s) => s.agent_id === "a1")).toBeDefined();
+    });
+});
 
 describe("subagent-source — subagent:abandoned wiring", () => {
     it("registered a handler for subagent:abandoned (the fix's own precondition)", () => {

--- a/frontend/app/view/agent/activity/subagent-source.ts
+++ b/frontend/app/view/agent/activity/subagent-source.ts
@@ -81,3 +81,17 @@ waveEventSubscribe({
 /** Every subagent currently known (active or recently completed), across the
  *  whole app. Callers filter by `parent_block_id` for their own pane. */
 export const allSubagentsAtom: Accessor<ActiveSubagent[]> = allSubagents;
+
+/**
+ * Force an immediate (non-debounced) refresh and resolve once it has
+ * actually landed — i.e. `allSubagentsAtom()` genuinely reflects the
+ * result, not just that a call was scheduled. `useSubagentBackfillGate.ts`
+ * uses this to know the dock's own data has caught up with a settled
+ * backend backfill before revealing the pane, instead of guessing a fixed
+ * duration (see that hook's doc comment and
+ * docs/reports/REPORT_AGENT_PANE_LOAD_RENDER_ARCHITECTURE_2026_08_27.md §2-3
+ * for why a blind timer raced ahead of this same refresh on a heavy agent).
+ */
+export function refreshSubagentsNow(): Promise<void> {
+    return refresh();
+}

--- a/frontend/app/view/agent/hooks/useSubagentBackfillGate.test.ts
+++ b/frontend/app/view/agent/hooks/useSubagentBackfillGate.test.ts
@@ -46,11 +46,52 @@ vi.mock("@/app/store/rpc-api", () => ({
     },
 }));
 
+// The settle decision now awaits these directly (2026-09-02 fix — see the
+// hook's own doc comment) instead of a blind timer, so tests drive settling
+// by resolving these mocks rather than advancing a fixed-duration clock.
+const refreshHub = vi.hoisted(() => ({
+    subagentsResolve: null as (() => void) | null,
+    dispatchesResolve: null as (() => void) | null,
+}));
+vi.mock("../activity/subagent-source", () => ({
+    refreshSubagentsNow: vi.fn(
+        () =>
+            new Promise<void>((resolve) => {
+                refreshHub.subagentsResolve = resolve;
+            })
+    ),
+}));
+vi.mock("../activity/dispatch-source", () => ({
+    refreshDispatchesNow: vi.fn(
+        () =>
+            new Promise<void>((resolve) => {
+                refreshHub.dispatchesResolve = resolve;
+            })
+    ),
+}));
+
 import { resolveBackfillStatus, useSubagentBackfillGate } from "./useSubagentBackfillGate";
+
+/** Resolve both settle-refresh mocks and flush the microtask queue so their
+ *  `.then()` chain (inside the hook) actually runs. Flushes twice up front
+ *  first — when "done" arrived via the async `EventReadHistoryCommand` path
+ *  rather than a synchronous live-event handler call, `scheduleSettle()`
+ *  (and therefore the calls that populate `refreshHub`) hasn't run yet at
+ *  the moment this is invoked. */
+async function resolveSettleRefresh(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+    refreshHub.subagentsResolve?.();
+    refreshHub.dispatchesResolve?.();
+    await Promise.resolve();
+    await Promise.resolve();
+}
 
 afterEach(() => {
     hub.handler = null;
     rpcHub.resolve = null;
+    refreshHub.subagentsResolve = null;
+    refreshHub.dispatchesResolve = null;
     vi.useRealTimers();
 });
 
@@ -112,7 +153,7 @@ describe("useSubagentBackfillGate", () => {
         expect(settled()).toBe(false);
     });
 
-    it("stays gated on a live 'started', settles (after the dock buffer) on a live 'done'", async () => {
+    it("stays gated on a live 'started', settles only once the dock's own refresh actually lands on a live 'done'", async () => {
         vi.useFakeTimers();
         const { settled } = mount("agent", true);
         rpcHub.resolve?.([]);
@@ -123,9 +164,14 @@ describe("useSubagentBackfillGate", () => {
         expect(settled()).toBe(false);
 
         hub.handler?.({ data: { status: "done" } });
-        expect(settled()).toBe(false); // buffer not elapsed yet
+        expect(settled()).toBe(false); // the settle refresh hasn't resolved yet
 
-        await vi.advanceTimersByTimeAsync(250);
+        // Even letting real time pass must not settle it early — only the
+        // actual refresh landing does now (the whole point of this fix).
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(settled()).toBe(false);
+
+        await resolveSettleRefresh();
         expect(settled()).toBe(true);
     });
 
@@ -145,7 +191,36 @@ describe("useSubagentBackfillGate", () => {
 
         // ...and finishes.
         hub.handler?.({ data: { status: "done" } });
-        await vi.advanceTimersByTimeAsync(250);
+        await resolveSettleRefresh();
+        expect(settled()).toBe(true);
+    });
+
+    it("a slow settle-refresh does not let a stale 'started' cycle settle late (generation guard)", async () => {
+        vi.useFakeTimers();
+        const { settled } = mount("agent", true);
+        rpcHub.resolve?.([]);
+        await vi.advanceTimersByTimeAsync(0);
+
+        // First cycle: "done" fires, kicking off a settle refresh that
+        // hasn't resolved yet.
+        hub.handler?.({ data: { status: "started" } });
+        hub.handler?.({ data: { status: "done" } });
+        expect(settled()).toBe(false);
+
+        // A NEW "started" re-closes the gate before that refresh landed
+        // (e.g. an overlapping re-registration, scan.rs's
+        // backfill_generation). The stale in-flight refresh from the FIRST
+        // cycle must not be allowed to settle this new cycle when it
+        // finally resolves.
+        hub.handler?.({ data: { status: "started" } });
+        expect(settled()).toBe(false);
+
+        await resolveSettleRefresh(); // resolves the FIRST cycle's stale refresh
+        expect(settled()).toBe(false); // must still be gated — that resolution was stale
+
+        // The new cycle's own "done" + refresh correctly settles it.
+        hub.handler?.({ data: { status: "done" } });
+        await resolveSettleRefresh();
         expect(settled()).toBe(true);
     });
 
@@ -168,7 +243,7 @@ describe("useSubagentBackfillGate", () => {
             { data: { status: "done" } },
         ]);
         await vi.advanceTimersByTimeAsync(0);
-        await vi.advanceTimersByTimeAsync(250);
+        await resolveSettleRefresh();
         expect(settled()).toBe(true);
     });
 
@@ -206,7 +281,7 @@ describe("useSubagentBackfillGate", () => {
         expect(hub.handler).not.toBeNull();
 
         rpcHub.resolve?.([{ data: { status: "done" } }]);
-        await vi.advanceTimersByTimeAsync(250);
+        await resolveSettleRefresh();
         expect(settled()).toBe(true);
     });
 
@@ -221,7 +296,7 @@ describe("useSubagentBackfillGate", () => {
 
         // First cycle settles normally.
         rpcHub.resolve?.([{ data: { status: "done" } }]);
-        await vi.advanceTimersByTimeAsync(250);
+        await resolveSettleRefresh();
         expect(settled()).toBe(true);
 
         // A later, legitimate re-registration re-closes the gate...

--- a/frontend/app/view/agent/hooks/useSubagentBackfillGate.test.ts
+++ b/frontend/app/view/agent/hooks/useSubagentBackfillGate.test.ts
@@ -285,6 +285,50 @@ describe("useSubagentBackfillGate", () => {
         expect(settled()).toBe(true);
     });
 
+    // codex P2 + reagentx P1 (PR #2937): a settle refresh still in flight
+    // when the view flips away from "agent" and back (before the NEW cycle
+    // gets its own "started"/"done") must not be allowed to resolve into
+    // the new cycle — `disposed` resets to false on re-entry, so only the
+    // generation bump on cleanup fences the stale promise out.
+    it("a settle refresh in flight when the view changes away and back must not prematurely settle the new cycle", async () => {
+        vi.useFakeTimers();
+        const [viewType, setViewType] = createSignal<string | undefined>("agent");
+        let settled: () => boolean = () => false;
+        createRoot(() => {
+            settled = useSubagentBackfillGate("block-1", viewType, () => true);
+        });
+
+        // First cycle: "done" fires, kicking off a settle refresh that
+        // will NOT resolve until later in this test.
+        rpcHub.resolve?.([]);
+        await vi.advanceTimersByTimeAsync(0);
+        hub.handler?.({ data: { status: "started" } });
+        hub.handler?.({ data: { status: "done" } });
+        expect(settled()).toBe(false);
+
+        // View changes away from "agent" (e.g. "Replace With...") while
+        // that refresh is still in flight, then immediately back — a
+        // brand-new cycle starts, gated again, with no "started"/"done" of
+        // its own yet.
+        rpcHub.resolve = null;
+        setViewType("term");
+        setViewType("agent");
+        expect(settled()).toBe(false);
+
+        // The FIRST cycle's stale refresh finally resolves. It must NOT
+        // settle the new cycle — the new cycle has received no "done" of
+        // its own.
+        await resolveSettleRefresh();
+        expect(settled()).toBe(false);
+
+        // The new cycle's own real "done" + refresh settles it correctly.
+        rpcHub.resolve?.([]);
+        await vi.advanceTimersByTimeAsync(0);
+        hub.handler?.({ data: { status: "done" } });
+        await resolveSettleRefresh();
+        expect(settled()).toBe(true);
+    });
+
     // reagentx P2 (PR #2781, round 7): the safety net used to only ever
     // arm once, at initial wiring — a legitimate LATER "started" (e.g. an
     // overlapping re-registration backfill_generation, scan.rs, explicitly

--- a/frontend/app/view/agent/hooks/useSubagentBackfillGate.ts
+++ b/frontend/app/view/agent/hooks/useSubagentBackfillGate.ts
@@ -268,6 +268,17 @@ export function useSubagentBackfillGate(
             // above, so a LATER change back to "agent" re-wires from
             // scratch rather than staying silently disabled forever.
             disposed = true;
+            // codex P2 + reagentx P1 (PR #2937): bump the generation here
+            // too, not just on a live "started". Without this, a "done"-
+            // triggered settle refresh still in flight when the view
+            // switches away from "agent" and back (before the NEW cycle
+            // gets its own "started"/"done") would resolve into the new
+            // cycle — `disposed` is reset to `false` on re-entry and
+            // `myGeneration` still equals `settleGeneration` (nothing else
+            // bumped it), so the stale refresh would pass both guards and
+            // prematurely settle the just-re-entered pane, reproducing the
+            // exact bug this PR fixes.
+            settleGeneration++;
             clearTimeout(safetyTimer);
             try { unsub(); } catch { /* ignore */ }
         });

--- a/frontend/app/view/agent/hooks/useSubagentBackfillGate.ts
+++ b/frontend/app/view/agent/hooks/useSubagentBackfillGate.ts
@@ -58,6 +58,23 @@
  *
  * Mirrors `useResumeRetryStream.ts`'s live-subscribe + mount-time
  * `EventReadHistoryCommand` read + discard-on-live-race shape.
+ *
+ * 2026-09-02 (docs/retro/retro-activitydock-appears-on-agent-pane-load-2026-09-02.md,
+ * following up on docs/reports/REPORT_AGENT_PANE_LOAD_RENDER_ARCHITECTURE_2026_08_27.md §2-3):
+ * the settle decision on a "done" event used to be a blind
+ * `DOCK_SETTLE_BUFFER_MS` (250ms) timer, guessed to give
+ * `subagent-source.ts`/`dispatch-source.ts`'s own independently-triggered,
+ * debounced refresh (`backfill-tracker.ts`'s `onNextBackfillSettle` →
+ * fire-and-forget `refreshNow()`) time to land before revealing the pane.
+ * There was no actual relationship between that guess and the real refresh
+ * — for a heavy agent (verified live: ~20 subagents replayed on reopen),
+ * the refresh's own RPC round trip could still be in flight well past
+ * 250ms, so the spinner faded and revealed a stale Activity Dock snapshot
+ * moments before the real data caught up and visibly corrected it — a
+ * flash on load, confirmed live via a CDP `MutationObserver` trace. Fixed
+ * by directly awaiting `refreshSubagentsNow()`/`refreshDispatchesNow()`
+ * (an explicit, non-debounced refresh of the exact data the dock renders)
+ * instead of guessing how long some OTHER refresh might take.
  */
 
 import { createEffect, createSignal, onCleanup, type Accessor } from "solid-js";
@@ -65,6 +82,8 @@ import { waveEventSubscribe } from "@/app/store/wps";
 import { WpsEvent } from "@/app/store/wps-events";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { refreshSubagentsNow } from "../activity/subagent-source";
+import { refreshDispatchesNow } from "../activity/dispatch-source";
 
 /**
  * Resolve a raw `subagent:backfill_status` WPS payload into `"started"` /
@@ -76,19 +95,6 @@ export function resolveBackfillStatus(data: unknown): "started" | "done" | null 
     const status = (data as Record<string, unknown>).status;
     return status === "started" || status === "done" ? status : null;
 }
-
-/**
- * codex P2 (PR #2781, round 2): the backend publishes "done" the instant
- * its own file-scan returns, but `dispatch-source.ts`/`subagent-source.ts`
- * only SCHEDULE their own trailing-edge-debounced `ListActive`/
- * `ListDispatches` refresh in reaction to the same burst of events
- * (`debounced-refresh.ts`, 100ms window) — so revealing the pane the
- * instant "done" lands can still race ahead of the Activity Dock's own
- * data actually catching up. Not a guarantee (a slow network response
- * could still exceed this), but a pragmatic buffer comfortably covering
- * the common case.
- */
-const DOCK_SETTLE_BUFFER_MS = 250;
 
 /**
  * Safety net (PR #2781 round 4): fail open rather than get stuck forever
@@ -128,8 +134,13 @@ export function useSubagentBackfillGate(
     // the full 20s safety-timeout on essentially every first message of
     // every new agent conversation.
     let decided = false;
-    let settleTimer: ReturnType<typeof setTimeout> | undefined;
     let safetyTimer: ReturnType<typeof setTimeout> | undefined;
+    // Bumped on every "started" and on unmount — guards the async settle
+    // refresh below against resolving into a stale cycle (a new "started"
+    // reopening the gate, or the hook tearing down, while the refresh from
+    // a PRIOR "done" is still in flight).
+    let settleGeneration = 0;
+    let disposed = false;
 
     createEffect(() => {
         const vt = viewType();
@@ -159,6 +170,7 @@ export function useSubagentBackfillGate(
             return;
         }
 
+        disposed = false; // fresh decide cycle — see round-6's re-entry note above
         setSettled(false);
 
         // reagentx P2 (PR #2781, round 7): re-armed on EVERY "started", not
@@ -183,17 +195,30 @@ export function useSubagentBackfillGate(
         armSafetyTimer();
 
         let receivedLiveEvent = false;
+        // Wait for the dock's ACTUAL data (subagents + dispatches) to catch
+        // up with the settled backend state, rather than guessing a fixed
+        // duration — see this module's doc comment for why a blind timer
+        // raced ahead of the real refresh on a heavy agent. `myGeneration`
+        // makes this resolution a no-op if superseded by a later "started"
+        // or the hook unmounting before the refresh lands.
         const scheduleSettle = () => {
-            clearTimeout(settleTimer);
-            settleTimer = setTimeout(() => {
-                clearTimeout(safetyTimer);
-                setSettled(true);
-            }, DOCK_SETTLE_BUFFER_MS);
+            const myGeneration = ++settleGeneration;
+            void Promise.all([refreshSubagentsNow(), refreshDispatchesNow()])
+                .catch(() => {
+                    // Best-effort — fall through to settle anyway rather than
+                    // stay gated forever; the safety-net timer above still
+                    // covers a hang in either RPC.
+                })
+                .then(() => {
+                    if (disposed || myGeneration !== settleGeneration) return;
+                    clearTimeout(safetyTimer);
+                    setSettled(true);
+                });
         };
         const applyStatus = (data: unknown) => {
             const status = resolveBackfillStatus(data);
             if (status === "started") {
-                clearTimeout(settleTimer);
+                settleGeneration++; // invalidate any in-flight settle refresh from a prior cycle
                 setSettled(false);
                 armSafetyTimer();
             } else if (status === "done") {
@@ -242,7 +267,7 @@ export function useSubagentBackfillGate(
             // re-run — `decided` is reset in the `vt !== "agent"` branch
             // above, so a LATER change back to "agent" re-wires from
             // scratch rather than staying silently disabled forever.
-            clearTimeout(settleTimer);
+            disposed = true;
             clearTimeout(safetyTimer);
             try { unsub(); } catch { /* ignore */ }
         });


### PR DESCRIPTION
## Summary

Two related but **distinct** fixes for the Activity Dock showing stale rows on agent pane load. They were found in that order; only the second one fixed the reported symptom.

### 1. Backend — ISO-8601 event timestamps (this is what fixed the reported bug)

`subagent_watcher/parse.rs` read each subagent event's `timestamp` with a bare `as_u64()`. Claude Code writes that field as an ISO-8601 **string** (`"2026-07-03T08:09:20.743Z"`); `as_u64()` returns `None` for a string, so it silently fell through to `now_millis()`. Every replayed historical event claimed to have happened at replay time.

`last_event_at` becomes the dock row's `endedAt` (`activity/subagent-adapter.ts`), and the dock keeps a terminal row only while `now - endedAt < RETENTION_MS[status]`. With `endedAt ≈ now`, every long-dead subagent passed that window, rendered, then aged out.

**Measured, not inferred:**
- `ListActive` returned all 19 of one agent's subagents with `spawned_at == last_event_at ==` exactly **127.6s ago** — identical across all 19, matching pane-open time, from a transcript dated two months earlier.
- Dock trace (CDP `MutationObserver`): appeared `07:22:15.005`, gone `07:22:18.362` = **3.357s**. `RETENTION_MS.stopped` (3000) + `EXIT_FLASH_MS` (400) = **3400ms**.
- After the fix the same query returns **58.2 / 58.3 / 62.0 / 67.5 days**, differing per subagent. Rows fail the retention filter and never paint. Confirmed visually by the repo owner on a rebuilt dev instance.

Also in this change:
- `jsonl.rs` — `spawned_at` derives from the earliest real event instead of replay time (elapsed display + newest-first ordering correctness).
- `scan.rs` — `reconcile_stale_subagents` retries on a bounded budget instead of giving up after a single 2s check. **Complementary, not the fix:** if reconcile fails the subagents stay `active`, whose retention is `Infinity`, so they'd show forever regardless of timestamps.

### 2. Frontend — backfill-gate settle race (real fix, but did NOT fix the reported symptom)

`useSubagentBackfillGate` decided the BrainSpinner could fade 250ms after the backend reported a backfill "done" — a blind guess at how long `subagent-source.ts`/`dispatch-source.ts`'s own debounced refresh would take. Replaced with directly awaiting `refreshSubagentsNow()`/`refreshDispatchesNow()`, plus a generation counter so a stale in-flight refresh can't settle a superseding cycle.

This is a genuine race worth closing and its tests are real — but it was **not** the cause of the dock flash. That's recorded honestly in the retro so the detour isn't repeated.

## Test plan
- [x] 4 new backend tests for `parse_event_timestamp`; verified genuine guards by reverting `parse.rs` to `as_u64()`-only (both ISO-8601 tests fail), then restoring (pass)
- [x] 87 `subagent_watcher` tests pass
- [x] Frontend: 17 `useSubagentBackfillGate` tests + `subagent-source`/`dispatch-source` coverage; verified as guards via the same stash-revert technique
- [x] `npx tsc --noEmit` clean
- [x] **Confirmed fixed live by the repo owner** on a rebuilt `task dev` instance
- [x] `check-doc-status.sh`, `gen-docs-index.sh`, `check-spec-citations.sh` all pass

## Also included
- `docs/retro/retro-activitydock-appears-on-agent-pane-load-2026-09-02.md` — full investigation, including the two wrong hypotheses eliminated along the way and a correction of its own original conclusion
- `docs/specs/SPEC_MUXSPECT_CROSS_TIER_INSTANCE_INSPECTION_2026_09_02.md` — cross-tier muxspect design drafted during this session (proposed; has open questions for the repo owner)

<!-- agentmux:agent_id=manoz -->
