### PR TITLE
feat(agent-pane): land the shared content-resize contract (step 2, no call sites)

### DIFF
--- a/.changesets/1788465977-feat-agent-pane-land-the-shared-content-resize-contract-no-c-ewre.md
+++ b/.changesets/1788465977-feat-agent-pane-land-the-shared-content-resize-contract-no-c-ewre.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-pane): land the shared content-resize contract (no call sites yet)

--- a/frontend/app/view/agent/resize-contract.test.ts
+++ b/frontend/app/view/agent/resize-contract.test.ts
@@ -1,0 +1,263 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * resize-contract.ts — step 2 of SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md.
+ *
+ * No component under test here — this file has no call sites yet (that's
+ * step 3). These tests exercise the two entry points directly against a
+ * plain DOM element, mirroring the FLIP-mechanics assertions
+ * ToolOverlayLog.test.tsx already makes for the (soon to be migrated)
+ * `flipHeight()` this replaces, plus the policy layer that function didn't
+ * have to reason about in isolation: reduced motion, unmeasurable
+ * (content-visibility/zero-size) elements, the magnitude cap, and
+ * per-element cancellation.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let reducedMotion = false;
+vi.mock("@/app/store/global", () => ({
+    atoms: {
+        prefersReducedMotionAtom: () => reducedMotion,
+    },
+}));
+
+import { beginHeightContinuity, withHeightContinuity } from "./resize-contract";
+
+/** Elements whose computed content-visibility should read "hidden". The
+ *  module under test only ever reads THIS one property off
+ *  getComputedStyle's return value, so replacing the global wholesale for
+ *  this file is safe and far simpler than partially mocking jsdom's CSSOM
+ *  (which doesn't recognize content-visibility as a settable inline style
+ *  property at all). */
+const hiddenEls = new Set<Element>();
+function setHidden(el: Element, hidden: boolean): void {
+    if (hidden) hiddenEls.add(el);
+    else hiddenEls.delete(el);
+}
+
+function setOffset(el: HTMLElement, height: number, width = 100): void {
+    Object.defineProperty(el, "offsetHeight", { configurable: true, value: height });
+    Object.defineProperty(el, "offsetWidth", { configurable: true, value: width });
+}
+
+// Real ids + real removal-on-cancel — NOT a no-op cancelAnimationFrame. A
+// no-op cancel would let this suite's cancellation test pass even with
+// cancellation itself deleted from the source: both the stale and the
+// fresh callback would still fire (in queue order), and since the fresh
+// one is queued second, it "wins" the final `el.style.height` value either
+// way — the bug is only observable by checking how many frames were
+// actually PENDING before the flush, which needs real bookkeeping here.
+let rafQueue: Map<number, FrameRequestCallback> = new Map();
+let nextRafId = 0;
+function flushRaf(): void {
+    const pending = [...rafQueue.values()];
+    rafQueue.clear();
+    for (const cb of pending) cb(0);
+}
+
+function endTransition(el: HTMLElement): void {
+    el.dispatchEvent(new (globalThis as any).TransitionEvent("transitionend", { propertyName: "height" }));
+}
+
+beforeEach(() => {
+    hiddenEls.clear();
+    rafQueue.clear();
+    nextRafId = 0;
+    reducedMotion = false;
+    vi.stubGlobal("getComputedStyle", (el: Element) => ({
+        contentVisibility: hiddenEls.has(el) ? "hidden" : "visible",
+    }) as CSSStyleDeclaration);
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+        const id = ++nextRafId;
+        rafQueue.set(id, cb);
+        return id;
+    });
+    vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+        rafQueue.delete(id);
+    });
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe("withHeightContinuity", () => {
+    it("freezes at the old height synchronously, then eases to the new height next frame", () => {
+        const el = document.createElement("div");
+        setOffset(el, 40);
+        withHeightContinuity(el, () => setOffset(el, 120));
+
+        // Synchronous: frozen at the FROM height, transition already armed —
+        // must happen before the new height is assigned, or there is nothing
+        // for the browser to ease.
+        expect(el.style.height).toBe("40px");
+        expect(el.style.transition).toContain("height");
+
+        flushRaf();
+        expect(el.style.height).toBe("120px");
+
+        endTransition(el);
+        expect(el.style.height).toBe("");
+        expect(el.style.transition).toBe("");
+        expect(el.style.overflowY).toBe("");
+    });
+
+    it("shrinking works the same way as growing", () => {
+        const el = document.createElement("div");
+        setOffset(el, 300);
+        withHeightContinuity(el, () => setOffset(el, 80));
+        expect(el.style.height).toBe("300px");
+        flushRaf();
+        expect(el.style.height).toBe("80px");
+    });
+
+    it("does not animate when the height doesn't change", () => {
+        const el = document.createElement("div");
+        setOffset(el, 60);
+        withHeightContinuity(el, () => setOffset(el, 60));
+        expect(el.style.height).toBe("");
+    });
+
+    it("does not animate under reduced motion, but the mutation still runs", () => {
+        reducedMotion = true;
+        const el = document.createElement("div");
+        setOffset(el, 40);
+        let mutated = false;
+        withHeightContinuity(el, () => {
+            mutated = true;
+            setOffset(el, 120);
+        });
+        expect(mutated).toBe(true);
+        expect(el.style.height).toBe("");
+    });
+
+    it("skips measurement entirely for a content-visibility:hidden element, even though its height genuinely changes", () => {
+        // mutate() must actually change the height here — a no-op mutate
+        // can't distinguish "correctly skipped" from "measured, but nothing
+        // changed so there was nothing to animate anyway." A prior version
+        // of this test used a no-op mutate and stayed green even with the
+        // content-visibility check deleted from the source.
+        const el = document.createElement("div");
+        setHidden(el, true);
+        setOffset(el, 999); // would be a huge FLIP if this were read as "from"
+        let mutated = false;
+        withHeightContinuity(el, () => {
+            mutated = true;
+            setOffset(el, 40); // real change — proves isMeasurable(), not shouldAnimate(), is what gated this
+        });
+        expect(mutated).toBe(true);
+        expect(el.style.height).toBe(""); // never touched
+    });
+
+    it("does not FLIP from a zero (display:none-equivalent) starting height", () => {
+        // Covered by shouldAnimate's own `fromPx <= 0` guard, not a
+        // dedicated isMeasurable branch — see that function's doc comment
+        // for why a separate zero-size check turned out to be redundant.
+        const el = document.createElement("div");
+        setOffset(el, 0, 0);
+        withHeightContinuity(el, () => setOffset(el, 200));
+        expect(el.style.height).toBe(""); // 0 -> 200 is a first appearance, not a shrink to ease
+    });
+
+    it("does not animate a delta past the magnitude cap — jumps straight to the mutation", () => {
+        const el = document.createElement("div");
+        setOffset(el, 40000);
+        withHeightContinuity(el, () => setOffset(el, 100));
+        expect(el.style.height).toBe(""); // no freeze attempted
+    });
+
+    it("cancels a still-in-flight transition's PENDING FRAME on the same element when a second mutation lands first", () => {
+        // The decisive check is the queue size, not the final height value:
+        // with the stale first flip's rAF callback still pending, it would
+        // ALSO fire on the next flush (in queue order, before the second
+        // flip's callback) and happen to still leave the same final value
+        // (the second one, queued later, overwrites it) — final state alone
+        // can't tell a genuinely cancelled first flip apart from one that
+        // just happened to lose a race. Only checking how many frames were
+        // actually pending distinguishes them.
+        const el = document.createElement("div");
+        setOffset(el, 100);
+        withHeightContinuity(el, () => setOffset(el, 300)); // first FLIP starts, one frame queued
+        expect(rafQueue.size).toBe(1);
+
+        withHeightContinuity(el, () => setOffset(el, 50)); // must cancel the first flip's frame
+        expect(rafQueue.size).toBe(1); // NOT 2 — the stale one was removed, not left stacked
+
+        flushRaf();
+        expect(el.style.height).toBe("50px");
+        endTransition(el);
+        expect(el.style.height).toBe("");
+    });
+
+    it("two independent elements animate without interfering with each other", () => {
+        const a = document.createElement("div");
+        const b = document.createElement("div");
+        setOffset(a, 40);
+        setOffset(b, 200);
+        withHeightContinuity(a, () => setOffset(a, 80));
+        withHeightContinuity(b, () => setOffset(b, 20));
+        expect(a.style.height).toBe("40px");
+        expect(b.style.height).toBe("200px");
+        flushRaf();
+        expect(a.style.height).toBe("80px");
+        expect(b.style.height).toBe("20px");
+    });
+});
+
+describe("beginHeightContinuity", () => {
+    it("captures the height now and eases on commit, once the mutation has landed", () => {
+        const el = document.createElement("div");
+        setOffset(el, 40);
+        const commit = beginHeightContinuity(el);
+
+        setOffset(el, 120); // the deferred mutation "lands" independently
+        expect(el.style.height).toBe(""); // not yet — commit() hasn't run
+
+        commit();
+        expect(el.style.height).toBe("40px"); // frozen at the height captured at begin() time
+        flushRaf();
+        expect(el.style.height).toBe("120px");
+    });
+
+    it("commit is a no-op if the element is unmeasurable by the time it's called", () => {
+        // offsetHeight is deliberately left non-zero (200) at commit time —
+        // if the commit-time isMeasurable() check were missing, that alone
+        // would be enough to make shouldAnimate's own fromPx<=0 guard NOT
+        // catch this case, so the height-still-empty assertion below only
+        // holds if the commit-time check is actually doing its job.
+        const el = document.createElement("div");
+        setOffset(el, 40);
+        const commit = beginHeightContinuity(el);
+        setHidden(el, true);
+        setOffset(el, 200);
+        commit();
+        expect(el.style.height).toBe("");
+    });
+
+    it("returns an inert no-op immediately when the element is already unmeasurable at capture time", () => {
+        // el has a genuine non-zero height (300) while hidden — if
+        // beginHeightContinuity captured it anyway (missing the
+        // capture-time check), that non-zero fromPx would survive into
+        // commit() and produce a real FLIP once made visible, rather than
+        // being silently blocked by shouldAnimate's fromPx<=0 guard the way
+        // an accidentally-still-zero offset would.
+        const el = document.createElement("div");
+        setHidden(el, true);
+        setOffset(el, 300);
+        const commit = beginHeightContinuity(el);
+        setHidden(el, false);
+        setOffset(el, 500);
+        commit(); // no "from" was ever captured — must do nothing, not FLIP 300 -> 500
+        expect(el.style.height).toBe("");
+    });
+
+    it("does not animate if the height at commit time is unchanged", () => {
+        const el = document.createElement("div");
+        setOffset(el, 60);
+        const commit = beginHeightContinuity(el);
+        commit();
+        expect(el.style.height).toBe("");
+    });
+});

--- a/frontend/app/view/agent/resize-contract.test.ts
+++ b/frontend/app/view/agent/resize-contract.test.ts
@@ -42,6 +42,31 @@ function setOffset(el: HTMLElement, height: number, width = 100): void {
     Object.defineProperty(el, "offsetWidth", { configurable: true, value: width });
 }
 
+/**
+ * A more realistic `offsetHeight` fake than `setOffset`'s fixed value,
+ * specifically for the re-entrancy tests below: an explicit inline
+ * `height` ALWAYS overrides content-based sizing in a real browser, so
+ * `offsetHeight` must report the PINNED value while one is set, and only
+ * fall through to the "natural" (content-driven) value once
+ * `el.style.height` is cleared. `setOffset`'s plain fixed value can't model
+ * this — it's exactly why the original version of the re-entrancy bug
+ * these tests cover went undetected (codex's review comment on PR #2954
+ * names this specifically: "the test misses this because it mocks
+ * offsetHeight independently of style.height").
+ */
+function makeHeightAware(el: HTMLElement): (naturalPx: number) => void {
+    let natural = 0;
+    Object.defineProperty(el, "offsetHeight", {
+        configurable: true,
+        get: () => {
+            const inline = el.style.height;
+            return inline.endsWith("px") ? parseFloat(inline) : natural;
+        },
+    });
+    Object.defineProperty(el, "offsetWidth", { configurable: true, value: 100 });
+    return (naturalPx: number) => { natural = naturalPx; };
+}
+
 // Real ids + real removal-on-cancel — NOT a no-op cancelAnimationFrame. A
 // no-op cancel would let this suite's cancellation test pass even with
 // cancellation itself deleted from the source: both the stale and the
@@ -151,6 +176,26 @@ describe("withHeightContinuity", () => {
         expect(el.style.height).toBe(""); // never touched
     });
 
+    it("skips measurement when an ANCESTOR (not el itself) is content-visibility:hidden", () => {
+        // codex P1, PR #2954: content-visibility is NON-INHERITED. The
+        // intended migration target (ToolOverlayLog.tsx) sets it on the
+        // PANEL, an ancestor of the scrollable log body that's actually
+        // passed as `el` — checking only el's own computed style would
+        // never see the panel's "hidden", exactly the gap this covers.
+        const panel = document.createElement("div");
+        const el = document.createElement("div");
+        panel.appendChild(el);
+        setHidden(panel, true); // el's OWN computed content-visibility stays "visible"
+        setOffset(el, 999);
+        let mutated = false;
+        withHeightContinuity(el, () => {
+            mutated = true;
+            setOffset(el, 40);
+        });
+        expect(mutated).toBe(true);
+        expect(el.style.height).toBe("");
+    });
+
     it("does not FLIP from a zero (display:none-equivalent) starting height", () => {
         // Covered by shouldAnimate's own `fromPx <= 0` guard, not a
         // dedicated isMeasurable branch — see that function's doc comment
@@ -191,6 +236,38 @@ describe("withHeightContinuity", () => {
         expect(el.style.height).toBe("");
     });
 
+    it("a re-entrant mutation while a prior FLIP is still in flight measures the TRUE current height, not the stale pin", () => {
+        // codex P1, PR #2954. Sequence: natural 40 -> 300 starts a FLIP (el
+        // is now pinned at "300px" inline, transitionend not yet fired —
+        // genuinely still in-flight). THEN a second, unrelated content
+        // change happens: natural 300 -> 999. Without cancelling the first
+        // flip before measuring, `fromPx`/`toPx` would both read the STALE
+        // PIN ("300", unaffected by the second mutate()'s natural-height
+        // change), see a zero delta, skip animating the real change
+        // entirely, and leave el wrongly stuck at 300px until the first
+        // flip's own unrelated transitionend eventually fires and SNAPS it
+        // straight to 999 with no easing at all — an uncontrolled jump,
+        // exactly what this module exists to prevent.
+        const el = document.createElement("div");
+        const setNatural = makeHeightAware(el);
+        setNatural(40);
+
+        withHeightContinuity(el, () => setNatural(300)); // flip #1 starts
+        flushRaf(); // el.style.height is now the literal string "300px" — still "in flight" (no transitionend yet)
+        expect(el.style.height).toBe("300px");
+
+        withHeightContinuity(el, () => setNatural(999)); // the re-entrant mutation
+        // Correct: cancelled flip #1 first (clears the pin), read true
+        // fromPx=300, ran mutate (natural=999), read true toPx=999, and
+        // started a NEW flip freezing at the real 300.
+        expect(el.style.height).toBe("300px");
+
+        flushRaf();
+        expect(el.style.height).toBe("999px");
+        endTransition(el);
+        expect(el.style.height).toBe("");
+    });
+
     it("two independent elements animate without interfering with each other", () => {
         const a = document.createElement("div");
         const b = document.createElement("div");
@@ -219,6 +296,27 @@ describe("beginHeightContinuity", () => {
         expect(el.style.height).toBe("40px"); // frozen at the height captured at begin() time
         flushRaf();
         expect(el.style.height).toBe("120px");
+    });
+
+    it("commit also cancels a DIFFERENT flip that started AFTER begin() was called (codex P1, PR #2954)", () => {
+        const el = document.createElement("div");
+        const setNatural = makeHeightAware(el);
+        setNatural(40);
+        const commit = beginHeightContinuity(el); // captures fromPx=40
+
+        // An UNRELATED flip starts and is still in flight when commit() runs.
+        withHeightContinuity(el, () => setNatural(300));
+        flushRaf();
+        expect(el.style.height).toBe("300px");
+
+        setNatural(999); // the deferred mutation this begin/commit pair was for
+        commit();
+        // Correct: cancelled the unrelated in-flight flip first, so toPx
+        // reads the true natural 999, not the stale "300" pin — FLIPs from
+        // the ORIGINALLY captured 40 straight to 999.
+        expect(el.style.height).toBe("40px");
+        flushRaf();
+        expect(el.style.height).toBe("999px");
     });
 
     it("commit is a no-op if the element is unmeasurable by the time it's called", () => {

--- a/frontend/app/view/agent/resize-contract.ts
+++ b/frontend/app/view/agent/resize-contract.ts
@@ -82,11 +82,24 @@ const inFlight = new WeakMap<HTMLElement, () => void>();
 
 /**
  * Can `el`'s height be usefully measured and FLIPped right now? Only one
- * case says no: `content-visibility: hidden` — reading `offsetHeight` there
- * would force a synchronous layout of a subtree the browser has
- * deliberately skipped laying out, which both emits a console warning AND
- * produces a measurement that doesn't reflect what will actually render
- * once visible again.
+ * case says no: `content-visibility: hidden` on `el` OR ANY ANCESTOR —
+ * reading `offsetHeight` there would force a synchronous layout of a
+ * subtree the browser has deliberately skipped laying out, which both
+ * emits a console warning AND produces a measurement that doesn't reflect
+ * what will actually render once visible again.
+ *
+ * Walks the ancestor chain rather than checking only `el` itself because
+ * `content-visibility` is a NON-INHERITED property (codex P1, PR #2954):
+ * for the intended `ToolOverlayLog` migration, `el` is
+ * `.agent-tool-overlay-log`, but `.agent-tool-panel--hidden` (the ancestor
+ * that actually sets `content-visibility: hidden`, `_document-nodes.scss`)
+ * is a DIFFERENT element — confirmed directly, `ToolOverlayLog.tsx`'s own
+ * current code walks `scrollRef.closest(".agent-tool-panel")` to reach it,
+ * proving it's an ancestor, not the element itself. `getComputedStyle(el)`
+ * on the descendant reports the descendant's OWN value (the initial
+ * `visible`, absent an explicit override) regardless of an ancestor
+ * skipping its layout — checking only `el` would never detect the one case
+ * this function exists to catch.
  *
  * A zero-size element (`display: none`, or genuinely 0px tall) does NOT
  * need a separate branch here — `shouldAnimate`'s own `fromPx <= 0` guard
@@ -97,19 +110,22 @@ const inFlight = new WeakMap<HTMLElement, () => void>();
  * deleting it and running the suite — nothing failed), which is exactly
  * why it was worth deleting rather than keeping "for safety."
  *
- * Deliberately reads the COMPUTED `content-visibility`, not a class name or
- * a `MutationObserver`-driven signal tracking one — this is the fix for the
- * bug SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md §3a traces in
- * `ToolOverlayLog.tsx`'s current `panelHidden`: a `MutationObserver` on a
- * `--hidden` class flips instantly, but the CSS collapse it triggers uses
- * `content-visibility ... allow-discrete`, which doesn't actually take
- * effect until the END of that transition — so for the whole transition
- * window, class-based detection says "hidden" while the computed style
- * (and the rendered pixels) still say otherwise. Reading the computed style
- * directly has no such lag.
+ * Deliberately reads the COMPUTED `content-visibility` at each ancestor,
+ * not a class name or a `MutationObserver`-driven signal tracking one —
+ * this is the fix for the bug SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md
+ * §3a traces in `ToolOverlayLog.tsx`'s current `panelHidden`: a
+ * `MutationObserver` on a `--hidden` class flips instantly, but the CSS
+ * collapse it triggers uses `content-visibility ... allow-discrete`, which
+ * doesn't actually take effect until the END of that transition — so for
+ * the whole transition window, class-based detection says "hidden" while
+ * the computed style (and the rendered pixels) still say otherwise.
+ * Reading the computed style directly has no such lag.
  */
 function isMeasurable(el: HTMLElement): boolean {
-    return getComputedStyle(el).contentVisibility !== "hidden";
+    for (let node: Element | null = el; node; node = node.parentElement) {
+        if (getComputedStyle(node).contentVisibility === "hidden") return false;
+    }
+    return true;
 }
 
 function shouldAnimate(fromPx: number, toPx: number): boolean {
@@ -128,7 +144,12 @@ function shouldAnimate(fromPx: number, toPx: number): boolean {
  * on/off as the height passes through intermediate values.
  */
 function flip(el: HTMLElement, fromPx: number, toPx: number): void {
-    inFlight.get(el)?.();
+    // No cancel-in-flight check here — by the time this runs, every call
+    // site has already cancelled any prior transition on `el` BEFORE
+    // measuring (see `withHeightContinuity`/`beginHeightContinuity`'s own
+    // comments for why measuring first is itself the bug). Cancelling here
+    // too would be redundant and one JS-visible tick too late to fix a
+    // measurement that already happened.
     el.style.transition = "none";
     el.style.height = `${fromPx}px`;
     el.style.overflowY = "hidden";
@@ -153,6 +174,27 @@ function flip(el: HTMLElement, fromPx: number, toPx: number): void {
 }
 
 /**
+ * Cancel any transition already in flight on `el`, BEFORE measuring it.
+ * Required, not optional (codex P1, PR #2954): while a prior FLIP is still
+ * running, `el` has an explicit inline `height` pinning its rendered size —
+ * an explicit height always overrides content-based sizing, so
+ * `el.offsetHeight` reports the PINNED value regardless of what the
+ * content actually is, for BOTH the "from" read (would report a stale
+ * pinned value instead of the true current height) and the "to" read after
+ * `mutate()` runs (a content change doesn't move a height-pinned box at
+ * all, so it would report the SAME pinned value again, making `shouldAnimate`
+ * see a zero delta and skip animating a real change — leaving `el` wrongly
+ * pinned at the stale height until the ORIGINAL transition's own
+ * `transitionend` eventually fires and clears it, at which point the box
+ * snaps instantly to the true height — an uncontrolled jump, exactly what
+ * this module exists to prevent). Cancelling first clears the pin so every
+ * subsequent read in this call reflects reality.
+ */
+function cancelInFlight(el: HTMLElement): void {
+    inFlight.get(el)?.();
+}
+
+/**
  * Run `mutate` (assumed to synchronously produce `el`'s new rendered
  * height — true for a plain Solid signal write, per the same synchronous-
  * effect guarantee `ToolOverlayLog.tsx`'s own comments already rely on),
@@ -161,6 +203,7 @@ function flip(el: HTMLElement, fromPx: number, toPx: number): void {
  * currently measurable — there is nothing to FLIP FROM.
  */
 export function withHeightContinuity(el: HTMLElement, mutate: () => void): void {
+    cancelInFlight(el);
     if (!isMeasurable(el)) {
         mutate();
         return;
@@ -177,13 +220,21 @@ export function withHeightContinuity(el: HTMLElement, mutate: () => void): void 
  * once the mutation has actually landed in the DOM. Calling the returned
  * function is what performs the measure-after + FLIP; if it's never called,
  * nothing happens (no timer, no listener left running).
+ *
+ * Cancels an in-flight transition at BOTH capture and commit time, not just
+ * once — a different mutation could start a fresh flip on the same `el`
+ * during the (potentially long) gap between calling this and calling the
+ * function it returns, and the "to" read needs the same unpinning the
+ * "from" read does, for the identical reason (see `cancelInFlight`).
  */
 export function beginHeightContinuity(el: HTMLElement): (this: void) => void {
+    cancelInFlight(el);
     if (!isMeasurable(el)) {
         return () => {};
     }
     const fromPx = el.offsetHeight;
     return () => {
+        cancelInFlight(el);
         if (!isMeasurable(el)) return;
         const toPx = el.offsetHeight;
         if (shouldAnimate(fromPx, toPx)) flip(el, fromPx, toPx);

--- a/frontend/app/view/agent/resize-contract.ts
+++ b/frontend/app/view/agent/resize-contract.ts
@@ -1,0 +1,191 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * A single content-resize contract for the agent pane — step 2 of
+ * docs/specs/SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md.
+ *
+ * Landed with NO call sites yet (spec §5 step 2) — zero runtime effect. The
+ * migration (step 3: `ToolOverlayLog.tsx`'s `flipHeight()`) is a separate,
+ * reviewable-in-isolation change.
+ *
+ * ## What this replaces
+ *
+ * Today, "a subtree is about to change height, ease it instead of jump-
+ * cutting" is reimplemented per call site — `ToolOverlayLog.tsx`'s
+ * `flipHeight()` tracks a `lastMeasuredHeight`/`lastBranch` pair across
+ * effect runs by hand, with its own reduced-motion check, its own
+ * content-visibility guard (`heightStale`), and its own `prevNodeId` reset
+ * for the streaming-buffer slot-reuse hazard. `ToolBlock.tsx` needed the
+ * identical `prevNodeId` guard for an unrelated reason (#1317). This module
+ * owns that machinery once.
+ *
+ * ## The physical constraint this respects
+ *
+ * `scrollTop` cannot be eased after a shrink — the browser clamps it to the
+ * new `scrollHeight - clientHeight` synchronously, in the same layout pass
+ * that produces the shrink, before any JS runs. See
+ * SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md §2 for the full argument. The
+ * only place easing can happen is the content layer, BEFORE that layout
+ * pass — freeze the shrinking element at its old height, then ease it down,
+ * so the browser's clamp lands in many imperceptible per-frame steps
+ * instead of one visible jump. That is what `flip()` below does; it is not
+ * a novel technique, just `ToolOverlayLog.tsx`'s existing `flipHeight()`
+ * moved here and given a shared policy layer.
+ *
+ * ## Two entry points, two call shapes
+ *
+ * `withHeightContinuity(el, mutate)` — the mutation is something YOU
+ * trigger (e.g. a signal write whose effect runs synchronously). Measure
+ * before, run it, measure after.
+ *
+ * `beginHeightContinuity(el)` — the mutation lands asynchronously (a
+ * throttled re-render's trailing commit, or a reactive effect reacting to a
+ * prop that changed from OUTSIDE, where there is no single call you make
+ * that "is" the mutation). Call this right before the mutation is set in
+ * motion; it captures the current height and returns a commit function —
+ * call that once the mutation has landed in the DOM.
+ *
+ * Both close over their OWN `fromPx` in their own call's closure — neither
+ * reads or writes any state shared across calls. This is what eliminates
+ * the node-identity-reset class of bug by construction rather than by a
+ * bespoke guard: `ToolOverlayLog.tsx`'s current `flipHeight()` needs a
+ * `prevNodeId` check specifically because its baseline
+ * (`lastMeasuredHeight`) is a variable shared across every effect
+ * invocation, so a streaming-buffer cap-advance swapping a different node
+ * into the same DOM slot without unmounting can make an unrelated old
+ * height leak into a new node's first real transition. Neither entry point
+ * here has an equivalent shared field for that to leak through.
+ */
+
+import { atoms } from "@/app/store/global";
+
+const HEIGHT_FLIP_MS = 150;
+const EASE = "cubic-bezier(0.4, 0, 0.2, 1)";
+
+/**
+ * Above this magnitude, skip the ease and let the mutation land instantly.
+ * The 08-22 findings doc's whole-pane 0px collapses were 21,000-44,000px —
+ * animating that at normal speed reads as absurd, and slowing the
+ * per-pixel rate down to compensate would make an ordinary small shrink
+ * feel sluggish. A shrink this large is a different phenomenon (§3 of that
+ * doc calls it "categorically different... not a third data point for the
+ * same mechanism") that a content-layer ease was never meant to smooth
+ * over — this cap keeps this module from trying anyway.
+ */
+const MAX_ANIMATED_DELTA_PX = 2000;
+
+/** One in-flight cancel fn per element, so re-entry (a second mutation
+ *  landing before the first ease finishes) cancels the previous transition
+ *  instead of stacking two `height` transitions on the same element. */
+const inFlight = new WeakMap<HTMLElement, () => void>();
+
+/**
+ * Can `el`'s height be usefully measured and FLIPped right now? Only one
+ * case says no: `content-visibility: hidden` — reading `offsetHeight` there
+ * would force a synchronous layout of a subtree the browser has
+ * deliberately skipped laying out, which both emits a console warning AND
+ * produces a measurement that doesn't reflect what will actually render
+ * once visible again.
+ *
+ * A zero-size element (`display: none`, or genuinely 0px tall) does NOT
+ * need a separate branch here — `shouldAnimate`'s own `fromPx <= 0` guard
+ * already refuses to FLIP from a zero "from" height, and a zero "to"
+ * height is just an ordinary small-delta shrink. An earlier version of
+ * this function had a redundant `offsetHeight > 0 || offsetWidth > 0`
+ * branch; removing it changed no observable behavior (confirmed by
+ * deleting it and running the suite — nothing failed), which is exactly
+ * why it was worth deleting rather than keeping "for safety."
+ *
+ * Deliberately reads the COMPUTED `content-visibility`, not a class name or
+ * a `MutationObserver`-driven signal tracking one — this is the fix for the
+ * bug SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md §3a traces in
+ * `ToolOverlayLog.tsx`'s current `panelHidden`: a `MutationObserver` on a
+ * `--hidden` class flips instantly, but the CSS collapse it triggers uses
+ * `content-visibility ... allow-discrete`, which doesn't actually take
+ * effect until the END of that transition — so for the whole transition
+ * window, class-based detection says "hidden" while the computed style
+ * (and the rendered pixels) still say otherwise. Reading the computed style
+ * directly has no such lag.
+ */
+function isMeasurable(el: HTMLElement): boolean {
+    return getComputedStyle(el).contentVisibility !== "hidden";
+}
+
+function shouldAnimate(fromPx: number, toPx: number): boolean {
+    if (atoms.prefersReducedMotionAtom()) return false;
+    if (fromPx <= 0) return false; // nothing to freeze FROM — first paint, not a resize
+    const delta = Math.abs(toPx - fromPx);
+    return delta > 1 && delta <= MAX_ANIMATED_DELTA_PX;
+}
+
+/**
+ * Classic FLIP height transition: freeze `el` at `fromPx` (forcing a reflow
+ * so the browser commits it before animating), then ease to `toPx`,
+ * clearing the inline style once the transition ends so the box goes back
+ * to tracking its content naturally. `overflow-y` is forced to `hidden` for
+ * the transition's duration only, so an internal scrollbar doesn't flash
+ * on/off as the height passes through intermediate values.
+ */
+function flip(el: HTMLElement, fromPx: number, toPx: number): void {
+    inFlight.get(el)?.();
+    el.style.transition = "none";
+    el.style.height = `${fromPx}px`;
+    el.style.overflowY = "hidden";
+    void el.offsetHeight; // force reflow so the "from" height commits before animating
+    el.style.transition = `height ${HEIGHT_FLIP_MS}ms ${EASE}`;
+    const raf = requestAnimationFrame(() => {
+        el.style.height = `${toPx}px`;
+    });
+    const onEnd = (e: TransitionEvent): void => {
+        if (e.target === el && e.propertyName === "height") cleanup();
+    };
+    const cleanup = (): void => {
+        cancelAnimationFrame(raf);
+        el.style.transition = "";
+        el.style.height = "";
+        el.style.overflowY = "";
+        el.removeEventListener("transitionend", onEnd);
+        inFlight.delete(el);
+    };
+    el.addEventListener("transitionend", onEnd);
+    inFlight.set(el, cleanup);
+}
+
+/**
+ * Run `mutate` (assumed to synchronously produce `el`'s new rendered
+ * height — true for a plain Solid signal write, per the same synchronous-
+ * effect guarantee `ToolOverlayLog.tsx`'s own comments already rely on),
+ * easing `el`'s height across the change if it's animatable. Falls straight
+ * through to `mutate()` with no measurement at all when `el` isn't
+ * currently measurable — there is nothing to FLIP FROM.
+ */
+export function withHeightContinuity(el: HTMLElement, mutate: () => void): void {
+    if (!isMeasurable(el)) {
+        mutate();
+        return;
+    }
+    const fromPx = el.offsetHeight;
+    mutate();
+    const toPx = el.offsetHeight;
+    if (shouldAnimate(fromPx, toPx)) flip(el, fromPx, toPx);
+}
+
+/**
+ * Two-phase variant for a mutation you can't wrap in a single synchronous
+ * call — capture `el`'s current height now, and return a function to call
+ * once the mutation has actually landed in the DOM. Calling the returned
+ * function is what performs the measure-after + FLIP; if it's never called,
+ * nothing happens (no timer, no listener left running).
+ */
+export function beginHeightContinuity(el: HTMLElement): (this: void) => void {
+    if (!isMeasurable(el)) {
+        return () => {};
+    }
+    const fromPx = el.offsetHeight;
+    return () => {
+        if (!isMeasurable(el)) return;
+        const toPx = el.offsetHeight;
+        if (shouldAnimate(fromPx, toPx)) flip(el, fromPx, toPx);
+    };
+}


### PR DESCRIPTION
## Summary

Step 2 of `SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md`. **No call sites — zero runtime effect.** Migration (step 3: `ToolOverlayLog.tsx`'s `flipHeight()`) is a separate, reviewable-in-isolation change, per the spec's own sequencing.

Gated on step 1's data landing first — it did (#2887, and real attribution finally came through today: 284/351 captured shrinks in a live session are `tool`-kind nodes, 0 `markdown`, confirming Source A dominates and de-prioritizing the `MarkdownBlock` migration the spec had queued after `ToolOverlayLog`).

`withHeightContinuity(el, mutate)` and `beginHeightContinuity(el)` — the two call shapes a caller actually has: a mutation you trigger synchronously (a signal write), or one that lands later (a throttled re-render's trailing commit, or a reactive effect reacting to a prop change from outside). Both do the same FLIP technique `ToolOverlayLog.tsx`'s `flipHeight()` already uses — moved here with a shared policy layer: reduced motion, a magnitude cap (skip the ease past 2000px — the 08-22 findings doc's whole-pane collapses were 21K-44K px, not the same phenomenon a content-layer ease was meant to smooth), per-element cancellation, and a content-visibility check.

The content-visibility check is written to directly fix the bug the spec's own §3a found in `ToolOverlayLog.tsx`'s current `heightStale`/`panelHidden`: it reads the **computed** `content-visibility`, not a class-attribute `MutationObserver` signal — the panel's close transition uses `content-visibility ... allow-discrete`, which doesn't actually apply until the END of the transition, so class-based detection reports "hidden" for the whole window it's still visibly collapsing. This PR doesn't fix that bug (no call sites yet) — it falls out for free once step 3 migrates.

## On the test process (worth flagging honestly)

The first pass — 13 tests, all green on the first run — turned out to be a weak signal by itself. Falsifying 5 of the assertions (deleting the exact behavior each claims to test) left the **same 13 tests green**, for three different reasons:
- A no-op fake `cancelAnimationFrame` that couldn't observe cancellation either way (final DOM state ended up correct regardless, since the later mutation's frame just overwrote the stale one's — order, not correctness, was doing the work).
- Two tests whose `mutate()` callback never actually changed the element's height, so "correctly skipped" and "measured, but nothing to animate" were indistinguishable.
- A genuinely redundant `isMeasurable` branch (`offsetHeight > 0 || offsetWidth > 0`) that `shouldAnimate`'s own `fromPx <= 0` guard already covered — confirmed by deleting it and finding nothing broke, then actually removed from the source rather than kept "for safety."

Rewrote the rAF fake with real ids and real cancellation-removal, rewrote every test whose `mutate()` needs to produce an observable height difference, and deleted the dead branch. Re-falsified all 5 — each now fails when its source line is removed, restored, clean diff.

## Test plan

- [x] 13 tests in `resize-contract.test.ts`, covering both entry points, reduced motion, content-visibility, the magnitude cap, cancellation, and independence across elements.
- [x] Every non-trivial assertion falsified individually (delete the behavior, confirm the specific test fails, restore, confirm clean diff) — not just run once and trusted.
- [x] `npx tsc --noEmit -p tsconfig.json` — clean.
- [x] No existing call sites touched — nothing else in the suite can regress from this PR.

<!-- agentmux:agent_id=agent1 -->