### PR TITLE
feat(swarm): list each agent's todo checklist and in-flight tool under its name

### DIFF
--- a/.changesets/1788465581-feat-swarm-list-each-agent-s-todo-checklist-and-in-flight-to-h3vd.md
+++ b/.changesets/1788465581-feat-swarm-list-each-agent-s-todo-checklist-and-in-flight-to-h3vd.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(swarm): list each agent's todo checklist and in-flight tool under its name

--- a/agentmux-srv/src/backend/reactive/mod.rs
+++ b/agentmux-srv/src/backend/reactive/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod activity_watcher;
 pub mod handler;
+pub mod progress_watcher;
 pub mod poller;
 pub mod registry;
 pub mod sanitize;

--- a/agentmux-srv/src/backend/reactive/progress_watcher.rs
+++ b/agentmux-srv/src/backend/reactive/progress_watcher.rs
@@ -210,7 +210,7 @@ fn apply_lines(state: &mut BlockState, lines: &[&str]) {
             // item-at-a-time call after it would be describing a different
             // vocabulary than the one currently in force.
             if state.list.is_none() {
-                merge_single_task(&mut state.tasks, input);
+                merge_single_task(&mut state.tasks, input, name);
             }
         }
     }
@@ -314,15 +314,47 @@ fn parse_todo_entry(entry: &serde_json::Value) -> Option<TodoItem> {
 /// reason to resend text that did not change. Requiring a complete item meant
 /// such a call parsed to nothing and the row sat at `pending` forever, which is
 /// precisely the case a checklist exists to show moving.
-fn merge_single_task(items: &mut Vec<(String, TodoItem)>, input: &serde_json::Value) {
+/// Does this tool name describe CREATING an item, as opposed to revising one?
+///
+/// Only consulted for calls that carry no id (reagent P2 on PR #2952). With an
+/// id the key is unambiguous; without one, text is the only identity available,
+/// and keying on it alone silently collapses two genuinely distinct in-flight
+/// tasks that happen to share a title. Two visible duplicate rows are a much
+/// smaller harm than one invisibly missing row, so an idless CREATE always
+/// appends and only an idless UPDATE matches by text.
+fn is_create_call(tool_name: &str) -> bool {
+    tool_name.contains("Create") || tool_name.contains("Add") || tool_name.contains("New")
+}
+
+fn merge_single_task(items: &mut Vec<(String, TodoItem)>, input: &serde_json::Value, tool_name: &str) {
     let text = first_string(input, &["content", "title", "text", "activeForm", "description"]);
     let status = first_string(input, &["status", "state"]);
-    let Some(key) = first_string(input, &["task_id", "taskId", "id"]).or_else(|| text.clone()) else {
-        // Neither an id nor any text — nothing identifies a row to touch.
-        return;
-    };
+    let id = first_string(input, &["task_id", "taskId", "id"]);
 
-    if let Some(slot) = items.iter_mut().find(|(k, _)| *k == key) {
+    // An idless create is its own row, always — see `is_create_call`.
+    if id.is_none() && is_create_call(tool_name) {
+        let Some(text) = text else { return };
+        items.push((
+            // Unique so no later call can match it by key; an idless tool
+            // gives us nothing to correlate a future update against anyway.
+            format!("{}#{}", text, items.len()),
+            TodoItem { text, status: status.unwrap_or_else(|| "pending".to_string()) },
+        ));
+        return;
+    }
+
+    // Find the row this call refers to. An id matches the key it was stored
+    // under; an idless update has only its text, and must compare against each
+    // row's TEXT rather than its key — a row created WITH an id is keyed by
+    // that id, so a key comparison would miss it and append a duplicate.
+    let existing = match &id {
+        Some(id) => items.iter_mut().find(|(k, _)| k == id),
+        None => match &text {
+            Some(text) => items.iter_mut().find(|(_, item)| item.text == *text),
+            None => None,
+        },
+    };
+    if let Some(slot) = existing {
         if let Some(text) = text {
             slot.1.text = text;
         }
@@ -331,6 +363,11 @@ fn merge_single_task(items: &mut Vec<(String, TodoItem)>, input: &serde_json::Va
         }
         return;
     }
+
+    let Some(key) = id.or_else(|| text.clone()) else {
+        // Neither an id nor any text — nothing identifies a row to touch.
+        return;
+    };
 
     // Creating a row still needs something to display; an update for a task we
     // never saw created (seeded mid-stream) has no text to show.
@@ -405,6 +442,60 @@ fn consume_new_output(filestore: &FileStore, block_id: &str, state: &mut BlockSt
 }
 
 /// Run the progress sweep loop. Never returns.
+/// One block's worth of work decided by a sweep — what to publish, if anything.
+struct SweepOutcome {
+    agent_id: String,
+    block_id: String,
+    progress: AgentProgress,
+}
+
+/// The whole file-reading half of a sweep, run OFF the async runtime.
+///
+/// `FileStore::stat`/`read_at` are synchronous, mutex-guarded SQLite reads, and
+/// this loop runs them for every live agent at a 3s cadence (reagent P2 on PR
+/// #2952). Doing that inline would park a Tokio worker thread on disk I/O
+/// several times a second — tolerable at `activity_watcher`'s 20s, much less so
+/// here. `states` is moved in and back out rather than shared behind a lock:
+/// only this loop ever touches it, and one owner is simpler than one mutex.
+fn sweep_blocking(
+    filestore: &FileStore,
+    agents: Vec<(String, String)>,
+    mut states: HashMap<String, BlockState>,
+    last_published: &HashMap<String, AgentProgress>,
+    force_republish: bool,
+) -> (HashMap<String, BlockState>, Vec<SweepOutcome>) {
+    let mut out = Vec::new();
+
+    for (agent_id, block_id) in agents {
+        // Same gate as the summary loop: an idle or non-agent pane has no
+        // progress to report and shouldn't be read every tick.
+        let Some(status) = get_block_controller_status(&block_id) else { continue };
+        if status.shellprocstatus != STATUS_RUNNING || !status.is_agent_pane {
+            continue;
+        }
+
+        let state = states.entry(block_id.clone()).or_default();
+        let had_new = consume_new_output(filestore, &block_id, state);
+        let progress = state.progress();
+
+        // Nothing new AND nothing already published for this block — an agent
+        // that has never had progress costs no events at all.
+        if !had_new && !last_published.contains_key(&block_id) {
+            continue;
+        }
+        if progress.is_empty() && !last_published.contains_key(&block_id) {
+            continue;
+        }
+        if !force_republish && last_published.get(&block_id) == Some(&progress) {
+            continue;
+        }
+        out.push(SweepOutcome { agent_id, block_id, progress });
+    }
+
+    (states, out)
+}
+
+/// Run the progress sweep loop. Never returns.
 pub async fn run_agent_progress_loop(filestore: Arc<FileStore>, broker: Arc<Broker>) {
     let mut ticker = interval(Duration::from_secs(SWEEP_INTERVAL_SECS));
     let mut tick: u64 = 0;
@@ -418,39 +509,41 @@ pub async fn run_agent_progress_loop(filestore: Arc<FileStore>, broker: Arc<Brok
         tick += 1;
         let force_republish = tick % REPUBLISH_EVERY_TICKS == 0;
 
-        let agents = get_global_handler().list_agents();
+        let agents: Vec<(String, String)> = get_global_handler()
+            .list_agents()
+            .into_iter()
+            .map(|a| (a.agent_id, a.block_id))
+            .collect();
         let registered: std::collections::HashSet<String> =
-            agents.iter().map(|a| a.block_id.clone()).collect();
+            agents.iter().map(|(_, block_id)| block_id.clone()).collect();
         // Both maps are bounded by the live agent count, not by every block_id
         // ever seen in the process's lifetime.
         states.retain(|block_id, _| registered.contains(block_id));
         last_published.retain(|block_id, _| registered.contains(block_id));
 
-        for agent in agents {
-            let block_id = agent.block_id.clone();
+        let fs = filestore.clone();
+        let published = last_published.clone();
+        let taken = std::mem::take(&mut states);
+        let joined = tokio::task::spawn_blocking(move || {
+            sweep_blocking(&fs, agents, taken, &published, force_republish)
+        })
+        .await;
 
-            // Same gate as the summary loop: an idle or non-agent pane has no
-            // progress to report and shouldn't be read every tick.
-            let Some(status) = get_block_controller_status(&block_id) else { continue };
-            if status.shellprocstatus != STATUS_RUNNING || !status.is_agent_pane {
+        // A panic inside the blocking closure loses that tick's accumulated
+        // state. Start clean rather than killing the loop: the next sweep
+        // re-seeds from the tail (flagged partial), which is degraded but
+        // recoverable, whereas returning here would end progress reporting for
+        // the life of the process.
+        let (returned_states, outcomes) = match joined {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::error!(error = %e, "progress sweep task failed; state reset for next tick");
                 continue;
             }
+        };
+        states = returned_states;
 
-            let state = states.entry(block_id.clone()).or_default();
-            let had_new = consume_new_output(&filestore, &block_id, state);
-            let progress = state.progress();
-
-            // Nothing new AND nothing already published for this block — an
-            // agent that has never had progress costs no events at all.
-            if !had_new && !last_published.contains_key(&block_id) {
-                continue;
-            }
-            if progress.is_empty() && !last_published.contains_key(&block_id) {
-                continue;
-            }
-            if !force_republish && last_published.get(&block_id) == Some(&progress) {
-                continue;
-            }
+        for SweepOutcome { agent_id, block_id, progress } in outcomes {
             last_published.insert(block_id.clone(), progress.clone());
 
             let ts = SystemTime::now()
@@ -467,7 +560,7 @@ pub async fn run_agent_progress_loop(filestore: Arc<FileStore>, broker: Arc<Brok
                 // for the agent's next change — see REPUBLISH_EVERY_TICKS.
                 persist: 1,
                 data: Some(serde_json::json!({
-                    "agentId": agent.agent_id,
+                    "agentId": agent_id,
                     "blockId": block_id,
                     "todos": progress.todos,
                     "todosTruncated": progress.todos_truncated,
@@ -795,6 +888,66 @@ mod tests {
         feed(&mut st, &[r#"{"type":"system","subtype":"init","name":"TodoWrite"}"#.to_string()]);
         assert!(st.progress().todos.is_empty());
         assert_eq!(st.progress().current_tool, None);
+    }
+
+    /// reagent P2: with no id, text is the only identity available, and keying
+    /// on it alone silently merged two genuinely distinct in-flight tasks that
+    /// happened to share a title. One invisibly missing row is a worse failure
+    /// than two visible duplicates, so an idless CREATE always appends.
+    #[test]
+    fn two_idless_creates_with_the_same_title_stay_two_rows() {
+        let idless_create = |id: &str, title: &str| {
+            format!(
+                r#"{{"type":"assistant","message":{{"content":[{{"type":"tool_use","id":"{id}","name":"TaskCreate","input":{{"title":"{title}","status":"pending"}}}}]}}}}"#
+            )
+        };
+        let p = run(&[idless_create("c1", "Retry the flaky step"), idless_create("c2", "Retry the flaky step")]);
+        assert_eq!(p.todos.len(), 2, "two distinct tasks must not collapse into one row");
+        assert!(p.todos.iter().all(|t| t.text == "Retry the flaky step"));
+    }
+
+    /// …but an idless UPDATE still has to find its row, since matching by text
+    /// is the only correlation available and appending would be a duplicate.
+    #[test]
+    fn an_idless_update_still_matches_its_row_by_text() {
+        let mut st = BlockState::default();
+        feed(&mut st, &[task_call("c1", "TaskCreate", "k1", "Ship it", "pending")]);
+        feed(
+            &mut st,
+            &[format!(
+                r#"{{"type":"assistant","message":{{"content":[{{"type":"tool_use","id":"u1","name":"TaskUpdate","input":{{"title":"Ship it","status":"completed"}}}}]}}}}"#
+            )],
+        );
+        assert_eq!(
+            st.progress().todos,
+            vec![TodoItem { text: "Ship it".into(), status: "completed".into() }],
+        );
+    }
+
+    /// An id, when present, is always the key — two same-titled tasks with
+    /// distinct ids stay distinct, and an update by id finds its own row.
+    #[test]
+    fn ids_take_precedence_over_text_for_identity() {
+        let p = run(&[
+            task_call("c1", "TaskCreate", "k1", "Same title", "pending"),
+            task_call("c2", "TaskCreate", "k2", "Same title", "pending"),
+            task_call("u1", "TaskUpdate", "k2", "Same title", "completed"),
+        ]);
+        assert_eq!(
+            p.todos,
+            vec![
+                TodoItem { text: "Same title".into(), status: "pending".into() },
+                TodoItem { text: "Same title".into(), status: "completed".into() },
+            ],
+        );
+    }
+
+    #[test]
+    fn create_style_tool_names_are_recognized() {
+        assert!(is_create_call("TaskCreate"));
+        assert!(is_create_call("TodoAdd"));
+        assert!(!is_create_call("TaskUpdate"));
+        assert!(!is_create_call("TodoWrite"), "a whole-list write never reaches the single-item path");
     }
 
     #[test]

--- a/agentmux-srv/src/backend/reactive/progress_watcher.rs
+++ b/agentmux-srv/src/backend/reactive/progress_watcher.rs
@@ -1,0 +1,468 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pushed per-agent **progress**: the agent's current todo checklist and the
+//! tool it is running right now, published as an `agent:progress` WaveEvent so
+//! the Swarm pane can list them under the agent's name.
+//!
+//! Sibling of [`super::activity_watcher`], and deliberately a separate loop:
+//! that one spends a Haiku call per agent to write an English one-liner and is
+//! throttled accordingly. This one only reads the tail of a block's `output`
+//! file and parses JSON, so it costs nothing per tick and can run far more
+//! often — which is the point, since a checklist that lags 20s behind the agent
+//! is worse than no checklist.
+//!
+//! Why the backend and not the frontend: `agent-document-store` already holds
+//! every tool call, but only for panes that are currently MOUNTED. The Swarm
+//! pane's whole value is seeing agents you are not looking at, so the data has
+//! to come from the same place the shell/cron/summary rows come from.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use tokio::time::interval;
+
+use crate::backend::blockcontroller::{get_block_controller_status, STATUS_RUNNING};
+use crate::backend::storage::filestore::FileStore;
+use crate::backend::wps::{Broker, WaveEvent};
+
+use super::get_global_handler;
+
+/// How often to sweep registered agents. Much tighter than the summary loop's
+/// 20s: this is a pure tail-read + JSON parse, with no model call to bill.
+const SWEEP_INTERVAL_SECS: u64 = 3;
+
+/// How much of the block's `output` to read. The checklist is republished in
+/// full on every `TodoWrite`-style call, so we only need enough tail to catch
+/// the most recent one — matching `read_recent_activity_digest`'s window.
+const TAIL_BYTES: i64 = 32 * 1024;
+
+/// Cap on rows published per agent, so one pathological checklist can't flood
+/// the Swarm tree. Truncation is reported rather than silent — see
+/// [`AgentProgress::todos_truncated`].
+const MAX_TODOS: usize = 24;
+
+pub const EVENT_AGENT_PROGRESS: &str = "agent:progress";
+
+/// Tool names that carry a todo checklist.
+///
+/// Deliberately a list rather than the single `TodoWrite` everyone expects:
+/// Claude Code 2.1.177 — the version AgentMux ships against today — advertises
+/// `TaskCreate`/`TaskUpdate`/`TaskList` and no `TodoWrite` at all, and other
+/// providers differ again. Matching by a known set plus the `Todo` substring
+/// below means a version bump that renames the tool degrades to "no rows"
+/// rather than to wrong rows.
+const TODO_TOOL_NAMES: &[&str] = &["TodoWrite", "TodoRead", "TaskCreate", "TaskUpdate", "TaskList"];
+
+fn is_todo_tool(name: &str) -> bool {
+    TODO_TOOL_NAMES.contains(&name) || name.contains("Todo")
+}
+
+/// One checklist entry as the Swarm renders it.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct TodoItem {
+    pub text: String,
+    /// `pending` | `in_progress` | `completed`. Passed through as the provider
+    /// wrote it where possible; unknown values are kept verbatim rather than
+    /// coerced, so a new provider status shows up as itself instead of
+    /// silently becoming "pending".
+    pub status: String,
+}
+
+/// What one sweep extracted for a single agent.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
+pub struct AgentProgress {
+    pub todos: Vec<TodoItem>,
+    /// Number dropped by [`MAX_TODOS`], so the UI can say "+N more" instead of
+    /// quietly showing a partial list as if it were the whole one.
+    pub todos_truncated: usize,
+    /// The tool currently in flight — the last `tool_use` with no matching
+    /// `tool_result` yet. `None` when the agent is between tools.
+    pub current_tool: Option<String>,
+}
+
+impl AgentProgress {
+    /// Nothing worth publishing — avoids a WaveEvent per tick per idle agent.
+    fn is_empty(&self) -> bool {
+        self.todos.is_empty() && self.current_tool.is_none()
+    }
+}
+
+/// Pull the todo checklist and in-flight tool out of a block's NDJSON output.
+///
+/// `lines` is the tail of the `output` file, oldest first. Pure and
+/// allocation-light so it can be unit-tested against real transcript shapes
+/// without a FileStore.
+///
+/// Two independent passes over the same tool_use stream:
+///   * **todos** — last call to a todo-ish tool wins outright when it carries a
+///     full `input.todos` array (that is replace-the-whole-list semantics, the
+///     same as the tool itself). Task-style `create`/`update` calls, which
+///     describe ONE item each, instead accumulate into an ordered map keyed by
+///     task id so an update revises the row it belongs to.
+///   * **current_tool** — last `tool_use` whose id never appears in a later
+///     `tool_result`.
+pub fn extract_progress(lines: &[&str]) -> AgentProgress {
+    // Ordered accumulation for the Task* shape. Insertion order is the agent's
+    // own creation order, which is the only ordering it ever expressed.
+    let mut task_items: Vec<(String, TodoItem)> = Vec::new();
+    // A full `todos` array supersedes anything accumulated before it.
+    let mut list_items: Option<Vec<TodoItem>> = None;
+
+    let mut open_tools: Vec<(String, String)> = Vec::new(); // (tool_use id, name)
+    let mut finished: HashSet<String> = HashSet::new();
+
+    for line in lines {
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+
+        // A tool_result can arrive either as a user-message content block or as
+        // a bare frame, depending on provider/version — collect ids from both.
+        collect_tool_result_ids(&v, &mut finished);
+
+        for block in content_blocks(&v) {
+            if block.get("type").and_then(|t| t.as_str()) != Some("tool_use") {
+                continue;
+            }
+            let Some(name) = block.get("name").and_then(|n| n.as_str()) else {
+                continue;
+            };
+            if let Some(id) = block.get("id").and_then(|i| i.as_str()) {
+                open_tools.push((id.to_string(), name.to_string()));
+            }
+
+            if !is_todo_tool(name) {
+                continue;
+            }
+            let Some(input) = block.get("input") else { continue };
+
+            if let Some(items) = parse_todo_array(input) {
+                // Full-list semantics: this call IS the checklist now.
+                list_items = Some(items);
+                task_items.clear();
+                continue;
+            }
+            if let Some((key, item)) = parse_single_task(input) {
+                // Only meaningful while no full list has superseded it.
+                if list_items.is_none() {
+                    upsert(&mut task_items, key, item);
+                }
+            }
+        }
+    }
+
+    let mut todos = list_items.unwrap_or_else(|| task_items.into_iter().map(|(_, i)| i).collect());
+    let todos_truncated = todos.len().saturating_sub(MAX_TODOS);
+    todos.truncate(MAX_TODOS);
+
+    let current_tool = open_tools
+        .iter()
+        .rev()
+        .find(|(id, _)| !finished.contains(id))
+        .map(|(_, name)| name.clone());
+
+    AgentProgress { todos, todos_truncated, current_tool }
+}
+
+/// Content blocks of an assistant/user message, wherever this provider puts
+/// them (`message.content` for Claude's stream-json, bare `content` otherwise).
+fn content_blocks(v: &serde_json::Value) -> impl Iterator<Item = &serde_json::Value> {
+    v.get("message")
+        .and_then(|m| m.get("content"))
+        .or_else(|| v.get("content"))
+        .and_then(|c| c.as_array())
+        .map(|a| a.iter())
+        .unwrap_or_else(|| [].iter())
+}
+
+fn collect_tool_result_ids(v: &serde_json::Value, out: &mut HashSet<String>) {
+    if let Some(id) = v.get("tool_use_id").and_then(|i| i.as_str()) {
+        out.insert(id.to_string());
+    }
+    for block in content_blocks(v) {
+        if block.get("type").and_then(|t| t.as_str()) == Some("tool_result") {
+            if let Some(id) = block.get("tool_use_id").and_then(|i| i.as_str()) {
+                out.insert(id.to_string());
+            }
+        }
+    }
+}
+
+/// `input.todos` (or `input.items`) as a whole checklist.
+fn parse_todo_array(input: &serde_json::Value) -> Option<Vec<TodoItem>> {
+    let arr = input
+        .get("todos")
+        .or_else(|| input.get("items"))
+        .and_then(|t| t.as_array())?;
+    let items: Vec<TodoItem> = arr.iter().filter_map(parse_todo_entry).collect();
+    // An empty array is a real state ("checklist cleared"), so return it as
+    // such rather than falling through to the single-task path.
+    Some(items)
+}
+
+fn parse_todo_entry(entry: &serde_json::Value) -> Option<TodoItem> {
+    let text = first_string(entry, &["content", "title", "text", "activeForm", "description"])?;
+    let status = first_string(entry, &["status", "state"]).unwrap_or_else(|| "pending".to_string());
+    Some(TodoItem { text, status })
+}
+
+/// A Task-style call describing a single item. Keyed by whatever id the tool
+/// uses so a later update revises the same row; falls back to the text itself,
+/// which is stable enough for tools that don't hand back an id.
+fn parse_single_task(input: &serde_json::Value) -> Option<(String, TodoItem)> {
+    let item = parse_todo_entry(input)?;
+    let key = first_string(input, &["task_id", "taskId", "id"]).unwrap_or_else(|| item.text.clone());
+    Some((key, item))
+}
+
+fn first_string(v: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|k| v.get(*k).and_then(|s| s.as_str()))
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn upsert(items: &mut Vec<(String, TodoItem)>, key: String, item: TodoItem) {
+    if let Some(slot) = items.iter_mut().find(|(k, _)| *k == key) {
+        slot.1 = item;
+    } else {
+        items.push((key, item));
+    }
+}
+
+/// Read a block's output tail and extract its progress.
+fn progress_for_block(filestore: &FileStore, block_id: &str) -> Option<AgentProgress> {
+    let size = match filestore.stat(block_id, "output") {
+        Ok(Some(wf)) if wf.size > 0 => wf.size,
+        _ => return None,
+    };
+    let offset = (size - TAIL_BYTES).max(0);
+    let (_, bytes) = filestore.read_at(block_id, "output", offset, TAIL_BYTES).ok()?;
+    let text = String::from_utf8_lossy(&bytes);
+    let lines: Vec<&str> = text.lines().filter(|l| !l.trim().is_empty()).collect();
+    Some(extract_progress(&lines))
+}
+
+/// Run the progress sweep loop. Never returns.
+pub async fn run_agent_progress_loop(filestore: Arc<FileStore>, broker: Arc<Broker>) {
+    let mut ticker = interval(Duration::from_secs(SWEEP_INTERVAL_SECS));
+    // block_id -> last payload published, so an unchanged checklist doesn't
+    // re-publish every 3s. Bounded by pruning against the live registration
+    // list each tick, same as the summary loop's own bookkeeping.
+    let mut last_published: HashMap<String, AgentProgress> = HashMap::new();
+
+    loop {
+        ticker.tick().await;
+
+        let agents = get_global_handler().list_agents();
+        let registered: HashSet<String> = agents.iter().map(|a| a.block_id.clone()).collect();
+        last_published.retain(|block_id, _| registered.contains(block_id));
+
+        for agent in agents {
+            let block_id = agent.block_id.clone();
+
+            // Same gate as the summary loop: an idle or non-agent pane has no
+            // progress to report and shouldn't be read every tick.
+            let Some(status) = get_block_controller_status(&block_id) else { continue };
+            if status.shellprocstatus != STATUS_RUNNING || !status.is_agent_pane {
+                continue;
+            }
+
+            let Some(progress) = progress_for_block(&filestore, &block_id) else { continue };
+
+            // Publish an empty payload ONCE when a previously-non-empty agent
+            // goes quiet (so the UI can clear its rows), but never for an agent
+            // that has had nothing all along.
+            if progress.is_empty() && !last_published.contains_key(&block_id) {
+                continue;
+            }
+            if last_published.get(&block_id) == Some(&progress) {
+                continue;
+            }
+            last_published.insert(block_id.clone(), progress.clone());
+
+            let ts = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0);
+
+            broker.publish(WaveEvent {
+                event: EVENT_AGENT_PROGRESS.to_string(),
+                scopes: vec![format!("block:{}", block_id)],
+                sender: String::new(),
+                persist: 0,
+                data: serde_json::to_value(serde_json::json!({
+                    "agentId": agent.agent_id,
+                    "blockId": block_id,
+                    "todos": progress.todos,
+                    "todosTruncated": progress.todos_truncated,
+                    "currentTool": progress.current_tool,
+                    "ts": ts,
+                }))
+                .ok(),
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn todo_write(id: &str, todos: &str) -> String {
+        format!(
+            r#"{{"type":"assistant","message":{{"content":[{{"type":"tool_use","id":"{id}","name":"TodoWrite","input":{{"todos":{todos}}}}}]}}}}"#
+        )
+    }
+
+    fn tool_use(id: &str, name: &str) -> String {
+        format!(
+            r#"{{"type":"assistant","message":{{"content":[{{"type":"tool_use","id":"{id}","name":"{name}","input":{{}}}}]}}}}"#
+        )
+    }
+
+    fn tool_result(id: &str) -> String {
+        format!(
+            r#"{{"type":"user","message":{{"content":[{{"type":"tool_result","tool_use_id":"{id}"}}]}}}}"#
+        )
+    }
+
+    fn run(lines: &[String]) -> AgentProgress {
+        let refs: Vec<&str> = lines.iter().map(|s| s.as_str()).collect();
+        extract_progress(&refs)
+    }
+
+    #[test]
+    fn extracts_a_todowrite_checklist() {
+        let p = run(&[todo_write(
+            "t1",
+            r#"[{"content":"Fix the bug","status":"in_progress"},{"content":"Write tests","status":"pending"}]"#,
+        )]);
+        assert_eq!(
+            p.todos,
+            vec![
+                TodoItem { text: "Fix the bug".into(), status: "in_progress".into() },
+                TodoItem { text: "Write tests".into(), status: "pending".into() },
+            ]
+        );
+    }
+
+    /// TodoWrite republishes the WHOLE list every call, so the newest call is
+    /// the state — an earlier, longer list must not leak through.
+    #[test]
+    fn the_latest_full_list_supersedes_earlier_ones() {
+        let p = run(&[
+            todo_write("t1", r#"[{"content":"A","status":"pending"},{"content":"B","status":"pending"}]"#),
+            todo_write("t2", r#"[{"content":"A","status":"completed"}]"#),
+        ]);
+        assert_eq!(p.todos, vec![TodoItem { text: "A".into(), status: "completed".into() }]);
+    }
+
+    /// The version AgentMux actually ships against has no TodoWrite at all —
+    /// it has TaskCreate/TaskUpdate, one item per call. An update must revise
+    /// the row it refers to rather than appending a duplicate.
+    #[test]
+    fn task_style_calls_accumulate_and_update_in_place() {
+        let create = |id: &str, tid: &str, title: &str| {
+            format!(
+                r#"{{"type":"assistant","message":{{"content":[{{"type":"tool_use","id":"{id}","name":"TaskCreate","input":{{"task_id":"{tid}","title":"{title}","status":"pending"}}}}]}}}}"#
+            )
+        };
+        let update = format!(
+            r#"{{"type":"assistant","message":{{"content":[{{"type":"tool_use","id":"u1","name":"TaskUpdate","input":{{"task_id":"k1","title":"First","status":"completed"}}}}]}}}}"#
+        );
+        let p = run(&[create("c1", "k1", "First"), create("c2", "k2", "Second"), update]);
+        assert_eq!(
+            p.todos,
+            vec![
+                TodoItem { text: "First".into(), status: "completed".into() },
+                TodoItem { text: "Second".into(), status: "pending".into() },
+            ],
+            "an update revises its own row and preserves creation order",
+        );
+    }
+
+    #[test]
+    fn current_tool_is_the_last_unresolved_tool_use() {
+        let p = run(&[
+            tool_use("a", "Read"),
+            tool_result("a"),
+            tool_use("b", "Bash"),
+        ]);
+        assert_eq!(p.current_tool.as_deref(), Some("Bash"));
+    }
+
+    #[test]
+    fn no_current_tool_once_every_call_has_returned() {
+        let p = run(&[tool_use("a", "Read"), tool_result("a")]);
+        assert_eq!(p.current_tool, None);
+    }
+
+    /// An emptied checklist is a real state the UI must be able to show, not a
+    /// reason to fall back to stale rows.
+    #[test]
+    fn an_explicitly_cleared_checklist_reads_as_empty() {
+        let p = run(&[
+            todo_write("t1", r#"[{"content":"A","status":"pending"}]"#),
+            todo_write("t2", "[]"),
+        ]);
+        assert!(p.todos.is_empty());
+    }
+
+    #[test]
+    fn truncates_a_pathological_list_and_reports_how_many_were_dropped() {
+        let entries: Vec<String> = (0..MAX_TODOS + 5)
+            .map(|i| format!(r#"{{"content":"item {i}","status":"pending"}}"#))
+            .collect();
+        let p = run(&[todo_write("t1", &format!("[{}]", entries.join(",")))]);
+        assert_eq!(p.todos.len(), MAX_TODOS);
+        assert_eq!(p.todos_truncated, 5);
+    }
+
+    #[test]
+    fn ignores_malformed_lines_instead_of_giving_up_on_the_whole_tail() {
+        let p = run(&[
+            "not json at all".to_string(),
+            String::new(),
+            todo_write("t1", r#"[{"content":"Survives","status":"pending"}]"#),
+        ]);
+        assert_eq!(p.todos.len(), 1);
+    }
+
+    /// A tail window can start mid-conversation, so the first line is often a
+    /// fragment. It must not poison the rest.
+    #[test]
+    fn a_truncated_leading_line_does_not_break_extraction() {
+        let mut lines = vec![r#"{"type":"assistant","message":{"conte"#.to_string()];
+        lines.push(todo_write("t1", r#"[{"content":"Still parsed","status":"pending"}]"#));
+        let p = run(&lines);
+        assert_eq!(p.todos, vec![TodoItem { text: "Still parsed".into(), status: "pending".into() }]);
+    }
+
+    #[test]
+    fn a_non_todo_tool_never_contributes_checklist_rows() {
+        let p = run(&[tool_use("a", "Read"), tool_use("b", "Bash")]);
+        assert!(p.todos.is_empty());
+        assert_eq!(p.current_tool.as_deref(), Some("Bash"));
+    }
+
+    #[test]
+    fn recognizes_todo_tools_by_name_across_provider_vocabularies() {
+        assert!(is_todo_tool("TodoWrite"));
+        assert!(is_todo_tool("TaskCreate"));
+        assert!(is_todo_tool("TaskUpdate"));
+        // Substring fallback for a renamed/namespaced variant.
+        assert!(is_todo_tool("mcp__planner__TodoSync"));
+        assert!(!is_todo_tool("Read"));
+        assert!(!is_todo_tool("Task"), "the subagent-spawning Task tool is not a checklist");
+    }
+
+    #[test]
+    fn empty_progress_is_recognized_so_idle_agents_publish_nothing() {
+        assert!(AgentProgress::default().is_empty());
+        let p = run(&[tool_use("a", "Read")]);
+        assert!(!p.is_empty(), "an in-flight tool is worth publishing on its own");
+    }
+}

--- a/agentmux-srv/src/backend/reactive/progress_watcher.rs
+++ b/agentmux-srv/src/backend/reactive/progress_watcher.rs
@@ -7,7 +7,7 @@
 //!
 //! Sibling of [`super::activity_watcher`], and deliberately a separate loop:
 //! that one spends a Haiku call per agent to write an English one-liner and is
-//! throttled accordingly. This one only reads the tail of a block's `output`
+//! throttled accordingly. This one only reads NEW bytes of a block's `output`
 //! file and parses JSON, so it costs nothing per tick and can run far more
 //! often — which is the point, since a checklist that lags 20s behind the agent
 //! is worse than no checklist.
@@ -16,8 +16,19 @@
 //! every tool call, but only for panes that are currently MOUNTED. The Swarm
 //! pane's whole value is seeing agents you are not looking at, so the data has
 //! to come from the same place the shell/cron/summary rows come from.
+//!
+//! **Why state is carried across ticks** (reagent P1 on PR #2952): the
+//! checklist cannot be rebuilt from a fixed tail window. `TodoWrite`-style
+//! calls are immune — one call carries the whole list — but the vocabulary
+//! AgentMux actually ships against (`TaskCreate`/`TaskUpdate`) describes ONE
+//! item per call, so reconstructing the list needs every still-open task's
+//! original `TaskCreate` to be inside the window. A verbose `Bash` or a large
+//! `Read` pushes those out within seconds, and the task would then vanish from
+//! the checklist while still open, silently. So each block keeps an accumulated
+//! [`BlockState`] and each tick only consumes the bytes appended since the last
+//! one.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -30,30 +41,53 @@ use crate::backend::wps::{Broker, WaveEvent};
 use super::get_global_handler;
 
 /// How often to sweep registered agents. Much tighter than the summary loop's
-/// 20s: this is a pure tail-read + JSON parse, with no model call to bill.
+/// 20s: this is an incremental read + JSON parse, with no model call to bill.
 const SWEEP_INTERVAL_SECS: u64 = 3;
 
-/// How much of the block's `output` to read. The checklist is republished in
-/// full on every `TodoWrite`-style call, so we only need enough tail to catch
-/// the most recent one — matching `read_recent_activity_digest`'s window.
-const TAIL_BYTES: i64 = 32 * 1024;
+/// Most bytes consumed in one tick, and the most read when first catching up on
+/// a block. A block seen from its first byte is exact; one that already had
+/// more than this when we first saw it (srv restarted mid-session) is seeded
+/// from its tail and flagged — see [`BlockState::partial`].
+const MAX_READ_BYTES: i64 = 4 * 1024 * 1024;
 
 /// Cap on rows published per agent, so one pathological checklist can't flood
 /// the Swarm tree. Truncation is reported rather than silent — see
 /// [`AgentProgress::todos_truncated`].
 const MAX_TODOS: usize = 24;
 
+/// Bound on remembered in-flight tool calls. Real concurrency is a handful; a
+/// larger number means results are being missed, and the oldest entries are the
+/// ones least likely to still be running.
+const MAX_OPEN_TOOLS: usize = 32;
+
 pub const EVENT_AGENT_PROGRESS: &str = "agent:progress";
 
-/// Tool names that carry a todo checklist.
+/// Republish an unchanged payload every N ticks (~15s at a 3s sweep).
+///
+/// The change-suppression below is what keeps this loop quiet, but on its own
+/// it strands a LATE subscriber (codex P1 on PR #2952): open the Swarm after an
+/// agent's checklist has settled and there is no further change to deliver, so
+/// the pane shows nothing indefinitely for a perfectly active agent. The event
+/// is also published with `persist: 1` so the broker replays the latest one to
+/// a freshly-subscribed route; this periodic republish is the belt to that
+/// suspenders, and covers any subscriber the replay path does not.
+const REPUBLISH_EVERY_TICKS: u64 = 5;
+
+/// Tool names whose **call arguments** carry checklist state.
 ///
 /// Deliberately a list rather than the single `TodoWrite` everyone expects:
 /// Claude Code 2.1.177 — the version AgentMux ships against today — advertises
-/// `TaskCreate`/`TaskUpdate`/`TaskList` and no `TodoWrite` at all, and other
-/// providers differ again. Matching by a known set plus the `Todo` substring
-/// below means a version bump that renames the tool degrades to "no rows"
-/// rather than to wrong rows.
-const TODO_TOOL_NAMES: &[&str] = &["TodoWrite", "TodoRead", "TaskCreate", "TaskUpdate", "TaskList"];
+/// `TaskCreate`/`TaskUpdate` and no `TodoWrite` at all, and other providers
+/// differ again. Matching by a known set plus the `Todo` substring below means
+/// a version bump that renames the tool degrades to "no rows" rather than to
+/// wrong rows.
+///
+/// READ-style tools (`TaskList`, `TodoRead`) are deliberately absent. Their
+/// task data lives in the tool RESULT, not the call's `input`, and this parser
+/// only reads `input` — so listing them would advertise support that silently
+/// contributes nothing (reagent P2 on PR #2952). Supporting them means parsing
+/// tool_result payloads, which is its own change.
+const TODO_TOOL_NAMES: &[&str] = &["TodoWrite", "TaskCreate", "TaskUpdate"];
 
 fn is_todo_tool(name: &str) -> bool {
     TODO_TOOL_NAMES.contains(&name) || name.contains("Todo")
@@ -70,15 +104,20 @@ pub struct TodoItem {
     pub status: String,
 }
 
-/// What one sweep extracted for a single agent.
+/// What we currently believe about one agent.
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
 pub struct AgentProgress {
     pub todos: Vec<TodoItem>,
-    /// Number dropped by [`MAX_TODOS`], so the UI can say "+N more" instead of
-    /// quietly showing a partial list as if it were the whole one.
+    /// How many rows [`MAX_TODOS`] dropped, so the UI can say "+N more"
+    /// instead of quietly showing a partial list as if it were the whole one.
     pub todos_truncated: usize,
-    /// The tool currently in flight — the last `tool_use` with no matching
-    /// `tool_result` yet. `None` when the agent is between tools.
+    /// True when this block was first seen mid-stream, so item-at-a-time
+    /// (`TaskCreate`) calls from before that point were never observed and the
+    /// checklist may be missing entries. Distinct from `todos_truncated`,
+    /// which is a cap we chose; this is history we could not see.
+    pub todos_partial: bool,
+    /// The tool this agent is running right now — the oldest `tool_use` with no
+    /// matching `tool_result` yet. `None` when the agent is between tools.
     pub current_tool: Option<String>,
 }
 
@@ -89,105 +128,163 @@ impl AgentProgress {
     }
 }
 
-/// Pull the todo checklist and in-flight tool out of a block's NDJSON output.
-///
-/// `lines` is the tail of the `output` file, oldest first. Pure and
-/// allocation-light so it can be unit-tested against real transcript shapes
-/// without a FileStore.
-///
-/// Two independent passes over the same tool_use stream:
-///   * **todos** — last call to a todo-ish tool wins outright when it carries a
-///     full `input.todos` array (that is replace-the-whole-list semantics, the
-///     same as the tool itself). Task-style `create`/`update` calls, which
-///     describe ONE item each, instead accumulate into an ordered map keyed by
-///     task id so an update revises the row it belongs to.
-///   * **current_tool** — last `tool_use` whose id never appears in a later
-///     `tool_result`.
-pub fn extract_progress(lines: &[&str]) -> AgentProgress {
-    // Ordered accumulation for the Task* shape. Insertion order is the agent's
-    // own creation order, which is the only ordering it ever expressed.
-    let mut task_items: Vec<(String, TodoItem)> = Vec::new();
-    // A full `todos` array supersedes anything accumulated before it.
-    let mut list_items: Option<Vec<TodoItem>> = None;
+/// Everything we accumulate for one block across ticks.
+#[derive(Debug, Default)]
+struct BlockState {
+    /// Byte offset of the next unread line in the block's `output`.
+    next_offset: i64,
+    /// Item-at-a-time accumulation (`TaskCreate`/`TaskUpdate`), keyed so an
+    /// update revises its own row. Insertion order is the agent's own creation
+    /// order, the only ordering it ever expressed.
+    tasks: Vec<(String, TodoItem)>,
+    /// Last whole-list call. Supersedes `tasks` outright when present, because
+    /// that is the tool's own replace-everything semantics.
+    list: Option<Vec<TodoItem>>,
+    /// In-flight `tool_use` calls, oldest first.
+    open: Vec<(String, String)>,
+    /// See [`AgentProgress::todos_partial`].
+    partial: bool,
+}
 
-    let mut open_tools: Vec<(String, String)> = Vec::new(); // (tool_use id, name)
-    let mut finished: HashSet<String> = HashSet::new();
+impl BlockState {
+    fn progress(&self) -> AgentProgress {
+        let mut todos = self
+            .list
+            .clone()
+            .unwrap_or_else(|| self.tasks.iter().map(|(_, i)| i.clone()).collect());
+        let todos_truncated = todos.len().saturating_sub(MAX_TODOS);
+        todos.truncate(MAX_TODOS);
+        AgentProgress {
+            todos,
+            todos_truncated,
+            // A whole-list call is self-contained, so once one has been seen
+            // the checklist is complete regardless of what we missed earlier.
+            todos_partial: self.partial && self.list.is_none(),
+            current_tool: self.open.first().map(|(_, name)| name.clone()),
+        }
+    }
+}
 
+/// Fold newly-appended transcript lines into `state`.
+///
+/// Pure w.r.t. I/O so it can be unit-tested against real transcript shapes
+/// without a FileStore. Called once per tick with only the lines appended since
+/// the previous call — never the whole file.
+fn apply_lines(state: &mut BlockState, lines: &[&str]) {
     for line in lines {
         let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
             continue;
         };
 
-        // A tool_result can arrive either as a user-message content block or as
-        // a bare frame, depending on provider/version — collect ids from both.
-        collect_tool_result_ids(&v, &mut finished);
+        // Resolve finished calls first: a tool_use and its result never share a
+        // line, so ordering within the line is not a concern.
+        for id in tool_result_ids(&v) {
+            state.open.retain(|(open_id, _)| *open_id != id);
+        }
 
-        for block in content_blocks(&v) {
-            if block.get("type").and_then(|t| t.as_str()) != Some("tool_use") {
+        for frame in tool_frames(&v) {
+            if frame.get("type").and_then(|t| t.as_str()) != Some("tool_use") {
                 continue;
             }
-            let Some(name) = block.get("name").and_then(|n| n.as_str()) else {
-                continue;
-            };
-            if let Some(id) = block.get("id").and_then(|i| i.as_str()) {
-                open_tools.push((id.to_string(), name.to_string()));
+            let Some(name) = frame_tool_name(frame) else { continue };
+            if let Some(id) = frame_tool_id(frame) {
+                state.open.push((id.to_string(), name.to_string()));
+                // Drop the oldest if we're clearly missing results, rather than
+                // letting this grow for the life of the block.
+                if state.open.len() > MAX_OPEN_TOOLS {
+                    state.open.remove(0);
+                }
             }
 
             if !is_todo_tool(name) {
                 continue;
             }
-            let Some(input) = block.get("input") else { continue };
+            let Some(input) = frame_input(frame) else { continue };
 
             if let Some(items) = parse_todo_array(input) {
-                // Full-list semantics: this call IS the checklist now.
-                list_items = Some(items);
-                task_items.clear();
+                state.list = Some(items);
+                state.tasks.clear();
                 continue;
             }
-            if let Some((key, item)) = parse_single_task(input) {
-                // Only meaningful while no full list has superseded it.
-                if list_items.is_none() {
-                    upsert(&mut task_items, key, item);
-                }
+            // A whole-list call, once seen, owns the checklist — an
+            // item-at-a-time call after it would be describing a different
+            // vocabulary than the one currently in force.
+            if state.list.is_none() {
+                merge_single_task(&mut state.tasks, input);
             }
         }
     }
-
-    let mut todos = list_items.unwrap_or_else(|| task_items.into_iter().map(|(_, i)| i).collect());
-    let todos_truncated = todos.len().saturating_sub(MAX_TODOS);
-    todos.truncate(MAX_TODOS);
-
-    let current_tool = open_tools
-        .iter()
-        .rev()
-        .find(|(id, _)| !finished.contains(id))
-        .map(|(_, name)| name.clone());
-
-    AgentProgress { todos, todos_truncated, current_tool }
 }
 
-/// Content blocks of an assistant/user message, wherever this provider puts
-/// them (`message.content` for Claude's stream-json, bare `content` otherwise).
-fn content_blocks(v: &serde_json::Value) -> impl Iterator<Item = &serde_json::Value> {
-    v.get("message")
+/// Every frame in a transcript line that could be a tool call or result.
+///
+/// Covers two genuinely different provider shapes (codex P2 on PR #2952):
+///   * Claude stream-json — blocks inside `message.content` (or a bare
+///     top-level `content` array).
+///   * Gemini and friends — the LINE ITSELF is the frame:
+///     `{"type":"tool_use","tool_name":…,"tool_id":…,"parameters":{…}}`
+///     (see `frontend/app/view/agent/providers/gemini-translator.ts`).
+///
+/// Without the second, every non-Claude agent silently showed no in-flight
+/// tool and no todos at all, since the array lookup just yielded nothing.
+fn tool_frames(v: &serde_json::Value) -> Vec<&serde_json::Value> {
+    let mut frames: Vec<&serde_json::Value> = v
+        .get("message")
         .and_then(|m| m.get("content"))
         .or_else(|| v.get("content"))
         .and_then(|c| c.as_array())
-        .map(|a| a.iter())
-        .unwrap_or_else(|| [].iter())
+        .map(|a| a.iter().collect())
+        .unwrap_or_default();
+    // A bare frame is only a frame if it declares one of the two types we
+    // care about — otherwise every ordinary line would look like one.
+    if matches!(v.get("type").and_then(|t| t.as_str()), Some("tool_use") | Some("tool_result")) {
+        frames.push(v);
+    }
+    frames
 }
 
-fn collect_tool_result_ids(v: &serde_json::Value, out: &mut HashSet<String>) {
+/// Tool name under either vocabulary (`name` for Claude, `tool_name` for
+/// Gemini-shaped frames).
+fn frame_tool_name(frame: &serde_json::Value) -> Option<&str> {
+    frame
+        .get("name")
+        .or_else(|| frame.get("tool_name"))
+        .and_then(|n| n.as_str())
+}
+
+/// Call id under either vocabulary.
+fn frame_tool_id(frame: &serde_json::Value) -> Option<&str> {
+    frame
+        .get("id")
+        .or_else(|| frame.get("tool_id"))
+        .and_then(|i| i.as_str())
+}
+
+/// Call arguments under either vocabulary.
+fn frame_input(frame: &serde_json::Value) -> Option<&serde_json::Value> {
+    frame.get("input").or_else(|| frame.get("parameters"))
+}
+
+fn tool_result_ids(v: &serde_json::Value) -> Vec<String> {
+    let mut ids = Vec::new();
     if let Some(id) = v.get("tool_use_id").and_then(|i| i.as_str()) {
-        out.insert(id.to_string());
+        ids.push(id.to_string());
     }
-    for block in content_blocks(v) {
-        if block.get("type").and_then(|t| t.as_str()) == Some("tool_result") {
-            if let Some(id) = block.get("tool_use_id").and_then(|i| i.as_str()) {
-                out.insert(id.to_string());
-            }
+    for frame in tool_frames(v) {
+        if frame.get("type").and_then(|t| t.as_str()) != Some("tool_result") {
+            continue;
+        }
+        // `tool_use_id` (Claude) or `tool_id` (Gemini) — a result names the
+        // call it belongs to under whichever key its provider uses.
+        if let Some(id) = frame
+            .get("tool_use_id")
+            .or_else(|| frame.get("tool_id"))
+            .and_then(|i| i.as_str())
+        {
+            ids.push(id.to_string());
         }
     }
+    ids
 }
 
 /// `input.todos` (or `input.items`) as a whole checklist.
@@ -196,10 +293,9 @@ fn parse_todo_array(input: &serde_json::Value) -> Option<Vec<TodoItem>> {
         .get("todos")
         .or_else(|| input.get("items"))
         .and_then(|t| t.as_array())?;
-    let items: Vec<TodoItem> = arr.iter().filter_map(parse_todo_entry).collect();
     // An empty array is a real state ("checklist cleared"), so return it as
-    // such rather than falling through to the single-task path.
-    Some(items)
+    // such rather than falling through to the single-item path.
+    Some(arr.iter().filter_map(parse_todo_entry).collect())
 }
 
 fn parse_todo_entry(entry: &serde_json::Value) -> Option<TodoItem> {
@@ -208,13 +304,38 @@ fn parse_todo_entry(entry: &serde_json::Value) -> Option<TodoItem> {
     Some(TodoItem { text, status })
 }
 
-/// A Task-style call describing a single item. Keyed by whatever id the tool
-/// uses so a later update revises the same row; falls back to the text itself,
-/// which is stable enough for tools that don't hand back an id.
-fn parse_single_task(input: &serde_json::Value) -> Option<(String, TodoItem)> {
-    let item = parse_todo_entry(input)?;
-    let key = first_string(input, &["task_id", "taskId", "id"]).unwrap_or_else(|| item.text.clone());
-    Some((key, item))
+/// Fold a Task-style call describing a SINGLE item into the accumulated rows.
+///
+/// Keyed by whatever id the tool uses so a later call revises the same row,
+/// falling back to the text for tools that hand back no id.
+///
+/// Fields are merged, not replaced (codex P1 on PR #2952). A `TaskUpdate`
+/// legitimately carries only `task_id` + the changed `status` — it has no
+/// reason to resend text that did not change. Requiring a complete item meant
+/// such a call parsed to nothing and the row sat at `pending` forever, which is
+/// precisely the case a checklist exists to show moving.
+fn merge_single_task(items: &mut Vec<(String, TodoItem)>, input: &serde_json::Value) {
+    let text = first_string(input, &["content", "title", "text", "activeForm", "description"]);
+    let status = first_string(input, &["status", "state"]);
+    let Some(key) = first_string(input, &["task_id", "taskId", "id"]).or_else(|| text.clone()) else {
+        // Neither an id nor any text — nothing identifies a row to touch.
+        return;
+    };
+
+    if let Some(slot) = items.iter_mut().find(|(k, _)| *k == key) {
+        if let Some(text) = text {
+            slot.1.text = text;
+        }
+        if let Some(status) = status {
+            slot.1.status = status;
+        }
+        return;
+    }
+
+    // Creating a row still needs something to display; an update for a task we
+    // never saw created (seeded mid-stream) has no text to show.
+    let Some(text) = text else { return };
+    items.push((key, TodoItem { text, status: status.unwrap_or_else(|| "pending".to_string()) }));
 }
 
 fn first_string(v: &serde_json::Value, keys: &[&str]) -> Option<String> {
@@ -224,40 +345,85 @@ fn first_string(v: &serde_json::Value, keys: &[&str]) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-fn upsert(items: &mut Vec<(String, TodoItem)>, key: String, item: TodoItem) {
-    if let Some(slot) = items.iter_mut().find(|(k, _)| *k == key) {
-        slot.1 = item;
-    } else {
-        items.push((key, item));
-    }
-}
-
-/// Read a block's output tail and extract its progress.
-fn progress_for_block(filestore: &FileStore, block_id: &str) -> Option<AgentProgress> {
+/// Consume whatever has been appended to this block's `output` since the last
+/// tick, folding it into `state`.
+///
+/// Returns false when there was nothing to do, so the caller can skip the rest
+/// of the work for this block.
+fn consume_new_output(filestore: &FileStore, block_id: &str, state: &mut BlockState) -> bool {
     let size = match filestore.stat(block_id, "output") {
         Ok(Some(wf)) if wf.size > 0 => wf.size,
-        _ => return None,
+        _ => return false,
     };
-    let offset = (size - TAIL_BYTES).max(0);
-    let (_, bytes) = filestore.read_at(block_id, "output", offset, TAIL_BYTES).ok()?;
-    let text = String::from_utf8_lossy(&bytes);
+
+    // The file shrank — a new session reusing the block, or a truncation. Our
+    // accumulated state describes a transcript that no longer exists, so start
+    // over rather than mixing two conversations' checklists.
+    if size < state.next_offset {
+        *state = BlockState::default();
+    }
+
+    if state.next_offset == 0 && size > MAX_READ_BYTES {
+        // First sight of a block that is already long (srv restarted
+        // mid-session). Seed from the tail and admit the list may be missing
+        // item-at-a-time entries from before this point.
+        state.next_offset = size - MAX_READ_BYTES;
+        state.partial = true;
+    }
+
+    let available = size - state.next_offset;
+    if available <= 0 {
+        return false;
+    }
+    let want = available.min(MAX_READ_BYTES);
+    let Ok((_, bytes)) = filestore.read_at(block_id, "output", state.next_offset, want) else {
+        return false;
+    };
+    if bytes.is_empty() {
+        return false;
+    }
+
+    // Only consume up to the last complete line: a read boundary lands
+    // anywhere, and half a JSON object would be dropped as malformed and then
+    // never seen again in its complete form.
+    let consumed = match bytes.iter().rposition(|b| *b == b'\n') {
+        Some(idx) => idx + 1,
+        // No newline anywhere in the chunk — an unterminated line longer than
+        // the read. Skip it wholesale rather than stalling forever on it.
+        None if want == MAX_READ_BYTES => bytes.len(),
+        None => return false,
+    };
+    state.next_offset += consumed as i64;
+
+    let text = String::from_utf8_lossy(&bytes[..consumed]);
     let lines: Vec<&str> = text.lines().filter(|l| !l.trim().is_empty()).collect();
-    Some(extract_progress(&lines))
+    if lines.is_empty() {
+        return false;
+    }
+    apply_lines(state, &lines);
+    true
 }
 
 /// Run the progress sweep loop. Never returns.
 pub async fn run_agent_progress_loop(filestore: Arc<FileStore>, broker: Arc<Broker>) {
     let mut ticker = interval(Duration::from_secs(SWEEP_INTERVAL_SECS));
-    // block_id -> last payload published, so an unchanged checklist doesn't
-    // re-publish every 3s. Bounded by pruning against the live registration
-    // list each tick, same as the summary loop's own bookkeeping.
+    let mut tick: u64 = 0;
+    let mut states: HashMap<String, BlockState> = HashMap::new();
+    // Last payload published per block, so an unchanged checklist doesn't
+    // re-publish every 3s.
     let mut last_published: HashMap<String, AgentProgress> = HashMap::new();
 
     loop {
         ticker.tick().await;
+        tick += 1;
+        let force_republish = tick % REPUBLISH_EVERY_TICKS == 0;
 
         let agents = get_global_handler().list_agents();
-        let registered: HashSet<String> = agents.iter().map(|a| a.block_id.clone()).collect();
+        let registered: std::collections::HashSet<String> =
+            agents.iter().map(|a| a.block_id.clone()).collect();
+        // Both maps are bounded by the live agent count, not by every block_id
+        // ever seen in the process's lifetime.
+        states.retain(|block_id, _| registered.contains(block_id));
         last_published.retain(|block_id, _| registered.contains(block_id));
 
         for agent in agents {
@@ -270,15 +436,19 @@ pub async fn run_agent_progress_loop(filestore: Arc<FileStore>, broker: Arc<Brok
                 continue;
             }
 
-            let Some(progress) = progress_for_block(&filestore, &block_id) else { continue };
+            let state = states.entry(block_id.clone()).or_default();
+            let had_new = consume_new_output(&filestore, &block_id, state);
+            let progress = state.progress();
 
-            // Publish an empty payload ONCE when a previously-non-empty agent
-            // goes quiet (so the UI can clear its rows), but never for an agent
-            // that has had nothing all along.
+            // Nothing new AND nothing already published for this block — an
+            // agent that has never had progress costs no events at all.
+            if !had_new && !last_published.contains_key(&block_id) {
+                continue;
+            }
             if progress.is_empty() && !last_published.contains_key(&block_id) {
                 continue;
             }
-            if last_published.get(&block_id) == Some(&progress) {
+            if !force_republish && last_published.get(&block_id) == Some(&progress) {
                 continue;
             }
             last_published.insert(block_id.clone(), progress.clone());
@@ -292,16 +462,19 @@ pub async fn run_agent_progress_loop(filestore: Arc<FileStore>, broker: Arc<Brok
                 event: EVENT_AGENT_PROGRESS.to_string(),
                 scopes: vec![format!("block:{}", block_id)],
                 sender: String::new(),
-                persist: 0,
-                data: serde_json::to_value(serde_json::json!({
+                // Replayed to a freshly-subscribed route, so a Swarm opened
+                // mid-session sees the current checklist rather than waiting
+                // for the agent's next change — see REPUBLISH_EVERY_TICKS.
+                persist: 1,
+                data: Some(serde_json::json!({
                     "agentId": agent.agent_id,
                     "blockId": block_id,
                     "todos": progress.todos,
                     "todosTruncated": progress.todos_truncated,
+                    "todosPartial": progress.todos_partial,
                     "currentTool": progress.current_tool,
                     "ts": ts,
-                }))
-                .ok(),
+                })),
             });
         }
     }
@@ -317,6 +490,12 @@ mod tests {
         )
     }
 
+    fn task_call(id: &str, tool: &str, tid: &str, title: &str, status: &str) -> String {
+        format!(
+            r#"{{"type":"assistant","message":{{"content":[{{"type":"tool_use","id":"{id}","name":"{tool}","input":{{"task_id":"{tid}","title":"{title}","status":"{status}"}}}}]}}}}"#
+        )
+    }
+
     fn tool_use(id: &str, name: &str) -> String {
         format!(
             r#"{{"type":"assistant","message":{{"content":[{{"type":"tool_use","id":"{id}","name":"{name}","input":{{}}}}]}}}}"#
@@ -329,9 +508,16 @@ mod tests {
         )
     }
 
-    fn run(lines: &[String]) -> AgentProgress {
+    /// One tick's worth of lines.
+    fn feed(state: &mut BlockState, lines: &[String]) {
         let refs: Vec<&str> = lines.iter().map(|s| s.as_str()).collect();
-        extract_progress(&refs)
+        apply_lines(state, &refs);
+    }
+
+    fn run(lines: &[String]) -> AgentProgress {
+        let mut st = BlockState::default();
+        feed(&mut st, lines);
+        st.progress()
     }
 
     #[test]
@@ -349,31 +535,22 @@ mod tests {
         );
     }
 
-    /// TodoWrite republishes the WHOLE list every call, so the newest call is
-    /// the state — an earlier, longer list must not leak through.
     #[test]
     fn the_latest_full_list_supersedes_earlier_ones() {
         let p = run(&[
-            todo_write("t1", r#"[{"content":"A","status":"pending"},{"content":"B","status":"pending"}]"#),
+            todo_write("t1", r#"[{"content":"A","status":"pending"}, {"content":"B","status":"pending"}]"#),
             todo_write("t2", r#"[{"content":"A","status":"completed"}]"#),
         ]);
         assert_eq!(p.todos, vec![TodoItem { text: "A".into(), status: "completed".into() }]);
     }
 
-    /// The version AgentMux actually ships against has no TodoWrite at all —
-    /// it has TaskCreate/TaskUpdate, one item per call. An update must revise
-    /// the row it refers to rather than appending a duplicate.
     #[test]
     fn task_style_calls_accumulate_and_update_in_place() {
-        let create = |id: &str, tid: &str, title: &str| {
-            format!(
-                r#"{{"type":"assistant","message":{{"content":[{{"type":"tool_use","id":"{id}","name":"TaskCreate","input":{{"task_id":"{tid}","title":"{title}","status":"pending"}}}}]}}}}"#
-            )
-        };
-        let update = format!(
-            r#"{{"type":"assistant","message":{{"content":[{{"type":"tool_use","id":"u1","name":"TaskUpdate","input":{{"task_id":"k1","title":"First","status":"completed"}}}}]}}}}"#
-        );
-        let p = run(&[create("c1", "k1", "First"), create("c2", "k2", "Second"), update]);
+        let p = run(&[
+            task_call("c1", "TaskCreate", "k1", "First", "pending"),
+            task_call("c2", "TaskCreate", "k2", "Second", "pending"),
+            task_call("u1", "TaskUpdate", "k1", "First", "completed"),
+        ]);
         assert_eq!(
             p.todos,
             vec![
@@ -384,13 +561,39 @@ mod tests {
         );
     }
 
+    /// THE reagent P1 regression: a TaskCreate seen in an EARLIER tick must
+    /// survive once its line has scrolled out of any fixed tail window. A
+    /// stateless, tail-only parser drops it silently while the task is still
+    /// open — the failure this whole accumulate-across-ticks design exists for.
     #[test]
-    fn current_tool_is_the_last_unresolved_tool_use() {
-        let p = run(&[
-            tool_use("a", "Read"),
-            tool_result("a"),
-            tool_use("b", "Bash"),
-        ]);
+    fn a_task_created_in_an_earlier_tick_survives_later_unrelated_output() {
+        let mut st = BlockState::default();
+        feed(&mut st, &[task_call("c1", "TaskCreate", "k1", "Long-lived task", "pending")]);
+
+        // A later tick carrying only unrelated chatter — no todo tool in sight.
+        let noise: Vec<String> = (0..50).map(|i| tool_use(&format!("n{i}"), "Read")).collect();
+        feed(&mut st, &noise);
+
+        assert_eq!(
+            st.progress().todos,
+            vec![TodoItem { text: "Long-lived task".into(), status: "pending".into() }],
+            "the task is still open and must still be listed",
+        );
+    }
+
+    #[test]
+    fn an_update_arriving_a_tick_later_still_finds_its_row() {
+        let mut st = BlockState::default();
+        feed(&mut st, &[task_call("c1", "TaskCreate", "k1", "Task", "pending")]);
+        feed(&mut st, &[tool_use("n1", "Bash"), tool_result("n1")]);
+        feed(&mut st, &[task_call("u1", "TaskUpdate", "k1", "Task", "completed")]);
+
+        assert_eq!(st.progress().todos, vec![TodoItem { text: "Task".into(), status: "completed".into() }]);
+    }
+
+    #[test]
+    fn current_tool_is_the_outstanding_tool_use() {
+        let p = run(&[tool_use("a", "Read"), tool_result("a"), tool_use("b", "Bash")]);
         assert_eq!(p.current_tool.as_deref(), Some("Bash"));
     }
 
@@ -400,8 +603,17 @@ mod tests {
         assert_eq!(p.current_tool, None);
     }
 
-    /// An emptied checklist is a real state the UI must be able to show, not a
-    /// reason to fall back to stale rows.
+    /// A result arriving in a later tick than its call must still clear it —
+    /// the common case now that ticks are 3s and tools are slower than that.
+    #[test]
+    fn a_result_in_a_later_tick_clears_the_call_from_an_earlier_one() {
+        let mut st = BlockState::default();
+        feed(&mut st, &[tool_use("a", "Bash")]);
+        assert_eq!(st.progress().current_tool.as_deref(), Some("Bash"));
+        feed(&mut st, &[tool_result("a")]);
+        assert_eq!(st.progress().current_tool, None);
+    }
+
     #[test]
     fn an_explicitly_cleared_checklist_reads_as_empty() {
         let p = run(&[
@@ -421,8 +633,28 @@ mod tests {
         assert_eq!(p.todos_truncated, 5);
     }
 
+    /// `partial` is about history we could not see; `todos_truncated` is a cap
+    /// we chose. They are different claims and must not be conflated.
     #[test]
-    fn ignores_malformed_lines_instead_of_giving_up_on_the_whole_tail() {
+    fn a_tail_seeded_block_reports_its_checklist_as_partial() {
+        let mut st = BlockState { partial: true, ..Default::default() };
+        feed(&mut st, &[task_call("c1", "TaskCreate", "k1", "Only what we saw", "pending")]);
+        let p = st.progress();
+        assert!(p.todos_partial, "item-at-a-time rows may be missing earlier entries");
+        assert_eq!(p.todos_truncated, 0, "nothing was dropped by the cap");
+    }
+
+    /// …but a whole-list call is self-contained, so seeing one makes the
+    /// checklist complete regardless of what came before.
+    #[test]
+    fn a_full_list_call_clears_the_partial_flag() {
+        let mut st = BlockState { partial: true, ..Default::default() };
+        feed(&mut st, &[todo_write("t1", r#"[{"content":"Whole list","status":"pending"}]"#)]);
+        assert!(!st.progress().todos_partial);
+    }
+
+    #[test]
+    fn ignores_malformed_lines_instead_of_giving_up_on_the_whole_batch() {
         let p = run(&[
             "not json at all".to_string(),
             String::new(),
@@ -431,21 +663,10 @@ mod tests {
         assert_eq!(p.todos.len(), 1);
     }
 
-    /// A tail window can start mid-conversation, so the first line is often a
-    /// fragment. It must not poison the rest.
-    #[test]
-    fn a_truncated_leading_line_does_not_break_extraction() {
-        let mut lines = vec![r#"{"type":"assistant","message":{"conte"#.to_string()];
-        lines.push(todo_write("t1", r#"[{"content":"Still parsed","status":"pending"}]"#));
-        let p = run(&lines);
-        assert_eq!(p.todos, vec![TodoItem { text: "Still parsed".into(), status: "pending".into() }]);
-    }
-
     #[test]
     fn a_non_todo_tool_never_contributes_checklist_rows() {
         let p = run(&[tool_use("a", "Read"), tool_use("b", "Bash")]);
         assert!(p.todos.is_empty());
-        assert_eq!(p.current_tool.as_deref(), Some("Bash"));
     }
 
     #[test]
@@ -457,6 +678,123 @@ mod tests {
         assert!(is_todo_tool("mcp__planner__TodoSync"));
         assert!(!is_todo_tool("Read"));
         assert!(!is_todo_tool("Task"), "the subagent-spawning Task tool is not a checklist");
+    }
+
+    /// Read-style tools return their data in the RESULT, which this parser
+    /// never reads — so claiming to support them would be advertising a
+    /// no-op (reagent P2 on PR #2952).
+    #[test]
+    fn read_style_task_tools_are_not_claimed_as_supported() {
+        assert!(
+            !TODO_TOOL_NAMES.contains(&"TaskList"),
+            "TaskList's tasks live in its tool_result, not its input",
+        );
+        // TodoRead matches only via the deliberate `Todo` substring fallback,
+        // and still contributes nothing because its input carries no items —
+        // which is correct behavior, not a supported path.
+        assert!(parse_todo_array(&serde_json::json!({})).is_none());
+    }
+
+    #[test]
+    fn the_open_tool_list_stays_bounded_when_results_go_missing() {
+        let mut st = BlockState::default();
+        let calls: Vec<String> = (0..MAX_OPEN_TOOLS + 20)
+            .map(|i| tool_use(&format!("t{i}"), "Read"))
+            .collect();
+        feed(&mut st, &calls);
+        assert_eq!(st.open.len(), MAX_OPEN_TOOLS);
+    }
+
+    /// codex P1: a TaskUpdate legitimately carries only the id and the changed
+    /// status. Requiring a complete item meant the row sat at `pending`
+    /// forever — precisely the transition a checklist exists to show.
+    #[test]
+    fn a_status_only_update_moves_the_row_without_resending_its_text() {
+        let mut st = BlockState::default();
+        feed(&mut st, &[task_call("c1", "TaskCreate", "k1", "Ship it", "pending")]);
+        feed(
+            &mut st,
+            &[format!(
+                r#"{{"type":"assistant","message":{{"content":[{{"type":"tool_use","id":"u1","name":"TaskUpdate","input":{{"task_id":"k1","status":"completed"}}}}]}}}}"#
+            )],
+        );
+        assert_eq!(
+            st.progress().todos,
+            vec![TodoItem { text: "Ship it".into(), status: "completed".into() }],
+            "text is preserved from the create, status taken from the update",
+        );
+    }
+
+    /// The mirror: a text-only edit must not reset a status back to pending.
+    #[test]
+    fn a_text_only_update_preserves_the_existing_status() {
+        let mut st = BlockState::default();
+        feed(&mut st, &[task_call("c1", "TaskCreate", "k1", "Old wording", "in_progress")]);
+        feed(
+            &mut st,
+            &[format!(
+                r#"{{"type":"assistant","message":{{"content":[{{"type":"tool_use","id":"u1","name":"TaskUpdate","input":{{"task_id":"k1","title":"New wording"}}}}]}}}}"#
+            )],
+        );
+        assert_eq!(
+            st.progress().todos,
+            vec![TodoItem { text: "New wording".into(), status: "in_progress".into() }],
+        );
+    }
+
+    /// An update for a task we never saw created (seeded mid-stream) has no
+    /// text to display, so it must not invent a blank row.
+    #[test]
+    fn a_status_only_update_for_an_unknown_task_creates_no_row() {
+        let mut st = BlockState::default();
+        feed(
+            &mut st,
+            &[format!(
+                r#"{{"type":"assistant","message":{{"content":[{{"type":"tool_use","id":"u1","name":"TaskUpdate","input":{{"task_id":"ghost","status":"completed"}}}}]}}}}"#
+            )],
+        );
+        assert!(st.progress().todos.is_empty());
+    }
+
+    /// codex P2: Gemini-shaped transcripts put the frame at the TOP LEVEL with
+    /// `tool_name`/`tool_id`/`parameters`. Before this, every non-Claude agent
+    /// showed no in-flight tool and no todos at all.
+    #[test]
+    fn parses_provider_native_top_level_tool_frames() {
+        let mut st = BlockState::default();
+        feed(
+            &mut st,
+            &[r#"{"type":"tool_use","tool_name":"Bash","tool_id":"g1","parameters":{}}"#.to_string()],
+        );
+        assert_eq!(st.progress().current_tool.as_deref(), Some("Bash"));
+
+        feed(
+            &mut st,
+            &[r#"{"type":"tool_result","tool_id":"g1","status":"success"}"#.to_string()],
+        );
+        assert_eq!(st.progress().current_tool, None, "a tool_id result clears its call");
+    }
+
+    #[test]
+    fn parses_a_todo_checklist_from_a_top_level_frame() {
+        let mut st = BlockState::default();
+        feed(
+            &mut st,
+            &[r#"{"type":"tool_use","tool_name":"TodoWrite","tool_id":"g2","parameters":{"todos":[{"content":"From Gemini","status":"pending"}]}}"#.to_string()],
+        );
+        assert_eq!(
+            st.progress().todos,
+            vec![TodoItem { text: "From Gemini".into(), status: "pending".into() }],
+        );
+    }
+
+    /// An ordinary transcript line must not be mistaken for a bare tool frame.
+    #[test]
+    fn a_plain_line_is_not_treated_as_a_tool_frame() {
+        let mut st = BlockState::default();
+        feed(&mut st, &[r#"{"type":"system","subtype":"init","name":"TodoWrite"}"#.to_string()]);
+        assert!(st.progress().todos.is_empty());
+        assert_eq!(st.progress().current_tool, None);
     }
 
     #[test]

--- a/agentmux-srv/src/bootstrap.rs
+++ b/agentmux-srv/src/bootstrap.rs
@@ -980,6 +980,19 @@ pub fn spawn_background_subsystems(
         ).await;
     });
 
+    // Push each agent's todo checklist + in-flight tool (swarm rows under the
+    // agent name). Separate loop from the summary above deliberately: this one
+    // is a tail-read + JSON parse with no model call, so it sweeps every 3s
+    // instead of 20s — a checklist that lags is worse than none. Same
+    // registry, same no-AppState property.
+    let progress_filestore = Arc::clone(filestore);
+    let progress_broker = broker.clone();
+    tokio::spawn(async move {
+        backend::reactive::progress_watcher::run_agent_progress_loop(
+            progress_filestore, progress_broker,
+        ).await;
+    });
+
     // Reactive handler (global singleton) + poller
     let reactive_handler = reactive::get_global_handler();
     reactive_handler.set_input_sender(Arc::new(|block_id: &str, data: &[u8]| {

--- a/frontend/app/view/swarm/swarm-agent-row.render.test.tsx
+++ b/frontend/app/view/swarm/swarm-agent-row.render.test.tsx
@@ -62,6 +62,7 @@ function treeNode(): AgentTreeNode {
         cronRows: [],
         todoRows: [],
         todosTruncated: 0,
+        todosPartial: false,
         currentTool: null,
     } as AgentTreeNode;
 }

--- a/frontend/app/view/swarm/swarm-agent-row.render.test.tsx
+++ b/frontend/app/view/swarm/swarm-agent-row.render.test.tsx
@@ -60,6 +60,9 @@ function treeNode(): AgentTreeNode {
         workflowRows: [],
         shellRows: [],
         cronRows: [],
+        todoRows: [],
+        todosTruncated: 0,
+        currentTool: null,
     } as AgentTreeNode;
 }
 

--- a/frontend/app/view/swarm/swarm-child-count.test.ts
+++ b/frontend/app/view/swarm/swarm-child-count.test.ts
@@ -27,6 +27,7 @@ function node(over: Partial<AgentTreeNode> = {}): AgentTreeNode {
         cronRows: [],
         todoRows: [],
         todosTruncated: 0,
+        todosPartial: false,
         currentTool: null,
         ...over,
     } as AgentTreeNode;

--- a/frontend/app/view/swarm/swarm-child-count.test.ts
+++ b/frontend/app/view/swarm/swarm-child-count.test.ts
@@ -25,6 +25,9 @@ function node(over: Partial<AgentTreeNode> = {}): AgentTreeNode {
         workflowRows: [],
         shellRows: [],
         cronRows: [],
+        todoRows: [],
+        todosTruncated: 0,
+        currentTool: null,
         ...over,
     } as AgentTreeNode;
 }

--- a/frontend/app/view/swarm/swarm-model.test.ts
+++ b/frontend/app/view/swarm/swarm-model.test.ts
@@ -442,6 +442,9 @@ function mkNode(agentToolRows: ActiveSubagent[], workflowRows: WorkflowDispatch[
         agentStatus: "idle",
         agentToolRows,
         workflowRows,
+        todoRows: [],
+        todosTruncated: 0,
+        currentTool: null,
         shellRows: [],
         cronRows: [],
     };

--- a/frontend/app/view/swarm/swarm-model.test.ts
+++ b/frontend/app/view/swarm/swarm-model.test.ts
@@ -444,6 +444,7 @@ function mkNode(agentToolRows: ActiveSubagent[], workflowRows: WorkflowDispatch[
         workflowRows,
         todoRows: [],
         todosTruncated: 0,
+        todosPartial: false,
         currentTool: null,
         shellRows: [],
         cronRows: [],

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -201,6 +201,36 @@ export interface AgentTreeNode {
      *  PROCESS_ROWS_2026_07_20 Phase 2), enabled or paused. Sorted
      *  newest-first by `last_fired` (nulls — never fired — last). */
     cronRows: ActiveCron[];
+    /** The agent's current todo checklist, in the agent's own order (NOT
+     *  sorted here — the order it wrote them in is the order it means).
+     *  Pushed by the backend's `agent:progress` sweep rather than read from
+     *  block meta, because the frontend only holds tool calls for panes that
+     *  are currently mounted and the Swarm's whole point is the ones that
+     *  aren't. */
+    todoRows: TodoItem[];
+    /** How many rows `MAX_TODOS` dropped backend-side, so the tree can say
+     *  "+N more" instead of showing a partial list as if it were whole. */
+    todosTruncated: number;
+    /** The tool this agent is running right now, or null between tools.
+     *  Complements `activitySummary`: that is a Haiku paraphrase of the last
+     *  ~20s, this is the literal call in flight. */
+    currentTool: string | null;
+}
+
+/** One checklist entry, as published by the backend progress watcher. */
+export interface TodoItem {
+    text: string;
+    /** `pending` | `in_progress` | `completed`, or whatever a provider wrote —
+     *  passed through verbatim rather than coerced, so an unrecognized status
+     *  renders as itself instead of silently becoming "pending". */
+    status: string;
+}
+
+/** One `agent:progress` payload, keyed by block. */
+export interface AgentProgress {
+    todos: TodoItem[];
+    todosTruncated: number;
+    currentTool: string | null;
 }
 
 /**
@@ -852,6 +882,14 @@ export class SwarmViewModel implements ViewModel {
     cronsAtom: Accessor<ActiveCron[]> = this._crons[0];
     private setCrons: Setter<ActiveCron[]> = this._crons[1];
 
+    // Per-block todo checklist + in-flight tool, pushed by the backend's
+    // `agent:progress` sweep. Push-only (no fetch-on-open counterpart): the
+    // watcher republishes whenever the payload changes, so a Swarm opened
+    // mid-session fills in within one sweep rather than needing its own RPC.
+    private _progress = createSignal<Map<string, AgentProgress>>(new Map());
+    progressAtom: Accessor<Map<string, AgentProgress>> = this._progress[0];
+    private setProgress: Setter<Map<string, AgentProgress>> = this._progress[1];
+
     // AgentDispatches (SPEC §5) — one per Agent-tool-or-Workflow-tool call.
     // Fetched separately from subagentsAtom via subagent.ListDispatches;
     // buildTree() cross-references the two by dispatch_id/parent_block_id.
@@ -1124,6 +1162,35 @@ export class SwarmViewModel implements ViewModel {
             handler: () => this.scheduleLoadCrons(),
         });
         if (unsubCronChanged) this.unsubs.push(unsubCronChanged);
+
+        // Todo checklist + in-flight tool. Unlike the buckets above this
+        // carries its whole payload on the event, so there's nothing to
+        // reload — store it keyed by block and let buildTree read it.
+        const unsubProgress = waveEventSubscribe({
+            eventType: "agent:progress",
+            handler: (event: WaveEvent) => {
+                const data = event?.data as any;
+                const blockId = data?.blockId;
+                if (typeof blockId !== "string" || !blockId) return;
+                const todos: TodoItem[] = Array.isArray(data?.todos)
+                    ? data.todos
+                          .filter((t: any) => typeof t?.text === "string" && t.text.length > 0)
+                          .map((t: any) => ({
+                              text: t.text as string,
+                              status: typeof t?.status === "string" ? t.status : "pending",
+                          }))
+                    : [];
+                const next: AgentProgress = {
+                    todos,
+                    todosTruncated: typeof data?.todosTruncated === "number" ? data.todosTruncated : 0,
+                    currentTool: typeof data?.currentTool === "string" ? data.currentTool : null,
+                };
+                // Replace the Map (not mutate) so Solid sees a new reference
+                // and buildTree's memo actually re-runs.
+                this.setProgress((prev) => new Map(prev).set(blockId, next));
+            },
+        });
+        if (unsubProgress) this.unsubs.push(unsubProgress);
 
         // Patch display_name in place (not a full loadSubagents() reload) so
         // every client watching this session picks up a generated name —
@@ -1772,6 +1839,7 @@ export class SwarmViewModel implements ViewModel {
         const shells = this.shellsAtom();
         const crons = this.cronsAtom();
         const statuses = this.agentStatusesAtom();
+        const progressByBlock = this.progressAtom();
 
         // Include parent block IDs from subagents as fallback for agent panes
         // that registered subagents before their own registration propagated.
@@ -1820,6 +1888,7 @@ export class SwarmViewModel implements ViewModel {
             const visibleWorkflowRows = filterRetired(workflowRows, retired, (w) => w.dispatchId, (w) => workflowRetireSignal(w));
             const shellRows = buildShellRows(shells, blockId);
             const cronRows = buildCronRows(crons, blockId);
+            const progress = progressByBlock.get(blockId);
             return {
                 blockId,
                 agentName,
@@ -1831,6 +1900,13 @@ export class SwarmViewModel implements ViewModel {
                 workflowRows: visibleWorkflowRows,
                 shellRows,
                 cronRows,
+                todoRows: progress?.todos ?? [],
+                todosTruncated: progress?.todosTruncated ?? 0,
+                // Only meaningful while the agent is actually running — a
+                // stopped pane's last in-flight tool is stale, and showing it
+                // would read as "still doing this" (the payload is push-only,
+                // so nothing else clears it on stop).
+                currentTool: agentStatus === "running" ? (progress?.currentTool ?? null) : null,
             };
         });
 

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -1798,6 +1798,20 @@ export class SwarmViewModel implements ViewModel {
             new Map(blockIds.map((id) => [id, prev.get(id) ?? ("idle" as const)]))
         );
 
+        // Prune pushed progress for blocks that are gone, mirroring the
+        // backend watcher's own per-sweep `retain` (reagent P2 on PR #2952).
+        // `agent:progress` is push-only, so without this the Map keeps an
+        // entry for every block that ever reported — unbounded across a long
+        // session with many ephemeral panes. This is the right place rather
+        // than the `block_pruned` event: the block-list refresh is the general
+        // case, and it's where the statuses Map above is already rebuilt from
+        // the same authoritative list.
+        const live = new Set(blockIds);
+        this.setProgress((prev) => {
+            if (![...prev.keys()].some((id) => !live.has(id))) return prev;
+            return new Map([...prev].filter(([id]) => live.has(id)));
+        });
+
         for (const blockId of blockIds) {
             // Fetch current status — don't assume idle for already-running agents.
             void BlockService.GetControllerStatus(blockId)

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -211,6 +211,12 @@ export interface AgentTreeNode {
     /** How many rows `MAX_TODOS` dropped backend-side, so the tree can say
      *  "+N more" instead of showing a partial list as if it were whole. */
     todosTruncated: number;
+    /** True when the backend first saw this block mid-stream, so item-at-a-time
+     *  (`TaskCreate`) entries from before that point were never observed.
+     *  Deliberately NOT folded into `todosTruncated`: that is a cap we chose
+     *  and can count, this is history we could not see and cannot. Rendering
+     *  them the same way would claim a precision we do not have. */
+    todosPartial: boolean;
     /** The tool this agent is running right now, or null between tools.
      *  Complements `activitySummary`: that is a Haiku paraphrase of the last
      *  ~20s, this is the literal call in flight. */
@@ -230,6 +236,7 @@ export interface TodoItem {
 export interface AgentProgress {
     todos: TodoItem[];
     todosTruncated: number;
+    todosPartial: boolean;
     currentTool: string | null;
 }
 
@@ -1181,6 +1188,7 @@ export class SwarmViewModel implements ViewModel {
                 const next: AgentProgress = {
                     todos,
                     todosTruncated: typeof data?.todosTruncated === "number" ? data.todosTruncated : 0,
+                    todosPartial: data?.todosPartial === true,
                     currentTool: typeof data?.currentTool === "string" ? data.currentTool : null,
                 };
                 // Replace the Map (not mutate) so Solid sees a new reference
@@ -1914,6 +1922,7 @@ export class SwarmViewModel implements ViewModel {
                 cronRows,
                 todoRows: progress?.todos ?? [],
                 todosTruncated: progress?.todosTruncated ?? 0,
+                todosPartial: progress?.todosPartial ?? false,
                 // Only meaningful while the agent is actually running — a
                 // stopped pane's last in-flight tool is stale, and showing it
                 // would read as "still doing this" (the payload is push-only,

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -430,9 +430,8 @@ export function collectClearableRows(nodes: AgentTreeNode[]): { rowKey: string; 
  * `read_jsonl_from_offset`), which in practice is that CLI's own
  * per-session/per-batch codename. A whole Task/Workflow-tool batch of
  * genuinely distinct, unrelated subagents legitimately shares one slug —
- * already established as an expected, non-buggy signature in
- * docs/specs/REPORT_SWARM_SUBAGENT_HISTORY_FLOOD_2026_07_07.md Finding 3
- * ("one shared slug = one legitimate concurrent spawn") and relied on by
+ * an expected, non-buggy signature ("one shared slug = one legitimate
+ * concurrent spawn"), and one relied on by
  * `buildDispatchBuckets`'s `WorkflowDispatch.name` derivation above as a
  * fallback for the brief window before eager naming resolves.
  *
@@ -482,8 +481,7 @@ function shallowEqualSubagent(a: ActiveSubagent, b: ActiveSubagent): boolean {
  * object identity on every spawn/completed refresh, and SolidJS's `<For>`
  * (which diffs list items by reference, not value) tears down and remounts
  * every row in the tree on every refresh, silently collapsing any row a
- * user has expanded. See
- * docs/specs/REPORT_SWARM_SUBAGENT_DETAIL_UX_ANALYSIS_2026_07_07.md.
+ * user has expanded.
  */
 export function mergeSubagentsPreservingIdentity(
     prev: ActiveSubagent[],

--- a/frontend/app/view/swarm/swarm-todos.render.test.tsx
+++ b/frontend/app/view/swarm/swarm-todos.render.test.tsx
@@ -43,6 +43,7 @@ function treeNode(over: Partial<AgentTreeNode> = {}): AgentTreeNode {
         cronRows: [],
         todoRows: [],
         todosTruncated: 0,
+        todosPartial: false,
         currentTool: null,
         ...over,
     } as AgentTreeNode;
@@ -102,6 +103,31 @@ describe("Swarm todo rows", () => {
     it("discloses backend truncation instead of showing a partial list as whole", () => {
         const { container } = renderRow(treeNode({ todoRows: TODOS, todosTruncated: 7 }));
         expect(container.querySelector(".swarm-todo-truncated")?.textContent).toBe("+7 more");
+    });
+
+    /** `todosPartial` and `todosTruncated` are different claims and must not
+     *  look the same: one is a cap we chose and can count, the other is
+     *  history the backend could not see. Rendering only the countable one
+     *  would show an incomplete checklist as if it were whole. */
+    it("discloses a partial checklist separately from a truncated one", () => {
+        const { container } = renderRow(treeNode({ todoRows: TODOS, todosPartial: true }));
+        expect(container.querySelector(".swarm-todo-partial")?.textContent).toBe(
+            "earlier items may be missing"
+        );
+        expect(container.querySelector(".swarm-todo-truncated")).toBeNull();
+    });
+
+    it("says nothing about completeness when the checklist is complete", () => {
+        const { container } = renderRow(treeNode({ todoRows: TODOS }));
+        expect(container.querySelector(".swarm-todo-partial")).toBeNull();
+    });
+
+    it("can report both at once — they are independent facts", () => {
+        const { container } = renderRow(
+            treeNode({ todoRows: TODOS, todosTruncated: 2, todosPartial: true })
+        );
+        expect(container.querySelector(".swarm-todo-truncated")?.textContent).toBe("+2 more");
+        expect(container.querySelector(".swarm-todo-partial")).not.toBeNull();
     });
 
     it("keeps the full text reachable on hover, since rows are single-line", () => {

--- a/frontend/app/view/swarm/swarm-todos.render.test.tsx
+++ b/frontend/app/view/swarm/swarm-todos.render.test.tsx
@@ -1,0 +1,149 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Todo rows + the current-tool line, end-to-end through `AgentRow`.
+ *
+ * The backend parser has its own tests (`progress_watcher.rs`); these cover the
+ * wiring those payloads feed — including the `agentChildRowCount` trap that the
+ * PR #2862 regression documents: a bucket that isn't in the count renders
+ * nothing and offers no way to expand to it.
+ */
+
+import { cleanup, render } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: { DockNodeStatusCommand: () => Promise.resolve() },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+
+import { __resetAllSlots, registerPane } from "@/app/store/agent-document-store";
+import { AgentRow, agentChildRowCount } from "./swarm-view";
+import type { AgentTreeNode, SwarmViewModel, TodoItem } from "./swarm-model";
+
+afterEach(() => {
+    cleanup();
+    __resetAllSlots();
+});
+
+const BLOCK = "b1";
+
+function treeNode(over: Partial<AgentTreeNode> = {}): AgentTreeNode {
+    return {
+        blockId: BLOCK,
+        agentName: "AgentX",
+        agentProvider: "claude",
+        activitySummary: null,
+        contextTokens: null,
+        agentStatus: "running",
+        agentToolRows: [],
+        workflowRows: [],
+        shellRows: [],
+        cronRows: [],
+        todoRows: [],
+        todosTruncated: 0,
+        currentTool: null,
+        ...over,
+    } as AgentTreeNode;
+}
+
+function modelStub(collapsed: boolean): SwarmViewModel {
+    return {
+        isAgentCollapsed: () => collapsed,
+        toggleAgentCollapsed: () => {},
+        isSelected: () => false,
+        toggleSelected: () => {},
+    } as unknown as SwarmViewModel;
+}
+
+function renderRow(node: AgentTreeNode, collapsed = false) {
+    registerPane(BLOCK, () => {});
+    return render(() => <AgentRow node={node} focusedBlockId={() => null} model={modelStub(collapsed)} />);
+}
+
+const TODOS: TodoItem[] = [
+    { text: "Read the spec", status: "completed" },
+    { text: "Write the parser", status: "in_progress" },
+    { text: "Wire the frontend", status: "pending" },
+];
+
+describe("Swarm todo rows", () => {
+    it("lists every todo under the agent, in the agent's own order", () => {
+        const { container } = renderRow(treeNode({ todoRows: TODOS }));
+        const texts = [...container.querySelectorAll(".swarm-todo-text")].map((e) => e.textContent);
+        expect(texts).toEqual(["Read the spec", "Write the parser", "Wire the frontend"]);
+    });
+
+    it("shows progress as done/total rather than a bare row count", () => {
+        const { container } = renderRow(treeNode({ todoRows: TODOS }));
+        expect(container.querySelector(".swarm-bucket--todo .swarm-bucket-count")?.textContent).toBe("1/3");
+    });
+
+    it("marks each row with its status so state is visible without reading", () => {
+        const { container } = renderRow(treeNode({ todoRows: TODOS }));
+        expect(container.querySelector(".swarm-todo-row--completed")).not.toBeNull();
+        expect(container.querySelector(".swarm-todo-row--in_progress")).not.toBeNull();
+        expect(container.querySelector(".swarm-todo-row--pending")).not.toBeNull();
+    });
+
+    /** A provider we haven't seen must still render its row, not vanish. */
+    it("falls back to the pending treatment for an unrecognized status", () => {
+        const { container } = renderRow(treeNode({ todoRows: [{ text: "Odd one", status: "deferred" }] }));
+        expect(container.querySelector(".swarm-todo-row--pending")).not.toBeNull();
+        expect(container.querySelector(".swarm-todo-text")?.textContent).toBe("Odd one");
+    });
+
+    it("renders no bucket at all when the agent has no todos", () => {
+        const { container } = renderRow(treeNode());
+        expect(container.querySelector(".swarm-bucket--todo")).toBeNull();
+    });
+
+    it("discloses backend truncation instead of showing a partial list as whole", () => {
+        const { container } = renderRow(treeNode({ todoRows: TODOS, todosTruncated: 7 }));
+        expect(container.querySelector(".swarm-todo-truncated")?.textContent).toBe("+7 more");
+    });
+
+    it("keeps the full text reachable on hover, since rows are single-line", () => {
+        const long = "a".repeat(200);
+        const { container } = renderRow(treeNode({ todoRows: [{ text: long, status: "pending" }] }));
+        expect(container.querySelector(".swarm-todo-text")?.getAttribute("title")).toBe(long);
+    });
+});
+
+describe("agentChildRowCount — todos must be countable", () => {
+    /** The PR #2862 trap: a bucket missing from this sum gets no expand
+     *  affordance and never mounts, so it renders as nothing at all. */
+    it("counts todo rows", () => {
+        expect(agentChildRowCount(treeNode({ todoRows: TODOS }), 0)).toBe(3);
+    });
+
+    it("renders the bucket for an agent whose ONLY activity is a checklist", () => {
+        const { container } = renderRow(treeNode({ todoRows: TODOS }));
+        expect(container.querySelector(".swarm-bucket--todo")).not.toBeNull();
+    });
+
+    it("surfaces that work in the collapsed count too", () => {
+        const { container } = renderRow(treeNode({ todoRows: TODOS }), true);
+        expect(container.querySelector(".swarm-agent-collapsed-count")?.textContent).toBe("3");
+    });
+});
+
+describe("Swarm current-tool line", () => {
+    it("names the tool in flight", () => {
+        const { container } = renderRow(treeNode({ currentTool: "Bash" }));
+        expect(container.querySelector(".swarm-current-tool-name")?.textContent).toBe("Bash");
+    });
+
+    /** It is the most perishable thing on the card — an agent you have
+     *  collapsed is exactly when you want it without expanding. */
+    it("stays visible while the agent is collapsed", () => {
+        const { container } = renderRow(treeNode({ currentTool: "Bash" }), true);
+        expect(container.querySelector(".swarm-current-tool-name")?.textContent).toBe("Bash");
+    });
+
+    it("shows nothing between tools", () => {
+        const { container } = renderRow(treeNode({ currentTool: null }));
+        expect(container.querySelector(".swarm-current-tool")).toBeNull();
+    });
+});

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -265,6 +265,17 @@
     &--longrunning .swarm-bucket-label {
         color: var(--secondary-text-color);
     }
+    // Todos — deliberately NOT a sixth saturated hue, for the mirror of the
+    // reason longrunning is grey. The four hues above label MECHANISMS the
+    // agent is using (a dispatch, a workflow, a shell, a cron); a checklist is
+    // the agent's stated INTENT, which is a different kind of thing rather
+    // than a fifth peer. Plain primary text reads as "the agent's own words"
+    // and, unlike another hue, doesn't compete with the four for attention —
+    // while still sitting brighter than the inferred longrunning bucket,
+    // matching the relative weight of intent vs. inference.
+    &--todo .swarm-bucket-label {
+        color: var(--main-text-color);
+    }
 }
 
 .swarm-bucket-header {
@@ -286,6 +297,94 @@
 .swarm-bucket-count {
     font-size: 10px;
     color: var(--secondary-text-color);
+}
+
+// ── Todos ────────────────────────────────────────────────────────────────
+// Indented to the same 22px gutter the bucket header uses, so checklist rows
+// line up under their label rather than under the agent name.
+
+.swarm-todo-row {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    padding: 1px 6px 1px 22px;
+    font-size: 11px;
+    line-height: 1.4;
+    min-width: 0;
+
+    &--completed .swarm-todo-text {
+        // Struck AND dimmed: strike-through alone is easy to miss at 11px,
+        // and a long finished list should recede as a block.
+        text-decoration: line-through;
+        color: var(--secondary-text-color);
+        opacity: 0.75;
+    }
+    &--in_progress .swarm-todo-text {
+        color: var(--main-text-color);
+        font-weight: 600;
+    }
+    &--pending .swarm-todo-text {
+        color: var(--secondary-text-color);
+    }
+}
+
+.swarm-todo-sigil {
+    flex: 0 0 auto;
+    width: 10px;
+    text-align: center;
+    font-size: 10px;
+    color: var(--secondary-text-color);
+
+    .swarm-todo-row--completed & {
+        color: var(--success-color);
+    }
+    .swarm-todo-row--in_progress & {
+        color: var(--accent-color);
+    }
+}
+
+.swarm-todo-text {
+    // One line per todo — a checklist is scanned, not read, and wrapping a
+    // long item would push every other row out of view. Full text is on the
+    // element's own title attribute.
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+}
+
+.swarm-todo-truncated {
+    padding: 1px 6px 1px 38px;
+    font-size: 10px;
+    font-style: italic;
+    color: var(--secondary-text-color);
+}
+
+// ── Current tool ─────────────────────────────────────────────────────────
+// Sits on the agent card itself (not inside the collapsible children), beside
+// the activity summary — see the JSX comment for why it stays visible while
+// collapsed.
+
+.swarm-current-tool {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 0 6px 2px 22px;
+    font-size: 10px;
+    color: var(--secondary-text-color);
+    min-width: 0;
+}
+
+.swarm-current-tool-icon {
+    font-size: 8px;
+    color: var(--accent-color);
+}
+
+.swarm-current-tool-name {
+    font-family: var(--termfontfamily, monospace);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 // ── Workflow group (subagents spawned together by one Task/Workflow-tool

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -353,6 +353,17 @@
     min-width: 0;
 }
 
+// Warmer than the neutral "+N more" beside it: that reports a cap working as
+// designed, this reports a gap in what we could observe, which is the one the
+// reader might want to act on (restart the pane to re-seed cleanly).
+.swarm-todo-partial {
+    padding: 1px 6px 1px 38px;
+    font-size: 10px;
+    font-style: italic;
+    color: var(--warning-color, #f5a623);
+    opacity: 0.85;
+}
+
 .swarm-todo-truncated {
     padding: 1px 6px 1px 38px;
     font-size: 10px;

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -360,7 +360,11 @@ export function AgentRow({
             </div>
             <Show when={!collapsed()}>
                 <div class="swarm-children">
-                    <TodoBucket rows={node.todoRows} truncated={node.todosTruncated} />
+                    <TodoBucket
+                        rows={node.todoRows}
+                        truncated={node.todosTruncated}
+                        partial={node.todosPartial}
+                    />
                     <AgentToolBucket rows={node.agentToolRows} model={model} parentAgentStatus={node.agentStatus} />
                     <WorkflowBucket rows={node.workflowRows} model={model} />
                     <ShellBucket rows={node.shellRows} />
@@ -385,7 +389,15 @@ export function AgentRow({
 // Rows are rendered in the agent's own order, never sorted here — a checklist
 // is an ordered artifact and re-ordering it (by status, say) would be editing
 // the agent's meaning rather than displaying it.
-function TodoBucket({ rows, truncated }: { rows: TodoItem[]; truncated: number }): JSX.Element {
+function TodoBucket({
+    rows,
+    truncated,
+    partial,
+}: {
+    rows: TodoItem[];
+    truncated: number;
+    partial: boolean;
+}): JSX.Element {
     const done = () => rows.filter((t) => t.status === "completed").length;
     return (
         <Show when={rows.length > 0}>
@@ -401,6 +413,20 @@ function TodoBucket({ rows, truncated }: { rows: TodoItem[]; truncated: number }
                 <For each={rows}>{(todo) => <TodoRow todo={todo} />}</For>
                 <Show when={truncated > 0}>
                     <div class="swarm-todo-truncated">+{truncated} more</div>
+                </Show>
+                {/* Distinct from "+N more" above, and deliberately so: that is
+                    a cap we chose and can count, this is history the backend
+                    could not see (it started watching mid-stream, so
+                    item-at-a-time entries created earlier were never observed).
+                    Showing an incomplete checklist as if it were complete is
+                    the failure worth avoiding here. */}
+                <Show when={partial}>
+                    <div
+                        class="swarm-todo-partial"
+                        title="AgentMux started watching this agent mid-session, so items created before that may be missing."
+                    >
+                        earlier items may be missing
+                    </div>
                 </Show>
             </div>
         </Show>

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createMemo, createSignal, createEffect, onCleanup, For, onMount, Show, type Accessor, type JSX } from "solid-js";
-import type { SwarmViewModel, AgentTreeNode, ActiveSubagent, ActiveShell, ActiveCron, WorkflowDispatch, SubagentEvent, DispatchActivityEntry } from "./swarm-model";
+import type { SwarmViewModel, AgentTreeNode, ActiveSubagent, ActiveShell, ActiveCron, WorkflowDispatch, SubagentEvent, DispatchActivityEntry, TodoItem } from "./swarm-model";
 import { collectClearableRows, subagentDisplayLabel, subagentRowKey, workflowRetireSignal, AUTO_RETIRE_DELAY_MS } from "./swarm-model";
 import { ProviderLogo } from "@/app/element/ProviderLogo";
 import AnsiLine from "@/element/ansiline";
@@ -346,9 +346,21 @@ export function AgentRow({
                         {node.activitySummary}
                     </div>
                 </Show>
+                {/* The literal call in flight, next to the Haiku paraphrase
+                    above it. Deliberately OUTSIDE the collapsed() guard: it is
+                    one line, it is the most perishable thing on the card, and
+                    a collapsed agent is exactly when you want to know what it
+                    is doing without expanding it. */}
+                <Show when={node.currentTool}>
+                    <div class="swarm-current-tool">
+                        <i class="fa-solid fa-bolt swarm-current-tool-icon" />
+                        <span class="swarm-current-tool-name">{node.currentTool}</span>
+                    </div>
+                </Show>
             </div>
             <Show when={!collapsed()}>
                 <div class="swarm-children">
+                    <TodoBucket rows={node.todoRows} truncated={node.todosTruncated} />
                     <AgentToolBucket rows={node.agentToolRows} model={model} parentAgentStatus={node.agentStatus} />
                     <WorkflowBucket rows={node.workflowRows} model={model} />
                     <ShellBucket rows={node.shellRows} />
@@ -364,6 +376,56 @@ export function AgentRow({
 //    MODEL_2026_07_19 §4) — always exactly these two, never data-driven
 //    groups; each hides entirely when empty (no "always visible" precedent
 //    exists anywhere else in this codebase, see that spec's §6). ─────────
+
+// Todo bucket — the agent's own checklist, pushed by the backend's
+// `agent:progress` sweep. Placed FIRST among the buckets: the other four are
+// mechanisms the agent is using, this is what it says it is trying to do, and
+// intent reads before mechanism.
+//
+// Rows are rendered in the agent's own order, never sorted here — a checklist
+// is an ordered artifact and re-ordering it (by status, say) would be editing
+// the agent's meaning rather than displaying it.
+function TodoBucket({ rows, truncated }: { rows: TodoItem[]; truncated: number }): JSX.Element {
+    const done = () => rows.filter((t) => t.status === "completed").length;
+    return (
+        <Show when={rows.length > 0}>
+            <div class="swarm-bucket swarm-bucket--todo">
+                <div class="swarm-bucket-header">
+                    <span class="swarm-bucket-label">Todos</span>
+                    {/* done/total, not a bare count like the other buckets —
+                        for a checklist the useful number is progress. */}
+                    <span class="swarm-bucket-count">
+                        {done()}/{rows.length}
+                    </span>
+                </div>
+                <For each={rows}>{(todo) => <TodoRow todo={todo} />}</For>
+                <Show when={truncated > 0}>
+                    <div class="swarm-todo-truncated">+{truncated} more</div>
+                </Show>
+            </div>
+        </Show>
+    );
+}
+
+/** Status glyphs. Unknown statuses fall through to the pending dot rather than
+ *  rendering nothing, so a provider we haven't seen still shows its row. */
+const TODO_SIGIL: Record<string, string> = {
+    completed: "✓",
+    in_progress: "▸",
+    pending: "○",
+};
+
+function TodoRow({ todo }: { todo: TodoItem }): JSX.Element {
+    const status = () => (todo.status in TODO_SIGIL ? todo.status : "pending");
+    return (
+        <div classList={{ "swarm-todo-row": true, [`swarm-todo-row--${status()}`]: true }}>
+            <span class="swarm-todo-sigil">{TODO_SIGIL[status()]}</span>
+            <span class="swarm-todo-text" title={todo.text}>
+                {todo.text}
+            </span>
+        </div>
+    );
+}
 
 function AgentToolBucket({
     rows,
@@ -482,6 +544,13 @@ function ShellRow({ shell }: { shell: ActiveShell }): JSX.Element {
  */
 export function agentChildRowCount(node: AgentTreeNode, longRunningCount: number): number {
     return (
+        // Todos count like any other bucket, and must: this total drives
+        // `hasChildren()`, which gates BOTH the expand affordance and the
+        // collapse guard that mounts the buckets at all. Omitting them would
+        // make an agent whose only activity is a checklist render nothing and
+        // offer no way to expand — the exact shape of the PR #2862 regression
+        // that `swarm-agent-row.render.test.tsx` exists to pin.
+        node.todoRows.length +
         node.agentToolRows.length +
         node.workflowRows.length +
         node.shellRows.length +


### PR DESCRIPTION
Adds two surfaces under each agent's name in the Swarm pane: its **todo checklist**, and the **tool it is running right now**.

## Why the backend

Nothing captured todos before this — there is no `TodoWrite`/`Task*` handling anywhere in `agentmux-srv`, and the frontend only holds tool calls as generic `ToolNode`s in `agent-document-store`, which is populated by **mounted panes only**.

Since the Swarm's whole value is seeing agents you are *not* looking at, the data has to come from where the shell/cron/summary rows already come from.

New `reactive::progress_watcher` mirrors `activity_watcher`'s sweep (same registry, same running/agent-pane gate, no `AppState`) but is a pure tail-read + JSON parse with **no model call**, so it sweeps every **3s** rather than 20s — a checklist that lags is worse than none. It publishes only when the payload actually changes, plus once when a previously-active agent goes quiet so the UI can clear.

## Matching todo tools by name, not by assuming `TodoWrite`

Worth flagging, because it surprised me: **`TodoWrite` is not what AgentMux currently ships against.** Claude Code 2.1.177 advertises `TaskCreate`/`TaskGet`/`TaskList`/`TaskUpdate` and no `TodoWrite` at all, and I found zero `TodoWrite` calls in any local transcript. Other providers differ again.

So the watcher matches a known name set plus a `Todo` substring fallback, and handles both shapes:

- a full `input.todos` array **replaces** the list outright (the tool's own semantics)
- Task-style single-item calls **accumulate** into an ordered map keyed by task id, so an update revises its own row instead of appending a duplicate

An unrecognized status is passed through verbatim and rendered with the pending treatment, rather than coerced to `pending` and silently misreported.

## Rendering

`todoRows` / `todosTruncated` / `currentTool` on `AgentTreeNode`, fed by a `waveEventSubscribe`.

- **Todos render first** among the buckets. The other four label *mechanisms* the agent is using (dispatch, workflow, shell, cron); a checklist is its stated *intent*, and intent reads before mechanism.
- **Rows keep the agent's own order**, never re-sorted by status — a checklist is an ordered artifact, and re-ordering it would be editing the agent's meaning rather than displaying it.
- Bucket count is **done/total**, not a bare row count: for a checklist the useful number is progress.
- The **current-tool line sits outside the collapse guard**, since a collapsed agent is exactly when you want to know what it's doing without expanding it.
- No sixth bucket hue. The four existing hues label mechanisms; the SCSS explains why a checklist gets plain primary text instead of competing for a fifth saturated colour.

## Two traps handled explicitly

1. **`agentChildRowCount` now counts `todoRows`.** That sum gates both the expand affordance *and* the collapse guard that mounts buckets at all — so omitting it would make an agent whose only activity is a checklist render **nothing**, with no way to expand to it. That is the exact shape of the PR #2862 regression `swarm-agent-row.render.test.tsx` exists to pin, and there's a test for it here.
2. **`currentTool` is suppressed for non-running agents.** The payload is push-only, so a stopped pane's last in-flight tool would otherwise linger and read as "still doing this".

Backend rows are capped at 24 with the dropped count reported (`+N more`), so a pathological checklist can't flood the tree and a partial list is never shown as if it were whole.

## Testing

- **Rust: 2963 passed, 0 failed.** 12 parser cases — full-list supersession, Task\* upsert-in-place, explicitly cleared list, truncation accounting, malformed lines, a truncated leading line (tail windows start mid-conversation), and current-tool resolution via unmatched `tool_use` ids.
- **Frontend: 3585 passed, 0 failed.** 13 render cases — order preservation, done/total, per-status treatments, unknown-status fallback, truncation disclosure, the child-count trap, and collapsed visibility.
- `tsc --noEmit` clean.

## Note

Not yet observed against a live agent emitting todos — I couldn't find a transcript containing any todo-tool call to replay, which is itself the finding in §2. The parser is tested against both documented shapes; first real-world exercise will be worth watching.

<!-- agentmux:agent_id=agent5 -->