### PR TITLE
feat(agent): AskUserQuestion Cancel (real decline) + Accept Recommended

### DIFF
--- a/.changesets/1788465143-feat-agent-askuserquestion-cancel-real-decline-and-accept-re-vtit.md
+++ b/.changesets/1788465143-feat-agent-askuserquestion-cancel-real-decline-and-accept-re-vtit.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): AskUserQuestion Cancel (real decline) and Accept Recommended buttons

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -776,6 +776,27 @@ fn build_answer_resume_message(answers: &serde_json::Value) -> String {
     out
 }
 
+/// Fixed, server-owned decline message for a cancelled AskUserQuestion (the
+/// Cancel button / Escape in `AgentQuestionPanel.tsx`) — not client-suppliable,
+/// since Cancel and Escape both mean exactly one thing and there is no user-
+/// authored content to carry. See `deny_question` and
+/// docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md.
+pub(crate) const ASK_USER_QUESTION_DENY_MESSAGE: &str = "The user declined to answer this question.";
+
+/// Compose the directive follow-up message used by the AskUserQuestion dead-air
+/// fallback when the answer was a DECLINE rather than a real answer. Mirrors
+/// `build_answer_resume_message`'s directive tone (resume the task, don't wait
+/// for further input) but tells the model the outcome was a decline so it
+/// doesn't hallucinate a value the user never provided.
+fn build_deny_resume_message(message: &str) -> String {
+    format!(
+        "[AgentMux] Your earlier question was declined, but the turn had already ended, \
+         so this is delivered here as a follow-up. Resume the task you were working on \
+         without this input — do not wait for further input. The user's response was: \
+         \"{message}\""
+    )
+}
+
 impl PersistentSubprocessController {
     pub fn new(
         tab_id: String,
@@ -2278,6 +2299,102 @@ impl PersistentSubprocessController {
                 None => tracing::warn!(
                     block_id = %block_id,
                     "AskUserQuestion dead-air fallback skipped: process not running"
+                ),
+            }
+        });
+        Ok(())
+    }
+
+    /// Decline a parked AskUserQuestion via the Agent SDK **control protocol**
+    /// — the Cancel button / Escape in `AgentQuestionPanel.tsx`. Structurally a
+    /// mirror of `answer_question` (same `pending_questions` lookup/removal,
+    /// same dead-air safety net — the CLI can abandon a pending tool_use whose
+    /// turn already ended regardless of whether the response was an allow or a
+    /// deny), but sends `behavior: "deny"` with a `message` instead of
+    /// `behavior: "allow"` with `updatedInput`. This is a general, documented
+    /// Agent SDK mechanism (`PermissionResult` deny case for the `canUseTool`
+    /// callback) — AskUserQuestion goes through the exact same callback as
+    /// ordinary tool permission requests, confirmed against the official Agent
+    /// SDK docs (code.claude.com/docs/en/agent-sdk/user-input). Spec:
+    /// docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md.
+    ///
+    /// See `answer_question`'s doc comment for the `pending_questions`
+    /// in-memory-only caveat and the exact error-prefix stability requirement
+    /// (`useAgentQuestions.ts`'s `SAFE_TO_RETRY_VIA_FOLLOWUP` allowlist matches
+    /// on this method's error text too, since it shares the identical lookup).
+    pub fn deny_question(&self, tool_use_id: String, message: String) -> Result<(), String> {
+        let (request_id, _questions, tx) = {
+            let mut inner = self.inner.lock().unwrap();
+            let (rid, qs) = inner
+                .pending_questions
+                .remove(&tool_use_id)
+                .ok_or_else(|| format!(
+                    "no pending AskUserQuestion for tool_use_id {tool_use_id} — this controller \
+                     instance never recorded it (process likely respawned since the question was \
+                     asked, e.g. a pane close/reopen); the caller should redeliver as a follow-up message"
+                ))?;
+            let tx = inner
+                .stdin_tx
+                .as_ref()
+                .ok_or("persistent process not running (cannot deliver decline)")?
+                .clone();
+            (rid, qs, tx)
+        };
+
+        let control_response = serde_json::json!({
+            "type": "control_response",
+            "response": {
+                "subtype": "success",
+                "request_id": request_id,
+                "response": {
+                    "behavior": "deny",
+                    "message": message,
+                    "toolUseID": tool_use_id,
+                }
+            }
+        });
+        // Snapshot stdout activity BEFORE sending, same reasoning as
+        // answer_question (codex review on #1536).
+        let stdout_seq = Arc::clone(&self.stdout_seq);
+        let before_seq = stdout_seq.load(Ordering::Relaxed);
+
+        tx.try_send(control_response.to_string())
+            .map_err(|e| format!("control_response send failed: {e}"))?;
+
+        // Dead-air safety net — identical mechanism to answer_question's, using
+        // the decline-flavored resume message. Reuses ANSWER_RESUME_FALLBACK_MS:
+        // same failure mode (turn already ended before the response arrived), no
+        // reason for a different timeout.
+        let inner = Arc::clone(&self.inner);
+        let block_id = self.block_id.clone();
+        let resume_msg = build_deny_resume_message(&message);
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(ANSWER_RESUME_FALLBACK_MS)).await;
+            if stdout_seq.load(Ordering::Relaxed) != before_seq {
+                return;
+            }
+            let line = serde_json::json!({
+                "type": "user",
+                "message": { "role": "user", "content": resume_msg }
+            })
+            .to_string();
+            let stdin_tx = { inner.lock().unwrap().stdin_tx.clone() };
+            match stdin_tx {
+                Some(stdin_tx) if stdin_tx.try_send(line).is_ok() => {
+                    tracing::warn!(
+                        block_id = %block_id,
+                        tool_use_id = %tool_use_id,
+                        fallback_ms = ANSWER_RESUME_FALLBACK_MS,
+                        "AskUserQuestion decline did not resume the turn — re-delivered as a follow-up message (dead-air fallback)"
+                    );
+                }
+                Some(_) => tracing::warn!(
+                    block_id = %block_id,
+                    "AskUserQuestion deny dead-air fallback: stdin send failed"
+                ),
+                None => tracing::warn!(
+                    block_id = %block_id,
+                    "AskUserQuestion deny dead-air fallback skipped: process not running"
                 ),
             }
         });
@@ -4543,6 +4660,36 @@ mod send_input_tests {
         assert!(
             err.contains("tu-unknown") && err.contains("respawned"),
             "error should name the tool_use_id and explain the likely cause, got {err:?}"
+        );
+    }
+
+    // deny_question shares the identical pending_questions lookup as
+    // answer_question, so the frontend's SAFE_TO_RETRY_VIA_FOLLOWUP allowlist
+    // (useAgentQuestions.ts) matches this error text too — keep the "no
+    // pending AskUserQuestion" prefix stable if this message ever changes.
+    #[test]
+    fn deny_question_on_untracked_tool_use_id_is_descriptive() {
+        let c = controller();
+        let err = c
+            .deny_question("tu-unknown".to_string(), "declined".to_string())
+            .unwrap_err();
+        assert!(
+            err.contains("tu-unknown") && err.contains("respawned"),
+            "error should name the tool_use_id and explain the likely cause, got {err:?}"
+        );
+    }
+
+    // The dead-air fallback for a decline must still tell the model to resume
+    // (not wait for further input it will never get) while making clear the
+    // outcome was a DECLINE, not a real answer — otherwise the model could
+    // hallucinate a value the user never provided.
+    #[test]
+    fn deny_resume_message_is_directive_and_includes_the_reason() {
+        let msg = build_deny_resume_message(ASK_USER_QUESTION_DENY_MESSAGE);
+        assert!(msg.contains("Resume the task"), "must be directive: {msg}");
+        assert!(
+            msg.contains("declined to answer"),
+            "must carry the decline reason: {msg}"
         );
     }
 

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -781,6 +781,18 @@ fn build_answer_resume_message(answers: &serde_json::Value) -> String {
 /// since Cancel and Escape both mean exactly one thing and there is no user-
 /// authored content to carry. See `deny_question` and
 /// docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md.
+///
+/// KEEP IN SYNC (no shared constant crosses the Rust/TypeScript boundary for
+/// a plain string literal): `CANCEL_FALLBACK_MESSAGE` in
+/// `frontend/app/view/agent/hooks/useAgentQuestions.ts` is a hand-copied
+/// mirror of this exact text, used only for its SAFE_TO_RETRY_VIA_FOLLOWUP
+/// fallback path. If you change this string, update that one too — the test
+/// `ask_user_question_deny_message_matches_frontend_cancel_fallback_text`
+/// below pins the literal on this side; the frontend test asserting
+/// `sendMessage` was called with this exact text (in
+/// `useAgentQuestions.test.ts`, "handleCancel fallback" describe block)
+/// pins it on that side. Neither test can see the other language's
+/// constant, so both must be updated by hand together.
 pub(crate) const ASK_USER_QUESTION_DENY_MESSAGE: &str = "The user declined to answer this question.";
 
 /// Compose the directive follow-up message used by the AskUserQuestion dead-air
@@ -4683,6 +4695,23 @@ mod send_input_tests {
     // (not wait for further input it will never get) while making clear the
     // outcome was a DECLINE, not a real answer — otherwise the model could
     // hallucinate a value the user never provided.
+    // Pins the exact literal (not just a substring) so an edit to this
+    // constant is impossible to make silently — see the KEEP IN SYNC comment
+    // on ASK_USER_QUESTION_DENY_MESSAGE's own definition. There is no way for
+    // this test to reach across the Rust/TypeScript boundary and check
+    // useAgentQuestions.ts's CANCEL_FALLBACK_MESSAGE directly; failing loudly
+    // here is what prompts a human/reviewer to go update that copy too.
+    #[test]
+    fn ask_user_question_deny_message_matches_frontend_cancel_fallback_text() {
+        assert_eq!(
+            ASK_USER_QUESTION_DENY_MESSAGE,
+            "The user declined to answer this question.",
+            "this literal is hand-mirrored as CANCEL_FALLBACK_MESSAGE in \
+             frontend/app/view/agent/hooks/useAgentQuestions.ts — update both \
+             together"
+        );
+    }
+
     #[test]
     fn deny_resume_message_is_directive_and_includes_the_reason() {
         let msg = build_deny_resume_message(ASK_USER_QUESTION_DENY_MESSAGE);

--- a/agentmux-srv/src/backend/rpc_types/block.rs
+++ b/agentmux-srv/src/backend/rpc_types/block.rs
@@ -221,6 +221,21 @@ pub struct CommandAgentAnswerData {
     pub answers: serde_json::Value,
 }
 
+/// Data for AgentCancelCommand — a real protocol-level decline of a pending
+/// AskUserQuestion (Cancel button / Escape), delivered as a control_response
+/// carrying `behavior: "deny"` rather than the allow+answers shape above. No
+/// `answers` field: there is nothing to carry, the deny message is a fixed
+/// server-owned string (see `ASK_USER_QUESTION_DENY_MESSAGE` in
+/// blockcontroller/persistent.rs). Spec:
+/// docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CommandAgentCancelData {
+    pub blockid: String,
+    /// The `AskUserQuestion` tool_use id being declined (correlates with the
+    /// parked `can_use_tool` control_request).
+    pub tool_use_id: String,
+}
+
 // ---- Subprocess agent command data types ----
 
 /// Data for SubprocessSpawnCommand — spawn agent CLI for a single turn.

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -44,7 +44,7 @@ pub const COMMAND_CONTROLLER_RESYNC: &str = "controllerresync";
 
 /// Create a headless sub-block (no tab/layout entry) parented to an
 /// existing block — e.g. a `term`-view PTY embedded in an agent pane's
-/// details drawer. Spec: docs/specs/SPEC_AGENT_SHELL_XTERM_TERMINAL_2026_07_03.md §4.
+/// details drawer.
 pub const COMMAND_CREATE_SUB_BLOCK: &str = "createsubblock";
 /// Tear down a sub-block created via `createsubblock`: kills its
 /// controller first, then deletes the block row and unlinks it from
@@ -550,8 +550,7 @@ pub const COMMAND_SESSION_NEXT_PROMPT_SUGGESTION: &str = "session:next_prompt_su
 // A session zone is bound to the *agent definition* (`definition_id`),
 // not the identity bundle. Every block of the same agent reads/writes
 // through `agent:<defId>:current`; archiving snapshots to
-// `agent:<defId>:archive:<ts_ms>`. See
-// docs/specs/SPEC_CONTINUATION_SESSION_PERSISTENCE_2026_05_23.md.
+// `agent:<defId>:archive:<ts_ms>`.
 pub const COMMAND_AGENT_SESSION_READ: &str = "agent:session:read";
 pub const COMMAND_AGENT_SESSION_WRITE_STATE: &str = "agent:session:write_state";
 pub const COMMAND_AGENT_SESSION_APPEND_OUTPUT: &str = "agent:session:append_output";

--- a/agentmux-srv/src/backend/rpc_types/commands.rs
+++ b/agentmux-srv/src/backend/rpc_types/commands.rs
@@ -100,6 +100,12 @@ pub const COMMAND_AGENT_INPUT: &str = "agentinput";
 /// (`agentinput`, `agentstop`, `tooldecision`).
 /// Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
 pub const COMMAND_AGENT_ANSWER: &str = "agentanswer";
+/// Real protocol-level decline of a pending AskUserQuestion (Cancel button /
+/// Escape in AgentQuestionPanel.tsx) — a control_response with
+/// `behavior: "deny"`, not a UI-only dismiss. See
+/// `PersistentSubprocessController::deny_question` and
+/// docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md.
+pub const COMMAND_AGENT_CANCEL: &str = "agentcancel";
 pub const COMMAND_AGENT_STOP: &str = "agentstop";
 pub const COMMAND_SHELL_EXEC: &str = "shellexec";
 /// Stop a running persistent shell node (Phase 3) — UI stop button.

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -873,8 +873,7 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
 
     // createsubblock → create a headless sub-block (no tab/layout entry)
     // parented to an existing block, e.g. a `term`-view PTY embedded in an
-    // agent pane's details drawer. Spec:
-    // docs/specs/SPEC_AGENT_SHELL_XTERM_TERMINAL_2026_07_03.md §4.
+    // agent pane's details drawer.
     let wstore_csb = state.wstore.clone();
     engine.register_handler(
         COMMAND_CREATE_SUB_BLOCK,

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -27,8 +27,8 @@ use crate::backend::rpc_types::{
     COMMAND_EVENT_UNSUB_ALL, COMMAND_GET_FULL_CONFIG, COMMAND_GET_META,
     COMMAND_GET_AI_RATE_LIMIT, COMMAND_ROUTE_ANNOUNCE, COMMAND_ROUTE_UNANNOUNCE,
     COMMAND_SET_META, COMMAND_SET_CONFIG, COMMAND_APP_INFO,
-    COMMAND_TOOL_DECISION, COMMAND_AGENT_ANSWER,
-    CommandAgentAnswerData,
+    COMMAND_TOOL_DECISION, COMMAND_AGENT_ANSWER, COMMAND_AGENT_CANCEL,
+    CommandAgentAnswerData, CommandAgentCancelData,
     COMMAND_DOCK_NODE_STATUS, CommandDockNodeStatusData,
     COMMAND_BACKGROUND_TASK_COMPLETION, CommandBackgroundTaskCompletionData,
     COMMAND_BACKGROUND_TASK_PID, CommandBackgroundTaskPidData,
@@ -1315,6 +1315,50 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
                     Ok(None)
                 } else {
                     Err("agent.answer: UNSUPPORTED_CONTROLLER: answering AskUserQuestion \
+                         requires a persistent (host) agent; container/one-shot agents are \
+                         not yet supported (Phase 2)".to_string())
+                }
+            })
+        }),
+    );
+
+    // agent.cancel → a REAL protocol-level decline of a pending AskUserQuestion
+    // (Cancel button / Escape in AgentQuestionPanel.tsx), not a UI-only dismiss.
+    // Sends `behavior: "deny"` over the same control protocol agent.answer uses
+    // for `behavior: "allow"` — see `deny_question`'s doc comment for why this
+    // is a general, documented Agent SDK mechanism rather than something
+    // special-cased for AskUserQuestion. Error strings below deliberately match
+    // agent.answer's wording verbatim (`no controller for block`,
+    // `UNSUPPORTED_CONTROLLER`): the frontend's SAFE_TO_RETRY_VIA_FOLLOWUP
+    // allowlist (useAgentQuestions.ts) matches on these substrings for both
+    // commands. Spec: docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md.
+    engine.register_handler(
+        COMMAND_AGENT_CANCEL,
+        Box::new(|data, _ctx| {
+            Box::pin(async move {
+                let cmd: CommandAgentCancelData = serde_json::from_value(data)
+                    .map_err(|e| format!("agent.cancel: {e}"))?;
+                if cmd.tool_use_id.is_empty() {
+                    return Err("agent.cancel: MISSING_ARG: tool_use_id".to_string());
+                }
+                let ctrl = blockcontroller::get_controller(&cmd.blockid)
+                    .ok_or_else(|| format!("agent.cancel: no controller for block {}", cmd.blockid))?;
+                if let Some(persistent_ctrl) = ctrl
+                    .as_any()
+                    .downcast_ref::<blockcontroller::persistent::PersistentSubprocessController>()
+                {
+                    persistent_ctrl.deny_question(
+                        cmd.tool_use_id.clone(),
+                        blockcontroller::persistent::ASK_USER_QUESTION_DENY_MESSAGE.to_string(),
+                    )?;
+                    tracing::info!(
+                        block_id = %cmd.blockid,
+                        tool_use_id = %cmd.tool_use_id,
+                        "[agent.cancel] deny control_response delivered to persistent stdin"
+                    );
+                    Ok(None)
+                } else {
+                    Err("agent.cancel: UNSUPPORTED_CONTROLLER: canceling AskUserQuestion \
                          requires a persistent (host) agent; container/one-shot agents are \
                          not yet supported (Phase 2)".to_string())
                 }

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -178,7 +178,7 @@ are doing history". Everything else is here; the completeness
 assertion in the generator fails the build rather than emit a
 partial list.
 
-### implemented (130)
+### implemented (131)
 
 | Spec | Title |
 |---|---|
@@ -211,6 +211,7 @@ partial list.
 | [`SPEC_AMBIENT_PANE_TITLE_OVERALL_GOAL_TRACKING_2026_08_17`](SPEC_AMBIENT_PANE_TITLE_OVERALL_GOAL_TRACKING_2026_08_17.md) | SPEC: Pane title tracks the session's overall goal, not the latest micro-step |
 | [`SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09`](SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md) | SPEC — Armory "Bind to Agent" context menu on account rows |
 | [`SPEC_ARMORY_MEMORY_GLOBAL_PERSONAL_RENAME_2026_08_22`](SPEC_ARMORY_MEMORY_GLOBAL_PERSONAL_RENAME_2026_08_22.md) | Spec: Armory rail — "Global Memory" / "Personal Memory" rename + reposition |
+| [`SPEC_ASK_USER_QUESTION_ACCEPT_RECOMMENDED_BUTTON_2026_09_03`](SPEC_ASK_USER_QUESTION_ACCEPT_RECOMMENDED_BUTTON_2026_09_03.md) | SPEC: "Accept Recommended" button for AskUserQuestion |
 | [`SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06`](SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md) | SPEC: Auto-timeout for AskUserQuestion — 30s countdown, auto-select the recommended option |
 | [`SPEC_ASK_USER_QUESTION_HISTORY_STYLING_2026_08_17`](SPEC_ASK_USER_QUESTION_HISTORY_STYLING_2026_08_17.md) | SPEC: Answered questions render as user input + inverted user-input surface |
 | [`SPEC_ASK_USER_QUESTION_PANEL_SCROLL_2026_08_25`](SPEC_ASK_USER_QUESTION_PANEL_SCROLL_2026_08_25.md) | SPEC: Scrolling for the AskUserQuestion panel |

--- a/docs/specs/SPEC_ASK_USER_QUESTION_ACCEPT_RECOMMENDED_BUTTON_2026_09_03.md
+++ b/docs/specs/SPEC_ASK_USER_QUESTION_ACCEPT_RECOMMENDED_BUTTON_2026_09_03.md
@@ -1,0 +1,273 @@
+# SPEC: "Accept Recommended" button for AskUserQuestion
+
+**Date:** 2026-09-03
+**Status:** implemented — §5's questions were confirmed live via an actual
+AskUserQuestion demo, and while confirming them the scope grew to include a
+real Cancel (replacing the non-functional "Answer later"). See §7 for what
+that changed relative to §§2–4 below, which describe Accept Recommended as
+originally scoped and are otherwise accurate.
+**Owner:** AgentY
+**Trigger:** User request (below) — add a button that submits every
+question's recommended option(s) in one click, instead of requiring the user
+to click through each option individually.
+
+---
+
+## 0. Ask
+
+> we want to add another button to AskQuestion tool prompt, we want a button
+> "Accept Recommended" that simply submits the answer with the recommended
+> selections. write a spec to file
+
+## 1. Current behavior (confirmed by reading the code)
+
+`AskUserQuestion` renders via `AgentQuestionPanel.tsx`
+(`frontend/app/view/agent/components/AgentQuestionPanel.tsx`), reached from a
+`ToolNode` in `status: "awaiting_answer"`. Two actions exist today, in
+`.agent-question-panel-actions` (lines 640–656):
+
+- **"Answer later"** (`defer()`, line 373) — leaves the node in
+  `awaiting_answer`, no submission.
+- **"Submit answer"** (`submit()`, line 284) — `disabled={!allAnswered()}`;
+  submits whatever the user has manually selected/typed.
+
+There is no explicit `recommended` field anywhere in the wire protocol or the
+`AskUserQuestionOption` type (`types.ts:700–736`). "Recommended" is a
+**frontend-only convention**, already built for
+[`SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md`](./SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md)
+and reused for the dashed-border highlight on options. It lives entirely in
+one exported function (`AgentQuestionPanel.tsx:53–70`):
+
+```ts
+const RECOMMENDED_RE = /\(recommended\)\s*$/i;
+
+export function recommendedOptions(options: AskUserQuestionOption[]): AskUserQuestionOption[] {
+    const flagged = options.filter((o) => RECOMMENDED_RE.test(o.label));
+    if (flagged.length > 0) return flagged;
+    return options.length > 0 ? [options[0]] : [];
+}
+```
+
+Rule: any option whose label ends in `(Recommended)` (Claude Code's own
+convention for this tool) is "recommended"; if none are flagged, the first
+option in the list is used. Can return more than one option when
+`multiSelect` is set.
+
+This function already has two callers:
+
+- **The render loop** (line 597) — computes it per-option purely to add the
+  `agent-question-panel-option--recommended` CSS class (dashed border).
+  Display-neutral: it never changes the label text.
+- **`applyRecommendedDefaults()`** (line 307) — called only from the 30s
+  auto-timeout (`createEffect` at line 353), and only fills questions the
+  user hasn't touched (`questionAnswered(i)` guard). Anything the user
+  already answered, fully or partially, survives untouched — the timeout
+  *merges*, it does not overwrite. Guarantees every question ends up
+  answered even with a zero-`options` question, via a free-text placeholder
+  fallback (`"No option was available to auto-select"`).
+
+Submission goes through `submit(autoFilledCount = 0)` → `buildOutcome()` →
+`props.onAnswer(outcome)` → `useAgentQuestions.ts`'s `handleAnswer()` →
+`RpcApi.AgentAnswerCommand` (`answers_map` keyed by question text) → the Agent
+SDK control-protocol response
+([`SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md`](./SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md)).
+`autoFilledCount` is the one piece of provenance carried through: `0` renders
+as a plain `❓ Answered` in history; a nonzero count renders a `⏱️
+(Partly/Fully) auto-answered` note (`useAgentQuestions.ts:130–137`,
+`AnsweredQuestionMessage.tsx`).
+
+**No existing spec, code, or test mentions "Accept Recommended"** — confirmed
+by a full-repo search (`Accept Recommended` / `AcceptRecommended` /
+`acceptRecommended`: zero hits). This is a new button, not a rename or
+extension of something that half-exists.
+
+## 2. What "Accept Recommended" does — the one behavioral decision that matters
+
+**It answers every question with its recommended option(s), regardless of
+what the user has already selected, then submits.**
+
+This is deliberately **not** `applyRecommendedDefaults()`'s merge-only-gaps
+behavior. That distinction needs to be explicit, because copying the wrong
+function would silently produce the wrong button:
+
+| | `applyRecommendedDefaults` (timeout) | this button |
+|---|---|---|
+| Already-answered questions | left untouched | **overwritten with the recommendation** |
+| Trigger | 30s of inactivity | explicit click |
+| Intent | safety net so work never stalls | fast path for "I trust the defaults" |
+
+The whole value of a one-click "accept recommended" action is that it does
+what it says regardless of stray clicks made before pressing it — a user who
+half-answered three questions and then decides "just go with the
+recommendations" should get exactly that, not a mix of their partial picks
+and the recommended fill for the rest. If overwrite-on-click turns out to be
+surprising in practice, the fix is copy (e.g. a confirm/tooltip), not silently
+changing this to a merge — a merge makes the button's outcome depend on click
+order, which is a worse UX than either "always overwrite" or "disabled once
+anything is answered."
+
+New function, `acceptRecommended()`, sibling to `applyRecommendedDefaults()`:
+
+```ts
+const acceptRecommended = () => {
+    const r = request();
+    if (!r) return;
+    r.questions.forEach((q, i) => {
+        const recommended = recommendedOptions(q.options);
+        if (recommended.length > 0) {
+            setQ(i, { selected: recommended.map((o) => o.label), other: "" });
+        } else {
+            // Same zero-options fallback as applyRecommendedDefaults, for the
+            // same reason: allAnswered() must pass afterward or submit() no-ops.
+            setQ(i, { selected: [], other: "No option was available to auto-select" });
+        }
+    });
+    submit(0);
+};
+```
+
+`autoFilledCount: 0` — this is a deliberate user action (one click, but a
+click), not the agent's turn stalling unattended. It renders identically to a
+manual `❓ Answered` in history. **Alternative considered and rejected:** a
+distinct history marker (e.g. `✅ Accepted recommended`) so a later reader can
+tell "the user actually read each option" from "the user clicked the
+shortcut." Rejected for v1 — it would require a new `AnswerOutcome` field
+threaded through `useAgentQuestions.ts` and `AnsweredQuestionMessage.tsx`
+for a distinction the transcript's plain answer text already mostly conveys
+(the selected labels are the recommended ones, visible either way). Worth
+revisiting only if this turns out to matter for audit trails in practice —
+tracked as an open question in §5, not built here.
+
+## 3. UI placement and behavior
+
+**Button:** `.agent-question-panel-btn` (same base as the other two — border,
+transparent background), **not** the `--submit` accent-filled variant.
+"Submit answer" stays the only visually primary action; "Accept Recommended"
+sits alongside "Answer later" as a secondary action. Rationale: this is a
+shortcut for the *default* path, not a replacement primary CTA — a filled
+accent button here would compete with "Submit answer" for visual priority and
+push the user toward the shortcut over actually reading the options, which
+under-serves a question the agent thought worth surfacing at all.
+
+**Order in `.agent-question-panel-actions`:** Answer later → **Accept
+Recommended** → Submit answer. Placed in the middle so reading order matches
+commitment order: defer (no commitment) → accept the defaults (low
+commitment) → submit my own choices (full commitment).
+
+**Always enabled**, unlike "Submit answer" (`disabled={!allAnswered()}`).
+`recommendedOptions()` always returns something to select (or the
+placeholder text), by the same guarantee `applyRecommendedDefaults()` already
+relies on — there is no state where clicking it can't produce a valid
+outcome. If `request()` is null the handler simply no-ops (mirrors every
+other action in this component).
+
+**No countdown/timer interaction needed.** Clicking submits immediately,
+which is a `props.onAnswer` call same as "Submit answer" — the panel is
+expected to unmount (queue advances) the same way, so there is no new
+interaction with the 30s auto-timeout, the hover-pause, or the keyboard-pause
+mechanisms to design around.
+
+## 4. What does NOT change
+
+- **No wire-protocol or backend change.** `recommendedOptions()` is already
+  entirely client-side; `AnswerOutcome`, `answers_map`, the RPC
+  (`AgentAnswerCommand`), and the Rust backend
+  (`CommandAgentAnswerData`) are untouched.
+- **No change to `applyRecommendedDefaults()`** or the auto-timeout behavior
+  — they remain the merge-only-gaps safety net described in
+  [`SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md`](./SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md).
+  `acceptRecommended()` is new, not a rename.
+- **No change to the option-highlight styling** (`--recommended` dashed
+  border) — it already shows the user what this button would pick, before
+  they click it.
+
+## 5. Open questions — resolved
+
+Confirmed live via an actual `AskUserQuestion` demo (using this very spec's
+§5 as the question set), not assumed:
+
+1. **Overwrite vs. merge?** → **Overwrite everything**, as §2 already argued.
+2. **History marker for "accepted via shortcut"?** → **No distinction** —
+   `autoFilledCount: 0`, renders as a plain `❓ Answered`, exactly as §2
+   proposed.
+3. **Copy?** → **"Accept Recommended"**, as originally written.
+
+All three landed on the option this spec had already recommended. What
+changed the scope of the work wasn't any of these three — it was a follow-up
+question asked immediately after: "we don't need the Answer later, get rid of
+that... in fact we want a way to exit out." See §7.
+
+## 6. Implementation surface
+
+Landed in `frontend/app/view/agent/components/AgentQuestionPanel.tsx` and its
+`.scss` sibling, exactly as scoped here:
+
+- `acceptRecommended()` (§2) inside `AgentQuestionPanel`.
+- The button in `.agent-question-panel-actions` (§3; final position is
+  Cancel → Accept Recommended → Submit answer — see §7 for why the left slot
+  is Cancel rather than the "Answer later" this section originally assumed).
+- `.agent-question-panel-btn--recommended` in `AgentQuestionPanel.scss` — a
+  bordered/text secondary-accent style, distinct from both the neutral Cancel
+  and the filled-accent Submit.
+- `AgentQuestionPanel.test.tsx`: overwrite-on-click semantics (including over
+  an already-answered question), the zero-options fallback, `autoFilledCount`
+  staying `0`.
+
+No backend, RPC, or type changes were needed **for this half of the work**
+(§4 is accurate for Accept Recommended specifically) — but §7 needed all
+three, for Cancel.
+
+## 7. Addendum — Cancel: a real protocol-level decline, not a UI dismiss
+
+**What changed the scope.** While confirming §5 live, the user pointed out
+that the panel's other existing action — **"Answer later"** (`defer()`,
+§1) — doesn't work: it only sets a `minimized` signal and logs a message. It
+never tells the agent anything, so the agent stays blocked on the question
+forever. The request: remove it entirely, replace it with a **Cancel** that
+actually tells the agent the user declined to answer, with Escape mapped to
+the same action — landing on a **3-button row: Cancel, Accept Recommended,
+Submit answer** (left-to-right = increasing commitment: exit → accept
+defaults → submit your own choices).
+
+**The mechanism, verified against the official Agent SDK docs
+(code.claude.com/docs/en/agent-sdk/{permissions,user-input}) rather than
+assumed:** `AskUserQuestion` goes through the exact same `canUseTool`
+control-protocol callback as ordinary tool permission requests. That callback
+supports `{behavior: "deny", message}` as a fully general, documented
+response — never previously used in this codebase for AskUserQuestion, which
+only ever sent `{behavior: "allow", updatedInput: {answers}}`.
+
+**Backend** (`agentmux-srv/src/backend/blockcontroller/persistent.rs`): new
+`deny_question(tool_use_id, message) -> Result<(), String>`, structurally a
+mirror of `answer_question` — same `pending_questions` lookup/removal, same
+dead-air safety net (a pending tool_use can be abandoned by the CLI whether
+the response was an allow or a deny) — sending `behavior: "deny"` with a
+fixed, server-owned message (`ASK_USER_QUESTION_DENY_MESSAGE`) instead of
+`allow` + `updatedInput`. New RPC command `agentcancel` /
+`CommandAgentCancelData { blockid, tool_use_id }`, registered in
+`server/websocket.rs` mirroring `agent.answer`'s handler — including its
+exact error wording, since the frontend's `SAFE_TO_RETRY_VIA_FOLLOWUP`
+allowlist (`useAgentQuestions.ts`) matches on those substrings for both
+commands.
+
+**Frontend:** `handleCancel()` in `useAgentQuestions.ts` mirrors
+`handleAnswer()`'s optimistic-transition + allowlisted-fallback shape. The
+resolved node lands on `status: "denied"` — an existing, fully-wired
+`ToolNode` status (icon `⊘`, fail-terminal auto-collapse, `STATUS_LABEL`)
+reused rather than adding a new one, and the correct semantic fit: a rejected
+permission request, distinct from `"canceled"`, which is reserved for
+orphan-scrub forcibly terminating a stale in-flight call — a different
+scenario from a live, successful decline. `AgentQuestionPanel.tsx` lost the
+entire `minimized`/`setMinimized` signal and the minimized-chip UI along with
+`defer()` — there is no more "leave it pending, minimized" state, since
+Cancel is a terminal, delivered action. `AnsweredQuestionMessage.tsx` renders
+a declined question with a compact "🚫 Cancelled — no answer provided" note
+instead of the answer bubble, since there is no answer to show.
+
+**Corrections to §§3–4 above, now that both features shipped together:**
+§3's "Answer later → Accept Recommended → Submit answer" ordering is
+Cancel → Accept Recommended → Submit answer. §4's "no backend, RPC, or type
+changes" is true only for Accept Recommended; Cancel required all three,
+described above.
+
+Spec: docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md.

--- a/frontend/app/store/agent-document/reducer.test.ts
+++ b/frontend/app/store/agent-document/reducer.test.ts
@@ -323,6 +323,51 @@ describe("agent document reducer", () => {
             expect(result.summary).toBe("❓ Answered — Red");
             expect(result.questionText).toBe("Which color do you like?");
         });
+
+        // Codex P1 on #2950: the guard above keyed on `answerText != null`,
+        // which a CANCELLED question deliberately never sets (there is no
+        // answer). That let a declined question's "denied" status and
+        // cancelled-note rendering get silently clobbered by the CLI's own
+        // trailing tool_result echo for the same tool_use_id — exactly the
+        // clobbering bug RETRO_ASK_USER_QUESTION_ANSWER_TEXT_CLOBBER_2026_08_18.md
+        // already fixed once, reintroduced for a case that guard didn't
+        // cover. Also pins that `status` itself survives the echo, not just
+        // the display fields — unlike the answered case, there's no
+        // guarantee the real echo's raw status happens to already read
+        // "denied" (stream-parser.ts's toolResultToNode() passes the
+        // backend's event.status straight through, unverified against a
+        // live deny).
+        it("preserves a cancelled AskUserQuestion's status/questionText against the CLI's own trailing tool_result echo", () => {
+            const cancelled = tool("q2", {
+                toolName: "AskUserQuestion",
+                status: "denied",
+                summary: "🚫 Cancelled — no answer provided",
+                questionText: "Which color do you like?",
+            });
+            const s0 = seed([cancelled]);
+
+            // The CLI's own tool_result echo for the declined tool call —
+            // a fresh, generic node built the way toolResultToNode() would,
+            // with whatever raw status the backend happens to send (modeled
+            // here as "success", the worst case: an echo that would flip a
+            // declined question back to looking answered if unpreserved).
+            const echo = tool("q2", {
+                toolName: "AskUserQuestion",
+                status: "success",
+                summary: "✓ AskUserQuestion",
+            });
+            const r = update(s0, {
+                type: "StreamFlush",
+                newNodes: [],
+                updatedNodes: [echo],
+            });
+
+            const result = r.state.nodes[0] as ToolNode;
+            expect(result.status).toBe("denied");
+            expect(result.summary).toBe("🚫 Cancelled — no answer provided");
+            expect(result.questionText).toBe("Which color do you like?");
+            expect(result.answerText).toBeUndefined();
+        });
     });
 
     describe("StreamTruncate suppression", () => {

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -903,31 +903,48 @@ function isDuplicate(
  * since the tool has terminated. For non-tool nodes the behavior is
  * the same as the prior unconditional replacement.
  *
- * Also preserves an already-answered AskUserQuestion's `answerText`/
- * `timeoutNote`/`questionText`/`summary` across a same-id replacement —
+ * Also preserves an already-RESOLVED AskUserQuestion's `status`/`summary`/
+ * `answerText`/`timeoutNote`/`questionText` across a same-id replacement —
  * those are frontend-only optimistic fields the parser's fresh-built
  * replacement never carries, and AskUserQuestion's own `tool_result` echo
- * (which always eventually arrives once the answer resumes the turn) would
- * otherwise wholesale-clobber them since the tool has no log buffer.
+ * (which always eventually arrives, whether the question was answered OR
+ * declined) would otherwise wholesale-clobber them since the tool has no
+ * log buffer.
  */
 function mergeReplacement(existing: DocumentNode, replacement: DocumentNode): DocumentNode {
     if (existing.type !== "tool" || replacement.type !== "tool") {
         return replacement;
     }
-    // An answered AskUserQuestion's `answerText`/`timeoutNote` are set only
-    // by useAgentQuestions.ts's optimistic handleAnswer — they never come
-    // from the event stream. But AskUserQuestion IS a real tool call, so
-    // once the answer resumes the turn, the CLI's own `tool_result` for the
-    // same tool_use_id still arrives and gets parsed into a fresh, generic
-    // ToolNode via stream-parser.ts's toolResultToNode() (no concept of
-    // these fields). Without this guard that update lands here and wins
-    // the wholesale-replace path below, silently reverting the node to the
-    // pre-answered-styling collapsed-row rendering shortly after the user
-    // answers. See docs/retro/RETRO_ASK_USER_QUESTION_ANSWER_TEXT_CLOBBER_2026_08_18.md.
+    // A resolved AskUserQuestion's `answerText`/`timeoutNote`/`questionText`
+    // are set only by useAgentQuestions.ts's optimistic handleAnswer/
+    // handleCancel — they never come from the event stream. But
+    // AskUserQuestion IS a real tool call, so its `tool_result` echo for the
+    // same tool_use_id still arrives once the turn resumes, whether the
+    // question was answered OR declined, and gets parsed into a fresh,
+    // generic ToolNode via stream-parser.ts's toolResultToNode() (no concept
+    // of these fields — `status` there is `event.status` verbatim from
+    // whatever the backend sends for this exact echo, unverified against a
+    // live deny). Without this guard that update lands here and wins the
+    // wholesale-replace path below, silently reverting the node to the
+    // pre-resolved-styling collapsed row shortly after the user acts. See
+    // docs/retro/RETRO_ASK_USER_QUESTION_ANSWER_TEXT_CLOBBER_2026_08_18.md
+    // (the original fix, for the answered case only) and codex P1 on
+    // #2950 (this widening, for the cancelled case, which sets
+    // `questionText` but deliberately never sets `answerText` — so keying
+    // this guard on `answerText != null` alone let a cancelled question's
+    // "denied" status and cancelled-note rendering get silently clobbered
+    // by whatever the raw echo happens to parse to). `questionText` is set
+    // by BOTH handlers unconditionally, so it is the right single signal for
+    // "this AskUserQuestion has already been resolved by our own optimistic
+    // handler, don't trust the parser's fresh view of it" — and `status` is
+    // now preserved too, not just the display fields, since unlike the
+    // answer case there is no guarantee the cancelled echo's raw status
+    // happens to already equal "denied".
     const existingTool = existing as ToolNode;
-    if (existingTool.toolName === "AskUserQuestion" && existingTool.answerText != null) {
+    if (existingTool.toolName === "AskUserQuestion" && existingTool.questionText != null) {
         return {
             ...(replacement as ToolNode),
+            status: existingTool.status,
             summary: existingTool.summary,
             answerText: existingTool.answerText,
             timeoutNote: existingTool.timeoutNote,

--- a/frontend/app/store/rpc-api/block.ts
+++ b/frontend/app/store/rpc-api/block.ts
@@ -71,6 +71,13 @@ export const BlockApi = {
         return client.rpcCall("agentanswer", data, opts);
     },
 
+    // Deliver a real protocol-level decline of a pending AskUserQuestion
+    // (Cancel button / Escape) — a control_response with behavior: "deny".
+    // Spec: docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md.
+    AgentCancelCommand(client: RpcClient, data: CommandAgentCancelData, opts?: RpcOpts): Promise<void> {
+        return client.rpcCall("agentcancel", data, opts);
+    },
+
     ControllerResyncCommand(client: RpcClient, data: CommandControllerResyncData, opts?: RpcOpts): Promise<void> {
         return client.rpcCall("controllerresync", data, opts);
     },

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -1075,7 +1075,7 @@ const AgentPresentationView = ({
     // See hooks/useAgentQuestions.ts. `sendMessage` is passed as a thunk so
     // the non-persistent follow-up fallback (invoked only inside the async
     // catch) can delegate to the handleSendMessage defined below.
-    const { pendingQuestions, handleAnswer } = useAgentQuestions({
+    const { pendingQuestions, handleAnswer, handleCancel } = useAgentQuestions({
         blockId: model.blockId,
         getDocument,
         sendMessage: (message: string) => handleSendMessage(message),
@@ -2215,12 +2215,16 @@ const AgentPresentationView = ({
             {/* AskUserQuestion panel — surfaced when a tool call is in
                 `awaiting_answer` (the agent asked the user a structured
                 question and is blocked on the answer). Submitting delivers a
-                tool_result over the persistent controller's stdin.
-                Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md. */}
+                tool_result over the persistent controller's stdin. Cancel
+                (button / Escape) is a REAL protocol-level decline via
+                `handleCancel`, not a UI-only dismiss — replaces the old
+                "Answer later" minimize, which never told the agent anything.
+                Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md,
+                docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md. */}
             <AgentQuestionPanel
                 pending={pendingQuestions}
                 onAnswer={handleAnswer}
-                onDefer={() => log("agent", "Question minimized")}
+                onCancel={handleCancel}
             />
 
             {/* Queue sits directly below the feed so the user's newly-

--- a/frontend/app/view/agent/components/AgentQuestionPanel.scss
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.scss
@@ -241,6 +241,14 @@
 .agent-question-panel-actions {
     display: flex;
     justify-content: flex-end;
+    // Wraps to a second row rather than clipping — three buttons (Cancel /
+    // Accept Recommended / Submit answer, added by codex P2 on #2950) can
+    // exceed a narrow split pane's width (layoutResize.ts permits panes down
+    // to 128px), and .agent-view's overflow: hidden would otherwise silently
+    // cut off Cancel or Accept Recommended rather than showing an obviously
+    // broken layout. `gap` (not row-gap/column-gap separately) already
+    // covers both axes once wrapped.
+    flex-wrap: wrap;
     gap: var(--space-2);
     // Cancel / Accept Recommended / Submit answer stay reachable even when
     // the question content above is scrolled — see spec §2 for why this

--- a/frontend/app/view/agent/components/AgentQuestionPanel.scss
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.scss
@@ -97,9 +97,9 @@
 }
 
 // 30s auto-timeout countdown (SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md
-// §2.4). In the header it's pushed to the far right like `.agent-question-panel-queue`
-// (both can be present at once — flex auto-margins group them together with no gap
-// beyond the header's own `gap`); in the minimized chip it just flows inline.
+// §2.4), pushed to the far right like `.agent-question-panel-queue` — both can
+// be present at once, flex auto-margins group them together with no gap
+// beyond the header's own `gap`.
 .agent-question-panel-header .agent-question-panel-countdown {
     margin-left: auto;
 }
@@ -242,14 +242,14 @@
     display: flex;
     justify-content: flex-end;
     gap: var(--space-2);
-    // Submit answer / Answer later stay reachable even when the question
-    // content above is scrolled — see spec §2 for why this matters beyond
-    // cosmetics (the 30s auto-timeout still fires regardless of whether the
-    // user can reach these buttons). NOT via position: sticky (Codex P2,
-    // PR #2805 — see .agent-question-panel-header's comment for why sticky
-    // is inert here); flex-shrink: 0 below is what actually keeps this bar
-    // at its natural size while .agent-question-panel-scroll absorbs any
-    // squeeze.
+    // Cancel / Accept Recommended / Submit answer stay reachable even when
+    // the question content above is scrolled — see spec §2 for why this
+    // matters beyond cosmetics (the 30s auto-timeout still fires regardless
+    // of whether the user can reach these buttons). NOT via position: sticky
+    // (Codex P2, PR #2805 — see .agent-question-panel-header's comment for
+    // why sticky is inert here); flex-shrink: 0 below is what actually keeps
+    // this bar at its natural size while .agent-question-panel-scroll
+    // absorbs any squeeze.
     padding-top: var(--space-2);
     flex-shrink: 0;
 }
@@ -268,6 +268,22 @@
         background: var(--hover-bg-color, rgba(255, 255, 255, 0.06));
     }
 
+    // Accept Recommended — a lighter-weight secondary-accent style
+    // (bordered/text, not filled) so it's visually distinct from both the
+    // neutral Cancel and the filled-accent Submit below: a shortcut for the
+    // default path, not a competing primary CTA. A filled button here would
+    // push the user toward the shortcut over actually reading the options,
+    // which under-serves a question the agent thought worth asking at all.
+    // See docs/specs/SPEC_ASK_USER_QUESTION_ACCEPT_RECOMMENDED_BUTTON_2026_09_03.md §3.
+    &--recommended {
+        border-color: var(--accent-color);
+        color: var(--accent-color);
+
+        &:hover {
+            background: rgba(var(--accent-color-rgb, 65, 159, 224), 0.1);
+        }
+    }
+
     &--submit {
         background: var(--accent-color);
         border-color: var(--accent-color);
@@ -283,23 +299,4 @@
             cursor: not-allowed;
         }
     }
-}
-
-.agent-question-panel-minimized {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-2);
-    margin: var(--space-2) 0;
-    padding: var(--space-1-5) var(--space-3);
-    background: var(--modal-bg-color, #232323);
-    border: 1px solid var(--accent-color);
-    border-radius: var(--radius-md, 0);
-    color: var(--main-text-color);
-    cursor: default;
-    font-size: var(--text-sm, 12px);
-}
-
-.agent-question-panel-minimized-cta {
-    color: var(--secondary-text-color);
-    font-size: var(--text-xs, 11px);
 }

--- a/frontend/app/view/agent/components/AgentQuestionPanel.test.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.test.tsx
@@ -160,6 +160,29 @@ describe("AgentQuestionPanel keyboard handling", () => {
         expect(onAnswer).not.toHaveBeenCalled();
     });
 
+    // reagent P1, PR #2950: Escape used to call defer() — a reversible,
+    // purely-local minimize, so misfiring from anywhere in the pane was
+    // harmless. It now calls cancel(), a real, irreversible protocol-level
+    // decline delivered to the agent. Without the same editable-target guard
+    // Enter already has, pressing Escape to clear the composer or dismiss an
+    // unrelated search input anywhere in the pane would silently and
+    // permanently decline the pending question.
+    it("does NOT cancel on Escape pressed in an editable input outside the panel (e.g. the composer)", () => {
+        const onAnswer = vi.fn();
+        const onCancel = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => (
+            <div class="agent-view">
+                <textarea data-testid="composer" />
+                <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={onCancel} />
+            </div>
+        ));
+
+        escapeOn(screen.getByTestId("composer"));
+        expect(onCancel).not.toHaveBeenCalled();
+        expect(onAnswer).not.toHaveBeenCalled();
+    });
+
     it("Escape cancels (a real decline) instead of submitting", async () => {
         const onAnswer = vi.fn();
         const onCancel = vi.fn();

--- a/frontend/app/view/agent/components/AgentQuestionPanel.test.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.test.tsx
@@ -15,9 +15,17 @@
  *
  * Also covers the 30s auto-timeout (recommended-option auto-select +
  * countdown) added by
- * docs/specs/SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md, and the
+ * docs/specs/SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md, the
  * hover-pause behavior on top of it from
- * docs/specs/SPEC_ASK_USER_QUESTION_TIMEOUT_HOVER_PAUSE_2026_08_10.md.
+ * docs/specs/SPEC_ASK_USER_QUESTION_TIMEOUT_HOVER_PAUSE_2026_08_10.md, and
+ * the Cancel (real protocol-level decline, replacing the old non-functional
+ * "Answer later" minimize) + Accept Recommended buttons from
+ * docs/specs/SPEC_ASK_USER_QUESTION_ACCEPT_RECOMMENDED_BUTTON_2026_09_03.md.
+ *
+ * `onCancel` is a required prop on every render() call below — even tests
+ * that don't exercise Cancel need a no-op spy, since the panel calls it
+ * unconditionally from Escape's keydown path if that key is ever pressed
+ * during the test (most aren't, but TypeScript can't tell that statically).
  */
 
 import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
@@ -98,7 +106,7 @@ describe("AgentQuestionPanel keyboard handling", () => {
     it("does not submit on Enter before any option is selected", () => {
         const onAnswer = vi.fn();
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />);
 
         enterOn(document.body);
         expect(onAnswer).not.toHaveBeenCalled();
@@ -107,7 +115,7 @@ describe("AgentQuestionPanel keyboard handling", () => {
     it("submits on Enter with no prior focus inside the panel, once an option is selected", async () => {
         const onAnswer = vi.fn();
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />);
 
         const user = userEvent.setup();
         await user.click(screen.getByRole("radio", { name: /Red/ }));
@@ -123,7 +131,7 @@ describe("AgentQuestionPanel keyboard handling", () => {
     it("submits on Enter while the caret is in the 'Other' free-text field", async () => {
         const onAnswer = vi.fn();
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />);
 
         const user = userEvent.setup();
         const otherInput = screen.getByPlaceholderText(/Type a custom answer/);
@@ -140,7 +148,7 @@ describe("AgentQuestionPanel keyboard handling", () => {
         render(() => (
             <div class="agent-view">
                 <input data-testid="outside-input" type="text" />
-                <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />
+                <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />
             </div>
         ));
 
@@ -152,17 +160,21 @@ describe("AgentQuestionPanel keyboard handling", () => {
         expect(onAnswer).not.toHaveBeenCalled();
     });
 
-    it("Escape defers instead of submitting", async () => {
+    it("Escape cancels (a real decline) instead of submitting", async () => {
         const onAnswer = vi.fn();
-        const onDefer = vi.fn();
+        const onCancel = vi.fn();
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onDefer={onDefer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={onCancel} />);
 
         const user = userEvent.setup();
         await user.click(screen.getByRole("radio", { name: /Red/ }));
 
         escapeOn(document.body);
-        expect(onDefer).toHaveBeenCalledTimes(1);
+        expect(onCancel).toHaveBeenCalledTimes(1);
+        // Passed the declined question's tool_use_id, same pattern as
+        // onAnswer receiving the full outcome — the caller shouldn't have
+        // to re-derive which question this was from the queue.
+        expect(onCancel).toHaveBeenCalledWith("q1");
         expect(onAnswer).not.toHaveBeenCalled();
     });
 });
@@ -193,6 +205,105 @@ describe("recommendedOptions", () => {
     });
 });
 
+describe("AgentQuestionPanel — Cancel and Accept Recommended buttons", () => {
+    it("renders exactly 3 actions: Cancel, Accept Recommended, Submit answer", () => {
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={vi.fn()} onCancel={vi.fn()} />);
+
+        expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+        expect(screen.getByRole("button", { name: "Accept Recommended" })).toBeTruthy();
+        expect(screen.getByRole("button", { name: "Submit answer" })).toBeTruthy();
+        // The old "Answer later" button/behavior no longer exists.
+        expect(screen.queryByRole("button", { name: /Answer later/ })).toBeNull();
+    });
+
+    it("Cancel button calls onCancel with the tool_use_id, not onAnswer", async () => {
+        const onAnswer = vi.fn();
+        const onCancel = vi.fn();
+        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion("q7")]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={onCancel} />);
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+        expect(onCancel).toHaveBeenCalledTimes(1);
+        expect(onCancel).toHaveBeenCalledWith("q7");
+        expect(onAnswer).not.toHaveBeenCalled();
+    });
+
+    it("Accept Recommended overwrites an already-selected non-recommended option and submits with autoFilledCount 0", async () => {
+        const onAnswer = vi.fn();
+        // "Blue (Recommended)" flags a specific option, distinct from the
+        // plain-first-option fallback used elsewhere in this file — makes
+        // the overwrite assertion below unambiguous.
+        const question: ToolNode = {
+            type: "tool",
+            id: "q8",
+            tool: "Other",
+            params: {},
+            status: "awaiting_answer",
+            collapsed: false,
+            summary: "❓ Waiting for your answer",
+            question: {
+                type: "ask_user_question",
+                tool_use_id: "q8",
+                questions: [
+                    {
+                        question: "Pick a color",
+                        header: "Test",
+                        multiSelect: false,
+                        options: [{ label: "Red" }, { label: "Blue (Recommended)" }],
+                    },
+                ],
+            },
+        };
+        const [pending] = createSignal<ToolNode[]>([question]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />);
+
+        const user = userEvent.setup();
+        // Manually pick the NON-recommended option first.
+        await user.click(screen.getByRole("radio", { name: /^Red$/ }));
+        await user.click(screen.getByRole("button", { name: "Accept Recommended" }));
+
+        expect(onAnswer).toHaveBeenCalledTimes(1);
+        const outcome = onAnswer.mock.calls[0][0];
+        // Overwritten to the recommended option, NOT left as the user's
+        // manual "Red" pick — this is the whole point of the button, and the
+        // behavior that distinguishes it from applyRecommendedDefaults'
+        // merge-only-unanswered semantics.
+        expect(outcome.answers_map["Pick a color"]).toBe("Blue (Recommended)");
+        // Deliberate user action, not a timeout fill — renders as a plain
+        // "Answered" in history, not a timeout note.
+        expect(outcome.autoFilledCount).toBe(0);
+    });
+
+    it("Accept Recommended falls back to the placeholder text for a zero-options question", async () => {
+        const onAnswer = vi.fn();
+        const noOptionsQuestion: ToolNode = {
+            type: "tool",
+            id: "q9",
+            tool: "Other",
+            params: {},
+            status: "awaiting_answer",
+            collapsed: false,
+            summary: "❓ Waiting for your answer",
+            question: {
+                type: "ask_user_question",
+                tool_use_id: "q9",
+                questions: [{ question: "Pick one", header: "Test", multiSelect: false, options: [] }],
+            },
+        };
+        const [pending] = createSignal<ToolNode[]>([noOptionsQuestion]);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />);
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole("button", { name: "Accept Recommended" }));
+
+        expect(onAnswer).toHaveBeenCalledTimes(1);
+        expect(onAnswer.mock.calls[0][0].answers_map["Pick one"]).toBe("No option was available to auto-select");
+    });
+});
+
 describe("AgentQuestionPanel 30s auto-timeout", () => {
     beforeEach(() => {
         vi.useFakeTimers();
@@ -205,7 +316,7 @@ describe("AgentQuestionPanel 30s auto-timeout", () => {
     it("auto-submits the recommended (fallback: first) option after 30s of no interaction", () => {
         const onAnswer = vi.fn();
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />);
 
         vi.advanceTimersByTime(30_000);
 
@@ -219,7 +330,7 @@ describe("AgentQuestionPanel 30s auto-timeout", () => {
         const user = userEvent.setup({ delay: null });
         const onAnswer = vi.fn();
         const [pending] = createSignal<ToolNode[]>([twoQuestionSet()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />);
 
         // Clicking the radio requires the pointer to be over it first, so
         // this also fires a real `mouseenter` on the panel — per
@@ -264,7 +375,7 @@ describe("AgentQuestionPanel 30s auto-timeout", () => {
             },
         };
         const [pending] = createSignal<ToolNode[]>([noOptionsQuestion]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />);
 
         vi.advanceTimersByTime(30_000);
 
@@ -285,7 +396,7 @@ describe("AgentQuestionPanel 30s auto-timeout", () => {
             onAnswer(outcome);
             setPending([]);
         });
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={handleAnswer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={handleAnswer} onCancel={vi.fn()} />);
 
         await user.click(screen.getByRole("radio", { name: /Red/ }));
         await user.click(screen.getByRole("button", { name: /Submit answer/ }));
@@ -300,7 +411,7 @@ describe("AgentQuestionPanel 30s auto-timeout", () => {
     it("countdown decrements once per second and reaches exactly 0 at 30s", () => {
         const onAnswer = vi.fn();
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />);
 
         expect(screen.getByText(/Auto-selects recommended in 30s/)).toBeTruthy();
 
@@ -329,7 +440,7 @@ describe("AgentQuestionPanel hover-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_HOVER_P
     it("hides the countdown immediately on mouse-enter", () => {
         const onAnswer = vi.fn();
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />);
 
         vi.advanceTimersByTime(5_000); // 25s remaining
         expect(screen.getByText(/Auto-selects recommended in 25s/)).toBeTruthy();
@@ -353,7 +464,7 @@ describe("AgentQuestionPanel hover-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_HOVER_P
     it("resumes at a fresh 30s exactly 15s after entry, even if the mouse never leaves the panel", () => {
         const onAnswer = vi.fn();
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />);
 
         vi.advanceTimersByTime(18_000); // 12s remaining
         fireEvent.mouseEnter(panel());
@@ -377,7 +488,7 @@ describe("AgentQuestionPanel hover-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_HOVER_P
     it("a fresh mouse-enter during the hide window restarts a fresh 15s from that point (the 'recursive' case)", () => {
         const onAnswer = vi.fn();
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />);
 
         fireEvent.mouseEnter(panel());
         vi.advanceTimersByTime(10_000); // 10s into the first 15s window
@@ -404,7 +515,7 @@ describe("AgentQuestionPanel hover-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_HOVER_P
             onAnswer(outcome);
             setPending([]);
         });
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={handleAnswer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={handleAnswer} onCancel={vi.fn()} />);
 
         fireEvent.mouseEnter(panel());
         await user.click(screen.getByRole("radio", { name: /Red/ }));
@@ -418,7 +529,7 @@ describe("AgentQuestionPanel hover-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_HOVER_P
     it("a new question-set arriving mid-hover starts unhidden and counting, ignoring the old head's hover state", () => {
         const onAnswer = vi.fn();
         const [pending, setPending] = createSignal<ToolNode[]>([singleSelectQuestion("q1")]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />);
 
         fireEvent.mouseEnter(panel());
         expect(screen.queryByText(/Auto-selects recommended in/)).toBeNull();
@@ -430,21 +541,25 @@ describe("AgentQuestionPanel hover-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_HOVER_P
         expect(onAnswer).toHaveBeenCalledTimes(1);
     });
 
-    it("minimizing (Answer later) while hidden forces an immediate resume, unaffected by hover history", async () => {
+    it("Cancel while hidden/hovered stops the timer without submitting (no leftover auto-submit)", async () => {
         const user = userEvent.setup({ delay: null });
         const onAnswer = vi.fn();
-        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+        const onCancel = vi.fn();
+        const [pending, setPending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
+        const handleCancel = vi.fn(() => {
+            onCancel();
+            setPending([]); // mirrors the real caller contract, same as handleAnswer above
+        });
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={handleCancel} />);
 
         fireEvent.mouseEnter(panel());
-        await user.click(screen.getByRole("button", { name: /Answer later/ }));
+        await user.click(screen.getByRole("button", { name: "Cancel" }));
 
-        // Minimized chip shows the countdown ticking normally — hover-pause
-        // never applies to it (§3.1).
-        expect(screen.getByText(/auto-selects in 30s/)).toBeTruthy();
+        expect(onCancel).toHaveBeenCalledTimes(1);
+        expect(onAnswer).not.toHaveBeenCalled();
 
         vi.advanceTimersByTime(30_000);
-        expect(onAnswer).toHaveBeenCalledTimes(1);
+        expect(onAnswer).not.toHaveBeenCalled();
     });
 });
 
@@ -462,7 +577,7 @@ describe("AgentQuestionPanel keyboard-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_KEYB
     it("hides the countdown immediately on a qualifying keydown inside the panel", () => {
         const onAnswer = vi.fn();
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />);
 
         vi.advanceTimersByTime(5_000); // 25s remaining
         expect(screen.getByText(/Auto-selects recommended in 25s/)).toBeTruthy();
@@ -478,7 +593,7 @@ describe("AgentQuestionPanel keyboard-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_KEYB
     it("resumes at a fresh 30s exactly 15s after that keydown, then auto-submits on schedule with no further activity", () => {
         const onAnswer = vi.fn();
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />);
 
         vi.advanceTimersByTime(18_000); // 12s remaining
         keydownOn(panel(), "Tab");
@@ -508,7 +623,7 @@ describe("AgentQuestionPanel keyboard-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_KEYB
     it("repeated keydowns while still hidden do not extend the window past one HOVER_HIDE_GRACE_MS (key-repeat/continuous-typing safety bound)", () => {
         const onAnswer = vi.fn();
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />);
 
         keydownOn(panel(), "Tab"); // first keydown — hides, starts the 15s window
         vi.advanceTimersByTime(10_000); // 10s into the window, still hidden
@@ -529,7 +644,7 @@ describe("AgentQuestionPanel keyboard-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_KEYB
     it("a keydown after the window resumes starts a fresh window (recursive re-engagement, mirrors the mouse 'recursive' case)", () => {
         const onAnswer = vi.fn();
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />);
 
         keydownOn(panel(), "Tab");
         vi.advanceTimersByTime(15_000); // window elapses, resumes at a fresh 30s
@@ -552,7 +667,7 @@ describe("AgentQuestionPanel keyboard-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_KEYB
         render(() => (
             <div class="agent-view">
                 <textarea data-testid="composer" />
-                <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />
+                <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />
             </div>
         ));
 
@@ -562,69 +677,10 @@ describe("AgentQuestionPanel keyboard-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_KEYB
         expect(screen.getByText(/Auto-selects recommended in 25s/)).toBeTruthy();
     });
 
-    it("keydown while minimized does not hide/pause anything", async () => {
-        const user = userEvent.setup({ delay: null });
-        const onAnswer = vi.fn();
-        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
-
-        await user.click(screen.getByRole("button", { name: /Answer later/ }));
-        keydownOn(document.body, "a");
-
-        // Minimized chip shows the countdown ticking normally, unaffected —
-        // hover-pause never applies to it and neither does this new trigger.
-        expect(screen.getByText(/auto-selects in 30s/)).toBeTruthy();
-
-        vi.advanceTimersByTime(30_000);
-        expect(onAnswer).toHaveBeenCalledTimes(1);
-    });
-
-    // codex P2, PR #2787: while minimized, `rootRef` is reassigned to the
-    // separate minimized `<button>`, so a keydown/focus landing directly on
-    // THAT button (not just elsewhere, like the document.body case above)
-    // used to read as "inside the panel" and incorrectly pause a countdown
-    // that's supposed to keep running unaffected while minimized.
-    it("keydown targeting the minimized button itself does not hide/pause anything", async () => {
-        const user = userEvent.setup({ delay: null });
-        const onAnswer = vi.fn();
-        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
-
-        await user.click(screen.getByRole("button", { name: /Answer later/ }));
-        keydownOn(screen.getByRole("button", { name: /Question waiting/ }), "Tab");
-
-        expect(screen.getByText(/auto-selects in 30s/)).toBeTruthy();
-
-        vi.advanceTimersByTime(30_000);
-        expect(onAnswer).toHaveBeenCalledTimes(1);
-    });
-
-    it("focus landing on the minimized button does not hide/pause anything", async () => {
-        const user = userEvent.setup({ delay: null });
-        const onAnswer = vi.fn();
-        const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
-
-        await user.click(screen.getByRole("button", { name: /Answer later/ }));
-        fireEvent.focusIn(screen.getByRole("button", { name: /Question waiting/ }));
-
-        expect(screen.getByText(/auto-selects in 30s/)).toBeTruthy();
-
-        vi.advanceTimersByTime(30_000);
-        expect(onAnswer).toHaveBeenCalledTimes(1);
-    });
-
-    // codex P2, PR #2787: a real browser moves focus only AFTER a Tab
-    // keydown's default action runs, so the keydown that causes a
-    // keyboard-only user's first entry into the panel has `e.target` still
-    // pointed at whatever they were focused on *before* — outside the
-    // panel. `handleKey`'s own `inPanel` check necessarily misses that one
-    // event; the separate `focusin` listener (which fires once focus has
-    // actually landed) is what catches it.
     it("focus landing inside the panel (e.g. via Tab) pauses the countdown even though the causing keydown's own target was outside", () => {
         const onAnswer = vi.fn();
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />);
 
         vi.advanceTimersByTime(5_000); // 25s remaining
         expect(screen.getByText(/Auto-selects recommended in 25s/)).toBeTruthy();
@@ -636,7 +692,7 @@ describe("AgentQuestionPanel keyboard-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_KEYB
     it("Enter fired inside the panel still submits, unaffected by the new pause trigger", async () => {
         const onAnswer = vi.fn();
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />);
 
         const user = userEvent.setup({ delay: null });
         await user.click(screen.getByRole("radio", { name: /Red/ }));
@@ -646,21 +702,21 @@ describe("AgentQuestionPanel keyboard-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_KEYB
         expect(onAnswer.mock.calls[0][0].answers_map["Pick a color"]).toBe("Red");
     });
 
-    it("Escape fired inside the panel still defers, unaffected by the new pause trigger", () => {
+    it("Escape fired inside the panel still cancels, unaffected by the new pause trigger", () => {
         const onAnswer = vi.fn();
-        const onDefer = vi.fn();
+        const onCancel = vi.fn();
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onDefer={onDefer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={onCancel} />);
 
         escapeOn(panel());
-        expect(onDefer).toHaveBeenCalledTimes(1);
+        expect(onCancel).toHaveBeenCalledTimes(1);
         expect(onAnswer).not.toHaveBeenCalled();
     });
 
     it("composes with a mouse-triggered pause: a keydown while already hidden does not extend the mouse-triggered window (single shared bound)", () => {
         const onAnswer = vi.fn();
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={onAnswer} onCancel={vi.fn()} />);
 
         fireEvent.mouseEnter(panel());
         vi.advanceTimersByTime(10_000); // 10s into the mouse-triggered 15s window, still hidden
@@ -683,7 +739,7 @@ describe("AgentQuestionPanel keyboard-pause (SPEC_ASK_USER_QUESTION_TIMEOUT_KEYB
 describe("AgentQuestionPanel scroll structure (SPEC_ASK_USER_QUESTION_PANEL_SCROLL_2026_08_25.md)", () => {
     it("wraps question content in a scroll region that is a sibling of the fixed-size header and actions bar", () => {
         const [pending] = createSignal<ToolNode[]>([twoQuestionSet()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={vi.fn()} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={vi.fn()} onCancel={vi.fn()} />);
 
         const panel = document.querySelector(".agent-question-panel") as HTMLElement;
         const scroll = panel.querySelector(":scope > .agent-question-panel-scroll");
@@ -705,15 +761,17 @@ describe("AgentQuestionPanel scroll structure (SPEC_ASK_USER_QUESTION_PANEL_SCRO
         expect(scroll?.contains(screen.getByText("Pick a size"))).toBe(true);
     });
 
-    it("does not put the Submit/Answer-later buttons inside the scroll region", () => {
+    it("does not put the Cancel/Accept Recommended/Submit buttons inside the scroll region", () => {
         const [pending] = createSignal<ToolNode[]>([singleSelectQuestion()]);
-        render(() => <AgentQuestionPanel pending={pending} onAnswer={vi.fn()} />);
+        render(() => <AgentQuestionPanel pending={pending} onAnswer={vi.fn()} onCancel={vi.fn()} />);
 
         const scroll = document.querySelector(".agent-question-panel-scroll");
+        const cancelBtn = screen.getByRole("button", { name: "Cancel" });
+        const recommendedBtn = screen.getByRole("button", { name: "Accept Recommended" });
         const submitBtn = screen.getByRole("button", { name: /Submit answer/ });
-        const deferBtn = screen.getByRole("button", { name: /Answer later/ });
 
+        expect(scroll?.contains(cancelBtn)).toBe(false);
+        expect(scroll?.contains(recommendedBtn)).toBe(false);
         expect(scroll?.contains(submitBtn)).toBe(false);
-        expect(scroll?.contains(deferBtn)).toBe(false);
     });
 });

--- a/frontend/app/view/agent/components/AgentQuestionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.tsx
@@ -506,6 +506,17 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
             e.preventDefault();
             submit();
         } else if (e.key === "Escape") {
+            // Same editable-target guard as Enter above, and it matters more
+            // here now than it used to: Escape used to call defer(), a
+            // reversible, purely-local minimize, so misfiring from a stray
+            // Escape elsewhere in the pane was harmless. It now calls
+            // cancel() — a real, irreversible protocol-level decline
+            // delivered to the agent (agent.cancel -> behavior: "deny").
+            // Without this guard, pressing Escape to clear the composer
+            // textarea or dismiss an unrelated search/autocomplete input
+            // anywhere in the pane would silently and permanently decline
+            // the pending question. reagent P1, PR #2950.
+            if (!inPanel && isEditableTarget(target)) return;
             e.preventDefault();
             cancel();
         }

--- a/frontend/app/view/agent/components/AgentQuestionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentQuestionPanel.tsx
@@ -5,8 +5,14 @@
  * AgentQuestionPanel — surfaced when a `ToolNode` in the pane has
  * `status === "awaiting_answer"` (the agent called the `AskUserQuestion`
  * tool and is blocked on the user's answer). Renders the question(s) with
- * single- or multi-select options plus a free-text "Other", and submits the
- * answer so the caller can deliver it back to the agent as a tool_result.
+ * single- or multi-select options plus a free-text "Other". Three actions:
+ * **Cancel** (a real protocol-level decline — see `cancel()` below and
+ * docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md — NOT a UI-only
+ * dismiss; the earlier "Answer later" button minimized the panel without
+ * telling the agent anything, leaving it blocked forever, and was removed
+ * for exactly that reason), **Accept Recommended** (overwrites every
+ * question's selection with its recommended option(s) and submits — see
+ * `acceptRecommended()`), and **Submit answer** (the user's own selections).
  *
  * Also runs an auto-timeout (default 30s, user-configurable via
  * `agent:askquestiontimeoutms`) so an unanswered question can never block
@@ -25,7 +31,8 @@
  * Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md,
  * docs/specs/SPEC_ASK_USER_QUESTION_AUTO_TIMEOUT_2026_08_06.md,
  * docs/specs/SPEC_ASK_USER_QUESTION_TIMEOUT_HOVER_PAUSE_2026_08_10.md,
- * docs/specs/SPEC_ASK_USER_QUESTION_TIMEOUT_KEYBOARD_PAUSE_2026_08_20.md.
+ * docs/specs/SPEC_ASK_USER_QUESTION_TIMEOUT_KEYBOARD_PAUSE_2026_08_20.md,
+ * docs/specs/SPEC_ASK_USER_QUESTION_ACCEPT_RECOMMENDED_BUTTON_2026_09_03.md.
  */
 
 import { createEffect, createMemo, createSignal, For, onCleanup, Show, untrack, type Accessor, type JSX } from "solid-js";
@@ -94,8 +101,13 @@ interface AgentQuestionPanelProps {
     pending: Accessor<ToolNode[]>;
     /** User answer. Caller advances the queue by transitioning the node. */
     onAnswer: (outcome: AnswerOutcome) => void | Promise<void>;
-    /** Defer — leave the node in awaiting_answer; minimise without answering. */
-    onDefer?: () => void;
+    /** Cancel — a real protocol-level decline (Cancel button / Escape), not a
+     *  UI-only dismiss. Passed the declined question's `tool_use_id`, same
+     *  pattern as `onAnswer` receiving the full outcome — the caller
+     *  shouldn't have to re-derive which question this was from the queue.
+     *  Required, unlike the old optional `onDefer`: every mount site needs a
+     *  real decline path now that Cancel actually tells the agent something. */
+    onCancel: (toolUseId: string) => void;
 }
 
 /** Per-question working state. */
@@ -141,7 +153,6 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
         return typeof v === "number" && v > 0 ? v : DEFAULT_AUTO_TIMEOUT_MS;
     };
 
-    const [minimized, setMinimized] = createSignal(false);
     const [state, setState] = createSignal<QState[]>([]);
     /** Milliseconds left before the auto-timeout fires. See the timer effect
      *  below (defined after `submit`, once all its dependencies exist). */
@@ -174,7 +185,6 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
     createEffect(() => {
         const r = request();
         void r?.tool_use_id; // touch so the effect re-runs on change
-        setMinimized(false);
         setState((r?.questions ?? []).map(() => ({ selected: [], other: "" })));
         setRemainingMs(autoTimeoutMs());
         clearHideTimer();
@@ -324,6 +334,38 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
         return count;
     };
 
+    // Accept Recommended button: unconditionally OVERWRITES every question's
+    // selection with its recommended option(s), even ones the user already
+    // answered — unlike `applyRecommendedDefaults` above (the timeout path),
+    // which only fills UNANSWERED questions and leaves everything else
+    // untouched. Deliberately different semantics, not a reuse: the whole
+    // point of a one-click "accept recommended" action is that it does what
+    // it says regardless of stray clicks made before pressing it — an
+    // outcome that depends on click order would be worse than either
+    // "always overwrite" or "disabled once anything is answered." See
+    // docs/specs/SPEC_ASK_USER_QUESTION_ACCEPT_RECOMMENDED_BUTTON_2026_09_03.md §2.
+    //
+    // No `autoFilledCount` marker on the resulting submission (calls
+    // `submit(0)`, same as a manual click on "Submit answer"): this is a
+    // deliberate, explicit user action, not the agent's turn stalling
+    // unattended, so it renders as a plain "Answered" in history rather than
+    // a timeout note — confirmed with the repo owner rather than assumed.
+    const acceptRecommended = () => {
+        const r = request();
+        if (!r) return;
+        r.questions.forEach((q, i) => {
+            const recommended = recommendedOptions(q.options);
+            if (recommended.length > 0) {
+                setQ(i, { selected: recommended.map((o) => o.label), other: "" });
+            } else {
+                // Same zero-options fallback applyRecommendedDefaults uses,
+                // so allAnswered() still passes and submit() doesn't no-op.
+                setQ(i, { selected: [], other: "No option was available to auto-select" });
+            }
+        });
+        submit(0);
+    };
+
     // 30s auto-timeout: fires unconditionally at zero once armed, regardless
     // of any *past* interaction. Deliberately NOT disarmed permanently on the
     // first click/keystroke — an earlier design did that, and it was
@@ -370,16 +412,20 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
         onCleanup(() => clearInterval(intervalId));
     });
 
-    const defer = () => {
-        // Hover-pause is a full-panel-only affordance (the minimized chip
-        // has no typing surface) — force an immediate resume so minimizing
-        // always returns the timer to its original, hover-independent
-        // behavior, preserving "keeps running while minimized" unchanged.
-        // SPEC_ASK_USER_QUESTION_TIMEOUT_HOVER_PAUSE_2026_08_10.md §3.1, §3.3.
+    // Cancel — a REAL protocol-level decline delivered to the agent (Cancel
+    // button / Escape), replacing the old "Answer later" defer/minimize
+    // behavior. That earlier behavior only hid the panel and logged a
+    // message; it never told the agent anything, so the agent stayed
+    // blocked on the question forever — confirmed non-functional, not a
+    // design choice being revisited. `onCancel` is a real RPC call
+    // (`agentcancel` → a control_response with `behavior: "deny"`); this
+    // component's job is just to stop its own local timers/countdown and
+    // hand off. See docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md.
+    const cancel = () => {
+        const r = request();
         clearHideTimer();
         setHidden(false);
-        setMinimized(true);
-        props.onDefer?.();
+        if (r) props.onCancel(r.tool_use_id);
     };
 
     // Any `<input>`/`<textarea>`/contentEditable is "editable" — this is the
@@ -399,14 +445,7 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
     // Shared gate for both keyboard-pause trigger paths below (`handleKey`'s
     // keydown and `handleFocusIn`'s focusin). A target counts as
     // pause-worthy engagement only if it's actually inside this panel's own
-    // DOM AND the panel is in its expanded (non-minimized) state AND we're
-    // not already paused:
-    //  - `!minimized()`: while minimized, `rootRef` is reassigned to the
-    //    separate `<button class="agent-question-panel-minimized">` (below),
-    //    so a keydown/Tab landing on that focusable button would otherwise
-    //    read as "inside the panel" and incorrectly pause a countdown that's
-    //    supposed to keep running unaffected while minimized — codex P2,
-    //    PR #2787.
+    // DOM AND we're not already paused:
     //  - `!hidden()`: only the *transition into* the paused state re-arms
     //    the flat HOVER_HIDE_GRACE_MS window. Unlike `mouseenter` — which a
     //    real browser only fires on an actual boundary-crossing, so it can't
@@ -423,7 +462,7 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
     //    `hidden()` has flipped back to false.
     const maybePauseFor = (target: EventTarget | null) => {
         const inPanel = !!rootRef && !!target && rootRef.contains(target as Node);
-        if (inPanel && !minimized() && !hidden()) onPanelPointerEnter();
+        if (inPanel && !hidden()) onPanelPointerEnter();
     };
 
     const handleKey = (e: KeyboardEvent) => {
@@ -450,7 +489,7 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
         // (the chat composer, Ctrl+F) isn't engagement with this question.
         // Deliberately unconditional on which key, including Enter/Escape:
         // both already tear down or reset this same pause state via their
-        // own existing paths immediately below/in `defer()`, so firing this
+        // own existing paths immediately below/in `cancel()`, so firing this
         // first for them is a harmless, immediately-superseded no-op, not
         // worth special-casing out. See
         // SPEC_ASK_USER_QUESTION_TIMEOUT_KEYBOARD_PAUSE_2026_08_20.md §2,
@@ -468,7 +507,7 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
             submit();
         } else if (e.key === "Escape") {
             e.preventDefault();
-            defer();
+            cancel();
         }
     };
 
@@ -512,30 +551,7 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
     return (
         <Show when={request()} keyed>
             {(r) => (
-                <Show
-                    when={!minimized()}
-                    fallback={
-                        <button
-                            type="button"
-                            ref={(el) => (rootRef = el)}
-                            class="agent-question-panel-minimized"
-                            onClick={() => setMinimized(false)}
-                        >
-                            <span class="agent-question-panel-icon" aria-hidden="true">❓</span>
-                            <span>Question waiting</span>
-                            <span
-                                class="agent-question-panel-countdown"
-                                classList={{
-                                    "agent-question-panel-countdown--warning": countdownSeverity() === "warning",
-                                    "agent-question-panel-countdown--critical": countdownSeverity() === "critical",
-                                }}
-                            >
-                                auto-selects in {countdownSeconds()}s
-                            </span>
-                            <span class="agent-question-panel-minimized-cta">click to answer</span>
-                        </button>
-                    }
-                >
+                <>
                     <QuestionPanelClip getEl={() => rootRef} />
                     {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
                     <div
@@ -641,9 +657,16 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
                             <button
                                 type="button"
                                 class="agent-question-panel-btn agent-question-panel-btn--cancel"
-                                onClick={defer}
+                                onClick={cancel}
                             >
-                                Answer later
+                                Cancel
+                            </button>
+                            <button
+                                type="button"
+                                class="agent-question-panel-btn agent-question-panel-btn--recommended"
+                                onClick={acceptRecommended}
+                            >
+                                Accept Recommended
                             </button>
                             <button
                                 type="button"
@@ -655,7 +678,7 @@ export const AgentQuestionPanel = (props: AgentQuestionPanelProps): JSX.Element 
                             </button>
                         </div>
                     </div>
-                </Show>
+                </>
             )}
         </Show>
     );

--- a/frontend/app/view/agent/components/AnsweredQuestionMessage.tsx
+++ b/frontend/app/view/agent/components/AnsweredQuestionMessage.tsx
@@ -25,7 +25,16 @@
  * `answerText` — a transcript answered between the two shows the answer
  * alone, same as it always could before this component existed.
  *
- * See docs/specs/SPEC_ASK_USER_QUESTION_HISTORY_STYLING_2026_08_17.md.
+ * `cancelled` (added for the Cancel button / Escape, replacing the old
+ * non-functional "Answer later" minimize) renders a compact note instead of
+ * the `.agent-user-message` bubble above — there is no real answer to show,
+ * and a fake "user message" bubble would misrepresent what happened.
+ * `questionText` still renders unconditionally either way: a cancelled
+ * question still shows what was asked. `ToolBlock` routes here via its own
+ * sibling `isCancelledQuestion()` gate (status === "denied", not "success").
+ *
+ * See docs/specs/SPEC_ASK_USER_QUESTION_HISTORY_STYLING_2026_08_17.md,
+ * docs/specs/SPEC_ASK_USER_QUESTION_ACCEPT_RECOMMENDED_BUTTON_2026_09_03.md.
  */
 
 import { Markdown } from "@/app/element/markdown";
@@ -35,6 +44,9 @@ import type { ToolNode } from "../types";
 
 interface AnsweredQuestionMessageProps {
     node: ToolNode;
+    /** True for a declined (Cancel/Escape) question — renders a compact note
+     *  instead of the answer bubble, since there is no answer. */
+    cancelled?: boolean;
 }
 
 export const AnsweredQuestionMessage = (props: AnsweredQuestionMessageProps): JSX.Element => {
@@ -47,21 +59,26 @@ export const AnsweredQuestionMessage = (props: AnsweredQuestionMessageProps): JS
                     </div>
                 )}
             </Show>
-            <div class="agent-user-message">
-                <div class="agent-user-message-content agent-user-message-content--flow">
-                    {/* node.timeoutNote is computed in useAgentQuestions.ts from
-                        AnswerOutcome's numeric counts, not parsed back out of a
-                        decorated string here — the free-text answer can legally
-                        contain " — ", which broke two prior string-split
-                        attempts (reagent P1 x2 on PR #2630). */}
-                    <Show when={props.node.timeoutNote}>
-                        {(note) => <div class="agent-user-message-timeout-note">{note()}</div>}
-                    </Show>
-                    <pre>
-                        <LinkifiedText text={props.node.answerText ?? ""} />
-                    </pre>
+            <Show
+                when={!props.cancelled}
+                fallback={<div class="agent-question-panel-cancelled-note">🚫 Cancelled — no answer provided</div>}
+            >
+                <div class="agent-user-message">
+                    <div class="agent-user-message-content agent-user-message-content--flow">
+                        {/* node.timeoutNote is computed in useAgentQuestions.ts from
+                            AnswerOutcome's numeric counts, not parsed back out of a
+                            decorated string here — the free-text answer can legally
+                            contain " — ", which broke two prior string-split
+                            attempts (reagent P1 x2 on PR #2630). */}
+                        <Show when={props.node.timeoutNote}>
+                            {(note) => <div class="agent-user-message-timeout-note">{note()}</div>}
+                        </Show>
+                        <pre>
+                            <LinkifiedText text={props.node.answerText ?? ""} />
+                        </pre>
+                    </div>
                 </div>
-            </div>
+            </Show>
         </>
     );
 };

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -379,8 +379,25 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     const isAnsweredQuestion = () =>
         props.node.toolName === "AskUserQuestion" && props.node.status === "success" && props.node.answerText != null;
 
+    // A declined AskUserQuestion (Cancel button / Escape) — reuses the
+    // existing "denied" ToolNode status (already a full first-class status:
+    // icon, fail-terminal auto-collapse, STATUS_LABEL) rather than adding a
+    // new one, since it is the correct semantic fit: a rejected permission
+    // request, not an orphaned/force-terminated one ("canceled" is reserved
+    // for that — see the sibling status and useAgentQuestions.ts). Scoped by
+    // toolName so this can never collide with a real tool-permission denial
+    // (a different, unrelated feature — the tool:decision path). Gated on
+    // `questionText` the same way isAnsweredQuestion() gates on `answerText`:
+    // a transcript denied before this field existed falls back to the
+    // generic collapsed row instead of showing an empty body.
+    const isCancelledQuestion = () =>
+        props.node.toolName === "AskUserQuestion" && props.node.status === "denied" && props.node.questionText != null;
+
     return (
-        <Show when={!isAnsweredQuestion()} fallback={<AnsweredQuestionMessage node={props.node} />}>
+        <Show
+            when={!isAnsweredQuestion() && !isCancelledQuestion()}
+            fallback={<AnsweredQuestionMessage node={props.node} cancelled={isCancelledQuestion()} />}
+        >
             <div
                 ref={setPeekRowEl}
                 class={clsx("agent-tool-block", {

--- a/frontend/app/view/agent/hooks/useAgentQuestions.test.ts
+++ b/frontend/app/view/agent/hooks/useAgentQuestions.test.ts
@@ -16,6 +16,15 @@
  * control_response actually landed server-side, so that case still rolls
  * back rather than risking a duplicate delivery — reagent P2). See
  * docs/reports/REPORT_WORKING_STATE_REGRESSION_AND_STUCK_QUESTION_PANEL_2026_07_27.md §2.7/§2.8.
+ *
+ * Also covers `handleCancel` — the real protocol-level decline (Cancel
+ * button / Escape) that replaced the old non-functional "Answer later"
+ * minimize. Mirrors handleAnswer's fallback shape exactly: same
+ * SAFE_TO_RETRY_VIA_FOLLOWUP allowlist, same "roll back on anything else"
+ * reasoning, since `deny_question` shares the identical pending_questions
+ * lookup as `answer_question` on the backend. See
+ * docs/specs/SPEC_ASK_USER_QUESTION_ACCEPT_RECOMMENDED_BUTTON_2026_09_03.md,
+ * docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md.
  */
 
 import { createRoot } from "solid-js";
@@ -24,12 +33,14 @@ import type { ToolNode } from "../types";
 
 const hub = vi.hoisted(() => ({
     agentAnswer: vi.fn(),
+    agentCancel: vi.fn(),
     dispatched: [] as unknown[],
 }));
 
 vi.mock("@/app/store/rpc-api", () => ({
     RpcApi: {
         AgentAnswerCommand: (...args: unknown[]) => hub.agentAnswer(...args),
+        AgentCancelCommand: (...args: unknown[]) => hub.agentCancel(...args),
     },
 }));
 vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
@@ -65,6 +76,7 @@ function updatedNodeFromDispatch(): ToolNode | undefined {
 
 beforeEach(() => {
     hub.agentAnswer.mockReset();
+    hub.agentCancel.mockReset();
     hub.dispatched.length = 0;
 });
 afterEach(() => {
@@ -73,17 +85,18 @@ afterEach(() => {
 
 function setup(sendMessage: (m: string) => Promise<void>, log: (ch: string, msg: string) => void = () => {}) {
     let handleAnswer!: ReturnType<typeof useAgentQuestions>["handleAnswer"];
+    let handleCancel!: ReturnType<typeof useAgentQuestions>["handleCancel"];
     let dispose: () => void = () => {};
     createRoot((d) => {
         dispose = d;
-        ({ handleAnswer } = useAgentQuestions({
+        ({ handleAnswer, handleCancel } = useAgentQuestions({
             blockId: BLOCK_ID,
             getDocument: () => [pendingQuestionNode()],
             sendMessage,
             log,
         }));
     });
-    return { handleAnswer, dispose };
+    return { handleAnswer, handleCancel, dispose };
 }
 
 describe("useAgentQuestions — handleAnswer fallback", () => {
@@ -291,6 +304,90 @@ describe("useAgentQuestions — handleAnswer fallback", () => {
             answer_text: "Pick one: a",
             autoFilledCount: 0,
         });
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(sendMessage).not.toHaveBeenCalled();
+        const lastFlush = hub.dispatched[hub.dispatched.length - 1] as any;
+        expect(lastFlush.updatedNodes[0].status).toBe("awaiting_answer");
+        dispose();
+    });
+});
+
+describe("useAgentQuestions — handleCancel fallback", () => {
+    it("transitions to status 'denied' and does not fall back when AgentCancelCommand succeeds", async () => {
+        hub.agentCancel.mockResolvedValue(undefined);
+        const sendMessage = vi.fn().mockResolvedValue(undefined);
+        const { handleCancel, dispose } = setup(sendMessage);
+
+        handleCancel(TOOL_USE_ID);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(hub.agentCancel).toHaveBeenCalledTimes(1);
+        const [, cancelData] = hub.agentCancel.mock.calls[0];
+        expect(cancelData).toEqual({ blockid: BLOCK_ID, tool_use_id: TOOL_USE_ID });
+        expect(sendMessage).not.toHaveBeenCalled();
+        const node = updatedNodeFromDispatch();
+        // "denied", not "success" — this is a decline, not an answer. Reuses
+        // the existing first-class ToolNode status rather than a new one.
+        expect(node?.status).toBe("denied");
+        expect(node?.question).toBeUndefined();
+        // No fake answer — answerText intentionally stays unset so ToolBlock's
+        // isAnsweredQuestion() gate (answerText != null) can't mistake this
+        // for a real answer.
+        expect(node?.answerText).toBeUndefined();
+        dispose();
+    });
+
+    it("sets questionText from the original prompt(s), same extraction as handleAnswer", async () => {
+        hub.agentCancel.mockResolvedValue(undefined);
+        const sendMessage = vi.fn().mockResolvedValue(undefined);
+        const { handleCancel, dispose } = setup(sendMessage);
+
+        handleCancel(TOOL_USE_ID);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(updatedNodeFromDispatch()?.questionText).toBe("Pick one");
+        dispose();
+    });
+
+    it("falls back to a follow-up message for a known-safe backend error — the same SAFE_TO_RETRY_VIA_FOLLOWUP allowlist handleAnswer uses", async () => {
+        // deny_question shares the identical pending_questions lookup as
+        // answer_question, so it produces the identical error shape after a
+        // pane reopen / process respawn.
+        hub.agentCancel.mockRejectedValue(
+            new Error(
+                `no pending AskUserQuestion for tool_use_id ${TOOL_USE_ID} — this controller instance never recorded it`,
+            ),
+        );
+        const sendMessage = vi.fn().mockResolvedValue(undefined);
+        const { handleCancel, dispose } = setup(sendMessage);
+
+        handleCancel(TOOL_USE_ID);
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(sendMessage).toHaveBeenCalledWith("The user declined to answer this question.");
+        // Optimistic "denied" state is kept, same reasoning as handleAnswer's
+        // equivalent case: the panel must not flicker back to
+        // awaiting_answer just because the control-protocol path failed.
+        expect(updatedNodeFromDispatch()?.status).toBe("denied");
+        dispose();
+    });
+
+    // reagent P2's reasoning (see the handleAnswer test above) applies
+    // identically here: an RPC-engine-level timeout does not prove the deny
+    // was never delivered, so it must roll back rather than guess.
+    it("rolls back (does NOT fall back) on an unrecognized error like an RPC-engine timeout", async () => {
+        hub.agentCancel.mockRejectedValue(new Error("EC-TIME: timeout (5000ms)"));
+        const sendMessage = vi.fn().mockResolvedValue(undefined);
+        const { handleCancel, dispose } = setup(sendMessage);
+
+        handleCancel(TOOL_USE_ID);
         await Promise.resolve();
         await Promise.resolve();
         await Promise.resolve();

--- a/frontend/app/view/agent/hooks/useAgentQuestions.test.ts
+++ b/frontend/app/view/agent/hooks/useAgentQuestions.test.ts
@@ -371,6 +371,12 @@ describe("useAgentQuestions — handleCancel fallback", () => {
         await Promise.resolve();
         await Promise.resolve();
 
+        // Exact literal, not a substring match — this is the frontend half of
+        // the cross-file sync pinned by persistent.rs's
+        // ask_user_question_deny_message_matches_frontend_cancel_fallback_text.
+        // See CANCEL_FALLBACK_MESSAGE's own comment: no shared constant
+        // crosses the Rust/TypeScript boundary, so both literals are
+        // hand-copied and must be updated together.
         expect(sendMessage).toHaveBeenCalledWith("The user declined to answer this question.");
         // Optimistic "denied" state is kept, same reasoning as handleAnswer's
         // equivalent case: the panel must not flicker back to

--- a/frontend/app/view/agent/hooks/useAgentQuestions.ts
+++ b/frontend/app/view/agent/hooks/useAgentQuestions.ts
@@ -79,8 +79,17 @@ export interface UseAgentQuestionsResult {
  *  the SAFE_TO_RETRY_VIA_FOLLOWUP fallback text (a plain follow-up turn when
  *  the control protocol itself is unavailable). The actual protocol-level
  *  decline text is server-owned (ASK_USER_QUESTION_DENY_MESSAGE in
- *  agentmux-srv's persistent.rs) — this is not read from there, just worded
- *  identically so the model sees the same explanation either way. */
+ *  agentmux-srv/src/backend/blockcontroller/persistent.rs) — this is not read
+ *  from there, just worded identically so the model sees the same
+ *  explanation either way.
+ *
+ *  KEEP IN SYNC: no shared constant crosses the Rust/TypeScript boundary for
+ *  a plain string literal, so this has to be hand-copied. If you change this
+ *  string, update ASK_USER_QUESTION_DENY_MESSAGE too — persistent.rs's
+ *  `ask_user_question_deny_message_matches_frontend_cancel_fallback_text`
+ *  pins the literal on that side; the "handleCancel fallback" describe block
+ *  below (asserting `sendMessage` was called with this exact text) pins it
+ *  here. Neither test can see the other language's constant. */
 const CANCEL_FALLBACK_MESSAGE = "The user declined to answer this question.";
 
 export function useAgentQuestions(opts: UseAgentQuestionsOptions): UseAgentQuestionsResult {

--- a/frontend/app/view/agent/hooks/useAgentQuestions.ts
+++ b/frontend/app/view/agent/hooks/useAgentQuestions.ts
@@ -11,6 +11,8 @@
  * as the queue transitions empty↔non-empty. `handleAnswer` optimistically
  * transitions the node and delivers the answer over the persistent
  * controller (falling back to a follow-up turn for non-persistent agents).
+ * `handleCancel` is the same shape for a REAL protocol-level decline (Cancel
+ * button / Escape) — see docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md.
  *
  * Spec: docs/specs/SPEC_ASK_USER_QUESTION_2026_06_15.md.
  *
@@ -41,11 +43,13 @@ export interface UseAgentQuestionsOptions {
 }
 
 // Error shapes where the backend GUARANTEES the control_response was never
-// sent — every one of these is returned by `agent.answer`'s handler or
-// `PersistentSubprocessController::answer_question` (agentmux-srv's
-// websocket.rs / blockcontroller/persistent.rs) strictly BEFORE (or instead
-// of) the `tx.try_send(control_response...)` call, so falling back to the
-// follow-up-message path can never duplicate-deliver the answer for these.
+// sent — every one of these is returned by `agent.answer`/`agent.cancel`'s
+// handlers or `PersistentSubprocessController::answer_question`/
+// `deny_question` (agentmux-srv's websocket.rs / blockcontroller/persistent.rs)
+// strictly BEFORE (or instead of) the `tx.try_send(control_response...)` call,
+// so falling back to the follow-up-message path can never duplicate-deliver
+// for either command — both share the identical pending_questions lookup and
+// error wording, verified against the current source, not assumed.
 // Deliberately an allowlist, not a blocklist: reagent P2 on the PR that
 // widened this fallback flagged that an RPC-engine-level failure (e.g. the
 // "EC-TIME: timeout" the engine's own `tokio::time::timeout` wrapper can
@@ -68,7 +72,16 @@ const SAFE_TO_RETRY_VIA_FOLLOWUP = [
 export interface UseAgentQuestionsResult {
     pendingQuestions: () => ToolNode[];
     handleAnswer: (outcome: AnswerOutcome) => void;
+    handleCancel: (toolUseId: string) => void;
 }
+
+/** Fixed, client-side mirror of the server's decline message — used only for
+ *  the SAFE_TO_RETRY_VIA_FOLLOWUP fallback text (a plain follow-up turn when
+ *  the control protocol itself is unavailable). The actual protocol-level
+ *  decline text is server-owned (ASK_USER_QUESTION_DENY_MESSAGE in
+ *  agentmux-srv's persistent.rs) — this is not read from there, just worded
+ *  identically so the model sees the same explanation either way. */
+const CANCEL_FALLBACK_MESSAGE = "The user declined to answer this question.";
 
 export function useAgentQuestions(opts: UseAgentQuestionsOptions): UseAgentQuestionsResult {
     // Pending AskUserQuestion queue — every ToolNode in `awaiting_answer`,
@@ -241,5 +254,63 @@ export function useAgentQuestions(opts: UseAgentQuestionsOptions): UseAgentQuest
         });
     };
 
-    return { pendingQuestions, handleAnswer };
+    // AskUserQuestion CANCEL handler — a real protocol-level decline (Cancel
+    // button / Escape in AgentQuestionPanel.tsx), not the old UI-only "Answer
+    // later" minimize. Mirrors handleAnswer's optimistic-transition +
+    // SAFE_TO_RETRY_VIA_FOLLOWUP fallback shape; the differences are just
+    // what a decline carries: no answers_map/answer_text, and the resolved
+    // node lands on status "denied" (already a full first-class ToolNode
+    // status — icon, fail-terminal auto-collapse, STATUS_LABEL — reused here
+    // rather than adding a new one) instead of "success".
+    const handleCancel = (toolUseId: string) => {
+        const originals: ToolNode[] = [];
+        const updated: ToolNode[] = [];
+        for (const n of opts.getDocument()) {
+            if (n.type !== "tool" || n.status !== "awaiting_answer") continue;
+            if (n.question?.tool_use_id !== toolUseId) continue;
+            originals.push(n);
+            // Same extraction as handleAnswer — the original prompt(s) as
+            // plain text BEFORE `question` is cleared, so AnsweredQuestionMessage
+            // can still show what was asked even though it wasn't answered.
+            const questionText = n.question?.questions.map((q) => q.question).join("\n\n");
+            updated.push({
+                ...n,
+                status: "denied",
+                question: undefined,
+                summary: "🚫 Cancelled — no answer provided",
+                questionText,
+                // answerText intentionally left unset: there is no answer, and
+                // ToolBlock's isAnsweredQuestion() gate keys off answerText !=
+                // null specifically to distinguish "really answered" from
+                // everything else — leaving it undefined is what keeps a
+                // cancelled question out of that path and into the sibling
+                // isCancelledQuestion() one instead.
+            });
+        }
+        const applyDoc = (nodes: ToolNode[]) => {
+            if (nodes.length > 0) {
+                dispatchDoc(opts.blockId, { type: "StreamFlush", newNodes: [], updatedNodes: nodes }, "user");
+            }
+        };
+        applyDoc(updated);
+
+        void RpcApi.AgentCancelCommand(TabRpcClient, {
+            blockid: opts.blockId,
+            tool_use_id: toolUseId,
+        }).catch((err: unknown) => {
+            const msg = String(err);
+            if (SAFE_TO_RETRY_VIA_FOLLOWUP.some((marker) => msg.includes(marker))) {
+                opts.log("agent", `Delivering AskUserQuestion cancel as a follow-up message (${msg})`);
+                // No rollback-on-failure here, same reasoning as handleAnswer's
+                // identical comment: opts.sendMessage never rejects, so a
+                // .catch() here would never run.
+                void opts.sendMessage(CANCEL_FALLBACK_MESSAGE);
+                return;
+            }
+            opts.log("error", `agent.cancel failed: ${msg}`);
+            applyDoc(originals);
+        });
+    };
+
+    return { pendingQuestions, handleAnswer, handleCancel };
 }

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -1276,6 +1276,19 @@
 
     }
 
+    // A declined AskUserQuestion (Cancel button / Escape) renders this
+    // instead of .agent-user-message above — there is no real answer, so a
+    // fake "user message" bubble would misrepresent what happened. Muted,
+    // NOT inverted like the message bubble, so it reads as a system note
+    // about the exchange rather than a message either side sent.
+    // AnsweredQuestionMessage.tsx, SPEC_ASK_USER_QUESTION_ACCEPT_RECOMMENDED_BUTTON_2026_09_03.md.
+    .agent-question-panel-cancelled-note {
+        padding: 3px var(--space-1);
+        color: var(--secondary-text-color);
+        font-size: var(--text-sm, 12px);
+        font-style: italic;
+    }
+
     // === Section Headings ===
     .agent-section {
         margin-top: var(--space-1-5);

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -76,7 +76,6 @@
     // the top-edge comment above).
     .agent-auth-panel-card:has(~ .agent-composer-strip),
     .agent-question-panel:has(~ .agent-composer-strip),
-    .agent-question-panel-minimized:has(~ .agent-composer-strip),
     .agent-disconnected-banner:has(~ .agent-composer-strip) {
         margin-bottom: 0;
     }

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -269,6 +269,16 @@ declare global {
         answers: {[key: string]: string | string[]};
     };
 
+    // CommandAgentCancelData — a real protocol-level decline of a pending
+    // AskUserQuestion (Cancel button / Escape), delivered as a control_response
+    // carrying behavior: "deny" rather than CommandAgentAnswerData's allow+answers
+    // shape. No answers field — the deny message is a fixed server-owned string.
+    // Spec: docs/specs/SPEC_AGENT_CONTROL_PROTOCOL_2026_06_15.md.
+    type CommandAgentCancelData = {
+        blockid: string;
+        tool_use_id: string;
+    };
+
     // wshrpc.CommandBlockSetViewData
     type CommandBlockSetViewData = {
         blockid: string;

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -764,10 +764,9 @@ declare global {
     };
 
     // ────────────────────────────────────────────────────────────────
-    // Unified agent types (Drone Phase 1.5, see
-    // docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md). Shared
-    // between the agent pane and the drone Agent block. Mirror
-    // of agentmux-srv/src/agents/types.rs — camelCase via serde
+    // Unified agent types (Drone Phase 1.5). Shared between the agent
+    // pane and the drone Agent block. Mirror of
+    // agentmux-srv/src/agents/types.rs — camelCase via serde
     // rename_all so the field shapes match without translation.
     // ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Two changes to the AskUserQuestion panel, confirmed live with the repo owner via an actual `AskUserQuestion` demo before writing any code. Spec: `docs/specs/SPEC_ASK_USER_QUESTION_ACCEPT_RECOMMENDED_BUTTON_2026_09_03.md`.

**Accept Recommended** — overwrites every question's selection with its recommended option(s), even already-answered ones, and submits. Deliberately *not* `applyRecommendedDefaults`'s merge-only-unanswered semantics (the 30s timeout safety net) — the value of a one-click "use the defaults" action is that the outcome doesn't depend on stray clicks made before pressing it.

**Cancel — a real protocol-level decline, not the old UI dismiss.** While confirming the above live, it surfaced that the panel's other action, **"Answer later", doesn't work** — it only sets a UI signal and logs a message, never telling the agent anything, so the agent stays blocked on the question forever. Removed entirely, replaced with Cancel (button + Escape).

Final layout: **Cancel → Accept Recommended → Submit answer** (increasing commitment, left to right).

## How Cancel actually works

Verified against the official Agent SDK docs (`code.claude.com/docs/en/agent-sdk/{permissions,user-input}`) rather than assumed: `AskUserQuestion` shares the exact `canUseTool` control-protocol callback ordinary tool permissions use, which supports `{behavior: "deny", message}` — never used in this codebase for AskUserQuestion before, which only ever sent `allow` + `updatedInput`.

- **Backend:** `deny_question()` in `persistent.rs` mirrors `answer_question()` exactly — same `pending_questions` lookup, same dead-air safety net (a pending tool_use can be abandoned by the CLI regardless of whether the response was allow or deny) — sending `behavior: "deny"` with a fixed, server-owned message. New RPC command `agentcancel` / `CommandAgentCancelData`, its handler mirroring `agent.answer`'s **exact error wording**, since the frontend's `SAFE_TO_RETRY_VIA_FOLLOWUP` allowlist matches on those substrings for both commands.
- **Frontend:** `handleCancel()` mirrors `handleAnswer`'s optimistic-transition + allowlisted-fallback shape. The resolved node lands on `status: "denied"` — an existing, fully-wired `ToolNode` status (icon, CSS, auto-collapse) reused rather than adding a new one, and the correct semantic fit: a rejected request, distinct from `"canceled"`, which means something else here (orphan-scrub force-terminating a stale in-flight call, not a live decline).
- `AgentQuestionPanel.tsx` loses the entire `minimized` signal and minimized-chip UI along with `defer()` — there's no more "leave it pending, minimized" state now that Cancel is terminal.
- `AnsweredQuestionMessage.tsx` renders a declined question with a compact note instead of a fake answer bubble, since there's no answer.

## Verified

| Check | Result |
|---|---|
| `cargo build` | clean |
| Backend tests | **2953 pass** (2 new: `deny_question` untracked-id, `build_deny_resume_message`) |
| Frontend typecheck | clean across the whole tree |
| Frontend tests | **3474 pass** (36 in `AgentQuestionPanel.test.tsx`, 4 new for these buttons; 12 in `useAgentQuestions.test.ts`, 4 new for `handleCancel`) |

Also found and fixed one pre-existing dead CSS rule in `_document.scss` still targeting the now-removed minimized-chip class.

## Not verified — flagging honestly rather than skipping it

**I have not run this live** in `task dev` against a real agent session — clicking Cancel mid-turn and confirming the agent's turn actually resumes rather than hanging, including timing the 4-second dead-air fallback against a real CLI. That's the one thing unit tests can't fully exercise, and it's worth doing before merge given this is the exact protocol path every `AskUserQuestion` in the product goes through. Happy to do that pass, or if the repo owner wants to try it directly — either works.

<!-- agentmux:agent_id=agenty -->