### PR TITLE
fix(agent-pane): Edit diff preview vanished when syntax highlighting resolved

### DIFF
--- a/.changesets/1788465685-fix-agent-pane-edit-diff-preview-vanished-when-syntax-highli-qkcd.md
+++ b/.changesets/1788465685-fix-agent-pane-edit-diff-preview-vanished-when-syntax-highli-qkcd.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): Edit diff preview vanished when syntax highlighting resolved

--- a/frontend/app/view/agent/components/DiffViewer.test.tsx
+++ b/frontend/app/view/agent/components/DiffViewer.test.tsx
@@ -1,0 +1,109 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The Edit tool's diff preview must survive Shiki resolving, and must survive
+ * the node being updated afterwards.
+ *
+ * User-reported regression: "I see the edited preview for a moment, but then it
+ * disappears and is replaced by a single path to the file."
+ */
+
+import { render, cleanup, waitFor } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSignal } from "solid-js";
+
+// Shiki is a heavy async ESM import; stub it with a synchronous-resolving
+// codeToHtml so the highlighted branch is reachable in a test.
+vi.mock("shiki/bundle/web", () => ({
+    codeToHtml: async (code: string) =>
+        `<pre><code>${code
+            .split("\n")
+            .map((l) => `<span class="line">${l}</span>`)
+            .join("")}</code></pre>`,
+}));
+
+import { DiffViewer } from "./DiffViewer";
+
+const params = (over: Record<string, unknown> = {}) => ({
+    file_path: "/repo/src/thing.ts",
+    old_string: "const a = 1;\nconst b = 2;",
+    new_string: "const a = 1;\nconst b = 3;",
+    ...over,
+}) as any;
+
+/** Everything the user can actually read in the rendered preview. */
+const visibleText = (c: HTMLElement) => c.textContent ?? "";
+
+describe("DiffViewer — the preview survives the Shiki swap", () => {
+    afterEach(cleanup);
+
+    it("shows the diff body before Shiki resolves (plain fallback)", () => {
+        const { container } = render(() => <DiffViewer params={params()} status="success" />);
+        expect(visibleText(container)).toContain("const b = 3;");
+    });
+
+    /** The regression: after the highlighted branch mounts, the body must not
+     *  be empty — leaving only the file-path header on screen. */
+    it("still shows the diff body AFTER Shiki resolves", async () => {
+        const { container } = render(() => <DiffViewer params={params()} status="success" />);
+        await waitFor(() => {
+            expect(container.querySelector(".agent-diff--highlighted")).toBeTruthy();
+        });
+        const body = container.querySelector(".agent-diff-highlighted-body");
+        expect(body, "highlighted body element exists").toBeTruthy();
+        expect(
+            body!.innerHTML,
+            "highlighted <pre> must be filled — an empty one leaves only the path header",
+        ).not.toBe("");
+        expect(visibleText(container)).toContain("const b = 3;");
+    });
+
+    /** A remount with a warm highlight cache: the html is resolved from the
+     *  module-level `diffCache` synchronously, so it can be known BEFORE the
+     *  <Show> has created the <pre> that receives it. An effect alone can run
+     *  while `preEl` is still undefined and then never re-run, leaving an
+     *  empty <pre> under a mounted `.agent-diff--highlighted` — the live
+     *  failure (height 0, textContent ""). */
+    it("fills the highlighted body on a remount that hits the highlight cache", async () => {
+        // First mount warms diffCache for this (filePath, diff) key.
+        const first = render(() => <DiffViewer params={params()} status="success" />);
+        await waitFor(() => {
+            expect(first.container.querySelector(".agent-diff--highlighted")).toBeTruthy();
+        });
+        cleanup();
+
+        // Second mount: same key, so the html is available immediately.
+        const { container } = render(() => <DiffViewer params={params()} status="success" />);
+        await waitFor(() => {
+            expect(container.querySelector(".agent-diff--highlighted")).toBeTruthy();
+        });
+        const body = container.querySelector(".agent-diff-highlighted-body");
+        expect(body!.innerHTML, "a warm-cache remount must still fill the <pre>").not.toBe("");
+        expect(visibleText(container)).toContain("const b = 3;");
+    });
+
+    /** The exact user-visible sequence: the node updates once more after the
+     *  highlight (the reducer replaces `params` wholesale on every node
+     *  update), which re-runs the highlight effect: null -> plain -> cached.
+     *  The body must come back, not vanish. */
+    it("still shows the diff body after the node updates post-highlight", async () => {
+        const [p, setP] = createSignal(params());
+        const { container } = render(() => <DiffViewer params={p()} status="success" />);
+
+        await waitFor(() => {
+            expect(container.querySelector(".agent-diff--highlighted")).toBeTruthy();
+        });
+
+        // Same content, new object identity — what mergeReplacement produces.
+        setP(params());
+
+        await waitFor(() => {
+            expect(container.querySelector(".agent-diff--highlighted")).toBeTruthy();
+        });
+        expect(
+            visibleText(container),
+            "the diff must not collapse to just the file path",
+        ).toContain("const b = 3;");
+    });
+});

--- a/frontend/app/view/agent/components/DiffViewer.tsx
+++ b/frontend/app/view/agent/components/DiffViewer.tsx
@@ -253,11 +253,31 @@ export const DiffViewer = (props: DiffViewerProps): JSX.Element => {
         })();
     });
 
+    // Applying the Shiki HTML has to happen BOTH when the html arrives and when
+    // the element is created, because neither event implies the other.
+    //
+    // The <pre> lives inside the `highlightedHtml() !== null` <Show> below, so
+    // the same signal that carries the html also creates the element that
+    // receives it. An effect alone loses that race: it can run while `preEl` is
+    // still undefined, the `if (preEl && ...)` guard silently does nothing, and
+    // because the signal never changes again nothing ever fills the freshly
+    // created <pre>. What the user sees is the diff appearing (the plain
+    // fallback, while Shiki loads) and then vanishing the moment highlighting
+    // resolves, leaving just the file-path header — reported as "the preview
+    // shows for a moment, then is replaced by a single path to the file", and
+    // confirmed live: `.agent-diff--highlighted` mounted with its <pre> at
+    // height 0 and textContent "".
+    //
+    // `applyHighlight` is therefore called from the ref callback too, which
+    // runs exactly when the element exists. Whichever happens last wins, and
+    // both orderings end up with a filled <pre>. (`HighlightedCode` never hit
+    // this because its <pre> is unconditionally mounted.)
     let preEl: HTMLPreElement | undefined;
-    createEffect(() => {
+    const applyHighlight = () => {
         const h = highlightedHtml();
         if (preEl && h !== null) preEl.innerHTML = h;
-    });
+    };
+    createEffect(applyHighlight);
 
     // --- No diff path ---
     if (!diff()) {
@@ -305,7 +325,13 @@ export const DiffViewer = (props: DiffViewerProps): JSX.Element => {
                     does not overwrite it. The <pre> receives only Shiki content. */}
                 <div class="agent-diff agent-diff--highlighted">
                     <div class="agent-diff-header">{filePath()}</div>
-                    <pre ref={preEl} class="agent-diff-highlighted-body" />
+                    <pre
+                        ref={(el) => {
+                            preEl = el;
+                            applyHighlight();
+                        }}
+                        class="agent-diff-highlighted-body"
+                    />
                 </div>
             </Show>
             <Show when={(diffCap()?.hiddenLines ?? 0) > 0}>


### PR DESCRIPTION
The Edit tool's diff showed for a moment and was then replaced by just the file path.

## Root cause

`DiffViewer`'s Shiki-highlighted `<pre>` lives **inside** the `highlightedHtml() !== null` `<Show>`, so the same signal that carries the HTML also creates the element that receives it:

```tsx
createEffect(() => {
    const h = highlightedHtml();
    if (preEl && h !== null) preEl.innerHTML = h;   // preEl may not exist yet
});
...
<Show when={highlightedHtml() !== null} fallback={<PlainDiff />}>
    <div class="agent-diff agent-diff--highlighted">
        <div class="agent-diff-header">{filePath()}</div>
        <pre ref={preEl} class="agent-diff-highlighted-body" />
    </div>
</Show>
```

Applying the HTML from an effect alone loses that race. The effect can run while `preEl` is still `undefined`; the `if (preEl && ...)` guard silently does nothing; and because the signal never changes again, nothing ever fills the freshly created `<pre>`. What survives is the header — which renders the file path and nothing else.

The moment of visible diff is the plain fallback: it renders the real diff while Shiki loads, then the branch swaps to the empty highlighted one.

`HighlightedCode` does the same Shiki dance and is fine, because its `<pre ref>` is unconditionally mounted — that contrast is what identified this.

## Evidence

Confirmed in a live pane, not inferred. For a real Edit, with the row still on screen:

| element | height | content |
|---|---|---|
| `.agent-diff--highlighted` | 20.77 | — |
| `.agent-diff-header` | 20.77 | `…\repro-target.txt` |
| `.agent-diff-highlighted-body` (`<pre>`) | **0** | **`""`** |

The positive `y` matters: the row had not scrolled off, which rules out the scroll-driven `expandedTools` release — the other candidate, since a collapsed tool row also renders as `✏️ Edit <file_path>`. I chased that one first and it was wrong.

## Fix

Apply the HTML from the `<pre>`'s `ref` callback as well as the effect. The ref runs exactly when the element exists, so whichever happens last wins and both orderings end with a filled `<pre>`.

## Why it "used to work"

The `<Show>`-wrapped `<pre>` dates to #388. This is a timing-sensitive race, not a structural break, so it can start showing up without the component changing — Shiki resolve latency vs. the branch swap depends on machine speed, diff size and cache state. Nothing in the last 48 commits touches this path, and `solid-js`/`shiki` have not moved in 60 days.

## Test

A remount with a warm highlight cache reproduces it deterministically — the HTML is resolved synchronously from `diffCache`, so it is known *before* the `<Show>` creates the `<pre>`. On the old code it fails with exactly the live signature:

```
AssertionError: a warm-cache remount must still fill the <pre>: expected '' not to be ''
```

4 tests total (plain fallback, post-Shiki, warm-cache remount, post-highlight node update). Full `app/view/agent` suite: 1620 passing. `tsc --noEmit` clean.

<!-- agentmux:agent_id=agent2 -->