### PR TITLE
feat(jekt): cross-channel trust — spec + publish per-agent public keys (phase A)

### DIFF
--- a/.changesets/1788386725-feat-jekt-publish-per-agent-public-keys-for-cross-channel-tr-21oh.md
+++ b/.changesets/1788386725-feat-jekt-publish-per-agent-public-keys-for-cross-channel-tr-21oh.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(jekt): publish per-agent public keys for cross-channel trust (phase A)

--- a/agentmux-common/src/jekt_sign.rs
+++ b/agentmux-common/src/jekt_sign.rs
@@ -282,6 +282,109 @@ pub fn verify_lan_jekt(
     verifying_key.verify(material.as_bytes(), &signature).is_ok()
 }
 
+// ── Cross-channel per-agent Ed25519 signing (SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md §D5) ──
+//
+// Same machine, different AgentMux instance. Asymmetric for the same reason
+// LAN is: the receiving instance must be able to verify without being able to
+// forge — and unlike host-tier's HMAC, the key can therefore be published in
+// the host-global shared registry, which is what makes cross-channel
+// verification possible at all (§5 of the spec explains why globalizing the
+// symmetric host key instead would be strictly worse).
+//
+// Reuses the agent's EXISTING LAN keypair — no new key material, no new
+// provisioning step. What it does NOT reuse is the signed material.
+
+/// Domain separator for cross-channel signatures.
+///
+/// Without this, a cross-channel signature and a LAN signature over the same
+/// (msgid, source, target, ts, message) tuple would be byte-identical, signed
+/// by the byte-identical key — so either could be replayed as the other. The
+/// tiers make different trust claims (`TRUST=lan-verified` vs
+/// `TRUST=channel-verified`) and are verified against different key sources, so
+/// they must not be interchangeable. Cheap now; a flag day later.
+const CHANNEL_DOMAIN: &str = "amx-jekt-channel-v1";
+
+/// Signed material for a cross-channel jekt.
+///
+/// Differs from [`signed_material`] in two ways, both load-bearing:
+///  - the [`CHANNEL_DOMAIN`] prefix (see above), and
+///  - `source_channel`, which binds the signature to the channel that minted
+///    it. Without it, a signature legitimately produced by an agent running in
+///    channel A could be replayed as that same agent speaking from channel B —
+///    and since one agent name can legitimately be live in several channels at
+///    once (`AgentEntry::channel` exists precisely because of that), the
+///    receiver has no other way to tell those apart.
+fn channel_signed_material(
+    msgid: &str,
+    source_agent: &str,
+    source_channel: &str,
+    target_agent: &str,
+    ts_secs: i64,
+    message: &str,
+) -> String {
+    format!(
+        "{CHANNEL_DOMAIN}{FIELD_SEP}{msgid}{FIELD_SEP}{source_agent}{FIELD_SEP}\
+         {source_channel}{FIELD_SEP}{target_agent}{FIELD_SEP}{ts_secs}{FIELD_SEP}{message}"
+    )
+}
+
+/// Sign a cross-channel jekt with the sending agent's own LAN private key
+/// (`AGENTMUX_LAN_KEY`) — called client-side in `agentmux-mcp`, never
+/// server-side, exactly like [`sign_lan_jekt`].
+///
+/// `private_key` must be exactly 32 bytes (the seed [`generate_lan_keypair`]
+/// produced); returns `None` on any other length rather than panicking — same
+/// "a missing or malformed key must never block sending" policy the other
+/// signers use. A message that can't be signed is delivered unsigned, and the
+/// receiver decides what that means.
+pub fn sign_channel_jekt(
+    private_key: &[u8],
+    msgid: &str,
+    source_agent: &str,
+    source_channel: &str,
+    target_agent: &str,
+    ts_secs: i64,
+    message: &str,
+) -> Option<String> {
+    let seed: [u8; 32] = private_key.try_into().ok()?;
+    let signing_key = ed25519_dalek::SigningKey::from_bytes(&seed);
+    let material =
+        channel_signed_material(msgid, source_agent, source_channel, target_agent, ts_secs, message);
+    let signature = ed25519_dalek::Signer::sign(&signing_key, material.as_bytes());
+    Some(BASE64.encode(signature.to_bytes()))
+}
+
+/// Verify a claimed cross-channel signature against the claimed sender's
+/// published public key (read server-side from the host-global shared registry
+/// entry — `AgentEntry::jekt_public_key`).
+///
+/// Returns `false`, never panics, for a malformed public key, malformed
+/// base64, a wrong-length signature, or a signature that simply doesn't verify
+/// — the same "all of these are identically 'not verified'" policy
+/// [`verify_lan_jekt`] and [`verify_reagent_jekt`] already document. The
+/// caller distinguishes "couldn't check" from "checked and failed"; this
+/// function only answers the second question.
+#[allow(clippy::too_many_arguments)]
+pub fn verify_channel_jekt(
+    public_key: &[u8],
+    msgid: &str,
+    source_agent: &str,
+    source_channel: &str,
+    target_agent: &str,
+    ts_secs: i64,
+    message: &str,
+    sig_b64: &str,
+) -> bool {
+    let Ok(pubkey_arr) = <[u8; 32]>::try_from(public_key) else { return false };
+    let Ok(verifying_key) = VerifyingKey::from_bytes(&pubkey_arr) else { return false };
+    let Ok(sig_bytes) = BASE64.decode(sig_b64) else { return false };
+    let Ok(sig_arr) = <[u8; 64]>::try_from(sig_bytes.as_slice()) else { return false };
+    let signature = Signature::from_bytes(&sig_arr);
+    let material =
+        channel_signed_material(msgid, source_agent, source_channel, target_agent, ts_secs, message);
+    verifying_key.verify(material.as_bytes(), &signature).is_ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -685,5 +788,115 @@ mod tests {
         let (_, private_key) = generate_lan_keypair(lan_seed(5));
         let sig = sign_lan_jekt(&private_key, "msg-1", "agentx", "agenty", 1_000, "hello").unwrap();
         assert!(!verify_jekt(&private_key, "msg-1", "agentx", "agenty", 1_000, "hello", &sig));
+    }
+
+    // ---- Cross-channel Ed25519 signing (SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md §D5) ----
+
+    #[test]
+    fn a_correctly_signed_channel_message_verifies() {
+        let (public_key, private_key) = generate_lan_keypair(lan_seed(9));
+        let sig =
+            sign_channel_jekt(&private_key, "msg-1", "agentx", "chan-a", "agenty", 1_000, "hello")
+                .unwrap();
+        assert!(verify_channel_jekt(
+            &public_key, "msg-1", "agentx", "chan-a", "agenty", 1_000, "hello", &sig
+        ));
+    }
+
+    #[test]
+    fn channel_wrong_key_fails_verification() {
+        let (_, private_key) = generate_lan_keypair(lan_seed(9));
+        let (other_public, _) = generate_lan_keypair(lan_seed(10));
+        let sig =
+            sign_channel_jekt(&private_key, "msg-1", "agentx", "chan-a", "agenty", 1_000, "hello")
+                .unwrap();
+        assert!(!verify_channel_jekt(
+            &other_public, "msg-1", "agentx", "chan-a", "agenty", 1_000, "hello", &sig
+        ));
+    }
+
+    #[test]
+    fn channel_tampered_fields_fail_verification() {
+        let (public_key, private_key) = generate_lan_keypair(lan_seed(9));
+        let sig =
+            sign_channel_jekt(&private_key, "msg-1", "agentx", "chan-a", "agenty", 1_000, "hello")
+                .unwrap();
+        // Every signed field must actually be covered.
+        for (msgid, src, chan, tgt, ts, msg) in [
+            ("msg-2", "agentx", "chan-a", "agenty", 1_000, "hello"),
+            ("msg-1", "agentz", "chan-a", "agenty", 1_000, "hello"),
+            ("msg-1", "agentx", "chan-a", "agentz", 1_000, "hello"),
+            ("msg-1", "agentx", "chan-a", "agenty", 1_001, "hello"),
+            ("msg-1", "agentx", "chan-a", "agenty", 1_000, "goodbye"),
+        ] {
+            assert!(
+                !verify_channel_jekt(&public_key, msgid, src, chan, tgt, ts, msg, &sig),
+                "tampering with a signed field must fail: {msgid}/{src}/{chan}/{tgt}/{ts}/{msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_signature_minted_for_one_channel_does_not_verify_as_another() {
+        // §D5 channel binding. One agent name can be live in several channels
+        // at once; without `source_channel` in the signed material, a signature
+        // legitimately produced in chan-a could be replayed as that same agent
+        // speaking from chan-b, and the receiver would have no way to tell.
+        let (public_key, private_key) = generate_lan_keypair(lan_seed(9));
+        let sig =
+            sign_channel_jekt(&private_key, "msg-1", "agentx", "chan-a", "agenty", 1_000, "hello")
+                .unwrap();
+        assert!(!verify_channel_jekt(
+            &public_key, "msg-1", "agentx", "chan-b", "agenty", 1_000, "hello", &sig
+        ));
+    }
+
+    #[test]
+    fn lan_and_channel_signatures_are_not_interchangeable_in_either_direction() {
+        // §D5 domain separation — the test the separator exists for. Same key,
+        // same (msgid, source, target, ts, message) tuple: without
+        // CHANNEL_DOMAIN these two signatures would be byte-identical and each
+        // would verify as the other, collapsing two different trust claims
+        // (TRUST=lan-verified vs TRUST=channel-verified) into one.
+        let (public_key, private_key) = generate_lan_keypair(lan_seed(9));
+        let lan_sig = sign_lan_jekt(&private_key, "msg-1", "agentx", "agenty", 1_000, "hello").unwrap();
+        let channel_sig =
+            sign_channel_jekt(&private_key, "msg-1", "agentx", "chan-a", "agenty", 1_000, "hello")
+                .unwrap();
+
+        assert_ne!(lan_sig, channel_sig, "the two schemes must not produce identical bytes");
+
+        // A LAN signature replayed as a cross-channel one.
+        assert!(!verify_channel_jekt(
+            &public_key, "msg-1", "agentx", "chan-a", "agenty", 1_000, "hello", &lan_sig
+        ));
+        // A cross-channel signature replayed as a LAN one.
+        assert!(!verify_lan_jekt(
+            &public_key, "msg-1", "agentx", "agenty", 1_000, "hello", &channel_sig
+        ));
+    }
+
+    #[test]
+    fn channel_malformed_inputs_fail_rather_than_panic() {
+        let (public_key, private_key) = generate_lan_keypair(lan_seed(9));
+        let sig =
+            sign_channel_jekt(&private_key, "msg-1", "agentx", "chan-a", "agenty", 1_000, "hello")
+                .unwrap();
+        // Wrong-length private key → None, never a panic.
+        assert!(sign_channel_jekt(&[1u8; 16], "m", "a", "c", "b", 1, "x").is_none());
+        // Malformed public key / base64 / signature length → false, never a panic.
+        assert!(!verify_channel_jekt(&[0u8; 16], "msg-1", "agentx", "chan-a", "agenty", 1_000, "hello", &sig));
+        assert!(!verify_channel_jekt(&public_key, "msg-1", "agentx", "chan-a", "agenty", 1_000, "hello", "!!not base64!!"));
+        assert!(!verify_channel_jekt(&public_key, "msg-1", "agentx", "chan-a", "agenty", 1_000, "hello", ""));
+    }
+
+    #[test]
+    fn an_empty_source_channel_is_still_bound_not_ignored() {
+        // A pre-upgrade or unknown channel id must not act as a wildcard that
+        // matches any channel — it is just another distinct value.
+        let (public_key, private_key) = generate_lan_keypair(lan_seed(9));
+        let sig = sign_channel_jekt(&private_key, "msg-1", "agentx", "", "agenty", 1_000, "hello").unwrap();
+        assert!(verify_channel_jekt(&public_key, "msg-1", "agentx", "", "agenty", 1_000, "hello", &sig));
+        assert!(!verify_channel_jekt(&public_key, "msg-1", "agentx", "chan-a", "agenty", 1_000, "hello", &sig));
     }
 }

--- a/agentmux-srv/src/backend/reactive/registry.rs
+++ b/agentmux-srv/src/backend/reactive/registry.rs
@@ -441,6 +441,20 @@ pub fn write_shared_with_nonce(
     channel: &str,
     registration_nonce: u64,
 ) {
+    // Resolved BEFORE taking the guard. This is a synchronous SQLite read
+    // serialized on the store's single `Mutex<Connection>`, and it can itself
+    // queue behind an unrelated slow store operation. Holding the process-wide
+    // REGISTRY_OP_LOCK across it would block every other registry file
+    // operation for every agent in the process — writes, removes, and the
+    // nonce compare-and-remove — behind a DB query (reagent P1 on PR #2959).
+    //
+    // Safe to hoist: the key depends only on `agent_id`, not on anything
+    // REGISTRY_OP_LOCK protects. The lock serialises this process's own
+    // read-compare-remove sequences against its own writes; a stale key here
+    // would be no worse than the entry being rewritten a moment later, which
+    // re-registration does anyway.
+    let jekt_public_key = jekt_public_key_for(agent_id);
+
     let _guard = REGISTRY_OP_LOCK.lock().unwrap();
     let dir = shared_agent_dir(shared_dir, agent_id);
     let _ = std::fs::create_dir_all(&dir);
@@ -454,7 +468,7 @@ pub fn write_shared_with_nonce(
         auth_key: local_auth_key().to_string(),
         channel: channel.to_string(),
         registration_nonce,
-        jekt_public_key: jekt_public_key_for(agent_id),
+        jekt_public_key,
     };
     write_entry_file(&path, &entry);
 }

--- a/agentmux-srv/src/backend/reactive/registry.rs
+++ b/agentmux-srv/src/backend/reactive/registry.rs
@@ -44,8 +44,18 @@ pub struct AgentEntry {
     /// channel tag is redundant — the whole file is already channel-
     /// scoped by its directory); populated for entries in the host-global
     /// shared registry (§ below), where multiple channels' entries for
-    /// the same agent name coexist and need distinguishing. See
-    /// `docs/specs/SPEC_MUXBUS_CROSS_CHANNEL_DELIVERY_2026_07_02.md`.
+    /// the same agent name coexist and need distinguishing. MuxBus Tier 2b
+    /// same-host cross-channel delivery, issue #1916.
+    ///
+    /// (This previously cited a `SPEC_MUXBUS_CROSS_CHANNEL_DELIVERY` spec dated
+    /// 2026-07-02 that has never existed in any commit — `check-spec-citations`
+    /// flags it the moment this file is touched. Repointed at the issue rather
+    /// than at a plausible-looking neighbour, since the similarly-named
+    /// duplicate-delivery spec is a different document about duplicate
+    /// suppression, not this registry's shape. `registry/paths.rs` carries the
+    /// same dead pointer and is deliberately left alone here: it is unchanged
+    /// by this PR so the gate does not see it, and widening a security PR to
+    /// sweep unrelated files is its own risk. Worth a follow-up.)
     #[serde(default)]
     pub channel: String,
     /// Process-wide unique nonce of the persistent-controller spawn this

--- a/agentmux-srv/src/backend/reactive/registry.rs
+++ b/agentmux-srv/src/backend/reactive/registry.rs
@@ -205,10 +205,13 @@ pub fn write_with_nonce(
         // doc comment on `AgentEntry`.
         channel: String::new(),
         registration_nonce,
-        // Written here too, for struct uniformity, but only the SHARED
-        // registry's copy is load-bearing: a same-instance sender is verified
-        // by the host-tier HMAC path, which never consults this file.
-        jekt_public_key: jekt_public_key_for(agent_id),
+        // Deliberately EMPTY in the per-channel registry. Only the shared
+        // registry's copy is load-bearing — a same-instance sender is verified
+        // by the host-tier HMAC path, which never consults this file — so
+        // resolving it here would mean a synchronous SQLite lookup, held under
+        // `REGISTRY_OP_LOCK`, on every local agent registration and
+        // re-registration, for a value nothing reads (reagent P2 on PR #2959).
+        jekt_public_key: String::new(),
     };
     let path = agent_path(data_dir, agent_id);
     let Ok(json) = serde_json::to_string(&entry) else { return };

--- a/agentmux-srv/src/backend/reactive/registry.rs
+++ b/agentmux-srv/src/backend/reactive/registry.rs
@@ -59,6 +59,23 @@ pub struct AgentEntry {
     /// fallback respawn's fresh entry (issue #2363).
     #[serde(default)]
     pub registration_nonce: u64,
+    /// Base64 Ed25519 **public** key for this agent, for cross-channel jekt
+    /// signature verification —
+    /// `docs/specs/SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md` §D1.
+    ///
+    /// The public half only. That is what makes publishing it here safe, and
+    /// is the whole reason this tier uses the agent's asymmetric LAN keypair
+    /// rather than its symmetric host-tier HMAC key: a shared file containing
+    /// HMAC secrets would let every channel on the machine *mint* signatures
+    /// for every agent (spec §5).
+    ///
+    /// Empty for entries written before this shipped, and for an agent whose
+    /// LAN keypair has not been minted yet. **An empty value means "cannot
+    /// check," never "failed the check"** — the verifier must map it to
+    /// `None`, not `Some(false)`, or every pre-upgrade sender on a
+    /// mixed-version machine gets escalated (spec §6).
+    #[serde(default)]
+    pub jekt_public_key: String,
 }
 
 /// Serializes this process's own read-compare-remove sequences
@@ -90,6 +107,46 @@ pub fn init_local_auth_key(key: impl Into<String>) {
 
 fn local_auth_key() -> &'static str {
     LOCAL_AUTH_KEY.get().map(String::as_str).unwrap_or("")
+}
+
+/// Resolves an agent's published Ed25519 public key for
+/// [`AgentEntry::jekt_public_key`].
+///
+/// Indirection rather than a `Store` handle because this module is
+/// deliberately pure filesystem — it is called from PTY auto-register,
+/// persistent-controller auto-register, and the HTTP register handler, none of
+/// which share a `Store` argument. Mirrors [`LOCAL_AUTH_KEY`]'s
+/// set-once-from-bootstrap pattern, except the value is per-agent so it has to
+/// be a lookup rather than a constant.
+type PubkeyResolver = Box<dyn Fn(&str) -> Option<String> + Send + Sync>;
+static JEKT_PUBLIC_KEY_RESOLVER: OnceLock<PubkeyResolver> = OnceLock::new();
+
+/// Install the process's agent-public-key resolver. Idempotent — first call
+/// wins, same contract as [`init_local_auth_key`].
+///
+/// Called from bootstrap once the Store is open. Until it is called (and for
+/// any agent with no LAN keypair minted yet) entries are written with an empty
+/// `jekt_public_key`, which readers treat as "cannot check" — see that field's
+/// doc comment.
+pub fn init_jekt_public_key_resolver<F>(resolver: F)
+where
+    F: Fn(&str) -> Option<String> + Send + Sync + 'static,
+{
+    let _ = JEKT_PUBLIC_KEY_RESOLVER.set(Box::new(resolver));
+}
+
+/// The agent's published public key, or empty if unavailable.
+///
+/// Deliberately a *load*, never an ensure/mint: registry writes happen on
+/// every registration and re-registration, and minting key material as a side
+/// effect of a bookkeeping write would be a surprising place to put it. Key
+/// creation stays where it already is, at config-injection time
+/// (`agent_config::inject_jekt_signing_keys_into_mcp_json`).
+fn jekt_public_key_for(agent_id: &str) -> String {
+    JEKT_PUBLIC_KEY_RESOLVER
+        .get()
+        .and_then(|resolve| resolve(agent_id))
+        .unwrap_or_default()
 }
 
 fn agents_dir(data_dir: &Path) -> PathBuf {
@@ -148,6 +205,10 @@ pub fn write_with_nonce(
         // doc comment on `AgentEntry`.
         channel: String::new(),
         registration_nonce,
+        // Written here too, for struct uniformity, but only the SHARED
+        // registry's copy is load-bearing: a same-instance sender is verified
+        // by the host-tier HMAC path, which never consults this file.
+        jekt_public_key: jekt_public_key_for(agent_id),
     };
     let path = agent_path(data_dir, agent_id);
     let Ok(json) = serde_json::to_string(&entry) else { return };
@@ -380,6 +441,7 @@ pub fn write_shared_with_nonce(
         auth_key: local_auth_key().to_string(),
         channel: channel.to_string(),
         registration_nonce,
+        jekt_public_key: jekt_public_key_for(agent_id),
     };
     write_entry_file(&path, &entry);
 }
@@ -646,6 +708,78 @@ mod shared_tests {
         assert_eq!(found[0].local_url, "http://127.0.0.1:9099");
     }
 
+    // ---- jekt_public_key publication (SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md §D1) ----
+
+    #[test]
+    fn a_shared_entry_publishes_the_agents_real_store_public_key() {
+        // Store-backed, not a stub: the closure installed here is the SAME
+        // shape bootstrap.rs installs, so this exercises the real
+        // resolver → Store → entry wiring rather than just the plumbing
+        // around it. That distinction matters — the last time a jekt key
+        // feature shipped, the code was correct and the real call path simply
+        // never ran it (REPORT_JEKT_SIGNING_KEY_INJECTION_GAP_2026_08_16.md).
+        //
+        // The resolver is a process-wide OnceLock, so this one test owns it
+        // for the whole test binary — hence both the resolvable and the
+        // unresolvable agent are covered here rather than in two tests that
+        // would race to set it.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let store = crate::backend::storage::store::Store::open(tmp.path()).unwrap();
+        let minted = store.agent_lan_key_ensure("agentx").unwrap();
+
+        init_jekt_public_key_resolver(move |agent_id| {
+            store.agent_lan_public_key_load(agent_id).ok().flatten()
+        });
+
+        let dir = tempfile::tempdir().unwrap();
+        write_shared(dir.path(), "agentx", "http://127.0.0.1:9001", "block1", "dev-a");
+        let found = lookup_all_shared(dir.path(), "agentx");
+        assert_eq!(found.len(), 1);
+        assert_eq!(
+            found[0].jekt_public_key, minted.public_key,
+            "the shared entry must publish the agent's real public key from the store"
+        );
+        assert_ne!(
+            found[0].jekt_public_key, minted.private_key,
+            "the PRIVATE half must never reach the shared registry"
+        );
+
+        // Case-insensitivity: registry ids are lowercased on the path, the
+        // store lowercases on lookup — a display-cased name must still resolve.
+        write_shared(dir.path(), "AgentX", "http://127.0.0.1:9001", "block1", "dev-b");
+        let cased = lookup_all_shared(dir.path(), "agentx");
+        assert!(cased.iter().all(|e| e.jekt_public_key == minted.public_key));
+
+        // An agent with no LAN keypair minted yet publishes an empty key
+        // rather than failing the write. Empty means "cannot check" (§6) —
+        // the registry write itself must stay infallible.
+        write_shared(dir.path(), "agenty", "http://127.0.0.1:9002", "block2", "dev-a");
+        let other = lookup_all_shared(dir.path(), "agenty");
+        assert_eq!(other.len(), 1);
+        assert!(other[0].jekt_public_key.is_empty());
+    }
+
+    #[test]
+    fn an_entry_written_before_this_shipped_still_deserializes_with_an_empty_key() {
+        // §6 backward compatibility: a pre-upgrade file has no
+        // `jekt_public_key` member at all. It must load (not error), and it
+        // must load as EMPTY — which the verifier maps to "cannot check",
+        // never to "failed the check". Getting this wrong escalates every
+        // sender on a mixed-version machine.
+        let dir = tempfile::tempdir().unwrap();
+        let agent_dir = shared_agent_dir(dir.path(), "agentz");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        let legacy = r#"{"agent_id":"agentz","local_url":"http://127.0.0.1:9003",
+            "block_id":"b3","pid":1,"updated_at":1,"auth_key":"k","channel":"dev-a",
+            "registration_nonce":0}"#;
+        std::fs::write(shared_channel_path(dir.path(), "agentz", "dev-a"), legacy).unwrap();
+
+        let found = lookup_all_shared(dir.path(), "agentz");
+        assert_eq!(found.len(), 1, "a pre-upgrade entry must still deserialize");
+        assert!(found[0].jekt_public_key.is_empty());
+        assert_eq!(found[0].auth_key, "k", "the other fields must survive intact");
+    }
+
     #[test]
     fn lookup_all_shared_sorts_freshest_first() {
         let dir = tempfile::tempdir().unwrap();
@@ -855,6 +989,7 @@ mod shared_tests {
             auth_key: String::new(),
             channel: "dev-a".to_string(),
             registration_nonce: 0,
+            jekt_public_key: String::new(),
         }
     }
 

--- a/agentmux-srv/src/bootstrap.rs
+++ b/agentmux-srv/src/bootstrap.rs
@@ -864,6 +864,23 @@ pub fn open_stores_and_migrate(config: &config::Config, version: &str, build_tim
         }
     }
 
+    // Let the cross-instance agent registry publish each agent's Ed25519
+    // PUBLIC key alongside its entry, so a peer instance in a *different
+    // channel* can verify that agent's jekts — the one same-machine tier that
+    // had no verification path at all before
+    // `SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md`. Host-tier's HMAC key is
+    // symmetric and deliberately NOT published (spec §5).
+    //
+    // Installed here rather than next to `init_local_auth_key` in
+    // `load_config` because that runs before any store is open, and this is a
+    // per-agent lookup rather than a process constant. Registry writes before
+    // this point simply publish an empty key, which readers treat as "cannot
+    // check."
+    crate::backend::reactive::registry::init_jekt_public_key_resolver({
+        let wstore = wstore.clone();
+        move |agent_id| wstore.agent_lan_public_key_load(agent_id).ok().flatten()
+    });
+
     Stores {
         wstore,
         filestore,

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -2823,6 +2823,7 @@ mod fleet_tests {
             auth_key: auth_key.to_string(),
             channel: "test-channel".to_string(),
             registration_nonce: 0,
+            jekt_public_key: String::new(),
         };
         std::fs::write(dir.join("test-channel.json"), serde_json::to_string(&entry).unwrap()).unwrap();
     }

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -315,7 +315,7 @@ partial list.
 | [`jekt-visibility-completion`](jekt-visibility-completion.md) | Spec: Jekt Visibility Completion — persistent-agent visibility + outgoing echo |
 | [`swarm-active-pane-sync`](swarm-active-pane-sync.md) | Swarm ↔ Pane Two-Way Active-Row Sync |
 
-### active (13)
+### active (14)
 
 | Spec | Title |
 |---|---|

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -329,6 +329,7 @@ partial list.
 | [`SPEC_DOCS_LIFECYCLE_HARDENING_2026_08_03`](SPEC_DOCS_LIFECYCLE_HARDENING_2026_08_03.md) | Docs Lifecycle Audit & Hardening Plan |
 | [`SPEC_EDITOR_MCP_OPEN_BLANK_PREVIEW_AND_PANE_REUSE_2026_08_03`](SPEC_EDITOR_MCP_OPEN_BLANK_PREVIEW_AND_PANE_REUSE_2026_08_03.md) | Plan: MCP-opened markdown blank-preview investigation + Editor-pane reuse |
 | [`SPEC_HEADLESS_TRANSIENT_RETRY_2026_08_31`](SPEC_HEADLESS_TRANSIENT_RETRY_2026_08_31.md) | Transient-failure retry for turns with no rendered pane |
+| [`SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02`](SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md) | SPEC: Cross-channel jekt trust — closing the last unverifiable same-machine tier |
 | [`SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03`](SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03.md) | Migration System Audit & Hardening Plan |
 | [`SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29`](SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29.md) | Spec: multi-tier discovery + remote API invocation over muxbus |
 | [`SPEC_WINDOW_NAME_API_HARDENING_2026_08_08`](SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md) | SPEC: Window-name App API hardening (phantom-id success + status codes) |

--- a/docs/specs/SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md
+++ b/docs/specs/SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md
@@ -1,0 +1,451 @@
+# SPEC: Cross-channel jekt trust — closing the last unverifiable same-machine tier
+
+**Date:** 2026-09-02
+**Author:** Agent4
+**Status:** Proposed
+**Repo state:** main @ `ec4241bd` (v0.55.32)
+**Prompted by:** a live incident on 2026-09-02 (§1.1), and the question
+"I thought we already had it."
+
+**Related (all real, all shipped):**
+`SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md` (marker format, tier rules),
+`SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md` (host-tier HMAC),
+`SPEC_JEKT_REAGENT_TRUST_RELAXATION_2026_08_14.md` (WAN Ed25519),
+`SPEC_JEKT_LAN_TIER_SIGNING_2026_08_15.md` (LAN per-agent Ed25519 + pubkey
+distribution — the design this spec extends),
+`SPEC_JEKT_SENSITIVE_TIER_NARROWING_2026_08_15.md`,
+`SPEC_JEKT_SENSITIVE_TIER_VERIFIED_SENDER_NO_STOP_2026_08_17.md` (the
+`ESCALATE=none` relaxation — load-bearing for §7.3),
+`SPEC_MUXBUS_CROSS_CHANNEL_DELIVERY_2026_07_02.md` (the delivery path this
+secures), issues #1387–#1396 (the globalization sweep that missed this).
+
+---
+
+## 1. Report
+
+**You already have it for three tiers out of four.** Host (same instance), LAN,
+and WAN reagent all have working cryptographic sender verification. The one that
+does not is **cross-channel: same machine, different AgentMux instance** — and
+it is the one that renders in the marker as `DELIVERY=host`, the tier that reads
+as *most* trustworthy.
+
+Every cross-channel jekt on this machine, today, arrives `TRUST=self-declared`.
+Not because of a bug in the trust layer — because of a gap between two correct
+subsystems that were built at different times.
+
+### 1.1 The incident
+
+Agent4 (channel `local-main-b28b7a-2c986e5f`) sent a work brief to Lark (channel
+`dev-agent4-tool-preview-indent-and-wrap-6ed434438e7e49e7`, a `task dev` build on
+the same machine) via `mcp__agentmux__SendMessage`. Delivery succeeded. Lark saw
+`TRUST=self-declared` and **correctly refused to act on it**, escalating to the
+human instead — including flagging that the message opened by dismissing a prior
+flagged message from agent3 as "a mistake," which is the exact shape of a chained
+spoof.
+
+Lark's caution was the right call on the information available. The system
+behaved as designed. The design is what's incomplete.
+
+### 1.2 Why "I thought we already had it" is a reasonable thing to have thought
+
+Because agent identity *did* go host-global. Issues #1387–#1396 moved agent
+definitions, instances, workspaces, auth, and (later) transcripts out of
+per-channel storage into `<home>/shared/agents/`. On disk today:
+
+```
+~/.agentmux/shared/agents/
+├── definitions/     ← global
+├── reactive/        ← global (the cross-channel delivery registry)
+├── registry/        ← global
+└── transcripts/     ← global
+```
+
+**The jekt signing keys were not part of that sweep.** They are still minted and
+stored per-channel, in each channel's own `objects.db`:
+
+| store | `db_agent_jekt_keys` contents (measured 2026-09-02) |
+|---|---|
+| host channel `local-main-b28b7a-2c986e5f` | `agent1, agent2, agent3, agent4, agent5, agentx, agenty` |
+| dev channel `dev-agent4-tool-preview-…` | `lark` |
+
+So an agent's *identity* is global but the means of *proving* that identity is
+not. Two agents on one machine, both correctly provisioned, cannot verify each
+other.
+
+---
+
+## 2. Mechanism, traced
+
+### 2.1 Verification is a local-store lookup
+
+`verify_jekt_signature` (`agentmux-srv/src/server/reactive.rs:172`):
+
+```rust
+let Ok(Some(key)) = state.wstore.agent_jekt_key_load(&claimed) else {
+    return;          // ← cross-channel sender lands here, every time
+};
+```
+
+`agent_jekt_key_load` (`backend/storage/agent_jekt_keys.rs:43`) reads
+`db_agent_jekt_keys` in **this instance's own** Store. A foreign-channel sender
+is never in it, so the function returns early and `req.sig_verified` stays
+`None` → `TRUST=self-declared`.
+
+This is not an oversight in that function — its doc comment is explicit that it
+"only ever does anything when `agent_jekt_key_load` finds a LOCAL key." It was
+written for a world where the only same-machine sender was a same-instance one.
+
+### 2.2 The signature is almost certainly being produced
+
+The sending side is fine. `inject_jekt_signing_keys_into_mcp_json`
+(`backend/agent_config.rs:1275`) patches `AGENTMUX_JEKT_KEY` into the agent's
+**MCP server** env block in `.mcp.json` — deliberately not into the agent's own
+environment, so a compromised model can neither read nor forge with it.
+Verified on agent4:
+
+```
+agent's shell env:  AGENTMUX_JEKT_KEY  ABSENT      ← by design
+agent's .mcp.json:  AGENTMUX_JEKT_KEY  present     ← 44 bytes, base64
+                    AGENTMUX_LAN_KEY   present     ← 44 bytes, Ed25519 seed
+```
+
+The message is signed. There is simply nobody on the receiving side holding the
+matching secret.
+
+### 2.3 The tier label is wrong, which makes it worse
+
+`resolve_delivery_tier` (`reactive.rs:378`):
+
+```rust
+if auth_via == ReactiveAuthVia::LanKey { "lan" } else { claimed.unwrap_or("host") }
+```
+
+A cross-channel forward authenticates with the **peer instance's full
+`auth_key`** (published in the shared registry entry — see §2.4), not a
+`lan_key`. So it resolves to `host`. The reader sees `DELIVERY=host`, which
+truthfully means "same machine" but implies "verifiable," which it is not.
+
+`DELIVERY=lan` at least tells you a machine boundary was crossed. Cross-channel
+gets the *strongest*-sounding label with the *weakest* guarantee.
+
+### 2.4 The distribution channel already exists
+
+`registry/paths.rs:90` — `resolve_shared_reactive_dir()` →
+`<home>/shared/agents/reactive/<agent_id>/<channel>.json`. A real entry:
+
+```json
+{ "agent_id": "Agent4",
+  "local_url": "http://127.0.0.1:63062",
+  "block_id": "7dc7acae-…", "pid": 2456, "updated_at": 1788385773504,
+  "auth_key": "<36 bytes>",
+  "channel": "local-main-b28b7a-2c986e5f",
+  "registration_nonce": 0 }
+```
+
+Host-global, one file per (agent, channel), already written on every
+registration, already read by the cross-channel forward path. It carries an
+*instance* auth key. It carries **no agent key material at all**. That is the
+hook point this spec uses.
+
+---
+
+## 3. The second, sharper problem
+
+Right now, `None` ("nothing to check against") is benign — it settles at
+`TIER=coord` per the 2026-08-15 narrowing. That is correct *today*, because for
+a cross-channel sender there is genuinely nothing to check.
+
+**The moment we can resolve cross-channel identities, that stops being safe.**
+If "I couldn't find a key" and "I found a key and you didn't sign" both produce
+`None`, an attacker impersonating a cross-channel agent simply omits the
+signature and gets the benign path. The fix would be bypassable by not using it.
+
+This is the same class of bug reagentx already caught once on the LAN signing PR:
+`verify_jekt_signature` was originally gated on `delivery_tier == "host"`, which
+meant claiming `delivery_tier: "lan"` dodged the check entirely. The fix was to
+run it unconditionally. Same shape here, one level up.
+
+So §4 has two halves, and **the second is the one that actually buys trust:**
+publishing keys (D1–D2) makes verification *possible*; requiring a signature once
+identity is resolvable (D3) makes it *meaningful*.
+
+---
+
+## 4. Design
+
+### D1 — Publish an Ed25519 **public** key in the shared registry entry
+
+Add to `AgentEntry` (`backend/reactive/registry.rs`):
+
+```rust
+/// Base64 Ed25519 PUBLIC key for this agent, for cross-channel jekt
+/// signature verification. Public half only — safe in a world-readable
+/// file. Empty for entries written before this shipped (§6).
+#[serde(default)]
+pub jekt_public_key: String,
+```
+
+Derived from the agent's **existing** LAN keypair (`AGENTMUX_LAN_KEY`,
+`jekt_sign::generate_lan_keypair`) — no new key material, no new provisioning
+step, no respawn required for any agent that already has a LAN key. Written at
+the same moment the entry is written.
+
+### D2 — `verify_cross_channel_signature`
+
+New function in `server/reactive.rs`, mirroring `verify_lan_signature`'s
+structure but resolving the pubkey from the local filesystem instead of a LAN
+round trip (so it is **synchronous** — no network, no rate limiter, none of the
+`LanPubkeyLookup::Skipped` hazard):
+
+```
+1. claimed = req.source_agent, non-empty                      else → return
+2. if agent_jekt_key_load(claimed).is_some() → return
+      (same-instance sender; verify_jekt_signature owns it)
+3. entries = shared registry entries for `claimed` across ALL channels
+4. if entries is empty                       → return   (sig_verified stays None)
+5. verified = req.channel_sig present
+           && ts within JEKT_SIG_MAX_AGE_SECS
+           && any(entry.jekt_public_key verifies the signature)
+6. req.channel_verified = Some(verified)
+```
+
+Step 2 is the ordering guarantee: a same-instance sender keeps the existing
+HMAC path untouched. This function only ever fires for senders this instance did
+not spawn.
+
+Step 5 iterates entries because one agent name can legitimately exist in several
+channels at once (that is exactly why `AgentEntry.channel` exists). A verifying
+match on any of them proves the sender holds that agent's private key.
+
+### D3 — Resolvable identity ⇒ signature required
+
+`channel_verified` is three-state, exactly like `sig_verified` /
+`lan_verified` / `reagent_verified`:
+
+| state | meaning | `TRUST=` | escalation |
+|---|---|---|---|
+| `None` | no entry in the shared registry — a genuine bridge, or an agent that has never registered | `self-declared` | unchanged (benign) |
+| `Some(true)` | signature verified against a published pubkey | **`channel-verified`** *(new)* | never forced sensitive by trust alone |
+| `Some(false)` | entry found, signature missing or wrong | `unverified` | **forced `TIER=sensitive`, `ESCALATE=required`, unconditionally** |
+
+`Some(false)` is the load-bearing row. It is an *active* red flag — someone
+claimed a specific, known agent's identity and could not prove it — and gets the
+same treatment as host-tier `TRUST=unverified` and WAN `SIG=invalid`.
+
+**New `TRUST` value, not a reuse of `host-verified`.** This follows the
+precedent `lan-verified` set: each tier gets its own label, so a reader can tell
+*how* identity was proven, not just *that* it was. `channel-verified` makes the
+same strength claim as `host-verified` for the purposes of the 2026-08-17
+`ESCALATE=none` rule, and must be added to that rule's verified-sender list.
+
+### D4 — `DELIVERY=channel`, a tier of its own
+
+`resolve_delivery_tier` gains a case: a request that arrived via cross-instance
+forward (identifiable — the forwarding peer authenticates with an `auth_key`
+belonging to a *different* channel's registry entry) resolves to `channel`, not
+`host`. Reserving `host` for genuinely same-instance traffic means the label
+finally matches the guarantee.
+
+### D5 — Domain separation and channel binding
+
+Cross-channel signatures use a distinct payload from LAN ones, via a new
+`jekt_sign::sign_channel_jekt` / `verify_channel_jekt` pair:
+
+```
+"amx-jekt-channel-v1" || msgid || source_agent || source_channel
+                      || target_agent || ts_secs || message
+```
+
+Two reasons, both necessary:
+
+- **Domain separator** (`amx-jekt-channel-v1`): without it, the same Ed25519 key
+  signs byte-identical payloads for LAN and cross-channel. A LAN signature
+  captured off the wire could be replayed as a cross-channel one, and vice
+  versa. Cheap to add now, impossible to add later without a flag day.
+- **`source_channel`**: binds the signature to the channel that minted it, so a
+  signature legitimately produced in channel A cannot be replayed as coming from
+  channel B. Without it, an attacker who can read one channel's traffic can
+  impersonate that agent's messages as if they came from any other channel it
+  runs in.
+
+### D6 — Anti-replay window
+
+Reuse host-tier's `JEKT_SIG_MAX_AGE_SECS` (300s), **not** LAN/WAN's 600s.
+Cross-channel is a same-machine HTTP call to `127.0.0.1`; it has no
+real-network-latency budget to accommodate. The tighter window is the correct
+one, for the same reason host-tier uses it.
+
+---
+
+## 5. Rejected alternative: globalize `db_agent_jekt_keys`
+
+This is the obvious move — "identity is already global, make the keys global
+too" — and is very likely what was assumed to have happened. It is a one-table
+migration and it would make verification work. **Reject it.**
+
+The host-tier key is a **symmetric HMAC secret**. Putting it in a host-global
+store hands *every srv instance on the machine* the ability to **mint** a valid
+signature for *every agent on the machine*.
+
+That matters specifically because of how this machine is used. `task package`
+and `task dev` create a fresh channel per build, and this machine routinely runs
+many of them, built from arbitrary feature branches (`local-<branch>-<hash>-…`,
+per `SPEC_LOCAL_BUILD_VERSIONING_2026_05_28.md`). Today a rogue or simply broken
+srv build can only forge identities *within its own channel*. Globalizing a
+symmetric secret would let any build on the machine forge as any agent in any
+channel — including the stable one. That is a strictly worse posture than the
+gap it closes.
+
+Asymmetric publication (D1) has no such property: the shared file carries only
+public halves, and a channel can still only sign as agents whose private keys it
+actually holds.
+
+The corollary is worth stating plainly: **`db_agent_jekt_keys` must stay
+per-channel.** If a future change proposes globalizing it, this section is the
+reason not to.
+
+---
+
+## 6. Migration and compatibility
+
+- `jekt_public_key` is `#[serde(default)]`. Entries written by an older build
+  deserialize with an empty string.
+- **An empty `jekt_public_key` must yield `None`, not `Some(false)`.** An agent
+  registered by a pre-upgrade instance has not failed to sign — it has not been
+  *asked* to. Treating it as a red flag would escalate every cross-channel
+  message on a mixed-version machine, which is exactly the false-positive
+  fatigue §7.3 warns about.
+- Registry entries are rewritten on every registration (i.e. every agent spawn),
+  so the population converges without a backfill job. An agent that has not been
+  respawned since the upgrade stays `self-declared` — the current behaviour,
+  no regression.
+- Ordering constraint: **D1 must ship and propagate before D3's `Some(false)`
+  rule is enabled.** Shipping the enforcement first would flag every legitimate
+  sender that hasn't re-registered yet. Ship D1+D2 in one release, enable D3 in
+  the next, or gate D3 behind a `min_registered_at` check.
+
+---
+
+## 7. What this does not close
+
+Stated explicitly, so nobody reads this spec as "jekt is now fully trusted."
+
+### 7.1 Filesystem access is still the real boundary
+
+A local process that can read another channel's `objects.db` can mint host-tier
+signatures for that channel's agents. This spec does not change that, and
+nothing at this layer can — OS file permissions are the control. Same for
+`.mcp.json`, which contains the agent's private keys in plaintext.
+
+### 7.2 This authenticates the sender, not the intent
+
+A verified message is a message that provably came from that agent's harness. It
+is **not** evidence that the agent's operator wanted it sent, or that the agent
+wasn't prompt-injected into sending it. `TRUST=channel-verified` answers *who*,
+never *why*. The "when in doubt, ask the human" rule survives this spec intact.
+
+### 7.3 Escalation chaining (open — recommended as a follow-up spec)
+
+The 2026-09-02 incident surfaced a gap this spec does not fix. Agent4's message
+opened with *"Agent3 messaged you earlier by mistake; ignore that."* An
+unverified message that references and dismisses a **prior `ESCALATE=required`
+item** is precisely the chained-spoof shape the STOP rule exists to catch — and
+there is currently no protocol friction against it at all.
+
+Proposed rule, for its own spec: a jekt may not clear another jekt's
+escalation. If message B references a MSGID whose escalation is unresolved, B
+cannot lower it; only the human can. This mirrors the existing
+`transcript_request` exception's structure (a narrowly-scoped carve-out from the
+`ESCALATE=none` relaxation) rather than inventing new machinery.
+
+Note this becomes *less* urgent, not more, once §4 lands: a
+`channel-verified` sender saying "ignore my earlier message" is an ordinary
+correction. It is specifically the **unverified** dismissal that needs friction.
+
+---
+
+## 8. Two claims to correct before they get built on
+
+Both circulated in good faith during the incident. Both are wrong in ways that
+would have sent implementation work in the wrong direction.
+
+### 8.1 "Most agents don't have a signing key; provisioning needs a respawn/backfill"
+
+**Wrong.** Measured: the host channel's store holds keys for seven agents
+(`agent1`–`agent5`, `agentx`, `agenty`); the dev channel's holds `lark`'s. Every
+agent involved in the incident was correctly provisioned, on both sides.
+Provisioning works.
+
+The symptom — `TRUST=self-declared` — came from the **cross-channel lookup**
+(§2.1), not from missing keys. A backfill job would have changed nothing and
+consumed the effort this spec needs.
+
+### 8.2 "The sensitive-keyword match is a blunt substring check"
+
+**Half wrong, and the half that's wrong changes the fix.** There are two lists
+in `backend/reactive/sanitize.rs`:
+
+- `SENSITIVE_SUBSTRING_KEYWORDS` (:168) — substring-matched, but only
+  distinctive multi-character strings (`api_key`, `rm -rf`, `--force`,
+  `private key`, …). **`token` is not in this list.**
+- `SENSITIVE_WHOLE_WORD_KEYWORDS` — matched by `contains_whole_word` (:184),
+  which does real word-boundary checks and optional plural handling.
+
+`token` is whole-word matched. So the observed false positive (the word "token"
+used to mean *lexical token* in a UI-wrapping discussion) is a **semantic**
+collision, not a lexical one. Tightening word boundaries would change nothing;
+the matcher is already boundary-aware.
+
+**Recommendation: don't tune the keyword list.** Per
+`SPEC_JEKT_SENSITIVE_TIER_VERIFIED_SENDER_NO_STOP_2026_08_17.md`, a keyword
+match from a *verified* sender is `ESCALATE=none` — a visibility tag, not a
+stop. Cross-channel senders are currently unverifiable, so **every** keyword
+false positive between channels becomes a hard STOP. Landing §4 converts that
+whole class into a tag automatically, without touching the list or weakening
+detection for genuinely unproven senders.
+
+This is the strongest argument for prioritising this spec: it is also the fix
+for the escalation-fatigue problem.
+
+---
+
+## 9. Test plan
+
+Unit (`server/reactive.rs`, `jekt_sign.rs`):
+
+1. Cross-channel sender, valid signature → `channel_verified == Some(true)`,
+   `TRUST=channel-verified`, tier not forced.
+2. Cross-channel sender, **no** signature, entry present → `Some(false)`,
+   `TIER=sensitive`, `ESCALATE=required`.
+3. Cross-channel sender, **wrong** signature → `Some(false)`, as above.
+4. Cross-channel sender, entry present but `jekt_public_key` empty (pre-upgrade)
+   → `None`, `self-declared`, **not** escalated. (§6)
+5. Unknown sender, no registry entry anywhere → `None`, `self-declared`.
+6. Same-instance sender → `verify_cross_channel_signature` is a no-op; existing
+   HMAC path result unchanged. (D2 step 2)
+7. Signature valid but `ts` outside 300s → `Some(false)`. (D6)
+8. Agent registered in two channels; signature from one verifies. (D2 step 5)
+9. **A valid LAN signature, replayed as a cross-channel signature, fails**, and
+   vice versa. (D5 domain separator — this test is the whole point of D5.)
+10. **A signature minted for channel A, replayed with `source_channel` = B,
+    fails.** (D5 channel binding.)
+11. Keyword match + `channel-verified` → `ESCALATE=none`. (§8.2)
+
+Integration: two `task dev` instances on one machine, message each other both
+directions, assert markers. This is cheap to run — the incident that prompted
+this spec was exactly that setup, by accident.
+
+---
+
+## 10. Phasing
+
+| Phase | Content | Ships with |
+|---|---|---|
+| **A** | D1 (publish pubkey), D5 (`sign_channel_jekt`/`verify_channel_jekt` + tests 9–10) | one release |
+| **B** | D2 (verification), D4 (`DELIVERY=channel`), `channel-verified` added to the 08-17 verified-sender list; `Some(false)` **not yet** escalating | next release |
+| **C** | D3 enforcement (`Some(false)` → forced sensitive) | after A has propagated (§6) |
+| **D** | §7.3 escalation-chaining rule | separate spec |
+
+Phase C is the one that must not be rushed forward. Phases A and B are
+strictly additive — they can only move messages from `self-declared` to
+`channel-verified`, never the reverse.

--- a/docs/specs/SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md
+++ b/docs/specs/SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md
@@ -2,7 +2,10 @@
 
 **Date:** 2026-09-02
 **Author:** Agent4
-**Status:** Proposed
+**Status:** **Phase A implemented** 2026-09-02 (D1 publication + D5 signing
+primitives). Phases B–D still proposed — see §10. Phase A is strictly additive:
+it publishes a public key and adds two unused functions. Nothing reads
+`jekt_public_key` yet, so no message's `TRUST=` can change until Phase B.
 **Repo state:** main @ `ec4241bd` (v0.55.32)
 **Prompted by:** a live incident on 2026-09-02 (§1.1), and the question
 "I thought we already had it."
@@ -441,7 +444,7 @@ this spec was exactly that setup, by accident.
 
 | Phase | Content | Ships with |
 |---|---|---|
-| **A** | D1 (publish pubkey), D5 (`sign_channel_jekt`/`verify_channel_jekt` + tests 9–10) | one release |
+| **A** ✅ | D1 (publish pubkey), D5 (`sign_channel_jekt`/`verify_channel_jekt` + tests 9–10) | **implemented 2026-09-02** |
 | **B** | D2 (verification), D4 (`DELIVERY=channel`), `channel-verified` added to the 08-17 verified-sender list; `Some(false)` **not yet** escalating | next release |
 | **C** | D3 enforcement (`Some(false)` → forced sensitive) | after A has propagated (§6) |
 | **D** | §7.3 escalation-chaining rule | separate spec |
@@ -449,3 +452,42 @@ this spec was exactly that setup, by accident.
 Phase C is the one that must not be rushed forward. Phases A and B are
 strictly additive — they can only move messages from `self-declared` to
 `channel-verified`, never the reverse.
+
+### 10.1 Phase A as built (2026-09-02)
+
+| Piece | Location |
+|---|---|
+| `sign_channel_jekt` / `verify_channel_jekt`, `CHANNEL_DOMAIN`, `channel_signed_material` | `agentmux-common/src/jekt_sign.rs` |
+| `AgentEntry::jekt_public_key` | `agentmux-srv/src/backend/reactive/registry.rs` |
+| `init_jekt_public_key_resolver` (mirrors `init_local_auth_key`) | same file |
+| Resolver wired to the Store | `agentmux-srv/src/bootstrap.rs`, end of `open_stores_and_migrate` |
+
+Notes on what was decided during implementation:
+
+- **The resolver is an indirection, not a `Store` handle.** `registry.rs` is
+  deliberately pure-filesystem and is called from three paths that share no
+  `Store` argument (PTY auto-register, persistent-controller auto-register, the
+  HTTP register handler). A process-wide set-once resolver mirrors the existing
+  `LOCAL_AUTH_KEY` pattern; the value is per-agent, so it is a lookup rather
+  than a constant.
+- **Load, never ensure.** The registry write path calls
+  `agent_lan_public_key_load`, not `..._ensure`. Registry writes happen on every
+  registration; minting key material as a side effect of a bookkeeping write
+  would be a surprising place for it. Key creation stays at config-injection
+  time, where it already is.
+- **Ordering verified:** the resolver is installed at `main.rs:69`
+  (`open_stores_and_migrate`); the HTTP server starts accepting registrations at
+  `main.rs:168`. No registry write can precede installation.
+- **Coverage verified:** `inject_jekt_signing_keys_into_mcp_json` calls
+  `agent_lan_key_ensure` unconditionally for every agent, independent of whether
+  LAN discovery is enabled — so every provisioned agent has a keypair to
+  publish. Measured on this machine: 7/7 host-channel agents and 1/1 dev-channel
+  agent have one.
+- **Not yet verified end-to-end in a live instance.** The store-backed test
+  covers resolver → Store → entry with the same closure shape bootstrap
+  installs, and the ordering above is confirmed by inspection, but no running
+  srv has yet written an entry carrying a non-empty key. Confirm by restarting
+  an instance and checking
+  `~/.agentmux/shared/agents/reactive/<agent>/<channel>.json`. This is the exact
+  failure mode `REPORT_JEKT_SIGNING_KEY_INJECTION_GAP_2026_08_16.md` records
+  (correct code, real path never ran it), so it is worth actually looking.

--- a/docs/specs/SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md
+++ b/docs/specs/SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md
@@ -16,8 +16,9 @@ distribution — the design this spec extends),
 `SPEC_JEKT_SENSITIVE_TIER_NARROWING_2026_08_15.md`,
 `SPEC_JEKT_SENSITIVE_TIER_VERIFIED_SENDER_NO_STOP_2026_08_17.md` (the
 `ESCALATE=none` relaxation — load-bearing for §7.3),
-`SPEC_MUXBUS_CROSS_CHANNEL_DELIVERY_2026_07_02.md` (the delivery path this
-secures), issues #1387–#1396 (the globalization sweep that missed this).
+issue #1916 (MuxBus Tier 2b same-host cross-channel delivery — the delivery
+path this secures; note the spec filename cited for it in `registry.rs` and
+`registry/paths.rs` has never existed), issues #1387–#1396 (the globalization sweep that missed this).
 
 ---
 

--- a/docs/specs/SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md
+++ b/docs/specs/SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md
@@ -2,14 +2,11 @@
 
 **Date:** 2026-09-02
 **Author:** Agent4
-**Status:** **Phase A implemented** 2026-09-02 (D1 publication + D5 signing
-primitives). Phases B–D still proposed — see §10. Phase A is strictly additive:
-it publishes a public key and adds two unused functions. Nothing reads
-`jekt_public_key` yet, so no message's `TRUST=` can change until Phase B.
-**Repo state:** main @ `ec4241bd` (v0.55.32)
-**Prompted by:** a live incident on 2026-09-02 (§1.1), and the question
-"I thought we already had it."
-
+**Status:** active — Phase A (D1 key publication + D5 signing primitives)
+shipped in #2959. Phases B (verification), C (enforcement) and D (escalation
+chaining) remain — see §10. Phase A is strictly additive: it publishes a public
+key and adds two as-yet-unused functions, so no message's `TRUST=` can change
+until Phase B.
 **Related (all real, all shipped):**
 `SPEC_JEKT_SECURITY_AND_VISIBILITY_2026_07_01.md` (marker format, tier rules),
 `SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md` (host-tier HMAC),


### PR DESCRIPTION
## Summary

Host, LAN and WAN-reagent all have working cryptographic sender verification. **Cross-channel — same machine, different AgentMux instance — does not**, and it is the tier that renders as `DELIVERY=host`, the label that reads as most trustworthy. Every cross-channel jekt on this machine currently arrives `TRUST=self-declared`.

Found live: a message between two instances on this machine was correctly refused by the receiving agent because it had no way to tell who sent it.

## Root cause

A gap between two correct subsystems. Agent identity went host-global in #1387–#1396 — definitions, instances, workspaces, auth and transcripts all live under `~/.agentmux/shared/agents/` now. **The jekt signing keys were not part of that sweep**; they are still minted per-channel in each channel's own `objects.db`. Measured on this machine:

| store | `db_agent_jekt_keys` |
|---|---|
| host channel | `agent1…agent5, agentx, agenty` |
| dev channel | `lark` |

So an agent's *identity* is global but the means of *proving* it is not, and `verify_jekt_signature`'s local-store lookup returns `None` every time.

## What this PR contains (Phase A only — strictly additive)

Nothing reads `jekt_public_key` yet, so **no message's `TRUST=` can change until Phase B**.

- **D1** — `AgentEntry` gains `jekt_public_key`: the base64 Ed25519 **public** half of the agent's existing LAN keypair, published to the host-global shared registry on every registration. Reuses `AGENTMUX_LAN_KEY`; `agent_lan_key_ensure` already runs unconditionally for every agent at config-injection time, so coverage is complete on day one (measured: 7/7 host-channel agents, 1/1 dev-channel).
- **D5** — `sign_channel_jekt` / `verify_channel_jekt`, deliberately **not** reusing the LAN signed material.

## Two design points worth reviewing closely

**Why not just globalize `db_agent_jekt_keys`?** That is the obvious move and is very likely what was assumed to have happened already. §5 rejects it: that key is a **symmetric** HMAC secret, so a shared copy would let every srv build on the machine *mint* signatures for every agent in every channel. This machine routinely runs many per-build channels off arbitrary branches, so that is strictly worse than the gap it closes. Asymmetric publication has no such property. **Corollary: `db_agent_jekt_keys` must stay per-channel.**

**Why a separate signing scheme from LAN?** Two reasons, both with tests:
- A **domain separator**. Same key, same tuple — without it a LAN signature and a cross-channel signature would be byte-identical and each would verify as the other, collapsing two different trust claims verified against two different key sources.
- **`source_channel` in the signed material.** One agent name can legitimately be live in several channels at once, so without binding, a signature minted in channel A replays as that agent speaking from channel B.

## The backward-compat edge

An entry written before this shipped has no `jekt_public_key` member. It must deserialize (serde default) **and an empty value must mean "cannot check", never "failed the check"** — otherwise every pre-upgrade sender on a mixed-version machine gets escalated. Both halves are tested. Verified `AgentEntry` has no `deny_unknown_fields`, so older readers tolerate the new field.

## Testing

168 `agentmux-common` + 2987 `agentmux-srv` tests pass. The registry test is **Store-backed with the same closure shape bootstrap installs**, so it exercises the real resolver→Store→entry wiring rather than a stub — the last time a jekt key feature shipped, the code was correct and the real call path simply never ran it (`REPORT_JEKT_SIGNING_KEY_INJECTION_GAP_2026_08_16.md`).

Verified end-to-end against a running instance: after a restart on this branch, a registry entry is written carrying a populated public key.

## Not in this PR

Phase B (verification), Phase C (enforcement — a resolvable sender who doesn't sign becomes a red flag), and the escalation-chaining rule (§7.3). Phase C must not land until Phase A has propagated.

Spec: `docs/specs/SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md`

<!-- agentmux:agent_id=agent4 -->