### PR TITLE
Camper@claudius: fix(docs): correct Node 22->24, complete Linux dep list, unpin brew node path

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -12,9 +12,11 @@ These instructions cover setting up dependencies and building AgentMux from sour
 
 | Tool | Version | Purpose |
 |------|---------|---------|
-| **Node.js** | v22 LTS | Frontend build (SolidJS/Vite) |
+| **Node.js** | v24 LTS | Frontend build (SolidJS/Vite) |
 | **Rust** | 1.77+ | Backend (agentmux-srv) + Host (agentmux-cef) |
 | **Task** | Latest | Build orchestration |
+| **CMake** | 3.20+ | CEF native build (cef-dll-sys) |
+| **Ninja** | 1.10+ | CEF native build (cef-dll-sys) |
 
 > **Note:** Go and Zig are no longer required. The backend is 100% Rust since v0.31.0.
 
@@ -52,9 +54,14 @@ AgentMux embeds Chromium via CEF — no system WebKitGTK or WebView2 required.
 
 1. **Install build tools** (Debian/Ubuntu):
    ```bash
-   sudo apt install cmake ninja-build build-essential curl wget file libssl-dev git zip
+   sudo apt install cmake ninja-build build-essential curl wget file libssl-dev git zip \
+     libwayland-dev libxkbcommon-dev libgtk-3-dev \
+     libglib2.0-dev libpango1.0-dev libcairo2-dev \
+     libgdk-pixbuf2.0-dev libatk1.0-dev
    ```
    CMake and Ninja are required by `cef-dll-sys`, which builds CEF's C wrapper at compile time.
+   The remaining packages are CEF/GTK runtime dev headers — see `.github/workflows/build-linux.yml`
+   for the list this repo's own CI installs; keep this list in sync with it.
 
 2. **Install Rust**:
    ```bash

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Cross-platform (Windows, macOS, Linux). 100% Rust backend (Tokio + Axum). CEF ho
 
 | Tool | Version | Purpose |
 |------|---------|---------|
-| **Node.js** | 22 LTS | Frontend build |
+| **Node.js** | 24 LTS | Frontend build |
 | **Rust** | 1.77+ | Backend + CEF host |
 | **[Task](https://taskfile.dev/)** | Latest | Build orchestration |
 | **CMake** | 3.20+ | CEF native build (cef-dll-sys) |
@@ -79,7 +79,7 @@ Cross-platform (Windows, macOS, Linux). 100% Rust backend (Tokio + Axum). CEF ho
 Platform-specific:
 - **Windows:** Visual Studio Build Tools (CMake + Ninja ship with VS, but Ninja must be on PATH — see CLAUDE.md)
 - **macOS:** Xcode Command Line Tools, `brew install cmake ninja`
-- **Linux:** Build essentials, `apt install cmake ninja-build build-essential` — see [Linux guide](docs/linux.md)
+- **Linux:** Build essentials, `apt install cmake ninja-build build-essential libwayland-dev libxkbcommon-dev libgtk-3-dev libglib2.0-dev libpango1.0-dev libcairo2-dev libgdk-pixbuf2.0-dev libatk1.0-dev` — see [Linux guide](docs/linux.md)
 
 ### Development
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,7 +13,7 @@ vars:
     APP_NAME: "AgentMux"
     BIN_DIR: "bin"
     VERSION:
-        sh: 'PATH="$HOME/.cargo/bin:/opt/homebrew/opt/node@20/bin:/opt/homebrew/bin:/usr/local/bin:$PATH" node version.cjs'
+        sh: 'PATH="$HOME/.cargo/bin:/opt/homebrew/opt/node/bin:/opt/homebrew/bin:/usr/local/bin:$PATH" node version.cjs'
     RM: '{{if eq OS "windows"}}pwsh -Command Remove-Item -Force -ErrorAction SilentlyContinue{{else}}rm -f{{end}}'
     RMRF: '{{if eq OS "windows"}}pwsh -Command Remove-Item -Force -Recurse -ErrorAction SilentlyContinue{{else}}rm -rf{{end}}'
     DATE: '{{if eq OS "windows"}}pwsh -Command Get-Date -UFormat{{else}}date{{end}}'


### PR DESCRIPTION
## Summary

First fix batch from the fresh-PC onboarding audit (#2940). Fixes the four confirmed, verified defects from that report (§2a-2d) — no design decisions, just correcting things that are flatly wrong today:

- **README.md/BUILD.md said Node 22 LTS; `.nvmrc`/`package.json` engines/all 7 CI workflows require 24.** A new user following the docs installs the wrong major and fails `npm install`'s engines check.
- **BUILD.md's/README's Linux apt list was missing 8 packages** `build-linux.yml` actually installs (`libwayland-dev`, `libxkbcommon-dev`, `libgtk-3-dev`, `libglib2.0-dev`, `libpango1.0-dev`, `libcairo2-dev`, `libgdk-pixbuf2.0-dev`, `libatk1.0-dev`) — caught by Codex reviewing the audit report itself; my first pass at the report had only found 3 of the 8.
- **BUILD.md's prerequisites table was missing CMake/Ninja rows** README already had.
- **Taskfile.yml's `VERSION` var had a hardcoded `node@20` brew path.** Fixed to the unversioned `/opt/homebrew/opt/node/bin` symlink rather than bumping the pin to `node@24`, so this doesn't go stale again at the next major bump.

## Test plan

- [x] `bash scripts/check-doc-status.sh` — clean
- [x] `bash scripts/check-spec-citations.sh` — clean
- [x] `task version` still resolves correctly after the Taskfile.yml PATH change
- [ ] The corrected Linux apt list is not yet verified on real hardware — tracked in #2940's plan (fresh Ubuntu machine test), not claimed as verified here

<!-- agentmux:agent_id=camper -->