### PR TITLE
feat(agent): hh:mm:ss dock timer, and label the tab strip's + as "+ New Agent"

### DIFF
--- a/.changesets/1788420752-feat-agent-label-the-agent-pane-tab-strip-s-button-as-new-ag-wija.md
+++ b/.changesets/1788420752-feat-agent-label-the-agent-pane-tab-strip-s-button-as-new-ag-wija.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent): label the agent pane tab strip's + button as "+ New Agent"

--- a/.changesets/1788420752-fix-dock-elapsed-clock-now-grows-hours-and-days-fields-inste-l0cd.md
+++ b/.changesets/1788420752-fix-dock-elapsed-clock-now-grows-hours-and-days-fields-inste-l0cd.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(dock): elapsed clock now grows hours and days fields instead of counting minutes past 60

--- a/frontend/app/element/PaneTabStrip.scss
+++ b/frontend/app/element/PaneTabStrip.scss
@@ -268,6 +268,28 @@
     }
 }
 
+// Labeled variant — opt-in via PaneTabStrip's `addLabel` prop (the agent pane's
+// "+ New Agent"). The bare 28×28px square above stays the default for the
+// editor and terminal strips, which have no label.
+//
+// `width: auto` rather than a wider fixed width: the label is caller-supplied,
+// so the button has to size to whatever text it is given. Note this widens the
+// tab strip itself, which in the agent pane is deliberately shrink-to-fit and
+// overlays the conversation (SPEC_AGENT_PANE_TAB_STRIP_OVERLAY_2026_08_10.md) —
+// so a longer label covers correspondingly more of the content beneath it.
+.pane-tab-strip-add-labeled {
+    width: auto;
+    padding: 0 8px;
+    gap: 4px;
+}
+
+// Smaller than the 15px glyph it sits beside: this is a text affordance, and at
+// the glyph's own size it would out-weigh the actual tab labels next to it.
+.pane-tab-strip-add-label {
+    font-size: 11px;
+    white-space: nowrap;
+}
+
 // The "+" glyph's own line box (centered by the button's flex align-items/
 // justify-content above) isn't the same as its visual ink — measured live
 // (screenshot pixel-sampling, 2026-08-25) at ~1-2px low relative to the

--- a/frontend/app/element/PaneTabStrip.test.tsx
+++ b/frontend/app/element/PaneTabStrip.test.tsx
@@ -177,6 +177,47 @@ describe("PaneTabStrip", () => {
         expect(onAdd).toHaveBeenCalledTimes(1);
     });
 
+    // The agent pane's "+ New Agent". Opt-in per pane so the editor and
+    // terminal strips keep the bare 28×28px glyph.
+    it("renders visible text beside the + when addLabel is given", () => {
+        const { container } = render(() => (
+            <PaneTabStrip
+                tabs={TABS}
+                activeId="a"
+                getId={(t: T) => t.id}
+                getLabel={(t: T) => t.label}
+                onActivate={vi.fn()}
+                onAdd={vi.fn()}
+                addTitle="New agent"
+                addLabel="New Agent"
+            />
+        ));
+        // Named by the label, not the tooltip — the visible text is what a
+        // screen reader should announce once there is one.
+        const addBtn = screen.getByRole("button", { name: "New Agent" });
+        expect(addBtn.textContent).toContain("+");
+        expect(addBtn.textContent).toContain("New Agent");
+        expect(container.querySelector(".pane-tab-strip-add-labeled")).toBe(addBtn);
+    });
+
+    it("stays a bare glyph — no label span, no widening class — without addLabel", () => {
+        const { container } = render(() => (
+            <PaneTabStrip
+                tabs={TABS}
+                activeId="a"
+                getId={(t: T) => t.id}
+                getLabel={(t: T) => t.label}
+                onActivate={vi.fn()}
+                onAdd={vi.fn()}
+                addTitle="New shell tab"
+            />
+        ));
+        const addBtn = screen.getByRole("button", { name: "New shell tab" });
+        expect(addBtn.textContent).toBe("+");
+        expect(container.querySelector(".pane-tab-strip-add-label")).toBeNull();
+        expect(container.querySelector(".pane-tab-strip-add-labeled")).toBeNull();
+    });
+
     it("renders custom label content from renderLabel instead of the plain label", () => {
         render(() => (
             <PaneTabStrip

--- a/frontend/app/element/PaneTabStrip.tsx
+++ b/frontend/app/element/PaneTabStrip.tsx
@@ -80,6 +80,10 @@ export interface PaneTabStripProps<T> {
      *  strip scroll state. */
     onAdd?: () => void;
     addTitle?: string;
+    /** Visible text beside the `+` glyph, e.g. "New Agent". Opt-in per pane:
+     *  omitted, the button stays the bare 28×28px glyph the editor and
+     *  terminal strips use, so labelling one pane can't widen the others. */
+    addLabel?: string;
 }
 
 export function PaneTabStrip<T>(props: PaneTabStripProps<T>): JSX.Element {
@@ -206,15 +210,18 @@ export function PaneTabStrip<T>(props: PaneTabStripProps<T>): JSX.Element {
                 <Show when={props.onAdd}>
                     <button
                         type="button"
-                        class="pane-tab-strip-add"
+                        class={`pane-tab-strip-add${props.addLabel ? " pane-tab-strip-add-labeled" : ""}`}
                         title={props.addTitle ?? "New tab"}
-                        aria-label={props.addTitle ?? "New tab"}
+                        aria-label={props.addLabel ?? props.addTitle ?? "New tab"}
                         onClick={() => props.onAdd!()}
                     >
                         {/* Wrapped so the glyph itself can be nudged (PaneTabStrip.scss's
                             .pane-tab-strip-add-glyph) without moving the button's own
                             box/hover-background/border — see that rule's comment. */}
                         <span class="pane-tab-strip-add-glyph">+</span>
+                        <Show when={props.addLabel}>
+                            <span class="pane-tab-strip-add-label">{props.addLabel}</span>
+                        </Show>
                     </button>
                 </Show>
             </div>

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -563,7 +563,8 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
                             )
                         }
                         onAdd={() => void handleNewAgentTab()}
-                        addTitle="New tab"
+                        addTitle="New agent"
+                        addLabel="New Agent"
                     />
                     <Show
                         when={isHistoryTab()}

--- a/frontend/util/format-time.test.ts
+++ b/frontend/util/format-time.test.ts
@@ -34,6 +34,28 @@ describe("formatElapsedClock", () => {
     it("floors negative durations to 0:00 (fixes the PersistentShellBlock gap)", () => {
         expect(formatElapsedClock(-65_000)).toBe("0:00");
     });
+
+    // The dock exists for processes that outlive a turn, so the minutes field
+    // overflowing past 60 was the common case, not an edge case.
+    it("grows an hours field instead of counting minutes past 60", () => {
+        expect(formatElapsedClock(3_599_000)).toBe("59:59");
+        expect(formatElapsedClock(3_600_000)).toBe("1:00:00");
+        expect(formatElapsedClock(4_505_000)).toBe("1:15:05");
+        // Previously rendered "75:03".
+        expect(formatElapsedClock(4_503_000)).toBe("1:15:03");
+    });
+
+    it("grows a days field instead of counting hours past 24", () => {
+        expect(formatElapsedClock(86_399_000)).toBe("23:59:59");
+        expect(formatElapsedClock(86_400_000)).toBe("1:00:00:00");
+        // Previously rendered "1508:22".
+        expect(formatElapsedClock(90_502_000)).toBe("1:01:08:22");
+    });
+
+    it("keeps the short form short — no leading zero fields under an hour", () => {
+        expect(formatElapsedClock(5_000)).toBe("0:05");
+        expect(formatElapsedClock(600_000)).toBe("10:00");
+    });
 });
 
 describe("formatTimeAgo", () => {

--- a/frontend/util/format-time.ts
+++ b/frontend/util/format-time.ts
@@ -23,16 +23,36 @@ export function formatElapsedCompact(ms: number): string {
 }
 
 /**
- * Clock form: "M:SS", zero-padded seconds. Floors negative durations to 0 —
- * one of the 5 original copies (`PersistentShellBlock.tsx`) was missing this
- * guard and could render e.g. "-1:05" on a clock-skew edge case; the other
- * clock-style copies already had it.
+ * Clock form, growing a field at a time as the duration does:
+ * `M:SS` → `H:MM:SS` → `D:HH:MM:SS`.
+ *
+ * The hour and day fields are not cosmetic. This drives the long-running
+ * process dock, whose whole purpose is processes that outlive a turn, and the
+ * minutes-only form silently kept counting past 60 — an hour-old `task dev`
+ * read "75:03", which is not a duration anyone can parse at a glance, and a
+ * day-old one read "1508:22".
+ *
+ * Fields are added rather than always padded (no "0:00:05" for a five-second
+ * tool call) because the overwhelmingly common case is seconds-to-minutes, and
+ * the dock shows these inline next to a title where width matters. Same
+ * convention as ffmpeg/YouTube timestamps.
+ *
+ * Floors negative durations to 0 — one of the 5 original copies
+ * (`PersistentShellBlock.tsx`) was missing this guard and could render e.g.
+ * "-1:05" on a clock-skew edge case; the other clock-style copies already
+ * had it.
  */
 export function formatElapsedClock(ms: number): string {
     const totalSec = Math.max(0, Math.floor(ms / 1000));
-    const m = Math.floor(totalSec / 60);
     const s = totalSec % 60;
-    return `${m}:${String(s).padStart(2, "0")}`;
+    const m = Math.floor(totalSec / 60) % 60;
+    const h = Math.floor(totalSec / 3_600) % 24;
+    const d = Math.floor(totalSec / 86_400);
+
+    const ss = String(s).padStart(2, "0");
+    if (d > 0) return `${d}:${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:${ss}`;
+    if (h > 0) return `${h}:${String(m).padStart(2, "0")}:${ss}`;
+    return `${m}:${ss}`;
 }
 
 /**


### PR DESCRIPTION
Two small, independent UI tweaks.

## 1. Dock elapsed clock respects hours and days

`formatElapsedClock` rendered `M:SS` only, so the minutes field just kept counting:

| Duration | Before | After |
|---|---|---|
| 5s | `0:05` | `0:05` |
| 10m | `10:00` | `10:00` |
| 1h 15m 3s | `75:03` | `1:15:03` |
| 1d 1h 8m 22s | `1508:22` | `1:01:08:22` |

The long-running process dock exists precisely for processes that outlive a turn, so this was the common case, not an edge case.

**Judgement call worth flagging:** fields are *added* as needed (`M:SS` → `H:MM:SS` → `D:HH:MM:SS`) rather than always padded, so a five-second tool call still reads `0:05` and not `0:00:05`. These render inline next to a title where width matters, and seconds-to-minutes is the overwhelmingly common duration. Same convention as ffmpeg/YouTube. Happy to switch to a fixed `hh:mm:ss` at all times if that's what was wanted.

`formatElapsedClock` is shared, so the **persistent shell block** and the **swarm pane** get the same fix — they had the identical overflow.

## 2. Agent pane's "+" now reads "+ New Agent"

`PaneTabStrip` is shared with the editor and terminal strips, so this is an **opt-in `addLabel` prop**, not a change to the glyph. Without it the button stays the bare 28×28px square those panes use; only `agent-view.tsx` passes it.

Two consequences worth naming:

- It **widens the agent tab strip**, which is deliberately shrink-to-fit and overlays the conversation (`SPEC_AGENT_PANE_TAB_STRIP_OVERLAY_2026_08_10.md`), so the button now covers a little more of the content beneath it. That's inherent to putting text there.
- `aria-label` now prefers the visible label over the tooltip, since the visible text is what should be announced once one exists.

Label is 11px against the glyph's 15px — at the glyph's size it out-weighed the actual tab labels beside it.

## Testing

- Full frontend suite: **3550 passed, 0 failed**. `tsc --noEmit` clean.
- Six new cases: the hour and day thresholds (including the exact `75:03` and `1508:22` regressions); that the short form stays short; that `addLabel` renders the text and the widening class; and that an **unlabeled** strip still renders a bare `+` with neither — the guard that keeps the editor/terminal panes unchanged.

## Note

`npx eslint` fails to load its config in this checkout (`TypeError: Unexpected array`). I verified it fails identically on a clean stashed tree, so it is pre-existing and unrelated to this change — CI's lint step is the authority.

<!-- agentmux:agent_id=agent5 -->