### PR TITLE
Camper@claudius: feat(bootstrap): split Task-installation from task init to fix a circular dependency

### DIFF
--- a/.changesets/1788403835-feat-bootstrap-task-init-now-verifies-the-toolchain-before-n-tsbm.md
+++ b/.changesets/1788403835-feat-bootstrap-task-init-now-verifies-the-toolchain-before-n-tsbm.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(bootstrap): task init now verifies the toolchain before npm install; new bootstrap.sh/bootstrap.ps1 install Task itself

--- a/BUILD.md
+++ b/BUILD.md
@@ -87,9 +87,12 @@ winget install Task.Task
 
 See full instructions: https://taskfile.dev/installation/
 
-**Starting from nothing?** `scripts/bootstrap.sh` (macOS/Linux) and
-`scripts/bootstrap.ps1` (Windows) run the commands above for you — see
-"Clone the Repository" below.
+**Starting from nothing?** `scripts/bootstrap.sh` (macOS/Linux, installs
+Task) and `scripts/bootstrap.ps1` (Windows, installs **Git and Task**) run
+the commands above for you — see "Bootstrap and Initialize" below. On
+Windows specifically, `bootstrap.ps1` is the one entry point that works
+before you've cloned anything, since a stock Windows install has neither
+Git nor Task.
 
 ---
 
@@ -100,28 +103,40 @@ git clone https://github.com/agentmuxai/agentmux.git
 cd agentmux
 ```
 
+macOS and most Linux distros ship (or trivially provide, via Xcode Command
+Line Tools / `apt`) a `git` you can clone with directly. A stock Windows
+install does not — see "Bootstrap and Initialize" below if you're starting
+from a completely bare Windows machine.
+
 ## Bootstrap and Initialize
 
 On a fresh machine with nothing installed, two steps get you to a working
 dev environment:
 
 ```bash
-# 1. Get Task itself installed (macOS/Linux):
+# 1. Get Task (and, on Windows, Git) installed:
+
+# macOS/Linux:
 sh scripts/bootstrap.sh
-# ...or on Windows (PowerShell):
+
+# Windows (PowerShell) — works even before cloning, since it installs Git too:
+irm https://raw.githubusercontent.com/agentmuxai/agentmux/main/scripts/bootstrap.ps1 | iex
+# ...or, after cloning some other way (zip download, GitHub Desktop, etc.):
 powershell -ExecutionPolicy Bypass -File scripts\bootstrap.ps1
 
-# 2. Verify the rest of the toolchain (Rust/Node/CMake/Ninja/git) and
-#    install frontend dependencies:
+# 2. Verify the rest of the toolchain (Rust/Node/CMake/Ninja/git — including
+#    minimum versions, not just presence) and install frontend dependencies:
 task init
 ```
 
 `task init` fails with a clear message (and does not run `npm install`) if
-anything required is still missing or the wrong version — reinstall the
-flagged tool and re-run it. It cannot install Task itself; that circularity
-is exactly why step 1 exists as a separate, non-Task script.
+anything required is still missing or below the minimum version — install
+or upgrade the flagged tool and re-run it. It cannot install Task itself, or
+(on Windows) the shell it needs to run its own cross-platform tasks; that
+circularity is exactly why step 1 exists as a separate, non-Task script.
 
-If you already have Task installed, you can skip straight to `task init`.
+If you already have Task (and, on Windows, Git) installed, you can skip
+straight to `task init`.
 
 ---
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -87,6 +87,10 @@ winget install Task.Task
 
 See full instructions: https://taskfile.dev/installation/
 
+**Starting from nothing?** `scripts/bootstrap.sh` (macOS/Linux) and
+`scripts/bootstrap.ps1` (Windows) run the commands above for you — see
+"Clone the Repository" below.
+
 ---
 
 ## Clone the Repository
@@ -95,6 +99,29 @@ See full instructions: https://taskfile.dev/installation/
 git clone https://github.com/agentmuxai/agentmux.git
 cd agentmux
 ```
+
+## Bootstrap and Initialize
+
+On a fresh machine with nothing installed, two steps get you to a working
+dev environment:
+
+```bash
+# 1. Get Task itself installed (macOS/Linux):
+sh scripts/bootstrap.sh
+# ...or on Windows (PowerShell):
+powershell -ExecutionPolicy Bypass -File scripts\bootstrap.ps1
+
+# 2. Verify the rest of the toolchain (Rust/Node/CMake/Ninja/git) and
+#    install frontend dependencies:
+task init
+```
+
+`task init` fails with a clear message (and does not run `npm install`) if
+anything required is still missing or the wrong version — reinstall the
+flagged tool and re-run it. It cannot install Task itself; that circularity
+is exactly why step 1 exists as a separate, non-Task script.
+
+If you already have Task installed, you can skip straight to `task init`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -83,9 +83,14 @@ Platform-specific:
 
 ### Development
 
+Starting from nothing (no Task, no toolchain installed yet)? See
+[BUILD.md](./BUILD.md#bootstrap-and-initialize) for `scripts/bootstrap.sh` /
+`scripts/bootstrap.ps1` and `task init`, which verify/install the
+prerequisites above before you run anything else.
+
 ```bash
-npm install        # install frontend dependencies
-task dev           # CEF host + Vite hot reload
+task init           # verify toolchain, install frontend dependencies
+task dev            # CEF host + Vite hot reload
 ```
 
 ### Production Build

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -371,7 +371,7 @@ tasks:
     init:
         desc: 'Initialize the project for development: verify the required toolchain is present (Rust/Node/CMake/Ninja/git), then npm install. See scripts/bootstrap.sh / scripts/bootstrap.ps1 first if Task itself was just installed.'
         cmds:
-            - bash scripts/check-toolchain.sh
+            - sh scripts/check-toolchain.sh
             - npm install
 
     dev:cleardata:windows:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -369,8 +369,9 @@ tasks:
             - task: dev:cleardata:macos
 
     init:
-        desc: Initialize the project for development.
+        desc: 'Initialize the project for development: verify the required toolchain is present (Rust/Node/CMake/Ninja/git), then npm install. See scripts/bootstrap.sh / scripts/bootstrap.ps1 first if Task itself was just installed.'
         cmds:
+            - bash scripts/check-toolchain.sh
             - npm install
 
     dev:cleardata:windows:

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -1,0 +1,46 @@
+# Entry point for a brand-new Windows machine with nothing installed yet —
+# deliberately outside Task, because reaching `task init` at all already
+# requires Task to be installed and working (Codex review finding on the
+# fresh-PC onboarding audit, #2940: `task init` cannot be what
+# detects/installs Task itself, that's circular on exactly the scenario
+# this exists for).
+#
+# This script only gets you as far as `task` being on PATH. Everything
+# after that -- Rust/Node/CMake/Ninja/git -- is `task init`'s job
+# (scripts/check-toolchain.sh, run via Git Bash), once Task itself exists.
+#
+# Usage (PowerShell):
+#   irm https://raw.githubusercontent.com/agentmuxai/agentmux/main/scripts/bootstrap.ps1 | iex
+#   # or, after cloning:
+#   powershell -ExecutionPolicy Bypass -File scripts\bootstrap.ps1
+
+$ErrorActionPreference = "Stop"
+
+if (Get-Command task -ErrorAction SilentlyContinue) {
+    $version = (task --version)
+    Write-Host "Task is already installed: $version"
+    Write-Host "Next: task init"
+    exit 0
+}
+
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    Write-Host "winget is not available on this system."
+    Write-Host "Install Task manually: https://taskfile.dev/installation/"
+    exit 1
+}
+
+Write-Host "Task not found. Installing via winget..."
+winget install Task.Task
+
+if (Get-Command task -ErrorAction SilentlyContinue) {
+    $version = (task --version)
+    Write-Host ""
+    Write-Host "Task installed: $version"
+    Write-Host "You may need to open a new terminal for PATH changes to take effect."
+    Write-Host "Next: clone the repo if you haven't, cd into it, then run: task init"
+} else {
+    Write-Host ""
+    Write-Host "winget reported success but 'task' is still not on PATH."
+    Write-Host "Open a new terminal and try again, or see: https://taskfile.dev/installation/"
+    exit 1
+}

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -67,17 +67,87 @@ function Install-WithWinget {
     return $false
 }
 
+# A working `git` on PATH does NOT imply `sh`/`bash` are too. Per this
+# repo's own CLAUDE.md ("Gap B"): a standard Git for Windows install adds
+# `Git\cmd` (git.exe and other shims) to PATH, not `Git\bin` where
+# sh.exe/bash.exe live. Two independent reviewers on PR #2943 caught that my
+# first fix here assumed installing Git was sufficient to unblock `task
+# init`'s `sh scripts/check-toolchain.sh` -- it wasn't.
+#
+# My first attempt at a real fix derived Git's bin directory from wherever
+# `Get-Command git` currently resolved (e.g. going up from .../cmd or
+# .../bin). Testing it on this machine caught a second, worse bug in that
+# approach before it shipped: here `git` resolves via `Git\mingw64\bin`
+# (some other PATH entry wins ahead of the standard shim), so deriving from
+# it computed `Git\mingw64\bin` as the target -- which contains a git.exe
+# but NOT sh.exe (that's under `Git\usr\bin`, a sibling of `mingw64`, not a
+# child of it). The derivation is exactly the kind of "looks right, isn't"
+# logic this whole onboarding effort exists to catch.
+#
+# scripts/dev-agent.cmd already solves this exact problem, for the exact
+# same reason (go-task spawning bash on Windows), by hardcoding the standard
+# Git for Windows install location instead of deriving it -- confirmed
+# real on this machine: sh.exe and bash.exe genuinely exist under
+# `Git\bin`, and sh.exe also under `Git\usr\bin`, regardless of what `git`
+# currently resolves to via other PATH entries. Matching that precedent
+# here rather than reinventing a fragile derivation.
+function Ensure-GitShellOnPath {
+    if (Get-Command sh -ErrorAction SilentlyContinue) {
+        return $true
+    }
+
+    $candidates = @(
+        "$env:ProgramFiles\Git\bin",
+        "$env:ProgramFiles\Git\usr\bin",
+        "${env:ProgramFiles(x86)}\Git\bin",
+        "${env:ProgramFiles(x86)}\Git\usr\bin"
+    )
+    $found = $candidates | Where-Object { Test-Path (Join-Path $_ "sh.exe") }
+
+    if (-not $found) {
+        Write-Host "Could not locate sh.exe under any standard Git for Windows install path ($($candidates -join ', '))."
+        Write-Host "If Git is installed somewhere else, add its bin directory to PATH manually."
+        return $false
+    }
+
+    foreach ($dir in $found) {
+        if ($env:Path -notlike "*$dir*") {
+            $env:Path = "$dir;$env:Path"
+        }
+    }
+
+    # Persist to the User PATH too, so a new terminal also has it without
+    # re-running this script -- Update-SessionPath only fixes the current
+    # process; without this, `task init` would work now but break again
+    # after closing this terminal.
+    $currentUserPath = [System.Environment]::GetEnvironmentVariable("Path", "User")
+    $toAdd = $found | Where-Object { $currentUserPath -notlike "*$_*" }
+    if ($toAdd) {
+        [System.Environment]::SetEnvironmentVariable("Path", ($currentUserPath, ($toAdd -join ";") -join ";"), "User")
+    }
+
+    return [bool](Get-Command sh -ErrorAction SilentlyContinue)
+}
+
 $gitOk = Install-WithWinget -DisplayName "Git" -Command "git" -WingetId "Git.Git"
+$shellOk = $false
+if ($gitOk) {
+    $shellOk = Ensure-GitShellOnPath
+    if (-not $shellOk) {
+        Write-Host "Git is installed but its shell (sh.exe/bash.exe) could not be found or added to PATH."
+        Write-Host "task init and other Task cross-platform commands need this -- see CLAUDE.md's Gap A/B notes."
+    }
+}
 $taskOk = Install-WithWinget -DisplayName "Task" -Command "task" -WingetId "Task.Task"
 
 Write-Host ""
 
-if ($gitOk -and $taskOk) {
-    Write-Host "Git and Task are both ready: $(git --version), $(task --version)"
+if ($gitOk -and $shellOk -and $taskOk) {
+    Write-Host "Git (with its shell on PATH) and Task are both ready: $(git --version), $(task --version)"
     Write-Host "Next: clone the repo if you haven't, cd into it, then run: task init"
     exit 0
 } else {
-    Write-Host "One or more tools could not be confirmed on PATH in this session."
+    Write-Host "One or more tools (or Git's shell) could not be confirmed on PATH in this session."
     Write-Host "Open a NEW terminal (PATH changes from installers often don't reach this one) and re-run this script."
     exit 1
 }

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -1,46 +1,83 @@
-# Entry point for a brand-new Windows machine with nothing installed yet —
+# Entry point for a brand-new Windows machine with nothing installed yet --
 # deliberately outside Task, because reaching `task init` at all already
-# requires Task to be installed and working (Codex review finding on the
-# fresh-PC onboarding audit, #2940: `task init` cannot be what
+# requires Task to be installed and working (Codex/reagent review finding on
+# the fresh-PC onboarding audit, #2940/#2943: `task init` cannot be what
 # detects/installs Task itself, that's circular on exactly the scenario
 # this exists for).
 #
-# This script only gets you as far as `task` being on PATH. Everything
-# after that -- Rust/Node/CMake/Ninja/git -- is `task init`'s job
-# (scripts/check-toolchain.sh, run via Git Bash), once Task itself exists.
+# Installs Git first, then Task. Git matters here for two reasons, both
+# raised in review of the first version of this script (which only
+# installed Task): a stock Windows machine has no way to `git clone` this
+# repo without it, and Task's own cross-platform tasks (init, dev, changeset,
+# release) invoke `sh`/`bash` for their cmds -- which Git for Windows is what
+# actually provides on Windows. Installing Task alone would get you to
+# `task init` only to have it fail with a raw "'sh' is not recognized"
+# instead of the intended diagnostic -- the same circularity this script
+# exists to avoid, one layer down.
 #
-# Usage (PowerShell):
+# Usage (PowerShell) -- this is the one entry point that works on a machine
+# with NOTHING installed yet, since it doesn't need git to already exist:
 #   irm https://raw.githubusercontent.com/agentmuxai/agentmux/main/scripts/bootstrap.ps1 | iex
-#   # or, after cloning:
+#   # or, after cloning some other way (zip download, GitHub Desktop, etc.):
 #   powershell -ExecutionPolicy Bypass -File scripts\bootstrap.ps1
 
 $ErrorActionPreference = "Stop"
 
-if (Get-Command task -ErrorAction SilentlyContinue) {
-    $version = (task --version)
-    Write-Host "Task is already installed: $version"
-    Write-Host "Next: task init"
-    exit 0
+# winget updates the registry PATH but does not propagate it to this
+# already-running process (reagent review finding on PR #2943: without this,
+# `Get-Command task` right after `winget install Task.Task` typically still
+# fails on the common success path, since $env:Path here is a snapshot taken
+# at process start). Re-reading both PATH scopes from the registry after each
+# install and rebuilding $env:Path is the standard fix.
+function Update-SessionPath {
+    $machinePath = [System.Environment]::GetEnvironmentVariable("Path", "Machine")
+    $userPath = [System.Environment]::GetEnvironmentVariable("Path", "User")
+    $env:Path = "$machinePath;$userPath"
 }
 
-if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
-    Write-Host "winget is not available on this system."
-    Write-Host "Install Task manually: https://taskfile.dev/installation/"
-    exit 1
+function Install-WithWinget {
+    param(
+        [string]$DisplayName,
+        [string]$Command,
+        [string]$WingetId
+    )
+
+    if (Get-Command $Command -ErrorAction SilentlyContinue) {
+        Write-Host "$DisplayName is already installed."
+        return $true
+    }
+
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+        Write-Host "$DisplayName not found, and winget is not available on this system."
+        Write-Host "Install $DisplayName manually, then re-run this script."
+        return $false
+    }
+
+    Write-Host "$DisplayName not found. Installing via winget ($WingetId)..."
+    winget install --id $WingetId --silent --accept-package-agreements --accept-source-agreements
+    Update-SessionPath
+
+    if (Get-Command $Command -ErrorAction SilentlyContinue) {
+        Write-Host "$DisplayName installed."
+        return $true
+    }
+
+    Write-Host "winget reported success but '$Command' is still not on PATH in this session."
+    Write-Host "Open a new terminal and re-run this script to confirm, or install manually."
+    return $false
 }
 
-Write-Host "Task not found. Installing via winget..."
-winget install Task.Task
+$gitOk = Install-WithWinget -DisplayName "Git" -Command "git" -WingetId "Git.Git"
+$taskOk = Install-WithWinget -DisplayName "Task" -Command "task" -WingetId "Task.Task"
 
-if (Get-Command task -ErrorAction SilentlyContinue) {
-    $version = (task --version)
-    Write-Host ""
-    Write-Host "Task installed: $version"
-    Write-Host "You may need to open a new terminal for PATH changes to take effect."
+Write-Host ""
+
+if ($gitOk -and $taskOk) {
+    Write-Host "Git and Task are both ready: $(git --version), $(task --version)"
     Write-Host "Next: clone the repo if you haven't, cd into it, then run: task init"
+    exit 0
 } else {
-    Write-Host ""
-    Write-Host "winget reported success but 'task' is still not on PATH."
-    Write-Host "Open a new terminal and try again, or see: https://taskfile.dev/installation/"
+    Write-Host "One or more tools could not be confirmed on PATH in this session."
+    Write-Host "Open a NEW terminal (PATH changes from installers often don't reach this one) and re-run this script."
     exit 1
 }

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env sh
+# Entry point for a brand-new macOS/Linux machine with nothing installed yet
+# — deliberately POSIX sh, not bash, and deliberately outside Task, because
+# reaching `task init` at all already requires Task to be installed and
+# working (Codex review finding on the fresh-PC onboarding audit, #2940:
+# `task init` cannot be what detects/installs Task itself, that's circular
+# on exactly the scenario this exists for).
+#
+# This script only gets you as far as `task` being on PATH. Everything
+# after that — Rust/Node/CMake/Ninja/git — is `task init`'s job
+# (scripts/check-toolchain.sh), run once Task itself exists.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/agentmuxai/agentmux/main/scripts/bootstrap.sh | sh
+#   # or, after cloning:
+#   sh scripts/bootstrap.sh
+set -eu
+
+if command -v task >/dev/null 2>&1; then
+  echo "Task is already installed: $(task --version)"
+  echo "Next: task init"
+  exit 0
+fi
+
+case "$(uname -s)" in
+  Darwin)
+    echo "Task not found. Installing via Homebrew..."
+    if ! command -v brew >/dev/null 2>&1; then
+      echo "Homebrew is not installed either. Install it first: https://brew.sh/"
+      echo "Then re-run this script, or install Task directly: https://taskfile.dev/installation/"
+      exit 1
+    fi
+    brew install go-task/tap/go-task
+    ;;
+  Linux)
+    echo "Task not found. Installing via snap..."
+    if ! command -v snap >/dev/null 2>&1; then
+      echo "snap is not available on this system. Install Task manually: https://taskfile.dev/installation/"
+      exit 1
+    fi
+    sudo snap install task --classic
+    ;;
+  *)
+    echo "Unrecognized platform ($(uname -s)). Install Task manually: https://taskfile.dev/installation/"
+    exit 1
+    ;;
+esac
+
+echo
+echo "Task installed: $(task --version)"
+echo "Next: clone the repo if you haven't, cd into it, then run: task init"

--- a/scripts/check-toolchain.sh
+++ b/scripts/check-toolchain.sh
@@ -1,17 +1,24 @@
-#!/usr/bin/env bash
-# Checks that the tools task dev/task package actually need are present,
-# before npm install runs and fails with a confusing error instead. See
+#!/bin/sh
+# Checks that the tools task dev/task package actually need are present AND
+# meet the documented minimum versions, before npm install runs and fails
+# with a confusing error instead. See
 # docs/reports/REPORT_FRESH_PC_ONBOARDING_AUDIT_2026_09_02.md and tracking
 # issue #2940 — nothing in this repo checked for Rust/CMake/Ninja/git
-# presence before this, so a missing one surfaced as a raw cargo/cef-dll-sys
-# build error deep into `task dev`, not a clear message up front.
+# presence before this, so a missing (or too-old) one surfaced as a raw
+# cargo/cef-dll-sys build error deep into `task dev`, not a clear message up
+# front (Codex review finding on PR #2943: an earlier version of this script
+# checked presence only, so an obsolete cargo/cmake/ninja still reported OK
+# and the same later build failure this exists to prevent still happened).
 #
 # Deliberately does NOT check for Task itself — reaching this script at all
 # already requires Task to be installed and working. That check lives in
 # scripts/bootstrap.sh / scripts/bootstrap.ps1 instead, which run before
-# Task exists (Codex review finding on PR #2941/#2940: a Task-based check
-# for Task is circular on exactly the fresh-PC scenario this exists for).
-set -uo pipefail
+# Task exists (Codex/reagent review finding on PR #2941/#2943: a Task-based
+# check for Task is circular on exactly the fresh-PC scenario this exists
+# for). For the same reason this script itself is invoked via `sh`, not
+# `bash` — bootstrap.ps1 is responsible for getting a shell onto PATH on
+# Windows in the first place.
+set -u
 
 case "$(uname -s)" in
   Darwin) OS_NAME=macos ;;
@@ -22,14 +29,56 @@ esac
 
 FAIL=0
 
+# $1 >= $2 for dotted version strings (e.g. "1.93.0" "1.77"). Pure POSIX —
+# no bc/awk dependency, so it works identically in dash, ash/busybox sh, and
+# bash's sh-compat mode.
+version_ge() {
+  i=1
+  while true; do
+    p1="$(echo "$1" | cut -d. -f"$i")"
+    p2="$(echo "$2" | cut -d. -f"$i")"
+    [ -z "$p1" ] && [ -z "$p2" ] && return 0
+    p1="${p1:-0}"
+    p2="${p2:-0}"
+    if [ "$p1" -gt "$p2" ] 2>/dev/null; then return 0; fi
+    if [ "$p1" -lt "$p2" ] 2>/dev/null; then return 1; fi
+    i=$((i + 1))
+  done
+}
+
+extract_version() {
+  echo "$1" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+|[0-9]+\.[0-9]+' | head -1
+}
+
+# check <display name> <command> <min version, or empty to skip the check> <install instructions>
 check() {
-  local name="$1" cmd="$2" instructions="$3"
-  if command -v "$cmd" >/dev/null 2>&1; then
-    local version
-    version="$("$cmd" --version 2>/dev/null | head -1)"
-    echo "  OK   $name — $version"
-  else
+  local name="$1" cmd="$2" min="$3" instructions="$4"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "  MISSING  $name"
+    echo "           $instructions"
+    FAIL=1
+    return
+  fi
+
+  local raw
+  raw="$("$cmd" --version 2>/dev/null | head -1)"
+
+  if [ -z "$min" ]; then
+    echo "  OK   $name — $raw"
+    return
+  fi
+
+  local found
+  found="$(extract_version "$raw")"
+  if [ -z "$found" ]; then
+    echo "  OK   $name — $raw (could not parse version to check against >=$min; assuming fine)"
+    return
+  fi
+
+  if version_ge "$found" "$min"; then
+    echo "  OK   $name — $raw"
+  else
+    echo "  TOO OLD  $name — found $found, need >=$min"
     echo "           $instructions"
     FAIL=1
   fi
@@ -38,26 +87,26 @@ check() {
 echo "Checking required toolchain (platform: $OS_NAME)..."
 echo
 
-check "git" git "https://git-scm.com/downloads"
+check "git" git "" "https://git-scm.com/downloads"
 
 case "$OS_NAME" in
   macos)
-    check "rust (cargo)" cargo "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
-    check "cmake" cmake "brew install cmake"
-    check "ninja" ninja "brew install ninja"
+    check "rust (cargo)" cargo "1.77" "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh, or: rustup update"
+    check "cmake" cmake "3.20" "brew install cmake  (or: brew upgrade cmake)"
+    check "ninja" ninja "1.10" "brew install ninja  (or: brew upgrade ninja)"
     ;;
   linux)
-    check "rust (cargo)" cargo "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
-    check "cmake" cmake "sudo apt install cmake ninja-build build-essential curl wget file libssl-dev git zip libwayland-dev libxkbcommon-dev libgtk-3-dev libglib2.0-dev libpango1.0-dev libcairo2-dev libgdk-pixbuf2.0-dev libatk1.0-dev"
-    check "ninja" ninja "sudo apt install cmake ninja-build build-essential curl wget file libssl-dev git zip libwayland-dev libxkbcommon-dev libgtk-3-dev libglib2.0-dev libpango1.0-dev libcairo2-dev libgdk-pixbuf2.0-dev libatk1.0-dev"
+    check "rust (cargo)" cargo "1.77" "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh, or: rustup update"
+    check "cmake" cmake "3.20" "sudo apt install cmake ninja-build build-essential curl wget file libssl-dev git zip libwayland-dev libxkbcommon-dev libgtk-3-dev libglib2.0-dev libpango1.0-dev libcairo2-dev libgdk-pixbuf2.0-dev libatk1.0-dev"
+    check "ninja" ninja "1.10" "sudo apt install cmake ninja-build build-essential curl wget file libssl-dev git zip libwayland-dev libxkbcommon-dev libgtk-3-dev libglib2.0-dev libpango1.0-dev libcairo2-dev libgdk-pixbuf2.0-dev libatk1.0-dev"
     ;;
   windows)
-    check "rust (cargo)" cargo "https://rustup.rs/ (rustup-init.exe), then install Visual Studio Build Tools with the 'Desktop development with C++' workload"
-    check "cmake" cmake "Ships with Visual Studio Build Tools — install the 'Desktop development with C++' workload from https://visualstudio.microsoft.com/visual-cpp-build-tools/"
-    check "ninja" ninja "Ships with Visual Studio but is not always on PATH — see CLAUDE.md's Build Prerequisites section for the exact copy command"
+    check "rust (cargo)" cargo "1.77" "https://rustup.rs/ (rustup-init.exe), then install Visual Studio Build Tools with the 'Desktop development with C++' workload, or: rustup update"
+    check "cmake" cmake "3.20" "Ships with Visual Studio Build Tools — install the 'Desktop development with C++' workload from https://visualstudio.microsoft.com/visual-cpp-build-tools/"
+    check "ninja" ninja "1.10" "Ships with Visual Studio but is not always on PATH — see CLAUDE.md's Build Prerequisites section for the exact copy command"
     ;;
   *)
-    echo "  Unrecognized platform ($OS_NAME) — skipping cmake/ninja/rust checks. See BUILD.md."
+    echo "  Unrecognized platform ($OS_NAME) — skipping cmake/ninja/rust version checks. See BUILD.md."
     ;;
 esac
 
@@ -83,8 +132,8 @@ fi
 echo
 
 if [ "$FAIL" -ne 0 ]; then
-  echo "One or more required tools are missing or the wrong version. Install them and re-run 'task init'."
+  echo "One or more required tools are missing or below the minimum version. Install/upgrade them and re-run 'task init'."
   exit 1
 fi
 
-echo "All required tools present."
+echo "All required tools present and up to date."

--- a/scripts/check-toolchain.sh
+++ b/scripts/check-toolchain.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Checks that the tools task dev/task package actually need are present,
+# before npm install runs and fails with a confusing error instead. See
+# docs/reports/REPORT_FRESH_PC_ONBOARDING_AUDIT_2026_09_02.md and tracking
+# issue #2940 — nothing in this repo checked for Rust/CMake/Ninja/git
+# presence before this, so a missing one surfaced as a raw cargo/cef-dll-sys
+# build error deep into `task dev`, not a clear message up front.
+#
+# Deliberately does NOT check for Task itself — reaching this script at all
+# already requires Task to be installed and working. That check lives in
+# scripts/bootstrap.sh / scripts/bootstrap.ps1 instead, which run before
+# Task exists (Codex review finding on PR #2941/#2940: a Task-based check
+# for Task is circular on exactly the fresh-PC scenario this exists for).
+set -uo pipefail
+
+case "$(uname -s)" in
+  Darwin) OS_NAME=macos ;;
+  Linux) OS_NAME=linux ;;
+  MINGW*|MSYS*|CYGWIN*) OS_NAME=windows ;;
+  *) OS_NAME=unknown ;;
+esac
+
+FAIL=0
+
+check() {
+  local name="$1" cmd="$2" instructions="$3"
+  if command -v "$cmd" >/dev/null 2>&1; then
+    local version
+    version="$("$cmd" --version 2>/dev/null | head -1)"
+    echo "  OK   $name — $version"
+  else
+    echo "  MISSING  $name"
+    echo "           $instructions"
+    FAIL=1
+  fi
+}
+
+echo "Checking required toolchain (platform: $OS_NAME)..."
+echo
+
+check "git" git "https://git-scm.com/downloads"
+
+case "$OS_NAME" in
+  macos)
+    check "rust (cargo)" cargo "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+    check "cmake" cmake "brew install cmake"
+    check "ninja" ninja "brew install ninja"
+    ;;
+  linux)
+    check "rust (cargo)" cargo "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+    check "cmake" cmake "sudo apt install cmake ninja-build build-essential curl wget file libssl-dev git zip libwayland-dev libxkbcommon-dev libgtk-3-dev libglib2.0-dev libpango1.0-dev libcairo2-dev libgdk-pixbuf2.0-dev libatk1.0-dev"
+    check "ninja" ninja "sudo apt install cmake ninja-build build-essential curl wget file libssl-dev git zip libwayland-dev libxkbcommon-dev libgtk-3-dev libglib2.0-dev libpango1.0-dev libcairo2-dev libgdk-pixbuf2.0-dev libatk1.0-dev"
+    ;;
+  windows)
+    check "rust (cargo)" cargo "https://rustup.rs/ (rustup-init.exe), then install Visual Studio Build Tools with the 'Desktop development with C++' workload"
+    check "cmake" cmake "Ships with Visual Studio Build Tools — install the 'Desktop development with C++' workload from https://visualstudio.microsoft.com/visual-cpp-build-tools/"
+    check "ninja" ninja "Ships with Visual Studio but is not always on PATH — see CLAUDE.md's Build Prerequisites section for the exact copy command"
+    ;;
+  *)
+    echo "  Unrecognized platform ($OS_NAME) — skipping cmake/ninja/rust checks. See BUILD.md."
+    ;;
+esac
+
+echo
+
+if command -v node >/dev/null 2>&1; then
+  NODE_VERSION="$(node --version 2>/dev/null)"
+  NODE_MAJOR="${NODE_VERSION#v}"
+  NODE_MAJOR="${NODE_MAJOR%%.*}"
+  if [ -n "$NODE_MAJOR" ] && [ "$NODE_MAJOR" -ge 24 ] 2>/dev/null; then
+    echo "  OK   node.js — $NODE_VERSION"
+  else
+    echo "  WRONG VERSION  node.js — found $NODE_VERSION, need >=24 (see .nvmrc)"
+    echo "                 https://nodejs.org/ or nvm install 24"
+    FAIL=1
+  fi
+else
+  echo "  MISSING  node.js"
+  echo "           https://nodejs.org/ or nvm install 24 — need >=24, see .nvmrc"
+  FAIL=1
+fi
+
+echo
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "One or more required tools are missing or the wrong version. Install them and re-run 'task init'."
+  exit 1
+fi
+
+echo "All required tools present."


### PR DESCRIPTION
## Summary

Second piece of the fresh-PC onboarding work (#2940), following the doc fixes in #2942.

`task init` existed already but did only `npm install` — no Rust/Node/CMake/Ninja/git checks — and wasn't documented anywhere. The obvious next step (grow `task init` into a real bootstrap) has a bug on exactly the scenario it targets: reaching `task init` at all already requires Task itself to be installed. Codex caught this as a P2 while reviewing the audit report on #2941, before any code existed for it — fixing it here rather than shipping the circular version.

Split into two layers:

- **`scripts/bootstrap.sh`** (POSIX sh, macOS/Linux) and **`scripts/bootstrap.ps1`** (native PowerShell, Windows) — check for `task` on PATH; if missing, install it via the exact brew/snap/winget commands BUILD.md already documents (single source of truth, not a second copy that can drift). Deliberately outside Task, and `bootstrap.ps1` deliberately doesn't assume bash is installed yet.
- **`scripts/check-toolchain.sh`** — checks git/rust/cmake/ninja/node (version, not just presence — must be `>=24` per `.nvmrc`), reusing BUILD.md's install commands verbatim. Non-zero exit blocks `npm install` from running against a broken toolchain and producing a confusing raw `cargo`/`cef-dll-sys` error instead.
- `task init` now runs `check-toolchain.sh` before `npm install`.

README.md and BUILD.md updated to document both entry points, with `task init` and the bootstrap scripts wired together (BUILD.md's new "Bootstrap and Initialize" section, linked from README).

## Test plan

Verified end-to-end on this Windows machine:
- [x] Happy path — all tools present, `check-toolchain.sh` reports OK for each, exit 0
- [x] Missing-tool path — excluded ninja from PATH, script correctly reports MISSING with the install command, exit 1
- [x] Wrong-version path — faked a `node --version` shim reporting v18, script correctly reports WRONG VERSION, exit 1
- [x] Full `task init` run completes successfully (toolchain check + `npm install`)
- [x] `bootstrap.sh`/`bootstrap.ps1`'s "Task already installed" path, on this machine
- [x] `check-doc-status.sh` / `check-spec-citations.sh` — clean
- [ ] `bootstrap.sh`/`bootstrap.ps1`'s actual install branches (brew/snap/winget) — not verified; I won't uninstall Task on this machine to test them, and Linux/macOS aren't available in this environment
- [ ] Real verification on the fresh Windows/Ubuntu machines — tracked in #2940's plan, not claimed here

<!-- agentmux:agent_id=camper -->