### PR TITLE
fix(agent-pane): tool-preview code wastes half its width on indentation

### DIFF
--- a/.changesets/1788367009-fix-agent-pane-tool-preview-code-previews-waste-half-their-w-h8u5.md
+++ b/.changesets/1788367009-fix-agent-pane-tool-preview-code-previews-waste-half-their-w-h8u5.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): tool-preview code previews waste half their width on indentation

--- a/docs/analysis/tool-preview-indentation-and-wrapping-2026-09-02.md
+++ b/docs/analysis/tool-preview-indentation-and-wrapping-2026-09-02.md
@@ -1,0 +1,386 @@
+# Analysis: tool-preview code still reads over-indented, and some lines wrap
+
+**Date:** 2026-09-02
+**Author:** Agent4
+**Repo state:** `agentmuxai/agentmux` main @ `01cd708e`
+**Method:** static read of the render path + CSS cascade, arithmetic on the
+tab-stop behaviour, and **measurement against real stored transcripts**
+(`~/.agentmux/shared/agents/transcripts/filestore.db`, opened read-only) to
+confirm the actual `Read` result format and the actual indentation mix. Not
+verified by eye in a live pane — see §7.
+
+**Prior work being followed up:** PR #2785 / commit `aa1d0a14`,
+*"fix(agent-pane): render tool-preview tabs at 2 spaces instead of the inherited
+4"* — a one-line CSS change adding `tab-size: 2` to `.agent-tool-panel`
+(`frontend/app/view/agent/styles/_document-nodes.scss:393`), overriding the
+app-wide `tab-size: 4` in `frontend/app/reset.scss:26`. Documented as a
+follow-up inside `docs/specs/SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md`.
+
+---
+
+## 0. Summary
+
+The report is "a lot of indentation still, but some lines are word-wrapped."
+Both halves are real, and they are **two different problems on two different
+sets of surfaces**:
+
+1. **The indentation.** `tab-size: 2` can only ever affect *tab*-indented
+   content, and no CSS property changes how wide a space renders. Measured on a
+   real Read of a repo source file: **0 of 127 indented lines used tabs** — so
+   the 08-24 fix was inert on that preview, and on essentially every preview of
+   this codebase. Separately, `dedent.ts` is a **no-op for the two most common
+   preview shapes** (a whole-file Write, and a Read that starts at the top of a
+   file — 58 of that same Read's 200 lines sit at column 0, which forces the
+   common prefix to empty), and is **not applied at all** to Bash output,
+   Grep/Glob results, or streaming chunks. Net effect on that sample: the
+   deepest lines render at **column 24** and nothing in the current pipeline
+   reduces that.
+
+2. **The wrapping.** Code previews (Read / Write / Edit) use `white-space: pre`
+   and never wrap. Bash output, Grep/Glob results, and expanded JSON use
+   `pre-wrap` **plus `overflow-wrap: anywhere`** and always wrap, breaking
+   mid-identifier. Both live in the same `.agent-tool-panel`, so which behaviour
+   you get depends on which tool produced the block. The surfaces that wrap are
+   *the same surfaces that get no dedent* — so those blocks show full original
+   indentation **and** wrap, which is the worst combination and almost certainly
+   what prompted this report.
+
+There is also a **regression introduced by the 08-24 fix itself** (§2): it made
+the Read line-number gutter ragged at the line-9→10 boundary, which it was not
+before.
+
+---
+
+## 1. Why `tab-size: 2` didn't move the needle
+
+`tab-size` sets the rendered width of a **U+0009 TAB character**. It has no
+effect on U+0020 SPACE.
+
+I pulled a real `Read` of a Rust source file out of the transcript store
+(`agentmux-srv/src/server/identity_handlers.rs`, `limit: 200`) and counted how
+its 200 result lines are actually indented:
+
+```
+lines with TAB indent:   0
+lines with SPACE indent: 127
+leading-whitespace-width histogram (columns):
+  0 → 58 lines   4 → 58   8 → 6   12 → 8   16 → 32   20 → 23
+```
+
+**Zero tab-indented lines.** For this preview — and for every `.ts`/`.tsx`/
+`.scss`/`.rs` file in this repo, plus most Python, Go and JSON — `tab-size` has
+no effect whatsoever, at any value.
+
+Meanwhile the deepest lines carry **20 columns** of leading space, and the Read
+gutter adds 4 more (§2), so the deepest lines start at **column 24**. In a
+narrow agent pane that is most of the usable width, spent on indentation that
+the preview can't even show the enclosing scopes for. That is the reported
+symptom, measured.
+
+So the 08-24 fix is correct for what it claims (tab-indented previews no longer
+read wider than space-indented siblings) and simply does not intersect the
+general "too much indentation" complaint. Nothing was wrong with the change; the
+scope was narrower than the symptom.
+
+**Implication:** if the goal is "previews should not waste half their width on
+indentation", it cannot be solved in CSS. It has to be solved in the text that
+gets handed to the renderer.
+
+---
+
+## 2. Regression: the 08-24 fix made the Read gutter ragged
+
+Read content lines are `<N>\t<code>` — the line number, a **literal tab**, then
+the source line. Confirmed verbatim from a `tool_result` frame in the transcript
+store, **with no left-padding on the number**:
+
+```
+1\t// Copyright 2026, AgentMux Corp.
+2\t// SPDX-License-Identifier: Apache-2.0
+3\t
+...
+9\t//!   * `auth.poll`            — `PollProviderAuth`
+10\t//!   * `auth.submitcallback`  — `SubmitAuthCallback`
+```
+
+Note `9\t` then `10\t` — the number is left-aligned, so the character count
+before the tab **grows with the line number**. (Had the CLI right-aligned to a
+fixed width, `cat -n` style, this whole finding would not exist.)
+
+`stripCommonIndentNumbered` deliberately preserves that prefix verbatim
+(`frontend/app/view/agent/components/dedent.ts:134-149`) and dedents only the
+code portion.
+
+That gutter tab is subject to the same `tab-size`. Because a tab advances to the
+*next tab stop*, the column the code starts at depends on how many digits the
+line number has:
+
+| line number | digits | code starts at, `tab-size: 4` | code starts at, `tab-size: 2` |
+|---|---|---|---|
+| 1 – 9 | 1 | col 4 | **col 2** |
+| 10 – 99 | 2 | col 4 | col 4 |
+| 100 – 999 | 3 | col 4 | col 4 |
+| 1000 – 9999 | 4 | col 8 | col 6 |
+
+Scanning every line number 1–19999, the code's start column shifts at:
+
+- `tab-size: 4` → **only at line 1000**
+- `tab-size: 2` → **at line 10, and again at line 1000**
+
+So every Read preview that spans the 9→10 boundary — i.e. essentially every read
+of a file head, and every short file — now has a **2-column step in its left
+edge partway down the block**. The transcript sample above is exactly such a
+case: its lines 1–9 render two columns left of its lines 10+. Before #2785 that
+block was flush. This is a new raggedness the change introduced.
+
+`tab-size: 4` is strictly better *for the gutter*; `tab-size: 2` is better *for
+relative indentation in a tab-indented file*. The two goals are in direct
+conflict as long as the gutter is rendered as a tab inside the same `<pre>`.
+§6.1 resolves the conflict by removing the gutter from the highlighted text
+entirely, which makes the `tab-size` value stop mattering for the gutter at all.
+
+---
+
+## 3. Where dedent does and doesn't run
+
+`dedent.ts` strips the **literal longest common leading-whitespace prefix**
+across the displayed lines. Three cases where that is correctly a no-op, and
+which together cover most previews:
+
+| Case | Why dedent does nothing | Where |
+|---|---|---|
+| **Write of a whole file** | Whole files start at column 0, so the common prefix is `""`. Spec §2 acknowledges this ("Dedent is a natural no-op"). | `ToolOverlayLog.tsx:529` |
+| **Read starting at the top of a file** | Same reason — any column-0 line in the visible range forces the common prefix to `""`. Only *mid-file* reads (`offset`) benefit. **Measured on the real Read in §1: 58 of its 200 lines sit at column 0, so the common prefix is `""` and dedent strips nothing at all** — while 23 lines sit at column 20. | `ToolOverlayLog.tsx:471` |
+| **Mixed tabs and spaces at the same depth** | Deliberate, spec §3.3: the comparison is a literal string prefix, so `"\tfoo"` and `"    bar"` share nothing and dedent declines rather than guessing a tab width. | `dedent.ts:64-81` |
+
+And three surfaces where it is **not wired up at all**, by explicit scope
+decision in spec §2's table:
+
+- **Bash** — "command output has no file-indentation semantic".
+- **Grep / Glob** — "each match line is independent, so 'common' indent across
+  unrelated lines is semantically weak." Listed as a candidate follow-up;
+  never done.
+- **Streaming chunks (`ChunkList`)** — dedent needs the full text to compute a
+  prefix, so it can't run mid-stream.
+
+Grep is the notable one: its result lines *are* code, they carry their full
+original file indentation, and they are the case a user is most likely to be
+looking at when they say "a lot of indentation".
+
+---
+
+## 4. Wrapping is inconsistent across surfaces inside one panel
+
+Every one of these renders inside the same `.agent-tool-panel`:
+
+| Surface | Class | `white-space` | Wraps? | Dedented? |
+|---|---|---|---|---|
+| Read / Write code | `.agent-highlighted-code` | `pre` (`_document-nodes.scss:666`) | **no** — h-scroll | yes |
+| Edit diff (Shiki) | `.agent-diff-highlighted-body` — a `<pre>`, UA default | `pre` | **no** | yes (shared prefix) |
+| Streaming chunks | `.agent-tool-log-line` | `pre` (`_tool-overlay-portal.scss:62`) | **no** | no |
+| Bash command row | `.agent-bash-cmd-code` | `pre-wrap` + `word-break: break-all` (`:805`, `:809`) | **yes, mid-token** | n/a |
+| Bash output, and any result with a string body | `.agent-terminal-output > div` | `pre-wrap` + `overflow-wrap: anywhere` (`:1772-1773`) | **yes** | no |
+| Grep/Glob & other structured results, expanded | `.agent-tool-compact-json` | `pre-wrap` + `overflow-wrap: anywhere` (`:1444-1445`) | **yes** | no |
+| Agent / Task / Workflow result text | `.agent-tool-agent-result` | `pre-wrap` (`:463`) | **yes** | no |
+
+Three consequences:
+
+**4.1 — The wrapping surfaces are exactly the non-dedented ones.** Bash output,
+Grep results, and compact JSON show full original indentation *and* wrap. When a
+line wraps, its continuation restarts at column 0, destroying the visual
+indentation that the rest of the block still carries. That reads as "lots of
+indentation, and ragged wrapping" — the reported symptom, precisely.
+
+**4.2 — `overflow-wrap: anywhere` / `word-break: break-all` break mid-identifier.**
+On `.agent-bash-cmd-code` this is deliberate and commented ("Force breaks inside
+long tokens (long paths, base64, etc.)"). On `.agent-terminal-output` and
+`.agent-tool-compact-json` it means a long path or symbol name is split at an
+arbitrary character. For code-bearing content that is worse than a horizontal
+scrollbar.
+
+**4.3 — A Bash block changes wrap behaviour when it finishes.** While running it
+renders through `ChunkList` → `.agent-tool-log-line` (`white-space: pre`, no
+wrap). On completion it re-renders through `BashOutputViewer` →
+`.agent-terminal-output > div` (`pre-wrap`, wraps). Same content, same panel,
+different layout — a visible reflow at the moment the tool completes.
+(`ToolOverlayLog.tsx:110-114` selects the branch.)
+
+---
+
+## 5. Two smaller findings in the same area
+
+**5.1 — `.agent-diff` declares no `white-space`, and its element type differs
+between the two render paths.** `DiffViewer.tsx:288` renders the plain fallback
+as `<pre class="agent-diff">` (UA `white-space: pre`), while `:306` renders the
+Shiki path as `<div class="agent-diff agent-diff--highlighted">`
+(`white-space: normal`). The code itself is safe either way — on the highlighted
+path it sits in an inner `<pre>` (`:308`). But `.agent-diff-header` (the file
+path, `:289` and `:307`) is a direct child on both paths, so **a long file path
+scrolls on the pre-Shiki render and wraps once Shiki resolves** — a small layout
+flip mid-render. It is also a latent trap: any future direct text child of
+`.agent-diff` on the highlighted path silently gets `normal` instead of `pre`.
+
+**5.2 — The markdown Read path still feeds line-numbered text to the markdown
+renderer.** `ToolOverlayLog.tsx:499-501` passes `dedentedText` — which retains
+the `<N>\t` gutter — into `<Markdown>`. Spec §2.1 flagged this in August as a
+pre-existing bug and explicitly deferred it; it is still present on main. A line
+`1\t# Title` is not a heading, and markdown prose wraps, so a Read of any `.md`
+file produces wrapped, mis-rendered output. If the report came from reading a
+markdown file, **this alone explains it**.
+
+Related and still undecided: spec §2.1 also parked "whether to keep rendering
+the number gutter at all (vs stripping it, vs promoting it to a styled
+non-selectable gutter element like the editor has)" as a separate refinement.
+It has not been revisited. Note the gutter is currently fed through Shiki as if
+it were source, so on a TypeScript preview the line number is lexed and coloured
+as a numeric literal.
+
+---
+
+## 6. Recommendations, in priority order
+
+> **Status 2026-09-02:** 6.2–6.6 are implemented on
+> `agent4/tool-preview-indent-and-wrap`. 6.1 was **not** done as written — see
+> the note under it for what shipped instead and why.
+
+### 6.1 Strip the Read line-number gutter out of the highlighted text (highest value)
+
+Either drop it, or promote it to a real gutter element outside the `<pre>` (a
+sibling column, `user-select: none`), as the Editor pane does. This single
+change:
+
+- reclaims 2–8 columns of preview width on every Read;
+- **eliminates the §2 raggedness entirely**, and makes the `tab-size` value stop
+  mattering for the gutter;
+- stops line numbers being syntax-highlighted as numeric literals;
+- fixes §5.2's markdown corruption for free;
+- lets `stripCommonIndentNumbered` collapse back to plain `stripCommonIndent`.
+
+The spec already anticipated this as the natural next refinement. It is the
+cheapest fix with the widest blast radius.
+
+> **What shipped instead (2026-09-02).** The *gutter-as-a-separate-column* half
+> was not built. A parallel column has to line up with Shiki's line boxes, and
+> Shiki emits `<span class="line">…</span>` separated by literal `\n` text
+> nodes inside an inline `<code>` — line-box behaviour there is subtle enough
+> that I could not verify alignment without a live pane, and a gutter that
+> drifts by one line is worse than no change at all.
+>
+> The *deterministic* half shipped: `renderNumberedGutter` re-emits the number
+> **right-aligned to a fixed width, separated by a single space instead of the
+> tab**. That gets the parts that mattered — the §2 raggedness is gone (the
+> gutter now ends at the same column on every line, unit-tested against a real
+> transcript sample), the tab no longer interacts with `tab-size` at all, and
+> the markdown path gets a gutter-free body so §5.2's corruption is fixed. What
+> it does *not* get: the gutter is still selectable and still passes through
+> the syntax highlighter. Those remain a follow-up, and the split/render
+> helpers are now factored so that follow-up is a rendering change only.
+
+### 6.2 Normalise indentation *width* in the text, not in CSS
+
+This is the only thing that addresses "a lot of indentation still" for
+space-indented files. Detect the preview's indent unit (tab / 2-space /
+4-space) from the displayed lines, then re-emit each line's **leading run only**
+at a fixed narrow unit — e.g. render every indent level as 2 columns.
+
+Constraints that must hold:
+
+- leading whitespace only; never touch alignment *inside* a line (aligned
+  trailing comments, ASCII tables, continuation alignment);
+- skip when the unit can't be inferred confidently (mixed/irregular), same
+  decline-rather-than-guess posture `dedent.ts` already takes for tabs vs
+  spaces;
+- skip for whitespace-significant content — Bash output especially, where
+  leading spaces may be real table alignment (spec §2 already excludes it);
+- apply *after* dedent, so the two compose.
+
+A cheaper first cut: leave the text alone and only apply this to Grep results,
+which is where indentation is most useless (each match line is from an unrelated
+file position anyway).
+
+### 6.3 Pick one wrapping policy for code-bearing surfaces
+
+Recommendation: **`white-space: pre` + horizontal scroll everywhere code is
+shown**, matching what Read/Write/Edit already do. Wrapping code at column 0
+destroys exactly the indentation structure that dedent exists to preserve, so
+wrapping and dedent are working against each other today.
+
+If wrapping must stay on Bash/Grep output, then at minimum:
+
+- drop `overflow-wrap: anywhere` / `word-break: break-all` from those surfaces
+  (`:1445`, `:1773`) so breaks land at token boundaries, not mid-identifier;
+- give wrapped lines a hanging indent (`text-indent: -Nch; padding-left: Nch`)
+  so continuations align under their own line's indentation instead of
+  restarting at column 0.
+
+### 6.4 Fix the streaming→final wrap flip (§4.3)
+
+Make `.agent-tool-log-line` and `.agent-terminal-output > div` agree. Whichever
+policy 6.3 picks, both should use it.
+
+### 6.5 Give `.agent-diff` an explicit `white-space` (§5.1)
+
+Declare it on `.agent-diff` itself so both the `<pre>` and `<div>` paths behave
+identically and the header stops flipping when Shiki resolves.
+
+### 6.6 Revisit `tab-size: 2`
+
+If 6.1 lands, the gutter conflict disappears and 2 is fine (it then only affects
+genuine relative indentation, which is what #2785 wanted). If 6.1 does *not*
+land, **`tab-size: 4` is the better value** — it confines gutter raggedness to
+the line-1000 boundary instead of the far more common line-10 one. Do not change
+this in isolation before deciding 6.1; it is a trade, not a fix.
+
+---
+
+## 7. Confidence and what is not verified
+
+Everything in §1–§5 is read directly from main @ `01cd708e` and cited by
+file:line. The tab-stop table in §2 is arithmetic on the CSS `tab-size`
+definition.
+
+**Settled by measurement** (real `tool_result` frames, transcript store opened
+read-only):
+
+- The `Read` result format is `<N>\t<code>` with the number **left-aligned, not
+  padded** — `9\t` then `10\t`. This is what makes §2's raggedness real rather
+  than hypothetical. Had the CLI right-aligned the numbers, §2 would not exist,
+  and `NUMBERED_LINE_RE` (`dedent.ts:28`) tolerates both shapes, so the code
+  alone could not have told us which was live.
+- A representative code `Read` is **100% space-indented, 0% tab-indented**
+  (0 / 127 lines), with 58 lines at column 0 and 23 at column 20. That
+  simultaneously confirms §1 (`tab-size` is inert here) and §3 (the column-0
+  lines force dedent to a no-op on the exact preview that most needs it).
+
+**One thing still open, and it changes the priority order:** which surface the
+reporter was actually looking at. "Some lines are word-wrapped" is *impossible*
+on the Read/Write/Edit code path (`white-space: pre`), so that block was a Bash
+output, a Grep result, an expanded JSON blob, an Agent/Task result, or a `.md`
+Read. If it was one of the first four, §6.3/§6.4 is the fix; if it was a `.md`
+Read, §5.2/§6.1 is. A screenshot settles it in seconds.
+
+The indentation half of the report does not depend on that question — §1, §2 and
+§3 hold regardless.
+
+## 8. Reproducing the measurements
+
+```bash
+python - <<'PY'
+import sqlite3, re, json, collections
+con = sqlite3.connect(
+    "file:%s/.agentmux/shared/agents/transcripts/filestore.db?mode=ro" % __import__("os").path.expanduser("~"),
+    uri=True)
+# transcripts are 64 KB parts of a stream-json NDJSON log, keyed by agent zone
+z = 'agent:<uuid>:current'
+parts = [r[0].decode('utf-8','replace') for r in con.execute(
+    "SELECT data FROM db_file_data WHERE zoneid=? AND name='output' "
+    "AND partidx<20 ORDER BY partidx", (z,))]
+t = "".join(parts)
+# find a Read tool_result and decode its JSON string body
+m = re.search(r'"type":"tool_result","content":"', t)
+...  # scan forward to the closing quote, json.loads, then split on \n
+PY
+```
+
+Full scripts are in the PR discussion; the two numbers that matter are the
+`<N>\t` shape (§2) and the tab-vs-space histogram (§1).

--- a/docs/analysis/tool-preview-indentation-and-wrapping-2026-09-02.md
+++ b/docs/analysis/tool-preview-indentation-and-wrapping-2026-09-02.md
@@ -2,6 +2,9 @@
 
 **Date:** 2026-09-02
 **Author:** Agent4
+**Status:** active — §6.2, §6.3, §6.5, §6.6 shipped in #2958; §6.4 WITHDRAWN (its premise was wrong, see §4.3). §6.1's gutter-as-a-separate-column
+half is deliberately NOT built (see the note under it); the raggedness and markdown
+halves of §6.1 did ship. Remaining: the gutter column, and the ACP question in §7.
 **Repo state:** `agentmuxai/agentmux` main @ `01cd708e`
 **Method:** static read of the render path + CSS cascade, arithmetic on the
 tab-stop behaviour, and **measurement against real stored transcripts**
@@ -198,12 +201,29 @@ long tokens (long paths, base64, etc.)"). On `.agent-terminal-output` and
 arbitrary character. For code-bearing content that is worse than a horizontal
 scrollbar.
 
-**4.3 — A Bash block changes wrap behaviour when it finishes.** While running it
-renders through `ChunkList` → `.agent-tool-log-line` (`white-space: pre`, no
-wrap). On completion it re-renders through `BashOutputViewer` →
-`.agent-terminal-output > div` (`pre-wrap`, wraps). Same content, same panel,
-different layout — a visible reflow at the moment the tool completes.
-(`ToolOverlayLog.tsx:110-114` selects the branch.)
+**4.3 — ~~A Bash block changes wrap behaviour when it finishes.~~ WRONG — see
+the correction below.**
+
+> **Correction (2026-09-03, codex P2 on PR #2958).** This claimed that a Bash
+> block streams through `.agent-tool-log-line` (`pre`) and completes through
+> `.agent-terminal-output > div` (`pre-wrap`), reflowing at completion. **The
+> completion viewer is wrong.** `renderBash` routes a completed Bash result to
+> `BashOutputViewer`, which renders `<pre class="agent-bash-output">` — a `<pre>`
+> with no `white-space` declaration, so UA `white-space: pre`, no wrap.
+>
+> **Bash was already consistent.** `pre` while streaming, `pre` when finished.
+> There was no flip.
+>
+> `.agent-terminal-output` is the `CompactResult`/string-body path — a different
+> set of tools. Whether *those* have a genuine streaming-vs-final mismatch is a
+> separate question this analysis did not actually establish.
+>
+> Acting on the wrong claim briefly *created* the reflow it described, in the
+> opposite direction: an earlier revision of #2958 switched
+> `.agent-tool-log-line` to `pre-wrap`, making Bash wrap while streaming and
+> snap to horizontal scroll on completion. Reverted before merge. The lesson is
+> narrow and worth stating: §4's table was assembled by reading CSS and matching
+> class names, without tracing which viewer each *tool* actually routes to.
 
 ---
 
@@ -313,10 +333,16 @@ If wrapping must stay on Bash/Grep output, then at minimum:
   so continuations align under their own line's indentation instead of
   restarting at column 0.
 
-### 6.4 Fix the streaming→final wrap flip (§4.3)
+### 6.4 ~~Fix the streaming→final wrap flip (§4.3)~~ — WITHDRAWN
 
-Make `.agent-tool-log-line` and `.agent-terminal-output > div` agree. Whichever
-policy 6.3 picks, both should use it.
+Withdrawn: the flip it was fixing does not exist. See the correction in §4.3 —
+Bash completes through `BashOutputViewer` → `<pre class="agent-bash-output">`
+(`white-space: pre`), not `.agent-terminal-output`, so streaming and final
+already agree. `.agent-tool-log-line` stays `pre`.
+
+If a genuine mismatch exists on the `CompactResult`/string-body path, it needs
+establishing first — by tracing which viewer the tool actually routes to, not by
+matching class names in the stylesheet.
 
 ### 6.5 Give `.agent-diff` an explicit `white-space` (§5.1)
 

--- a/frontend/app/view/agent/components/DiffViewer.tsx
+++ b/frontend/app/view/agent/components/DiffViewer.tsx
@@ -25,7 +25,7 @@ import type { EditParams, EditResult } from "../types";
 import { detectLanguage } from "./detectLanguage";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
 import { capText, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
-import { stripCommonIndentSharedPrefix } from "./dedent";
+import { formatDiffSides } from "./dedent";
 
 const ShikiTheme = "github-dark-high-contrast";
 
@@ -134,13 +134,16 @@ export const DiffViewer = (props: DiffViewerProps): JSX.Element => {
         if (succeeded) {
             const p = props.params;
             if (p && (p.old_string != null || p.new_string != null)) {
-                // Dedent BEFORE building the diff, with one prefix shared
-                // across both sides (SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md
-                // §3.2.2) — an independent per-side dedent could shift one
-                // side by a different amount than the other (e.g. new_string
-                // adding a shallower wrapper line) and manufacture a phantom
-                // indentation diff that was never actually part of the edit.
-                const { oldStr, newStr } = stripCommonIndentSharedPrefix(p.old_string ?? "", p.new_string ?? "");
+                // Dedent AND narrow BEFORE building the diff, with one prefix
+                // and one indent unit shared across both sides
+                // (SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md §3.2.2) — treating
+                // the sides independently could shift one by a different
+                // amount than the other (e.g. new_string adding a shallower
+                // wrapper line) and manufacture a phantom indentation diff
+                // that was never actually part of the edit. It has to happen
+                // here rather than on the built diff: once the +/- markers are
+                // on, the "leading whitespace" of a line is the marker.
+                const { oldStr, newStr } = formatDiffSides(p.old_string ?? "", p.new_string ?? "");
                 return buildDiffFromParams(oldStr, newStr);
             }
         }

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -27,7 +27,7 @@ import { DiffViewer } from "./DiffViewer";
 import { HighlightedCode } from "./HighlightedCode";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
 import { capChars, createChunkCapper, createSpinnerCollapser, capText, dropBashwrapStartingChunk, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
-import { formatCodePreview, formatReadPreview } from "./dedent";
+import { formatCodePreview, formatMarkdownPreview, formatReadPreview } from "./dedent";
 import { detectLanguage } from "./detectLanguage";
 import {
     registerToolRenderer,
@@ -542,6 +542,10 @@ function renderWrite(node: ToolNode): JSX.Element {
     // case anyway (a whole file starts at column 0) — which is exactly why the
     // narrowing half matters here: it's the only part that fires on a Write.
     const dedentedText = capped ? formatCodePreview(capped.text) : "";
+    // Markdown is indentation-sensitive — four leading spaces are a code
+    // block, and rescaling them to two turns it into prose. Dedent only for
+    // that path (codex P2 on PR #2958); `formatMarkdownPreview` documents why.
+    const markdownText = capped ? formatMarkdownPreview(capped.text) : "";
     const isMarkdown = filePath.endsWith(".md") || filePath.endsWith(".mdx");
     return (
         <div class="agent-tool-write">
@@ -563,7 +567,7 @@ function renderWrite(node: ToolNode): JSX.Element {
                     }
                 >
                     <div class="agent-tool-write-content agent-tool-write-md">
-                        <Markdown text={dedentedText} />
+                        <Markdown text={markdownText} />
                     </div>
                 </Show>
                 <Show when={capped!.hiddenLines > 0}>

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -27,7 +27,7 @@ import { DiffViewer } from "./DiffViewer";
 import { HighlightedCode } from "./HighlightedCode";
 import { OutputHiddenMarker } from "./OutputHiddenMarker";
 import { capChars, createChunkCapper, createSpinnerCollapser, capText, dropBashwrapStartingChunk, MAX_TOOL_OUTPUT_LINES } from "./output-cap";
-import { stripCommonIndent, stripCommonIndentNumbered } from "./dedent";
+import { formatCodePreview, formatReadPreview } from "./dedent";
 import { detectLanguage } from "./detectLanguage";
 import {
     registerToolRenderer,
@@ -468,13 +468,15 @@ function renderRead(node: ToolNode): JSX.Element {
     // the conversation DOM; HighlightedCode stays simple (it injects
     // innerHTML, so capping here is cleaner than inside it).
     const capped = content ? capText(content, MAX_TOOL_OUTPUT_LINES, "head") : null;
-    // Strip indentation common to every VISIBLE line — computed after
-    // capping so a deeper hidden tail can't reduce the dedent of what's
-    // actually shown (SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md §3.2.1). Claude
-    // Code's Read result lines are "<N>\t<code>"; the numbered variant
-    // splits off that prefix before dedenting so the line-number gutter
-    // itself is untouched.
-    const dedentedText = capped ? stripCommonIndentNumbered(capped.text) : "";
+    // Dedent (common to every VISIBLE line — computed after capping so a
+    // deeper hidden tail can't reduce the dedent of what's actually shown,
+    // SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md §3.2.1), narrow the remaining
+    // relative indentation to 2 columns per level, and re-emit Claude Code's
+    // "<N>\t" line-number gutter right-aligned at a fixed width. That last
+    // part removes the tab, and with it the sideways step the code column
+    // took at every digit-count boundary (9→10, 999→1000) — see dedent.ts's
+    // module header and docs/analysis/tool-preview-indentation-and-wrapping-2026-09-02.md.
+    const preview = capped ? formatReadPreview(capped.text) : null;
     // Render markdown files as formatted markdown, matching renderWrite. Without
     // this a .md Read shows raw source instead of a rendered preview.
     const isMarkdown = filePath.endsWith(".md") || filePath.endsWith(".mdx");
@@ -493,7 +495,7 @@ function renderRead(node: ToolNode): JSX.Element {
                     when={isMarkdown}
                     fallback={
                         <HighlightedCode
-                            code={dedentedText}
+                            code={preview!.withGutter}
                             // Language detection reads the RAW (non-dedented) first
                             // line — shebang/content sniffing should see the file
                             // as-is; only the displayed text is dedented.
@@ -503,7 +505,12 @@ function renderRead(node: ToolNode): JSX.Element {
                     }
                 >
                     <div class="agent-tool-read-content agent-tool-read-md">
-                        <Markdown text={dedentedText} />
+                        {/* `body`, not `withGutter`: a line-number column is
+                            meaningless in rendered markdown and actively
+                            corrupts it (a "1\t# Title" line is not a heading).
+                            SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md §2.1 flagged
+                            this in August and deferred it; this is the fix. */}
+                        <Markdown text={preview!.body} />
                     </div>
                 </Show>
                 <Show when={capped!.hiddenLines > 0}>
@@ -525,14 +532,16 @@ function renderWrite(node: ToolNode): JSX.Element {
     const content: string | undefined = (node.params as any).content;
     const bytes: number | undefined = (node.result as any)?.bytesWritten;
     const capped = content ? capText(content, MAX_TOOL_OUTPUT_LINES, "head") : null;
-    // Plain dedent, NOT the Read-specific numbered variant
+    // Plain dedent + narrow, NOT the Read-specific gutter-aware variant
     // (SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md §3.2.3) — Write content has no
-    // CLI-added "<N>\t" line-number prefix, so stripCommonIndentNumbered's
+    // CLI-added "<N>\t" line-number prefix, so formatReadPreview's numbered
     // heuristic would misfire on a genuine tab-delimited file (TSV/BED/GTF)
     // whose every non-blank line happens to start with digits+tab, silently
-    // dropping that real leading column. stripCommonIndent has no such
-    // ambiguity and is a no-op for the common already-flush case anyway.
-    const dedentedText = capped ? stripCommonIndent(capped.text) : "";
+    // dropping that real leading column. formatCodePreview has no such
+    // ambiguity, and its dedent half is a no-op for the common already-flush
+    // case anyway (a whole file starts at column 0) — which is exactly why the
+    // narrowing half matters here: it's the only part that fires on a Write.
+    const dedentedText = capped ? formatCodePreview(capped.text) : "";
     const isMarkdown = filePath.endsWith(".md") || filePath.endsWith(".mdx");
     return (
         <div class="agent-tool-write">

--- a/frontend/app/view/agent/components/dedent.test.ts
+++ b/frontend/app/view/agent/components/dedent.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+    formatMarkdownPreview,
     formatCodePreview,
     formatReadPreview,
     normalizeIndentWidth,
@@ -179,7 +180,9 @@ describe("formatReadPreview", () => {
         // common 8-space prefix stripped; the remaining 4-space level narrowed
         // to 2; gutter right-aligned at width 2 with a single space.
         expect(out.withGutter).toBe('80 unsetEnv: ["CLAUDECODE"],\n81   authConfigDirEnvVar: "X",');
-        expect(out.body).toBe('unsetEnv: ["CLAUDECODE"],\n  authConfigDirEnvVar: "X",');
+        // `body` feeds the Markdown renderer, so it is dedent-only — the 4-space
+        // relative level survives rather than being halved (codex P2 on #2958).
+        expect(out.body).toBe('unsetEnv: ["CLAUDECODE"],\n    authConfigDirEnvVar: "X",');
     });
 
     it("removes the 9→10 column step that the raw <N>\\t gutter produced", () => {
@@ -196,7 +199,8 @@ describe("formatReadPreview", () => {
     it("degrades to plain dedent+narrow for unnumbered input", () => {
         const out = formatReadPreview("        a();\n            b();");
         expect(out.withGutter).toBe("a();\n  b();");
-        expect(out.body).toBe(out.withGutter);
+        // dedent-only, deliberately NOT narrowed — see formatMarkdownPreview
+        expect(out.body).toBe("a();\n    b();");
     });
 
     it("handles an empty string", () => {
@@ -267,8 +271,13 @@ describe("formatReadPreview — real transcript sample", () => {
     it("keeps relative structure intact — the nesting levels all survive", () => {
         // Source depths are 0/8/12/16; GCD is 4, so each halves to 0/4/6/8.
         // Same number of distinct levels, same ordering, half the width.
+        // Measured on the CODE half (`withGutter`), which is the one that gets
+        // narrowed; `body` is dedent-only for the Markdown renderer's sake.
         const depths = formatReadPreview(REAL)
-            .body.split("\n")
+            .withGutter.split("\n")
+            .map((l) => l.replace(/^\s*\d+ ?/, ""))
+            // strip the gutter FIRST — a blank source line is gutter-only, and
+            // filtering before stripping would count it as a depth-0 code line
             .filter((l) => l.trim() !== "")
             .map((l) => l.length - l.trimStart().length);
         expect(depths).toEqual([0, 0, 0, 4, 6, 6, 6, 6, 8]);
@@ -283,6 +292,37 @@ describe("formatReadPreview — real transcript sample", () => {
 
     it("contains no tab characters at all — the gutter tab is gone", () => {
         expect(formatReadPreview(REAL).withGutter).not.toContain("\t");
+    });
+});
+
+describe("formatMarkdownPreview — indentation is load-bearing in markdown", () => {
+    // codex P2 on PR #2958. Width normalisation is a readability win for a
+    // syntax-highlighted source preview and a correctness bug for a rendered one.
+
+    it("does NOT rescale a four-space indented code block into prose", () => {
+        const md = "# Title\n\n    const x = 1;\n    const y = 2;\n";
+        // 4 leading spaces = an indented code block. formatCodePreview would
+        // halve it to 2 and markdown would render it as an ordinary paragraph.
+        expect(formatCodePreview(md)).toContain("  const x = 1;");
+        expect(formatMarkdownPreview(md)).toContain("    const x = 1;");
+    });
+
+    it("does NOT re-nest nested lists", () => {
+        const md = "- a\n    - b\n        - c\n";
+        expect(formatMarkdownPreview(md)).toBe(md);
+    });
+
+    it("still dedents a uniformly-indented body (pre-existing behaviour)", () => {
+        expect(formatMarkdownPreview("  # Title\n  text")).toBe("# Title\ntext");
+    });
+
+    it("formatReadPreview.body is markdown-safe while withGutter is normalised", () => {
+        const read = "1\t# Title\n2\t\n3\t    code block line\n";
+        const out = formatReadPreview(read);
+        expect(out.body).toContain("    code block line");
+        expect(out.body).not.toMatch(/^\s*\d+ /m);
+        // the source-preview half keeps the narrowing
+        expect(out.withGutter).toContain("  code block line");
     });
 });
 

--- a/frontend/app/view/agent/components/dedent.test.ts
+++ b/frontend/app/view/agent/components/dedent.test.ts
@@ -2,7 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { stripCommonIndent, stripCommonIndentNumbered, stripCommonIndentSharedPrefix } from "./dedent";
+import {
+    formatCodePreview,
+    formatReadPreview,
+    normalizeIndentWidth,
+    renderNumberedGutter,
+    splitNumberedGutter,
+    stripCommonIndent,
+    stripCommonIndentSharedPrefix,
+} from "./dedent";
 import { TRUNCATED_MARKER } from "./output-cap";
 
 describe("stripCommonIndent", () => {
@@ -70,56 +78,221 @@ describe("stripCommonIndent", () => {
     });
 });
 
-describe("stripCommonIndentNumbered", () => {
-    it("preserves the N\\t prefix and dedents only the code portion", () => {
+describe("normalizeIndentWidth", () => {
+    it("rescales a 4-space-per-level file to 2 columns per level", () => {
+        const input = "a();\n    b();\n        c();\n            d();";
+        expect(normalizeIndentWidth(input)).toBe("a();\n  b();\n    c();\n      d();");
+    });
+
+    it("rescales an 8-space unit the same way — the unit is inferred, not assumed", () => {
+        const input = "a();\n        b();\n                c();";
+        expect(normalizeIndentWidth(input)).toBe("a();\n  b();\n    c();");
+    });
+
+    it("rescales a 3-space unit", () => {
+        expect(normalizeIndentWidth("a();\n   b();\n      c();")).toBe("a();\n  b();\n    c();");
+    });
+
+    it("is a no-op when the file is already at or below the target unit", () => {
+        const input = "a();\n  b();\n    c();";
+        expect(normalizeIndentWidth(input)).toBe(input);
+    });
+
+    it("DECLINES when a continuation-alignment line makes the unit irregular", () => {
+        // `19` is not a multiple of 4, so the GCD collapses to 1 and the whole
+        // transform backs off — rescaling would shift `b` out of alignment
+        // with `a`. This is the property that makes the heuristic safe.
+        const input = "    return foo(a,\n                   b);\n        next();";
+        expect(normalizeIndentWidth(input)).toBe(input);
+    });
+
+    it("is a no-op on tab-indented text — tab width is CSS's business", () => {
+        const input = "a();\n\tb();\n\t\tc();";
+        expect(normalizeIndentWidth(input)).toBe(input);
+    });
+
+    it("is a no-op when tabs and spaces are mixed in a leading run", () => {
+        const input = "a();\n    b();\n\t    c();";
+        expect(normalizeIndentWidth(input)).toBe(input);
+    });
+
+    it("never rewrites whitespace inside a line, only the leading run", () => {
+        const input = "a();\n    b = 1;    // aligned comment";
+        expect(normalizeIndentWidth(input)).toBe("a();\n  b = 1;    // aligned comment");
+    });
+
+    it("leaves blank lines and the truncation marker untouched", () => {
+        const input = `    a();\n\n${TRUNCATED_MARKER}\n        b();`;
+        expect(normalizeIndentWidth(input)).toBe(`  a();\n\n${TRUNCATED_MARKER}\n    b();`);
+    });
+
+    it("is a no-op when nothing is indented, and on empty input", () => {
+        expect(normalizeIndentWidth("a();\nb();")).toBe("a();\nb();");
+        expect(normalizeIndentWidth("")).toBe("");
+    });
+
+    it("honours an explicit target unit", () => {
+        expect(normalizeIndentWidth("a();\n    b();", 1)).toBe("a();\n b();");
+    });
+});
+
+describe("splitNumberedGutter", () => {
+    it("splits the <N>\\t prefix off every line", () => {
+        const out = splitNumberedGutter("9\t  a();\n10\t  b();")!;
+        expect(out.numbers).toEqual(["9", "10"]);
+        expect(out.body).toBe("  a();\n  b();");
+    });
+
+    it("keeps positional alignment for blank lines and the marker", () => {
+        const out = splitNumberedGutter(`1\ta();\n2\t\n${TRUNCATED_MARKER}`)!;
+        expect(out.numbers).toEqual(["1", "2", ""]);
+        expect(out.body).toBe(`a();\n\n${TRUNCATED_MARKER}`);
+    });
+
+    it("returns null for non-uniformly-numbered and for unnumbered input", () => {
+        expect(splitNumberedGutter("1\tfoo();\nnot numbered\n3\tbar();")).toBeNull();
+        expect(splitNumberedGutter("    a();\n    b();")).toBeNull();
+        expect(splitNumberedGutter("")).toBeNull();
+    });
+});
+
+describe("renderNumberedGutter", () => {
+    it("right-aligns to a fixed width so the code column never steps sideways", () => {
+        // The whole point: with the original `9\t` / `10\t`, the code column
+        // moved at the 9→10 boundary. Here both land at column 3.
+        expect(renderNumberedGutter(["9", "10"], "a();\nb();")).toBe(" 9 a();\n10 b();");
+    });
+
+    it("emits no trailing pad for a blank code line", () => {
+        expect(renderNumberedGutter(["1", "2", "3"], "a();\n\nb();")).toBe("1 a();\n2\n3 b();");
+    });
+
+    it("leaves unnumbered lines (marker) at column 0", () => {
+        expect(renderNumberedGutter(["1", ""], `a();\n${TRUNCATED_MARKER}`)).toBe(`1 a();\n${TRUNCATED_MARKER}`);
+    });
+});
+
+describe("formatReadPreview", () => {
+    it("dedents, narrows, and re-emits an aligned gutter — end to end", () => {
         const input = "80\t        unsetEnv: [\"CLAUDECODE\"],\n81\t            authConfigDirEnvVar: \"X\",";
-        const out = stripCommonIndentNumbered(input);
-        expect(out).toBe('80\tunsetEnv: ["CLAUDECODE"],\n81\t    authConfigDirEnvVar: "X",');
+        const out = formatReadPreview(input);
+        // common 8-space prefix stripped; the remaining 4-space level narrowed
+        // to 2; gutter right-aligned at width 2 with a single space.
+        expect(out.withGutter).toBe('80 unsetEnv: ["CLAUDECODE"],\n81   authConfigDirEnvVar: "X",');
+        expect(out.body).toBe('unsetEnv: ["CLAUDECODE"],\n  authConfigDirEnvVar: "X",');
     });
 
-    it("falls through to plain dedent for non-uniformly-numbered input", () => {
-        const input = "1\tfoo();\nnot numbered\n3\tbar();";
-        // Not every non-blank line matches the numbered shape, so this
-        // falls through to stripCommonIndent on the raw text — which finds
-        // no common leading whitespace here (lines start with digits/text),
-        // so it's a no-op.
-        expect(stripCommonIndentNumbered(input)).toBe(input);
+    it("removes the 9→10 column step that the raw <N>\\t gutter produced", () => {
+        const out = formatReadPreview("9\ta();\n10\tb();").withGutter;
+        const [l1, l2] = out.split("\n");
+        expect(l1.indexOf("a();")).toBe(l2.indexOf("b();"));
     });
 
-    it("falls through to plain dedent for completely unnumbered input", () => {
-        const input = "    a();\n    b();";
-        expect(stripCommonIndentNumbered(input)).toBe("a();\nb();");
+    it("body drops the gutter entirely, for the markdown path", () => {
+        const out = formatReadPreview("1\t# Title\n2\t\n3\tsome text");
+        expect(out.body).toBe("# Title\n\nsome text");
     });
 
-    it("is a no-op when the numbered code portions have no common indent", () => {
-        const input = "1\ta();\n2\t    b();";
-        expect(stripCommonIndentNumbered(input)).toBe(input);
-    });
-
-    it("handles blank lines within numbered content", () => {
-        const input = "1\t    a();\n2\t\n3\t    b();";
-        const out = stripCommonIndentNumbered(input);
-        expect(out).toBe("1\ta();\n2\t\n3\tb();");
+    it("degrades to plain dedent+narrow for unnumbered input", () => {
+        const out = formatReadPreview("        a();\n            b();");
+        expect(out.withGutter).toBe("a();\n  b();");
+        expect(out.body).toBe(out.withGutter);
     });
 
     it("handles an empty string", () => {
-        expect(stripCommonIndentNumbered("")).toBe("");
+        expect(formatReadPreview("")).toEqual({ withGutter: "", body: "" });
+    });
+});
+
+describe("formatReadPreview — real transcript sample", () => {
+    // Lifted verbatim from a stored `Read` tool_result
+    // (agentmux-srv/src/server/identity_handlers.rs), so this asserts against
+    // the shape the CLI actually emits rather than an invented one. Note the
+    // 1-digit and 3-digit line numbers in the same body — that mix is what
+    // made the raw `<N>\t` gutter step sideways.
+    const REAL =
+        "1\t// Copyright 2026, AgentMux Corp.\n" +
+        "2\t// SPDX-License-Identifier: Apache-2.0\n" +
+        "3\t\n" +
+        "4\t//! Pre-launch OAuth flow RPC handlers.\n" +
+        "125\t        Box::new(move |data, _ctx| {\n" +
+        "126\t            let mgr = mgr.clone();\n" +
+        "127\t            let wstore = wstore.clone();\n" +
+        "128\t            let broker = broker.clone();\n" +
+        "129\t            Box::pin(async move {\n" +
+        "130\t                let req: StartProviderAuthReq = serde_json::from_value(data)";
+
+    /** Column the first source character lands on, expanding tabs the way the
+     *  browser does at `tabSize` — i.e. what the eye actually sees, not the
+     *  character offset. Everything up to and including the gutter separator
+     *  is skipped. */
+    const codeColumn = (line: string, tabSize = 2): number => {
+        const gutter = /^\s*\d+[\t ]/.exec(line);
+        if (!gutter) return 0;
+        let col = 0;
+        for (const ch of line.slice(0, gutter[0].length) + line.slice(gutter[0].length).match(/^[ \t]*/)![0]) {
+            if (ch === "\t") col = (Math.floor(col / tabSize) + 1) * tabSize;
+            else col += 1;
+        }
+        return col;
+    };
+
+    it("ends the gutter at the same column on every line, whatever the digit count", () => {
+        // This is the regression the 08-24 tab-size change introduced: with the
+        // raw `<N>\t`, a 1-digit number put the gutter at column 2 and a
+        // 3-digit one at column 4, so the code's left edge stepped sideways.
+        const rawGutterCols = new Set(
+            REAL.split("\n")
+                .filter((l) => /\S/.test(l.replace(/^\d+\t/, "")))
+                .map((l) => codeColumn(l.replace(/^(\d+\t)[ \t]*/, "$1"))),
+        );
+        expect(rawGutterCols.size).toBeGreaterThan(1); // ragged before
+
+        const fixedGutterCols = new Set(
+            formatReadPreview(REAL)
+                .withGutter.split("\n")
+                .filter((l) => /^\s*\d+ \S/.test(l))
+                .map((l) => /^\s*\d+ /.exec(l)![0].length),
+        );
+        expect([...fixedGutterCols]).toEqual([4]); // 3-digit gutter + one space
     });
 
-    it("handles a single numbered line", () => {
-        expect(stripCommonIndentNumbered("1\t    solo();")).toBe("1\tsolo();");
+    it("halves the deepest line's rendered indentation", () => {
+        const before = REAL.split("\n").at(-1)!;
+        const after = formatReadPreview(REAL).withGutter.split("\n").at(-1)!;
+        expect(codeColumn(before)).toBe(20); // "130" → tab stop 4, + 16 spaces
+        expect(codeColumn(after)).toBe(12); // 3-digit gutter + space, + 8 spaces
     });
 
-    it("tolerates multi-digit line numbers and varying digit widths", () => {
-        const input = "9\t    a();\n10\t    b();\n100\t    c();";
-        const out = stripCommonIndentNumbered(input);
-        expect(out).toBe("9\ta();\n10\tb();\n100\tc();");
+    it("keeps relative structure intact — the nesting levels all survive", () => {
+        // Source depths are 0/8/12/16; GCD is 4, so each halves to 0/4/6/8.
+        // Same number of distinct levels, same ordering, half the width.
+        const depths = formatReadPreview(REAL)
+            .body.split("\n")
+            .filter((l) => l.trim() !== "")
+            .map((l) => l.length - l.trimStart().length);
+        expect(depths).toEqual([0, 0, 0, 4, 6, 6, 6, 6, 8]);
+
+        const sourceDepths = REAL.split("\n")
+            .map((l) => l.replace(/^\d+\t/, ""))
+            .filter((l) => l.trim() !== "")
+            .map((l) => l.length - l.trimStart().length);
+        expect(sourceDepths).toEqual([0, 0, 0, 8, 12, 12, 12, 12, 16]);
+        expect(new Set(depths).size).toBe(new Set(sourceDepths).size);
     });
 
-    it("ignores a trailing truncation marker so the numbered-shape check still passes and the code still dedents", () => {
-        const input = `80\t    a();\n81\t    b();\n${TRUNCATED_MARKER}`;
-        const out = stripCommonIndentNumbered(input);
-        expect(out).toBe(`80\ta();\n81\tb();\n${TRUNCATED_MARKER}`);
+    it("contains no tab characters at all — the gutter tab is gone", () => {
+        expect(formatReadPreview(REAL).withGutter).not.toContain("\t");
+    });
+});
+
+describe("formatCodePreview", () => {
+    it("dedents then narrows", () => {
+        expect(formatCodePreview("    a();\n        b();\n            c();")).toBe("a();\n  b();\n    c();");
+    });
+
+    it("narrows even when dedent finds nothing to strip", () => {
+        expect(formatCodePreview("a();\n    b();")).toBe("a();\n  b();");
     });
 });
 

--- a/frontend/app/view/agent/components/dedent.ts
+++ b/frontend/app/view/agent/components/dedent.ts
@@ -2,19 +2,43 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Common-indentation stripping for tool previews (Read/Write/Edit). A
- * mid-file snippet — a Read at an offset, or an Edit hunk deep inside a
- * nested scope — carries the source file's original leading indentation on
- * every line even though the preview can't show the enclosing scopes that
- * indentation refers to. Stripping the indentation common to every
- * displayed line makes the shallowest line render flush-left while keeping
- * the *relative* indentation between lines — the part that actually
- * encodes structure.
+ * Indentation handling for tool previews (Read/Write/Edit). Three concerns,
+ * applied in this order by the `format*Preview` entry points at the bottom:
  *
- * SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md.
+ *  1. **Dedent** — a mid-file snippet (a Read at an offset, an Edit hunk deep
+ *     inside a nested scope) carries the source file's original leading
+ *     indentation on every line even though the preview can't show the
+ *     enclosing scopes that indentation refers to. Stripping the indentation
+ *     common to every displayed line makes the shallowest line render
+ *     flush-left while keeping the *relative* indentation between lines — the
+ *     part that actually encodes structure.
+ *
+ *  2. **Narrow** (`normalizeIndentWidth`) — dedent only removes what's
+ *     *common*, so a preview that includes a column-0 line keeps every deeper
+ *     line at full width. A 4-space-per-level file still spends 20 columns on
+ *     five levels of nesting, and no CSS property can narrow a space the way
+ *     `tab-size` narrows a tab. Rescaling the leading run to a 2-column unit
+ *     is the only lever that works on space-indented source.
+ *
+ *  3. **Gutter** (`splitNumberedGutter` / `renderNumberedGutter`) — Claude
+ *     Code's `Read` results are `<N>\t<code>` with the number LEFT-aligned
+ *     (`9\t` then `10\t`, verified against stored transcripts). Rendered
+ *     inline, that tab lands on a tab stop whose column depends on the line
+ *     number's digit count, so the code's left edge steps sideways partway
+ *     down the preview. Re-emitting the number right-aligned to a fixed width
+ *     removes the tab, and with it the raggedness.
+ *
+ * SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md,
+ * docs/analysis/tool-preview-indentation-and-wrapping-2026-09-02.md.
  */
 
 import { TRUNCATED_MARKER } from "./output-cap";
+
+/** Target width, in columns, of one level of indentation in a preview.
+ *  Matches the `tab-size: 2` this app already applies to tool previews
+ *  (`_document-nodes.scss`), so tab- and space-indented files finally render
+ *  at the same width as each other. */
+export const PREVIEW_INDENT_UNIT = 2;
 
 /** Leading run of spaces/tabs. `\r` is deliberately excluded so a CRLF
  *  line's trailing `\r` (see `splitLines`) never gets treated as part of
@@ -105,48 +129,166 @@ export function stripCommonIndent(text: string): string {
     return stripPrefixFromLines(lines, prefix).join("\n");
 }
 
+/** Greatest common divisor, for inferring a file's indent unit. */
+function gcd(a: number, b: number): number {
+    while (b !== 0) {
+        const t = b;
+        b = a % b;
+        a = t;
+    }
+    return a;
+}
+
 /**
- * Read-tool variant of {@link stripCommonIndent}: Claude Code's `Read`
- * result lines are `<N>\t<code>` (verified against real session
- * transcripts) — a plain whole-line dedent would see every line start with
- * a different digit and find no common prefix at all. When every non-blank
- * line matches that shape, this splits off the `<N>\t` prefix, dedents only
- * the code portions together (so relative indentation across lines is
- * still computed correctly), and rejoins. Any line that doesn't match the
- * numbered shape — including a completely unnumbered body, e.g. if this
- * ever runs on non-Read content — falls through to the plain
- * {@link stripCommonIndent} over the whole text, which is always safe (at
- * worst a no-op).
+ * Rescale each line's leading whitespace so one level of indentation renders
+ * `targetUnit` columns wide instead of whatever the source file used.
+ *
+ * The unit is inferred as the GCD of every non-zero leading-run width, which
+ * makes the transform **self-limiting in exactly the right way**: a file
+ * indented in clean multiples (4, 8) yields a GCD equal to its indent unit and
+ * gets rescaled, while a file containing continuation-alignment lines (`foo(a,`
+ * / 19 spaces / `b)`) yields a GCD of 1 and is left completely alone. Guessing
+ * a unit that isn't really there would shift aligned code out of alignment —
+ * so, exactly like {@link commonLeadingWhitespace}'s refusal to conflate tabs
+ * with spaces, this declines rather than guesses.
+ *
+ * A no-op (returns `text` unchanged) when: any leading run contains a tab (its
+ * rendered width is a CSS `tab-size` concern, not a character count — see the
+ * module header), no line is indented at all, or the inferred unit is already
+ * at or below `targetUnit`.
+ *
+ * Only the LEADING run is touched. Whitespace inside a line — aligned trailing
+ * comments, ASCII tables — is never rewritten.
  */
-export function stripCommonIndentNumbered(text: string): string {
+export function normalizeIndentWidth(text: string, targetUnit: number = PREVIEW_INDENT_UNIT): string {
     if (!text) return text;
     const lines = splitLines(text);
-    // Blank lines AND the truncation marker are excluded from the
-    // "every line is numbered" check, same rationale as everywhere else in
-    // this file: neither is real Read content, so requiring either to match
-    // the `<N>\t` shape would wrongly reject an otherwise-fully-numbered,
-    // truncated body and fall through to a whole-text dedent that finds no
-    // common prefix at all (every real line still starts with a digit).
-    const relevant = lines.filter((l) => !isIgnorableForIndent(l));
-    const allNumbered = relevant.length > 0 && relevant.every((l) => NUMBERED_LINE_RE.test(l));
-    if (!allNumbered) return stripCommonIndent(text);
 
-    const numberPrefixes: string[] = [];
+    const widths: number[] = [];
+    for (const line of lines) {
+        if (isIgnorableForIndent(line)) continue;
+        const indent = LEADING_WHITESPACE_RE.exec(line)![0];
+        if (indent.includes("\t")) return text; // tab width is CSS's business
+        if (indent.length > 0) widths.push(indent.length);
+    }
+    if (widths.length === 0) return text;
+
+    let unit = widths[0];
+    for (const w of widths) unit = gcd(unit, w);
+    if (unit <= targetUnit) return text;
+
+    return lines
+        .map((line) => {
+            if (isIgnorableForIndent(line)) return line;
+            const indent = LEADING_WHITESPACE_RE.exec(line)![0];
+            if (indent.length === 0) return line;
+            return " ".repeat((indent.length / unit) * targetUnit) + line.slice(indent.length);
+        })
+        .join("\n");
+}
+
+/** A `Read` body split into its line-number gutter and its code. */
+export interface NumberedSplit {
+    /** One entry per line of {@link body}. Empty string for lines that carry
+     *  no number (blank lines, the truncation marker) — kept positional so the
+     *  two arrays never drift out of step. */
+    numbers: string[];
+    /** The code with every `<N>\t` prefix removed, lines rejoined with `\n`. */
+    body: string;
+}
+
+/**
+ * Split Claude Code `Read` output (`<N>\t<code>` per line) into its
+ * line-number gutter and its code, so the code can be dedented and narrowed
+ * without the digits interfering and without the gutter's tab surviving into
+ * the rendered output.
+ *
+ * Returns `null` when the text isn't in that shape — including a completely
+ * unnumbered body — so callers fall back to treating it as plain code. Blank
+ * lines and the truncation marker are exempt from the "every line is numbered"
+ * check: neither is real Read content, and requiring either to match would
+ * wrongly reject an otherwise-fully-numbered (e.g. capped) body.
+ */
+export function splitNumberedGutter(text: string): NumberedSplit | null {
+    if (!text) return null;
+    const lines = splitLines(text);
+    const relevant = lines.filter((l) => !isIgnorableForIndent(l));
+    if (relevant.length === 0 || !relevant.every((l) => NUMBERED_LINE_RE.test(l))) return null;
+
+    const numbers: string[] = [];
     const codes: string[] = [];
     for (const line of lines) {
         if (isIgnorableForIndent(line)) {
-            numberPrefixes.push("");
+            numbers.push("");
             codes.push(line);
             continue;
         }
         const m = NUMBERED_LINE_RE.exec(line)!;
-        numberPrefixes.push(m[0]);
+        numbers.push(m[0].replace(/\s+$/, "").trim());
         codes.push(line.slice(m[0].length));
     }
-    const commonCodeIndent = commonLeadingWhitespace(codes);
-    if (commonCodeIndent === "") return text;
-    const dedentedCodes = stripPrefixFromLines(codes, commonCodeIndent);
-    return lines.map((_, i) => numberPrefixes[i] + dedentedCodes[i]).join("\n");
+    return { numbers, body: codes.join("\n") };
+}
+
+/**
+ * Re-attach a {@link splitNumberedGutter} gutter to (possibly rewritten) code,
+ * right-aligned to a fixed width and separated by a single space rather than
+ * the original tab.
+ *
+ * Fixed width is what kills the raggedness: with the original `<N>\t`, the code
+ * column depended on the number's digit count (`9\t` → column 2, `10\t` →
+ * column 4 at `tab-size: 2`), so the left edge stepped sideways at every
+ * digit-count boundary. Right-aligning to `max(digits)` puts every code line at
+ * the same column regardless.
+ *
+ * Lines with no number, and lines whose code is empty, get no trailing pad —
+ * the gutter still reads as a continuous right-aligned column, without
+ * emitting selectable trailing whitespace.
+ */
+export function renderNumberedGutter(numbers: readonly string[], body: string): string {
+    const codes = splitLines(body);
+    const width = numbers.reduce((w, n) => Math.max(w, n.length), 0);
+    if (width === 0) return body;
+    return codes
+        .map((code, i) => {
+            const n = numbers[i] ?? "";
+            if (n === "") return code;
+            const padded = n.padStart(width, " ");
+            return code === "" ? padded : `${padded} ${code}`;
+        })
+        .join("\n");
+}
+
+/**
+ * Full preview pipeline for non-Read code bodies (Write, and anything else
+ * that arrives as plain source): dedent to flush-left, then narrow the
+ * remaining relative indentation.
+ */
+export function formatCodePreview(text: string): string {
+    return normalizeIndentWidth(stripCommonIndent(text));
+}
+
+/**
+ * Full preview pipeline for a `Read` body. Splits the `<N>\t` gutter off,
+ * dedents and narrows the code, then re-emits the gutter right-aligned
+ * (see {@link renderNumberedGutter}).
+ *
+ * `withGutter` is what the code preview renders. `body` is the same code with
+ * no gutter at all — used by the markdown path, where a line-number column is
+ * meaningless and actively corrupts the render (a `1\t# Title` line is not a
+ * heading; SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md §2.1 flagged this).
+ *
+ * Unnumbered input degrades to {@link formatCodePreview} for both fields.
+ */
+export function formatReadPreview(text: string): { withGutter: string; body: string } {
+    if (!text) return { withGutter: text, body: text };
+    const split = splitNumberedGutter(text);
+    if (!split) {
+        const plain = formatCodePreview(text);
+        return { withGutter: plain, body: plain };
+    }
+    const body = formatCodePreview(split.body);
+    return { withGutter: renderNumberedGutter(split.numbers, body), body };
 }
 
 /**
@@ -167,5 +309,30 @@ export function stripCommonIndentSharedPrefix(oldStr: string, newStr: string): {
     return {
         oldStr: stripPrefixFromLines(oldLines, prefix).join("\n"),
         newStr: stripPrefixFromLines(newLines, prefix).join("\n"),
+    };
+}
+
+/**
+ * Full preview pipeline for an Edit hunk: the shared-prefix dedent above,
+ * then the indent narrowing — with ONE unit inferred across both sides
+ * together, for exactly the same reason the dedent prefix is shared.
+ * Inferring per-side could pick a different unit for each (say `old` contains
+ * a continuation-alignment line that collapses its GCD to 1 while `new`
+ * doesn't) and rescale one side but not the other, manufacturing an
+ * indentation diff that was never part of the edit.
+ *
+ * Must run BEFORE the diff is built, while the two sides are still plain
+ * source: once `+`/`-` markers are prepended, the leading run every function
+ * in this module looks at is the marker, not the indentation.
+ */
+export function formatDiffSides(oldStr: string, newStr: string): { oldStr: string; newStr: string } {
+    const stripped = stripCommonIndentSharedPrefix(oldStr ?? "", newStr ?? "");
+    const oldLines = splitLines(stripped.oldStr);
+    const newLines = splitLines(stripped.newStr);
+    // Line count is preserved by normalizeIndentWidth, so the split is exact.
+    const combined = splitLines(normalizeIndentWidth([...oldLines, ...newLines].join("\n")));
+    return {
+        oldStr: combined.slice(0, oldLines.length).join("\n"),
+        newStr: combined.slice(oldLines.length).join("\n"),
     };
 }

--- a/frontend/app/view/agent/components/dedent.ts
+++ b/frontend/app/view/agent/components/dedent.ts
@@ -269,6 +269,24 @@ export function formatCodePreview(text: string): string {
 }
 
 /**
+ * Preview pipeline for text that will be handed to a **Markdown renderer**:
+ * dedent only, **never** {@link normalizeIndentWidth}.
+ *
+ * Markdown is indentation-sensitive in a way source code is not. Four leading
+ * spaces make an indented code block; rescaling them to two turns that block
+ * into ordinary prose, and the same rescale silently re-nests nested lists.
+ * Width normalisation is a readability win for a syntax-highlighted source
+ * preview and a correctness bug for a rendered one (codex P2 on PR #2958).
+ *
+ * Dedent is kept because it only removes a prefix *common to every line*, which
+ * is the pre-existing behaviour for this path and does not change relative
+ * structure.
+ */
+export function formatMarkdownPreview(text: string): string {
+    return stripCommonIndent(text);
+}
+
+/**
  * Full preview pipeline for a `Read` body. Splits the `<N>\t` gutter off,
  * dedents and narrows the code, then re-emits the gutter right-aligned
  * (see {@link renderNumberedGutter}).
@@ -283,12 +301,14 @@ export function formatCodePreview(text: string): string {
 export function formatReadPreview(text: string): { withGutter: string; body: string } {
     if (!text) return { withGutter: text, body: text };
     const split = splitNumberedGutter(text);
-    if (!split) {
-        const plain = formatCodePreview(text);
-        return { withGutter: plain, body: plain };
-    }
-    const body = formatCodePreview(split.body);
-    return { withGutter: renderNumberedGutter(split.numbers, body), body };
+    const raw = split ? split.body : text;
+    // `body` is dedent-only. It feeds the Markdown renderer, which is
+    // indentation-sensitive — see `formatMarkdownPreview`. Only `withGutter`,
+    // which feeds the syntax-highlighted source preview, gets the width
+    // normalisation. (codex P2 on PR #2958)
+    const body = formatMarkdownPreview(raw);
+    const code = formatCodePreview(raw);
+    return { withGutter: split ? renderNumberedGutter(split.numbers, code) : code, body };
 }
 
 /**

--- a/frontend/app/view/agent/styles/_document-nodes.scss
+++ b/frontend/app/view/agent/styles/_document-nodes.scss
@@ -385,11 +385,27 @@
             // the global 4-wide (or the browser's 8-wide UA default,
             // wherever nothing overrides it) a tab-indented preview reads
             // noticeably wider than the same file's space-indented sibling.
-            // 2 matches this app's own soft-tab width elsewhere. Scoped to
-            // this shared tool-preview ancestor only, not reset.scss itself
-            // — the Editor pane's CodeMirror instance intentionally keeps
-            // the global default (its own tabSize facet already agrees
-            // with reset.scss's 4; changing that is a separate concern).
+            // Scoped to this shared tool-preview ancestor only, not
+            // reset.scss itself — the Editor pane's CodeMirror instance
+            // intentionally keeps the global default (its own tabSize facet
+            // already agrees with reset.scss's 4; changing that is a
+            // separate concern).
+            //
+            // 2 is now the SAME number as `PREVIEW_INDENT_UNIT` in dedent.ts,
+            // which rescales space indentation to 2 columns per level. That
+            // pairing is the point: this rule alone only ever moved
+            // tab-indented previews (measured: 0 of 127 indented lines in a
+            // real Read of this repo used tabs), so a space-indented file
+            // stayed at full width no matter what value went here. Keep the
+            // two in step — if one changes, the other must.
+            //
+            // This value used to fight the Read line-number gutter, whose
+            // `<N>\t` tab landed on a tab stop that depended on the number's
+            // digit count (col 2 for lines 1-9, col 4 for 10+), stepping the
+            // code's left edge sideways partway down every preview. dedent.ts
+            // now re-emits that gutter right-aligned with no tab at all, so
+            // the conflict is gone and this only governs real indentation.
+            // docs/analysis/tool-preview-indentation-and-wrapping-2026-09-02.md.
             tab-size: 2;
             // Quick smooth transition on all collapse-related properties.
             // Per 2026-05-26 user request — the prior instant-snap (no
@@ -689,6 +705,15 @@
         border-radius: 0;
         overflow-x: auto;
         font-size: 12px;
+        // Declared explicitly because the two render paths use DIFFERENT
+        // elements: the plain fallback is `<pre class="agent-diff">` (UA
+        // `white-space: pre`), the Shiki path is `<div class="agent-diff
+        // agent-diff--highlighted">` (UA `normal`). Without this, the file-path
+        // header — a direct child on both paths — scrolled before Shiki
+        // resolved and wrapped after, flipping layout mid-render. It also made
+        // any future direct text child silently wrap on one path only.
+        // DiffViewer.tsx:288 vs :306.
+        white-space: pre;
 
         .agent-diff-header {
             background: color-mix(in srgb, var(--main-text-color) 10%, transparent);
@@ -805,8 +830,14 @@
                 white-space: pre-wrap;
                 color: var(--accent-color);
                 // Force breaks inside long tokens (long paths, base64, etc.)
-                // so commands never overflow the portal width.
-                word-break: break-all;
+                // so commands never overflow the portal width — but only as a
+                // LAST resort. `word-break: break-all` (what this was) breaks
+                // greedily at whatever character hits the edge, splitting a
+                // path mid-name even when it would have fit whole on the next
+                // line. `overflow-wrap: anywhere` gives the same
+                // never-overflow guarantee while preferring normal break
+                // opportunities first.
+                overflow-wrap: anywhere;
 
                 :global(.line) {
                     display: inline;
@@ -1456,6 +1487,12 @@
             font-size: 11px;
             white-space: pre-wrap;
             overflow-wrap: anywhere;
+            // Hanging indent — see .agent-terminal-output > div for the
+            // rationale. JSON.stringify(_, 2) output is deeply indented and
+            // gets no dedent, so wrapped continuations restarting at column 0
+            // is exactly the readability problem this fixes.
+            padding-left: calc(var(--space-1-5) + 3ch);
+            text-indent: -3ch;
         }
     }
 }
@@ -1784,6 +1821,16 @@
         min-height: 1.45em;
         white-space: pre-wrap;
         overflow-wrap: anywhere;
+        // Hanging indent: a wrapped continuation restarts at column 0 without
+        // this, which is indistinguishable from a genuine new line and throws
+        // away whatever indentation the line had. Command output is one of the
+        // surfaces that gets NO dedent (it can carry meaningful alignment —
+        // SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md §2), so it is also the most
+        // deeply-indented thing in the panel and the worst place to lose the
+        // distinction. 3ch reads as clearly-not-an-indent-level next to the
+        // 2-column unit dedent.ts normalises real indentation to.
+        padding-left: 3ch;
+        text-indent: -3ch;
     }
 }
 

--- a/frontend/app/view/agent/styles/_tool-overlay-portal.scss
+++ b/frontend/app/view/agent/styles/_tool-overlay-portal.scss
@@ -59,8 +59,17 @@
         font-family: var(--fixed-font, monospace);
         font-size: 12px;
         line-height: 1.4;
-        white-space: pre;
-        overflow-wrap: normal;
+        // Must match `.agent-terminal-output > div` in _document-nodes.scss.
+        // These are the SAME bytes at two points in one tool's life: chunks
+        // render here while it streams, then the final result re-renders
+        // through the terminal/JSON viewers on completion. This used to be
+        // `pre` while that is `pre-wrap`, so a long-lined Bash block visibly
+        // reflowed at the moment it finished.
+        // docs/analysis/tool-preview-indentation-and-wrapping-2026-09-02.md §4.3.
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+        padding-left: 3ch;
+        text-indent: -3ch;
 
         &--stdout {
             color: var(--term-foreground, #d3d7cf);

--- a/frontend/app/view/agent/styles/_tool-overlay-portal.scss
+++ b/frontend/app/view/agent/styles/_tool-overlay-portal.scss
@@ -59,17 +59,23 @@
         font-family: var(--fixed-font, monospace);
         font-size: 12px;
         line-height: 1.4;
-        // Must match `.agent-terminal-output > div` in _document-nodes.scss.
-        // These are the SAME bytes at two points in one tool's life: chunks
-        // render here while it streams, then the final result re-renders
-        // through the terminal/JSON viewers on completion. This used to be
-        // `pre` while that is `pre-wrap`, so a long-lined Bash block visibly
-        // reflowed at the moment it finished.
-        // docs/analysis/tool-preview-indentation-and-wrapping-2026-09-02.md §4.3.
-        white-space: pre-wrap;
-        overflow-wrap: anywhere;
-        padding-left: 3ch;
-        text-indent: -3ch;
+        // Stays `pre`, deliberately — must match the viewer the completed tool
+        // actually renders through.
+        //
+        // An earlier revision of this PR switched these streaming chunks to
+        // `pre-wrap` to match `.agent-terminal-output > div`, on the theory that
+        // a Bash block reflowed when it finished. That was the wrong viewer:
+        // `renderBash` routes a completed Bash result to `BashOutputViewer`,
+        // which renders `<pre class="agent-bash-output">` — UA `white-space:
+        // pre`, no wrap. Bash was already consistent; the change *created* the
+        // reflow it claimed to remove, in the opposite direction (codex P2 on
+        // PR #2958).
+        //
+        // `.agent-terminal-output` is the CompactResult/string-body path, a
+        // different set of tools. Any genuine streaming-vs-final mismatch there
+        // is its own question and is not addressed here.
+        white-space: pre;
+        overflow-wrap: normal;
 
         &--stdout {
             color: var(--term-foreground, #d3d7cf);


### PR DESCRIPTION
## Summary

The 2026-08-24 `tab-size: 2` fix (#2785) could only ever move **tab**-indented previews. Measured against a real stored `Read` of this repo's own source: **0 of 127 indented lines used tabs**, so that rule was inert — and no CSS property narrows a space. Meanwhile 58 of those 200 lines sit at column 0, which forces `dedent.ts`'s common prefix to empty. Neither lever fired; the deepest lines rendered at **column 24**.

#2785 also introduced a regression. `Read` results are `<N>\t<code>` with the number **left-aligned** (`9\t` then `10\t`, confirmed verbatim from a stored `tool_result`). That gutter tab lands on a tab stop whose column depends on the digit count, so at `tab-size: 2` the code's left edge stepped sideways at the 9→10 boundary — i.e. in nearly every preview. At `tab-size: 4` the only step was at line 1000.

## What changed

Three changes, in the text rather than the stylesheet:

- **`normalizeIndentWidth`** rescales leading runs to 2 columns per level, with the unit inferred as the **GCD** of observed widths. That makes it self-limiting in the right way: clean 4/8-space files rescale, while a file containing continuation-alignment lines yields a GCD of 1 and is left alone rather than having aligned code shifted out of alignment. Same decline-rather-than-guess posture the module already takes for tabs vs spaces.
- **`splitNumberedGutter` / `renderNumberedGutter`** re-emit the `Read` gutter right-aligned at fixed width with no tab, removing the raggedness.
- **The markdown `Read` path** now gets a gutter-free body, fixing the corruption `SPEC_TOOL_PREVIEW_DEDENT_2026_08_08.md` §2.1 flagged in August and deferred (a `1\t# Title` line is not a heading).

Edit hunks narrow with **one unit shared across both sides**, for the same reason the dedent prefix is shared — a per-side unit could rescale one side only and manufacture a phantom indentation diff.

**Wrapping**, the other half of the report: the surfaces that wrap (Bash output, Grep/JSON) are exactly the ones that get no dedent, and a wrapped continuation restarted at column 0 — indistinguishable from a real new line. They now carry a hanging indent. Streaming chunks were `pre` while the final render was `pre-wrap`, so a Bash block visibly reflowed the moment it finished; both now agree. `.agent-diff` gets an explicit `white-space` because its two render paths use different elements (`<pre>` plain, `<div>` highlighted), which flipped the header's layout when Shiki resolved.

## Measured effect

On the real transcript sample: deepest line **column 20 → 12**, gutter column constant, all four nesting levels preserved.

## Testing

- 3588 frontend tests pass (240 files), `tsc --noEmit` clean, `vite build` clean.
- `dedent.test.ts` includes 4 tests asserting against a **verbatim real transcript sample**, including one that fails if the gutter ever goes ragged again.

## Notes for review

- Analysis with the measurement method: `docs/analysis/tool-preview-indentation-and-wrapping-2026-09-02.md`
- **Not** visually verified in a live pane yet — the logic is unit-tested against real captured data, but no screenshot. Flagged honestly.
- The gutter-as-a-separate-column treatment was considered and **not** built: aligning a parallel column depends on Shiki's line boxes (it separates `<span class="line">` with literal `\n` inside an inline `<code>`), which I couldn't verify without a live pane. Recorded as a follow-up; the split/render helpers are factored so it becomes a rendering-only change.

<!-- agentmux:agent_id=agent4 -->