### PR TITLE
fix(agent-pane): hide bashwrap's internal starting-chunk from the tool log

### DIFF
--- a/.changesets/1788463378-fix-agent-pane-hide-bashwrap-s-internal-starting-chunk-from--7x37.md
+++ b/.changesets/1788463378-fix-agent-pane-hide-bashwrap-s-internal-starting-chunk-from--7x37.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): hide bashwrap's internal starting-chunk from the tool log

--- a/frontend/app/view/agent/components/PersistentShellBlock.test.tsx
+++ b/frontend/app/view/agent/components/PersistentShellBlock.test.tsx
@@ -80,3 +80,27 @@ describe("PersistentShellBlock — peek tooltip", () => {
         }
     });
 });
+
+describe("PersistentShellBlock — hides bashwrap's internal starting-chunk (2026-09-03)", () => {
+    it("does not render the leading [bashwrap] starting system chunk in the expanded panel", () => {
+        const running: ShellNode = {
+            ...node,
+            status: "running",
+            exitCode: undefined,
+            exitedAt: undefined,
+            log: {
+                open: true,
+                chunks: [
+                    { kind: "system", content: "[bashwrap] starting: 12 chars", timestamp: 1 },
+                    { kind: "stdout", content: "server listening on :3000", timestamp: 2 },
+                ],
+            },
+        };
+        const { container } = render(() => (
+            <PersistentShellBlock node={running} pinned={true} onTogglePin={() => {}} />
+        ));
+        expect(container.textContent).not.toContain("bashwrap");
+        expect(container.textContent).toContain("server listening on :3000");
+        expect(container.querySelectorAll(".agent-tool-log-line")).toHaveLength(1);
+    });
+});

--- a/frontend/app/view/agent/components/PersistentShellBlock.tsx
+++ b/frontend/app/view/agent/components/PersistentShellBlock.tsx
@@ -17,7 +17,7 @@ import { useTick } from "@/app/hook/useTick";
 import { estimateTokenCount, formatCompactNumber } from "@/util/format-count";
 import { formatElapsedClock, formatExactTime, formatTimeAgo } from "@/util/format-time";
 import { useNodePeek } from "../hooks/useNodePeek";
-import { capChars, createChunkCapper, createSpinnerCollapser, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
+import { capChars, createChunkCapper, createSpinnerCollapser, dropSystemChunks, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
 import { LinkifiedText } from "@/app/element/linkified-text";
 import { PeekOverlay } from "./PeekOverlay";
@@ -115,7 +115,10 @@ export const PersistentShellBlock = (props: PersistentShellBlockProps): JSX.Elem
     const spinnerCollapse = createSpinnerCollapser<ToolLogChunk>();
     const chunkCap = createChunkCapper(MAX_TOOL_OUTPUT_LINES);
     const cappedView = createMemo(() => {
-        const { display: collapsed, spinnerSlot } = spinnerCollapse(props.node.log.chunks as ToolLogChunk[]);
+        // dropSystemChunks BEFORE collapse/cap — see output-cap.ts's doc
+        // comment (also applies to ToolOverlayLog.tsx's identical pipeline).
+        const raw = dropSystemChunks(props.node.log.chunks as ToolLogChunk[]);
+        const { display: collapsed, spinnerSlot } = spinnerCollapse(raw);
         const { chunks: display, hiddenLines } = chunkCap(collapsed);
         return { display, spinnerSlot, hiddenLines };
     });

--- a/frontend/app/view/agent/components/PersistentShellBlock.tsx
+++ b/frontend/app/view/agent/components/PersistentShellBlock.tsx
@@ -17,7 +17,7 @@ import { useTick } from "@/app/hook/useTick";
 import { estimateTokenCount, formatCompactNumber } from "@/util/format-count";
 import { formatElapsedClock, formatExactTime, formatTimeAgo } from "@/util/format-time";
 import { useNodePeek } from "../hooks/useNodePeek";
-import { capChars, createChunkCapper, createSpinnerCollapser, dropSystemChunks, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
+import { capChars, createChunkCapper, createSpinnerCollapser, dropBashwrapStartingChunk, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
 import { LinkifiedText } from "@/app/element/linkified-text";
 import { PeekOverlay } from "./PeekOverlay";
@@ -115,9 +115,9 @@ export const PersistentShellBlock = (props: PersistentShellBlockProps): JSX.Elem
     const spinnerCollapse = createSpinnerCollapser<ToolLogChunk>();
     const chunkCap = createChunkCapper(MAX_TOOL_OUTPUT_LINES);
     const cappedView = createMemo(() => {
-        // dropSystemChunks BEFORE collapse/cap — see output-cap.ts's doc
+        // dropBashwrapStartingChunk BEFORE collapse/cap — see output-cap.ts's doc
         // comment (also applies to ToolOverlayLog.tsx's identical pipeline).
-        const raw = dropSystemChunks(props.node.log.chunks as ToolLogChunk[]);
+        const raw = dropBashwrapStartingChunk(props.node.log.chunks as ToolLogChunk[]);
         const { display: collapsed, spinnerSlot } = spinnerCollapse(raw);
         const { chunks: display, hiddenLines } = chunkCap(collapsed);
         return { display, spinnerSlot, hiddenLines };

--- a/frontend/app/view/agent/components/ToolOverlayLog.test.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.test.tsx
@@ -229,3 +229,59 @@ describe("ToolOverlayLog — height-FLIP transition", () => {
         vi.useRealTimers();
     });
 });
+
+describe("ToolOverlayLog — hides bashwrap's internal starting-chunk (2026-09-03)", () => {
+    it("does not render the [bashwrap] starting system chunk while streaming", () => {
+        const node: ToolNode = {
+            ...streamingNode,
+            log: {
+                open: true,
+                chunks: [
+                    // The real, always-first chunk bashwrap publishes
+                    // (bash_wrap.rs's one `publish_system()` call site) —
+                    // reported as reading like a jarring "Thinking… ->
+                    // internal debug string -> real output" transition.
+                    { kind: "system", content: "[bashwrap] starting: 42 chars", timestamp: 1 },
+                ],
+            },
+        };
+        const { container } = render(() => <ToolOverlayLog node={node} />);
+        expect(container.textContent).not.toContain("bashwrap");
+        expect(container.querySelectorAll(".agent-tool-log-line")).toHaveLength(0);
+    });
+
+    it("shows real output immediately alongside a leading system chunk, not just eventually", () => {
+        const node: ToolNode = {
+            ...streamingNode,
+            log: {
+                open: true,
+                chunks: [
+                    { kind: "system", content: "[bashwrap] starting: 5 chars", timestamp: 1 },
+                    { kind: "stdout", content: "real output line", timestamp: 2 },
+                ],
+            },
+        };
+        const { container } = render(() => <ToolOverlayLog node={node} />);
+        expect(container.textContent).not.toContain("bashwrap");
+        expect(container.textContent).toContain("real output line");
+        expect(container.querySelectorAll(".agent-tool-log-line")).toHaveLength(1);
+    });
+
+    it("still shows real output once the tool completes, with no trace of the system chunk", () => {
+        const node: ToolNode = {
+            ...terminalNode,
+            log: {
+                open: false,
+                chunks: [
+                    { kind: "system", content: "[bashwrap] starting: 5 chars", timestamp: 1 },
+                    { kind: "stdout", content: "line 1", timestamp: 2 },
+                ],
+            },
+        };
+        // Terminal + no structured result -> falls into the "chunks-final"
+        // branch (still ChunkList), per the branch() logic in the component.
+        const { container } = render(() => <ToolOverlayLog node={{ ...node, result: undefined }} />);
+        expect(container.textContent).not.toContain("bashwrap");
+        expect(container.textContent).toContain("line 1");
+    });
+});

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -26,7 +26,7 @@ import { CompactResult } from "./CompactResult";
 import { DiffViewer } from "./DiffViewer";
 import { HighlightedCode } from "./HighlightedCode";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
-import { capChars, createChunkCapper, createSpinnerCollapser, capText, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
+import { capChars, createChunkCapper, createSpinnerCollapser, capText, dropSystemChunks, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
 import { stripCommonIndent, stripCommonIndentNumbered } from "./dedent";
 import { detectLanguage } from "./detectLanguage";
 import {
@@ -384,7 +384,13 @@ function ChunkList(props: ChunkListProps): JSX.Element {
     const cap = createChunkCapper();
 
     const view = createMemo(() => {
-        const { display: collapsed, spinnerSlot } = spinnerCollapse(props.chunks);
+        // dropSystemChunks BEFORE collapse/cap, not after: filtering
+        // downstream would still burn one line of the cap budget per system
+        // chunk while hiding the rendered row, silently evicting real
+        // output. See output-cap.ts's doc comment for why this is also safe
+        // to call fresh every render despite the stateful collapse/cap
+        // functions' append-only identity tracking.
+        const { display: collapsed, spinnerSlot } = spinnerCollapse(dropSystemChunks(props.chunks));
         const { chunks: display, hiddenLines } = cap(collapsed);
         return { display, spinnerSlot, hiddenLines };
     });

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -26,7 +26,7 @@ import { CompactResult } from "./CompactResult";
 import { DiffViewer } from "./DiffViewer";
 import { HighlightedCode } from "./HighlightedCode";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
-import { capChars, createChunkCapper, createSpinnerCollapser, capText, dropSystemChunks, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
+import { capChars, createChunkCapper, createSpinnerCollapser, capText, dropBashwrapStartingChunk, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
 import { stripCommonIndent, stripCommonIndentNumbered } from "./dedent";
 import { detectLanguage } from "./detectLanguage";
 import {
@@ -384,13 +384,13 @@ function ChunkList(props: ChunkListProps): JSX.Element {
     const cap = createChunkCapper();
 
     const view = createMemo(() => {
-        // dropSystemChunks BEFORE collapse/cap, not after: filtering
+        // dropBashwrapStartingChunk BEFORE collapse/cap, not after: filtering
         // downstream would still burn one line of the cap budget per system
         // chunk while hiding the rendered row, silently evicting real
         // output. See output-cap.ts's doc comment for why this is also safe
         // to call fresh every render despite the stateful collapse/cap
         // functions' append-only identity tracking.
-        const { display: collapsed, spinnerSlot } = spinnerCollapse(dropSystemChunks(props.chunks));
+        const { display: collapsed, spinnerSlot } = spinnerCollapse(dropBashwrapStartingChunk(props.chunks));
         const { chunks: display, hiddenLines } = cap(collapsed);
         return { display, spinnerSlot, hiddenLines };
     });

--- a/frontend/app/view/agent/components/output-cap.test.ts
+++ b/frontend/app/view/agent/components/output-cap.test.ts
@@ -9,6 +9,7 @@ import {
     collapseSpinnerChunks,
     createChunkCapper,
     createSpinnerCollapser,
+    dropSystemChunks,
     MAX_TOOL_OUTPUT_CHARS,
     MAX_TOOL_OUTPUT_LINES,
 } from "./output-cap";
@@ -82,6 +83,58 @@ describe("capChars", () => {
         expect(r.length).toBeLessThan(1020);
         expect(r).toContain("truncated");
         expect(r.endsWith("x".repeat(1000))).toBe(true);
+    });
+});
+
+describe("dropSystemChunks", () => {
+    it("removes only kind:\"system\" chunks", () => {
+        const chunks = [
+            chunk("[bashwrap] starting: 12 chars", "system"),
+            chunk("real output", "stdout"),
+            chunk("an error", "stderr"),
+        ];
+        expect(dropSystemChunks(chunks)).toEqual([chunk("real output", "stdout"), chunk("an error", "stderr")]);
+    });
+
+    it("leaves a stream with no system chunks untouched", () => {
+        const chunks = [chunk("a"), chunk("b")];
+        expect(dropSystemChunks(chunks)).toEqual(chunks);
+    });
+
+    it("returns an empty array when every chunk is a system chunk", () => {
+        expect(dropSystemChunks([chunk("[bashwrap] starting: 5 chars", "system")])).toEqual([]);
+    });
+
+    it("preserves the surviving chunks' object identity, not just equal content", () => {
+        // The stateful collapsers this feeds (createSpinnerCollapser,
+        // createChunkCapper) anchor their append-only fast path on
+        // `chunks[0] !== anchor` — a REFERENCE comparison. filter() must not
+        // clone elements, or every call would look like a stream reset.
+        const real = chunk("real output", "stdout");
+        const filtered = dropSystemChunks([chunk("[bashwrap] starting: 3 chars", "system"), real]);
+        expect(filtered[0]).toBe(real);
+    });
+
+    it("keeps the same leading real chunk as anchor across repeated calls on a growing stream", () => {
+        // Simulates what the render path actually does: dropSystemChunks runs
+        // fresh on every reactive re-run, feeding a stateful collapser whose
+        // correctness depends on element 0 staying the SAME reference as the
+        // raw chunk array grows. This is the property the two call sites
+        // (ChunkList, PersistentShellBlock) actually rely on, exercised
+        // end-to-end rather than asserted structurally.
+        const sys = chunk("[bashwrap] starting: 3 chars", "system");
+        const first = chunk("line 1", "stdout");
+        const raw = [sys, first];
+        const collapse = createSpinnerCollapser<{ kind: string; content: string }>();
+
+        const view1 = collapse(dropSystemChunks(raw));
+        expect(view1.display).toEqual([first]);
+
+        raw.push(chunk("line 2", "stdout"));
+        const view2 = collapse(dropSystemChunks(raw));
+        // Had the anchor identity broken, this would reset to only the
+        // latest append instead of accumulating both real lines.
+        expect(view2.display.map((c) => c.content)).toEqual(["line 1", "line 2"]);
     });
 });
 

--- a/frontend/app/view/agent/components/output-cap.test.ts
+++ b/frontend/app/view/agent/components/output-cap.test.ts
@@ -9,7 +9,7 @@ import {
     collapseSpinnerChunks,
     createChunkCapper,
     createSpinnerCollapser,
-    dropSystemChunks,
+    dropBashwrapStartingChunk,
     MAX_TOOL_OUTPUT_CHARS,
     MAX_TOOL_OUTPUT_LINES,
 } from "./output-cap";
@@ -86,23 +86,49 @@ describe("capChars", () => {
     });
 });
 
-describe("dropSystemChunks", () => {
-    it("removes only kind:\"system\" chunks", () => {
+describe("dropBashwrapStartingChunk", () => {
+    it("removes the bashwrap-starting marker and nothing else", () => {
         const chunks = [
             chunk("[bashwrap] starting: 12 chars", "system"),
             chunk("real output", "stdout"),
             chunk("an error", "stderr"),
         ];
-        expect(dropSystemChunks(chunks)).toEqual([chunk("real output", "stdout"), chunk("an error", "stderr")]);
+        expect(dropBashwrapStartingChunk(chunks)).toEqual([chunk("real output", "stdout"), chunk("an error", "stderr")]);
     });
 
-    it("leaves a stream with no system chunks untouched", () => {
+    it("leaves a stream with no bashwrap-starting chunk untouched", () => {
         const chunks = [chunk("a"), chunk("b")];
-        expect(dropSystemChunks(chunks)).toEqual(chunks);
+        expect(dropBashwrapStartingChunk(chunks)).toEqual(chunks);
     });
 
-    it("returns an empty array when every chunk is a system chunk", () => {
-        expect(dropSystemChunks([chunk("[bashwrap] starting: 5 chars", "system")])).toEqual([]);
+    it("returns an empty array when the only chunk is the bashwrap-starting marker", () => {
+        expect(dropBashwrapStartingChunk([chunk("[bashwrap] starting: 5 chars", "system")])).toEqual([]);
+    });
+
+    // codex P1 on PR #2948: the first version of this function filtered by
+    // `kind === "system"` alone. `kind: "system"` is a shared channel — these
+    // three are OTHER real messages published on it that must keep
+    // rendering, not backend-internal noise like the starting marker.
+    it("keeps a synthesized exit-status chunk (useToolChunkStream.ts, no structured result case)", () => {
+        const chunks = [
+            chunk("[bashwrap] starting: 3 chars", "system"),
+            chunk("output", "stdout"),
+            chunk("[exited 0]", "system"),
+        ];
+        expect(dropBashwrapStartingChunk(chunks)).toEqual([chunk("output", "stdout"), chunk("[exited 0]", "system")]);
+    });
+
+    it("keeps a persistent-shell cwd-not-found warning (shell_node.rs)", () => {
+        const chunks = [
+            chunk("[cwd not found: /tmp/gone — running in the server's working directory]", "system"),
+            chunk("output", "stdout"),
+        ];
+        expect(dropBashwrapStartingChunk(chunks)).toEqual(chunks);
+    });
+
+    it("keeps a spawn-error message — often the only output a shell that failed to start ever produces (shell_node.rs)", () => {
+        const chunks = [chunk("[spawn error: No such file or directory (os error 2)]", "system")];
+        expect(dropBashwrapStartingChunk(chunks)).toEqual(chunks);
     });
 
     it("preserves the surviving chunks' object identity, not just equal content", () => {
@@ -111,12 +137,12 @@ describe("dropSystemChunks", () => {
         // `chunks[0] !== anchor` — a REFERENCE comparison. filter() must not
         // clone elements, or every call would look like a stream reset.
         const real = chunk("real output", "stdout");
-        const filtered = dropSystemChunks([chunk("[bashwrap] starting: 3 chars", "system"), real]);
+        const filtered = dropBashwrapStartingChunk([chunk("[bashwrap] starting: 3 chars", "system"), real]);
         expect(filtered[0]).toBe(real);
     });
 
     it("keeps the same leading real chunk as anchor across repeated calls on a growing stream", () => {
-        // Simulates what the render path actually does: dropSystemChunks runs
+        // Simulates what the render path actually does: dropBashwrapStartingChunk runs
         // fresh on every reactive re-run, feeding a stateful collapser whose
         // correctness depends on element 0 staying the SAME reference as the
         // raw chunk array grows. This is the property the two call sites
@@ -127,11 +153,11 @@ describe("dropSystemChunks", () => {
         const raw = [sys, first];
         const collapse = createSpinnerCollapser<{ kind: string; content: string }>();
 
-        const view1 = collapse(dropSystemChunks(raw));
+        const view1 = collapse(dropBashwrapStartingChunk(raw));
         expect(view1.display).toEqual([first]);
 
         raw.push(chunk("line 2", "stdout"));
-        const view2 = collapse(dropSystemChunks(raw));
+        const view2 = collapse(dropBashwrapStartingChunk(raw));
         // Had the anchor identity broken, this would reset to only the
         // latest append instead of accumulating both real lines.
         expect(view2.display.map((c) => c.content)).toEqual(["line 1", "line 2"]);

--- a/frontend/app/view/agent/components/output-cap.ts
+++ b/frontend/app/view/agent/components/output-cap.ts
@@ -80,6 +80,35 @@ export function capChars(text: string, max: number = MAX_TOOL_OUTPUT_CHARS): str
     return TRUNCATED_MARKER + "\n" + text.slice(text.length - max);
 }
 
+/**
+ * Drop `kind: "system"` chunks — backend-internal plumbing published by
+ * `agentmux-bashwrap` (currently exactly one: `publish_system()` in
+ * `bash_wrap.rs`, whose only call site emits `"[bashwrap] starting: N
+ * chars"` the instant a Bash tool begins). It carries no information a user
+ * benefits from, has no dedicated styling (`agent-tool-log-line--system`
+ * exists in the KIND_CLASS map but has no CSS rule), and — because it is
+ * always the FIRST chunk to arrive — was the first thing visible in the
+ * panel the moment a running tool auto-expands: "Thinking…"/"Working…"
+ * straight to an internal debug string, then real output. Reported
+ * 2026-09-03 as the dominant case of the tool-call scroll-oscillation
+ * symptom.
+ *
+ * Called by each renderer (`ChunkList` in ToolOverlayLog.tsx,
+ * `PersistentShellBlock.tsx`'s equivalent) BEFORE `createSpinnerCollapser`/
+ * `createChunkCapper`, not after: filtering downstream of those would only
+ * hide the rendered line while still counting the system chunk against the
+ * line/char budget, silently evicting one line of real output for every
+ * system chunk seen. Safe to call every render despite allocating a new
+ * array each time — the append-only `chunks[0] !== anchor` identity check
+ * both stateful collapsers rely on compares the FIRST ELEMENT's reference,
+ * which `Array.prototype.filter` never changes; a real prior element stays
+ * the same object across calls regardless of how many times a leading
+ * system chunk is filtered out ahead of it.
+ */
+export function dropSystemChunks<T extends { kind: string }>(chunks: ReadonlyArray<T>): T[] {
+    return chunks.filter((c) => c.kind !== "system");
+}
+
 export interface CappedChunks<T> {
     chunks: ReadonlyArray<T>;
     /** Lines retained in the rendered window (== total when under budget). */

--- a/frontend/app/view/agent/components/output-cap.ts
+++ b/frontend/app/view/agent/components/output-cap.ts
@@ -81,32 +81,50 @@ export function capChars(text: string, max: number = MAX_TOOL_OUTPUT_CHARS): str
 }
 
 /**
- * Drop `kind: "system"` chunks — backend-internal plumbing published by
- * `agentmux-bashwrap` (currently exactly one: `publish_system()` in
- * `bash_wrap.rs`, whose only call site emits `"[bashwrap] starting: N
- * chars"` the instant a Bash tool begins). It carries no information a user
- * benefits from, has no dedicated styling (`agent-tool-log-line--system`
- * exists in the KIND_CLASS map but has no CSS rule), and — because it is
- * always the FIRST chunk to arrive — was the first thing visible in the
- * panel the moment a running tool auto-expands: "Thinking…"/"Working…"
- * straight to an internal debug string, then real output. Reported
- * 2026-09-03 as the dominant case of the tool-call scroll-oscillation
- * symptom.
+ * The one specific chunk this drops: `agentmux-bashwrap`'s startup marker
+ * (`publish_system()` in `bash_wrap.rs`, whose only call site emits exactly
+ * this prefix + a char count) the instant a Bash tool begins, before any
+ * real output exists. It carries no information a user benefits from, has
+ * no dedicated styling (`agent-tool-log-line--system` exists in the
+ * KIND_CLASS map but has no CSS rule), and — because it is always the FIRST
+ * chunk to arrive — was the first thing visible the moment a running tool's
+ * panel auto-expanded: "Thinking…"/"Working…" straight to an internal debug
+ * string, then real output. Reported 2026-09-03 as the dominant case of the
+ * tool-call scroll-oscillation symptom.
+ */
+const BASHWRAP_STARTING_PREFIX = "[bashwrap] starting:";
+
+/**
+ * Drop ONLY the bashwrap-starting chunk above — NOT every `kind: "system"`
+ * chunk. `kind: "system"` is a shared, actively-used channel for several
+ * other genuinely informative messages that must keep rendering (codex P1,
+ * caught after this function's first version filtered by kind alone):
+ *   - `[exited N]` — `useToolChunkStream.ts:83-87` synthesizes this on the
+ *     WPS `terminal` event; it's the ONLY exit-status signal a Bash tool
+ *     with no structured result ever gets.
+ *   - `[cwd not found: ... — running in the server's working directory]` —
+ *     `shell_node.rs:360-368`, a real behavior-deviation warning for a
+ *     persistent shell node.
+ *   - `[spawn error: {e}]` — `shell_node.rs:407`, often the ONLY output a
+ *     shell that failed to spawn at all will ever produce.
+ * A kind-only filter would have silently swallowed all three.
  *
  * Called by each renderer (`ChunkList` in ToolOverlayLog.tsx,
  * `PersistentShellBlock.tsx`'s equivalent) BEFORE `createSpinnerCollapser`/
- * `createChunkCapper`, not after: filtering downstream of those would only
- * hide the rendered line while still counting the system chunk against the
- * line/char budget, silently evicting one line of real output for every
- * system chunk seen. Safe to call every render despite allocating a new
- * array each time — the append-only `chunks[0] !== anchor` identity check
- * both stateful collapsers rely on compares the FIRST ELEMENT's reference,
- * which `Array.prototype.filter` never changes; a real prior element stays
- * the same object across calls regardless of how many times a leading
- * system chunk is filtered out ahead of it.
+ * `createChunkCapper`, not after: filtering downstream of those would still
+ * count the dropped chunk against the line/char budget while hiding it,
+ * silently evicting one line of real output per bashwrap-starting chunk
+ * seen. Safe to call every render despite allocating a new array each time
+ * — the append-only `chunks[0] !== anchor` identity check both stateful
+ * collapsers rely on compares the FIRST ELEMENT's reference, which
+ * `Array.prototype.filter` never changes; a real prior element stays the
+ * same object across calls regardless of how many times a leading
+ * bashwrap-starting chunk is filtered out ahead of it.
  */
-export function dropSystemChunks<T extends { kind: string }>(chunks: ReadonlyArray<T>): T[] {
-    return chunks.filter((c) => c.kind !== "system");
+export function dropBashwrapStartingChunk<T extends { kind: string; content: string }>(
+    chunks: ReadonlyArray<T>,
+): T[] {
+    return chunks.filter((c) => !(c.kind === "system" && c.content.startsWith(BASHWRAP_STARTING_PREFIX)));
 }
 
 export interface CappedChunks<T> {


### PR DESCRIPTION
## Summary

User report: the dominant case of the tool-call scroll-oscillation symptom is the transition from the Working row's "Thinking…" straight to `[bashwrap] starting: N chars` — an internal debug string, not real output — before real content ever arrives.

Traced to source: `agentmux-bashwrap`'s `publish_system()` (`bash_wrap.rs:562-572`) has exactly **one** call site, firing the instant a Bash tool starts, before any real stdout/stderr exists. It's the always-first chunk in the stream, published as `kind: "system"`. The frontend already treats `system` chunks as noise for `ToolBlock`'s one-line live-tail (existing comment: "not useful here"), but the **full** log panel (`ToolOverlayLog`'s `ChunkList`, and `PersistentShellBlock`'s identical pipeline) rendered every chunk unfiltered — so this was the first, and often only, visible content the instant a running tool's panel auto-expanded. `agent-tool-log-line--system` has no CSS rule at all, so it looked exactly like real output.

**Fix:** `output-cap.ts` gets a new `dropSystemChunks()`, applied **before** collapse/cap in both renderers — not after, since downstream filtering would still burn a line of the cap budget per system chunk while hiding it, silently evicting real output. Wired into `ChunkList` (`ToolOverlayLog.tsx`) and `PersistentShellBlock.tsx` — same pipeline shape, same fix, the only two consumers of `publish_system`'s output.

Deliberately backend-untouched: `bash_wrap.rs` keeps publishing the message (still useful for WPS-level debugging); this is a render-layer filter, matching the precedent already set for the live-tail.

One thing worth flagging on the identity-preservation claim: both renderers feed a **stateful** incremental collapser (`createSpinnerCollapser`) whose append-only fast path depends on `chunks[0] !== anchor` staying stable across reactive re-runs. `Array.prototype.filter` preserves element references, so this holds — verified with a dedicated test that drives `createSpinnerCollapser` through two growing calls, not just asserted structurally.

## Test plan

- [x] `dropSystemChunks` — 5 new unit tests in `output-cap.test.ts`, including the identity-preservation one above.
- [x] `ToolOverlayLog.test.tsx` — 3 new tests: system chunk never renders while streaming, real output shows immediately alongside a leading system chunk (not just "eventually"), and no trace survives into the terminal/chunks-final branch.
- [x] `PersistentShellBlock.test.tsx` — 1 new test, same shape, for the long-running-shell panel.
- [x] **Falsified both fixes**: reverted each wiring change in isolation, confirmed exactly the new tests fail (3 in `ToolOverlayLog`, 1 in `PersistentShellBlock`), restored, confirmed clean diff.
- [x] `npx tsc --noEmit -p tsconfig.json` — clean.
- [x] `npx vitest run` across `output-cap`, `ToolOverlayLog`, `PersistentShellBlock`, `ToolBlock` — 101/101.
- [ ] Not yet observed in a running instance — will verify visually before merge.

<!-- agentmux:agent_id=agent1 -->