### PR TITLE
Posa@Area54: chore: release v0.55.33

### DIFF
--- a/.changesets/1788386628-docs-record-the-openrouter-ori-harness-spike-jbhr.md
+++ b/.changesets/1788386628-docs-record-the-openrouter-ori-harness-spike-jbhr.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: record the OpenRouter Ori harness spike

--- a/.changesets/1788398766-fix-agent-activity-dock-settle-waits-for-the-real-dock-data--8iul.md
+++ b/.changesets/1788398766-fix-agent-activity-dock-settle-waits-for-the-real-dock-data--8iul.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): Activity Dock settle waits for the real dock-data refresh, not a fixed 250ms guess

--- a/.changesets/1788403835-feat-bootstrap-task-init-now-verifies-the-toolchain-before-n-tsbm.md
+++ b/.changesets/1788403835-feat-bootstrap-task-init-now-verifies-the-toolchain-before-n-tsbm.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(bootstrap): task init now verifies the toolchain before npm install; new bootstrap.sh/bootstrap.ps1 install Task itself

--- a/.changesets/1788420752-feat-agent-label-the-agent-pane-tab-strip-s-button-as-new-ag-wija.md
+++ b/.changesets/1788420752-feat-agent-label-the-agent-pane-tab-strip-s-button-as-new-ag-wija.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent): label the agent pane tab strip's + button as "+ New Agent"

--- a/.changesets/1788420752-fix-dock-elapsed-clock-now-grows-hours-and-days-fields-inste-l0cd.md
+++ b/.changesets/1788420752-fix-dock-elapsed-clock-now-grows-hours-and-days-fields-inste-l0cd.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(dock): elapsed clock now grows hours and days fields instead of counting minutes past 60

--- a/.changesets/1788421322-fix-subagent-parse-iso-8601-event-timestamps-so-replayed-sub-03aj.md
+++ b/.changesets/1788421322-fix-subagent-parse-iso-8601-event-timestamps-so-replayed-sub-03aj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(subagent): parse ISO-8601 event timestamps so replayed subagents stop flashing in the Activity Dock

--- a/.changesets/1788421605-docs-resolve-the-ori-codex-json-question-6txt.md
+++ b/.changesets/1788421605-docs-resolve-the-ori-codex-json-question-6txt.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: resolve the ori codex --json question

--- a/.changesets/1788421925-fix-agent-consolidate-the-two-separate-login-buttons-into-on-ri16.md
+++ b/.changesets/1788421925-fix-agent-consolidate-the-two-separate-login-buttons-into-on-ri16.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): consolidate the two separate login buttons into one CTA

--- a/.changesets/1788448629-fix-agent-pane-drop-accent-blue-from-the-working-row-match-t-5a7p.md
+++ b/.changesets/1788448629-fix-agent-pane-drop-accent-blue-from-the-working-row-match-t-5a7p.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): drop accent-blue from the Working row, match thinking-text font, go bold

--- a/.changesets/1788452181-fix-agent-gate-npm-based-providers-on-node-js-prereq-so-a-fr-0jg4.md
+++ b/.changesets/1788452181-fix-agent-gate-npm-based-providers-on-node-js-prereq-so-a-fr-0jg4.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): gate npm-based providers on Node.js prereq so a fresh machine gets a friendly install prompt instead of a raw npm-spawn crash

--- a/.changesets/1788463378-fix-agent-pane-hide-bashwrap-s-internal-starting-chunk-from--7x37.md
+++ b/.changesets/1788463378-fix-agent-pane-hide-bashwrap-s-internal-starting-chunk-from--7x37.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): hide bashwrap's internal starting-chunk from the tool log

--- a/.changesets/1788464170-fix-agent-track-mouse-y-in-the-hover-to-peek-metadata-panel-h8c4.md
+++ b/.changesets/1788464170-fix-agent-track-mouse-y-in-the-hover-to-peek-metadata-panel-h8c4.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): track mouse Y in the hover-to-peek metadata panel

--- a/.changesets/1788465143-feat-agent-askuserquestion-cancel-real-decline-and-accept-re-vtit.md
+++ b/.changesets/1788465143-feat-agent-askuserquestion-cancel-real-decline-and-accept-re-vtit.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): AskUserQuestion Cancel (real decline) and Accept Recommended buttons

--- a/.changesets/1788465581-feat-swarm-list-each-agent-s-todo-checklist-and-in-flight-to-h3vd.md
+++ b/.changesets/1788465581-feat-swarm-list-each-agent-s-todo-checklist-and-in-flight-to-h3vd.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(swarm): list each agent's todo checklist and in-flight tool under its name

--- a/.changesets/1788465685-fix-agent-pane-edit-diff-preview-vanished-when-syntax-highli-qkcd.md
+++ b/.changesets/1788465685-fix-agent-pane-edit-diff-preview-vanished-when-syntax-highli-qkcd.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): Edit diff preview vanished when syntax highlighting resolved

--- a/.changesets/1788465977-feat-agent-pane-land-the-shared-content-resize-contract-no-c-ewre.md
+++ b/.changesets/1788465977-feat-agent-pane-land-the-shared-content-resize-contract-no-c-ewre.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(agent-pane): land the shared content-resize contract (no call sites yet)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.32"
+version = "0.55.33"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.32"
+version = "0.55.33"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.32"
+version = "0.55.33"
 dependencies = [
  "base64",
  "dirs",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.32"
+version = "0.55.33"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.32"
+version = "0.55.33"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.32"
+version = "0.55.33"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.32"
+version = "0.55.33"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,25 @@
 # AgentMux Version History
 
+## 0.55.33 — 2026-09-03
+
+- docs: record the OpenRouter Ori harness spike
+- fix(agent): Activity Dock settle waits for the real dock-data refresh, not a fixed 250ms guess
+- feat(bootstrap): task init now verifies the toolchain before npm install; new bootstrap.sh/bootstrap.ps1 install Task itself
+- feat(agent): label the agent pane tab strip's + button as "+ New Agent"
+- fix(dock): elapsed clock now grows hours and days fields instead of counting minutes past 60
+- fix(subagent): parse ISO-8601 event timestamps so replayed subagents stop flashing in the Activity Dock
+- docs: resolve the ori codex --json question
+- fix(agent): consolidate the two separate login buttons into one CTA
+- fix(agent-pane): drop accent-blue from the Working row, match thinking-text font, go bold
+- fix(agent): gate npm-based providers on Node.js prereq so a fresh machine gets a friendly install prompt instead of a raw npm-spawn crash
+- fix(agent-pane): hide bashwrap's internal starting-chunk from the tool log
+- fix(agent): track mouse Y in the hover-to-peek metadata panel
+- feat(agent): AskUserQuestion Cancel (real decline) and Accept Recommended buttons
+- feat(swarm): list each agent's todo checklist and in-flight tool under its name
+- fix(agent-pane): Edit diff preview vanished when syntax highlighting resolved
+- feat(agent-pane): land the shared content-resize contract (no call sites yet)
+
+
 ## 0.55.32 — 2026-09-02
 
 - docs: merge the top-level specs/ tree into docs/specs/ (cleanup batch C)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.32",
+  "version": "0.55.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.32",
+      "version": "0.55.33",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.32",
+  "version": "0.55.33",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Release **v0.55.33**, consuming 16 pending changesets.

## Patch forced over a computed minor

Run as `task release -- --as patch`. The computed bump from the queued changesets was **minor** — two `feat` entries requested it:

- `feat(agent)`: AskUserQuestion Cancel (real decline) and Accept Recommended buttons
- `feat(swarm)`: list each agent's todo checklist and in-flight tool under its name

**Both still ship in this release and are changelogged** — they just ship under a patch version rather than `0.56.0`. The release script printed its intended loud `WARNING` for forcing a lower bump than the changesets request; flagging it here too so it is a visible decision rather than a buried one.

## Version consistency

`0.55.32 → 0.55.33`. All five locations verified independently after the script's own post-bump check:

| Location | Value |
|---|---|
| `package.json` | 0.55.33 |
| `package-lock.json` (root) | 0.55.33 |
| `Cargo.toml` `[workspace.package]` | 0.55.33 |
| `Cargo.lock` (`agentmux-cef`) | 0.55.33 |
| `VERSION_HISTORY.md` head | `## 0.55.33 — 2026-09-03` |

## Contents

```
docs: record the OpenRouter Ori harness spike
fix(agent): Activity Dock settle waits for the real dock-data refresh, not a fixed 250ms guess
feat(bootstrap): task init now verifies the toolchain before npm install; new bootstrap.sh/bootstrap.ps1 install Task itself
feat(agent): label the agent pane tab strip's + button as "+ New Agent"
fix(dock): elapsed clock now grows hours and days fields instead of counting minutes past 60
fix(subagent): parse ISO-8601 event timestamps so replayed subagents stop flashing in the Activity Dock
docs: resolve the ori codex --json question
fix(agent): consolidate the two separate login buttons into one CTA
fix(agent-pane): drop accent-blue from the Working row, match thinking-text font, go bold
fix(agent): gate npm-based providers on Node.js prereq so a fresh machine gets a friendly install prompt instead of a raw npm-spawn crash
fix(agent-pane): hide bashwrap's internal starting-chunk from the tool log
fix(agent): track mouse Y in the hover-to-peek metadata panel
feat(agent): AskUserQuestion Cancel (real decline) and Accept Recommended buttons
feat(swarm): list each agent's todo checklist and in-flight tool under its name
fix(agent-pane): Edit diff preview vanished when syntax highlighting resolved
feat(agent-pane): land the shared content-resize contract (no call sites yet)
```

## Notes for review

- No code changes — version files, `VERSION_HISTORY.md`, and the consumed changeset deletions only.
- Branched from `9fbc5c11c` (current `main`).
- The only judgement call here is the forced patch. If `0.56.0` is preferred given the two `feat` entries, say so and I will redo it without `--as`.

<!-- agentmux:agent_id=posa -->
