### PR TITLE
fix(reactive): deliver to persistent agents that have not spawned yet

### DIFF
--- a/.changesets/1788421232-fix-reactive-start-a-turn-for-persistent-agents-that-have-no-ir1w.md
+++ b/.changesets/1788421232-fix-reactive-start-a-turn-for-persistent-agents-that-have-no-ir1w.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(reactive): start a turn for persistent agents that have not spawned yet

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -4106,20 +4106,43 @@ impl PersistentSubprocessController {
     /// tell those two situations apart. See
     /// `docs/reports/REPORT_JEKT_DELIVERY_DROPS_UNSPAWNED_PERSISTENT_AGENTS_2026_09_03.md`.
     ///
-    /// Deliberately `&& !spawning_in_progress`: a caller that has already
-    /// committed to spawning owns this round (see `spawning_in_progress`'s doc
-    /// comment on the concurrent-spawn TOCTOU race). Reporting "needs spawn"
-    /// during that window would invite a second, racing spawn — the exact
-    /// orphaned-child bug that field exists to prevent. That window instead
-    /// surfaces as "still starting up — try again shortly", which is retryable
-    /// by design.
+    /// **The invariant this must uphold:** `needs_spawn() == true` implies a
+    /// subsequent `send_message` takes `decide_send_action`'s `BecomeSpawner`
+    /// branch — i.e. it really spawns and delivers. It must never be true in a
+    /// state where `send_message` would instead return `SendAction::Queued`,
+    /// because `Queued` returns `Ok(())` having delivered nothing, the reactive
+    /// path maps that to `Ok(true)`, and the caller is told the message landed
+    /// when it is still sitting in the queue. `cloud_subscriber` only retries
+    /// on `!success`, so a false success is a permanently lost message.
+    ///
+    /// That is why all three exclusions are here, and each mirrors one of
+    /// `decide_send_action`'s own guards:
+    ///
+    /// - `stdin_tx.is_none()` — a live process is steerable; `inject_message`
+    ///   handles it and no turn start is wanted.
+    /// - `!spawning_in_progress` — a caller has already claimed this spawn
+    ///   round (see that field's doc comment on the concurrent-spawn TOCTOU
+    ///   race). Reporting "needs spawn" here would invite a second, racing
+    ///   spawn and orphan a child.
+    /// - `!drain_claim` — a `RetryFlush` drain owns the round. This one is
+    ///   subtle and was missed on the first cut (reagent P1 on PR #2960): when
+    ///   a drain's target process dies mid-flush, the drain **deliberately
+    ///   retains** its claim for the fallback respawn while the exit handler
+    ///   clears `stdin_tx`. Without this term, that window reports "needs
+    ///   spawn", `decide_send_action` then returns `Queued` on the
+    ///   still-held claim, and the message is silently queued while the caller
+    ///   is told it was delivered.
+    ///
+    /// Both excluded windows are retryable rather than lost: the caller gets
+    /// the original delivery error back, which is what lets it come again.
     ///
     /// Racy by nature, and safe to be: the process can exit the instant after
     /// this returns `false`. It is a routing hint, not a guarantee — the spawn
-    /// claim inside `send_message` is what actually serialises spawners.
+    /// claim inside `send_message` is what actually serialises spawners. What
+    /// it must not do is report `true` for a state that cannot spawn.
     pub fn needs_spawn(&self) -> bool {
         let inner = self.inner.lock().unwrap();
-        inner.stdin_tx.is_none() && !inner.spawning_in_progress
+        inner.stdin_tx.is_none() && !inner.spawning_in_progress && !inner.drain_claim
     }
 
     /// Ask this controller to restart itself once the current turn ends,
@@ -4509,6 +4532,59 @@ mod send_input_tests {
             !c.needs_spawn(),
             "must not invite a second spawn while one is already claimed",
         );
+    }
+
+    #[test]
+    fn needs_spawn_is_false_while_a_retry_flush_drain_holds_its_claim() {
+        // reagent P1 on PR #2960. When a RetryFlush drain's target process dies
+        // mid-flush, the drain DELIBERATELY retains `drain_claim` for the
+        // fallback respawn while the exit handler clears `stdin_tx`. Without
+        // the `!drain_claim` term this window reported "needs spawn"; the
+        // reactive path then called send_message, decide_send_action returned
+        // Queued on the still-held claim, send_message returned Ok(()) having
+        // delivered nothing, and the caller was told the message landed.
+        // cloud_subscriber only retries on !success — so that is a lost message.
+        let c = controller();
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.stdin_tx = None;
+            inner.spawning_in_progress = false;
+            inner.drain_claim = true;
+        }
+        assert!(
+            !c.needs_spawn(),
+            "a held drain claim must not be reported as spawnable — send_message would only queue",
+        );
+    }
+
+    #[test]
+    fn needs_spawn_true_implies_decide_send_action_would_actually_spawn() {
+        // The invariant, asserted directly rather than trusted: whenever
+        // needs_spawn() is true, a real send must take the BecomeSpawner branch
+        // (which spawns and delivers) and never Queued (which returns Ok having
+        // delivered nothing). Covers all four flag combinations.
+        for (stdin, spawning, drain) in [
+            (false, false, false), // the only spawnable state
+            (false, false, true),
+            (false, true, false),
+            (true, false, false),
+        ] {
+            let c = controller();
+            let (tx, _rx) = mpsc::channel::<String>(4);
+            {
+                let mut inner = c.inner.lock().unwrap();
+                inner.stdin_tx = if stdin { Some(tx) } else { None };
+                inner.spawning_in_progress = spawning;
+                inner.drain_claim = drain;
+            }
+            if c.needs_spawn() {
+                assert!(
+                    matches!(c.decide_send_action("m", None), SendAction::BecomeSpawner { .. }),
+                    "needs_spawn() was true for (stdin={stdin}, spawning={spawning}, drain={drain}) \
+                     but a real send would not have spawned",
+                );
+            }
+        }
     }
 
     #[test]

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -4093,6 +4093,35 @@ impl PersistentSubprocessController {
         self.inner.lock().unwrap().session_id.clone()
     }
 
+    /// True when this controller is registered but has **no live process and no
+    /// spawn already in flight** — the state a lazily-registered controller sits
+    /// in between `register` ("spawns on first message") and its first
+    /// `send_message`.
+    ///
+    /// In that state `inject_message` cannot deliver: it has no spawn config and
+    /// only writes to a live `stdin_tx`, so it returns "persistent process not
+    /// running". The caller can, however, start a *turn* — `run_agent_turn`
+    /// re-reads the spawn config from block metadata and calls `send_message`,
+    /// which does spawn. This predicate is what lets the reactive delivery path
+    /// tell those two situations apart. See
+    /// `docs/reports/REPORT_JEKT_DELIVERY_DROPS_UNSPAWNED_PERSISTENT_AGENTS_2026_09_03.md`.
+    ///
+    /// Deliberately `&& !spawning_in_progress`: a caller that has already
+    /// committed to spawning owns this round (see `spawning_in_progress`'s doc
+    /// comment on the concurrent-spawn TOCTOU race). Reporting "needs spawn"
+    /// during that window would invite a second, racing spawn — the exact
+    /// orphaned-child bug that field exists to prevent. That window instead
+    /// surfaces as "still starting up — try again shortly", which is retryable
+    /// by design.
+    ///
+    /// Racy by nature, and safe to be: the process can exit the instant after
+    /// this returns `false`. It is a routing hint, not a guarantee — the spawn
+    /// claim inside `send_message` is what actually serialises spawners.
+    pub fn needs_spawn(&self) -> bool {
+        let inner = self.inner.lock().unwrap();
+        inner.stdin_tx.is_none() && !inner.spawning_in_progress
+    }
+
     /// Ask this controller to restart itself once the current turn ends,
     /// instead of being torn down and replaced right now.
     ///
@@ -4441,6 +4470,47 @@ mod send_input_tests {
     /// arriving in that window (and turn end is EXACTLY when the frontend
     /// flushes queued follow-ups) would take `DeliverDirect` into a process
     /// about to receive EOF: acknowledged, then lost.
+    // ---- needs_spawn: the reactive-delivery routing predicate ----
+    // REPORT_JEKT_DELIVERY_DROPS_UNSPAWNED_PERSISTENT_AGENTS_2026_09_03.md
+
+    #[test]
+    fn needs_spawn_is_true_for_a_freshly_registered_controller() {
+        // The state every persistent controller sits in after an srv restart:
+        // registered ("spawns on first message"), no process yet. This is the
+        // case that used to fail agent-to-agent delivery permanently.
+        let c = controller();
+        assert!(c.needs_spawn());
+    }
+
+    #[test]
+    fn needs_spawn_is_false_once_a_process_is_live() {
+        // A live process can be steered mid-turn by the ordinary delivery path;
+        // starting a second turn here would be wrong.
+        let c = controller();
+        let (tx, _rx) = mpsc::channel::<String>(4);
+        c.inner.lock().unwrap().stdin_tx = Some(tx);
+        assert!(!c.needs_spawn());
+    }
+
+    #[test]
+    fn needs_spawn_is_false_while_a_spawn_is_already_in_flight() {
+        // The load-bearing case. A caller that has claimed the spawn owns this
+        // round; reporting "needs spawn" here would invite a second, racing
+        // spawn — the orphaned-child bug `spawning_in_progress` exists to
+        // prevent. This window is retryable ("still starting up"), not
+        // spawnable.
+        let c = controller();
+        {
+            let mut inner = c.inner.lock().unwrap();
+            inner.stdin_tx = None;
+            inner.spawning_in_progress = true;
+        }
+        assert!(
+            !c.needs_spawn(),
+            "must not invite a second spawn while one is already claimed",
+        );
+    }
+
     #[test]
     fn a_committed_restart_refuses_deliver_direct_even_with_a_live_stdin() {
         let c = controller();

--- a/agentmux-srv/src/bootstrap.rs
+++ b/agentmux-srv/src/bootstrap.rs
@@ -1844,11 +1844,48 @@ pub fn install_agent_turn_delivery(state: &AppState) {
                 .downcast_ref::<backend::blockcontroller::subprocess::SubprocessController>()
                 .is_some();
             if !is_subprocess {
-                return match backend::blockcontroller::deliver_agent_message(block_id, message) {
-                    Ok(backend::blockcontroller::AgentDelivery::Structured) => Ok(true),
-                    Ok(backend::blockcontroller::AgentDelivery::Pty) => Ok(false),
-                    Err(e) => Err(e),
-                };
+                match backend::blockcontroller::deliver_agent_message(block_id, message) {
+                    Ok(backend::blockcontroller::AgentDelivery::Structured) => return Ok(true),
+                    Ok(backend::blockcontroller::AgentDelivery::Pty) => return Ok(false),
+                    Err(e) => {
+                        // A persistent controller that is REGISTERED BUT NOT YET
+                        // SPAWNED can't be steered — `deliver_agent_message`
+                        // writes to a live stdin and there isn't one — but it can
+                        // be STARTED. Controllers register lazily ("spawns on
+                        // first message"), so after any srv restart every
+                        // persistent agent sits in this state until a human sends
+                        // it something from the UI. Without this fall-through,
+                        // agent-to-agent delivery to such an agent fails
+                        // permanently with "persistent process not running", and
+                        // first contact is exactly the case that breaks.
+                        // #2930 built the machinery to start a turn from here and
+                        // scoped it to subprocess controllers; this widens it to
+                        // the one other case that needs it.
+                        // docs/reports/REPORT_JEKT_DELIVERY_DROPS_UNSPAWNED_PERSISTENT_AGENTS_2026_09_03.md
+                        //
+                        // Narrow on purpose. `needs_spawn()` is false while a
+                        // spawn is already in flight (that surfaces as the
+                        // retryable "still starting up"), and false for a live
+                        // process whose delivery failed for some other reason —
+                        // both must keep returning the original error rather than
+                        // starting a second turn.
+                        let recoverable = ctrl
+                            .as_any()
+                            .downcast_ref::<backend::blockcontroller::persistent::PersistentSubprocessController>()
+                            .is_some_and(|p| p.needs_spawn());
+                        if !recoverable {
+                            return Err(e);
+                        }
+                        // Nothing was persisted or written: `inject_message`
+                        // returns before its blockfile append, so falling through
+                        // cannot double-deliver.
+                        tracing::info!(
+                            block_id = %block_id,
+                            error = %e,
+                            "reactive delivery: persistent controller not yet spawned — starting a turn instead"
+                        );
+                    }
+                }
             }
 
             // `MessageSender` is synchronous but starting a turn is not, so this
@@ -1886,7 +1923,7 @@ pub fn install_agent_turn_delivery(state: &AppState) {
             // registered by construction. Do not "simplify" this to Register.
             let Ok(handle) = tokio::runtime::Handle::try_current() else {
                 return Err(
-                    "no tokio runtime available to start a subprocess agent turn".to_string(),
+                    "no tokio runtime available to start an agent turn".to_string(),
                 );
             };
             // `block_in_place` panics on a current-thread runtime. Production is
@@ -1894,7 +1931,7 @@ pub fn install_agent_turn_delivery(state: &AppState) {
             // is correct, since the alternative is the optimistic lie above.
             if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::CurrentThread {
                 return Err(
-                    "cannot start a subprocess agent turn from a current-thread runtime"
+                    "cannot start an agent turn from a current-thread runtime"
                         .to_string(),
                 );
             }
@@ -1903,7 +1940,8 @@ pub fn install_agent_turn_delivery(state: &AppState) {
             let message = message.to_string();
             tracing::info!(
                 block_id = %block_id_owned,
-                "reactive delivery: starting subprocess agent turn (no PTY fallback)"
+                kind = if is_subprocess { "subprocess" } else { "persistent (not yet spawned)" },
+                "reactive delivery: starting agent turn (no PTY fallback)"
             );
             let started = tokio::task::block_in_place(|| {
                 handle.block_on(crate::server::agent_handlers::run_agent_turn(
@@ -1920,7 +1958,7 @@ pub fn install_agent_turn_delivery(state: &AppState) {
                     tracing::error!(
                         block_id = %block_id_owned,
                         error = %e,
-                        "reactive delivery: subprocess agent turn failed to start"
+                        "reactive delivery: agent turn failed to start"
                     );
                     Err(e)
                 }

--- a/docs/reports/REPORT_JEKT_DELIVERY_DROPS_UNSPAWNED_PERSISTENT_AGENTS_2026_09_03.md
+++ b/docs/reports/REPORT_JEKT_DELIVERY_DROPS_UNSPAWNED_PERSISTENT_AGENTS_2026_09_03.md
@@ -114,9 +114,27 @@ and only in the state that needs it.
 ```rust
 pub fn needs_spawn(&self) -> bool {
     let inner = self.inner.lock().unwrap();
-    inner.stdin_tx.is_none() && !inner.spawning_in_progress
+    inner.stdin_tx.is_none() && !inner.spawning_in_progress && !inner.drain_claim
 }
 ```
+
+**The invariant:** `needs_spawn() == true` must imply a subsequent
+`send_message` takes `decide_send_action`'s `BecomeSpawner` branch. It must
+never be true in a state where that returns `SendAction::Queued`, because
+`Queued` returns `Ok(())` having delivered nothing, the reactive path maps that
+to `Ok(true)`, and `cloud_subscriber` only retries on `!success` — so a false
+success is a permanently lost message. Each excluded flag mirrors one of
+`decide_send_action`'s own guards, and there is a test asserting the implication
+directly across all four flag combinations.
+
+`!drain_claim` was **missed on the first cut** (reagent P1 on PR #2960) and is
+the subtle one. When a `RetryFlush` drain's target process dies mid-flush, the
+drain *deliberately retains* its claim for the fallback respawn while the exit
+handler clears `stdin_tx`. In that window the original predicate reported
+"needs spawn"; the fall-through then called `send_message`, which queued on the
+still-held claim and returned `Ok(())` — reporting a delivery that had not
+happened. That is the precise failure mode this whole area is built to avoid,
+reintroduced by the fix for it.
 
 `&& !spawning_in_progress` is load-bearing, not defensive tidying. A caller that
 has already claimed the spawn owns that round — see `spawning_in_progress`'s own
@@ -151,7 +169,7 @@ non-reentrant mutex the thread already holds.
 
 ## 5. Tests
 
-Three unit tests on the predicate, which is where the correctness lives (the
+Five unit tests on the predicate, which is where the correctness lives (the
 wiring is a two-line branch on it):
 
 | Test | Asserts |
@@ -159,6 +177,8 @@ wiring is a two-line branch on it):
 | `needs_spawn_is_true_for_a_freshly_registered_controller` | the post-restart state routes to a turn start |
 | `needs_spawn_is_false_once_a_process_is_live` | a running agent keeps the mid-turn steer, no second turn |
 | `needs_spawn_is_false_while_a_spawn_is_already_in_flight` | no second racing spawn; that window stays retryable |
+| `needs_spawn_is_false_while_a_retry_flush_drain_holds_its_claim` | the reagent P1: a held drain claim is not spawnable |
+| `needs_spawn_true_implies_decide_send_action_would_actually_spawn` | the invariant itself, across all four flag combinations |
 
 Full suite: 2963 `agentmux-srv` tests passing.
 

--- a/docs/reports/REPORT_JEKT_DELIVERY_DROPS_UNSPAWNED_PERSISTENT_AGENTS_2026_09_03.md
+++ b/docs/reports/REPORT_JEKT_DELIVERY_DROPS_UNSPAWNED_PERSISTENT_AGENTS_2026_09_03.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-09-03
 **Author:** Agent4
-**Status:** Fixed
+**Status:** Fixed — verified end-to-end 2026-09-03 (§6)
 **Repo state:** main @ `25664855` (v0.55.32)
 
 **Sibling:** `REPORT_JEKT_DELIVERY_DROPS_SUBPROCESS_AGENTS_2026_09_02.md` (PR
@@ -167,18 +167,59 @@ directly, and the fall-through lives in the real sender. Surfacing a genuine
 failure is still the required behaviour; this change only adds a recovery ahead
 of it.
 
-## 6. Verification
+## 6. Verification — observed
 
-**The failure is confirmed observed** (§1) — three real sends, with matching srv
-logs on both sides.
+**Before** (§1): three real sends, matching srv logs on both sides, permanent
+`"persistent process not running"`.
 
-**The fix is unit-tested but not yet confirmed end-to-end at the time of
-writing.** The repro is: restart an instance, then send a jekt to an agent in it
-whose pane has *not* been opened. Before: permanent `"persistent process not
-running"`. Expected after: the controller spawns and the message is delivered.
-This section will be updated with the observed result — it is deliberately not
-claimed until it has actually been run, since the whole point of this report is
-a case where the machinery existed and the real path never exercised it.
+**After:** confirmed end-to-end on 2026-09-03 against a real instance.
+
+Precondition established and checked, not assumed — instance restarted, target
+agent's controller registered with no process, target's pane **not** opened by
+anyone:
+
+```
+07:52:27  persistent controller registered (spawns on first message)
+          (no "persistent process spawned" follows; 0 CLI processes for the agent)
+```
+
+A jekt was then sent from another channel. The dev instance's srv log:
+
+```
+07:52:49.089  reactive inject request received
+07:52:49.090  reactive delivery: persistent controller not yet spawned — starting a turn instead
+07:52:49.090  reactive delivery: starting agent turn (no PTY fallback)
+07:52:49.090  injected CLAUDE_CONFIG_DIR for oauth provider claude
+07:52:49.258  persistent process spawned
+07:52:56      blockfile:line_count            ← message written to the agent's conversation
+```
+
+169 ms from inject to spawn. No `structured delivery failed`. The message that
+previously would have been dropped is what started the agent.
+
+### 6.1 Caveat found during verification: the caller can see a timeout
+
+The sending client (`mcp__agentmux__SendMessage`) returned
+`error sending request for url (…/reactive/inject)` **even though delivery
+succeeded**. The spawn path is synchronous under `block_in_place` — that is
+#2930's deliberate "bounded stalling beats silent loss" trade — so first contact
+now takes as long as a CLI spawn, which can exceed the caller's HTTP timeout.
+
+This is a strictly better failure than before (message delivered vs. message
+lost), but it is not free, and it is **not fixed here**:
+
+- A caller that retries on timeout will send a second inject. By then the process
+  is live, so the retry lands as an ordinary mid-turn steer — i.e. a **duplicate
+  message**, not an error.
+- `cloud_subscriber` releases a claim for retry on `!delivery.success`. A
+  transport-level timeout is not a `success: false` response, so the interaction
+  between that retry path and a slow-but-successful spawn deserves its own look.
+
+Recommended follow-up: either make the first-contact spawn asynchronous with an
+honest "accepted, starting" response, or make the timeout long enough to cover a
+cold spawn and idempotency-key the inject so a retry cannot duplicate. Filed here
+rather than fixed because it is a distinct design question from the drop bug, and
+picking wrong is how you turn a lost message into a doubled one.
 
 ## 7. Out of scope
 

--- a/docs/reports/REPORT_JEKT_DELIVERY_DROPS_UNSPAWNED_PERSISTENT_AGENTS_2026_09_03.md
+++ b/docs/reports/REPORT_JEKT_DELIVERY_DROPS_UNSPAWNED_PERSISTENT_AGENTS_2026_09_03.md
@@ -1,0 +1,190 @@
+# REPORT: agent-to-agent delivery drops persistent agents that haven't spawned yet
+
+**Date:** 2026-09-03
+**Author:** Agent4
+**Status:** Fixed
+**Repo state:** main @ `25664855` (v0.55.32)
+
+**Sibling:** `REPORT_JEKT_DELIVERY_DROPS_SUBPROCESS_AGENTS_2026_09_02.md` (PR
+#2930). Same failure family — a controller kind that agent-to-agent delivery
+cannot actually reach — and this fix reuses the machinery that one built.
+
+---
+
+## 1. Report
+
+After **any** srv restart, a persistent (stream-json) agent cannot receive
+agent-to-agent messages until a human sends it one from the UI. Every jekt to it
+fails with:
+
+```
+inject: structured delivery failed  target_agent=Lark  error="persistent process not running"
+```
+
+The sender sees `agent not found` / a failed delivery; the target sees nothing.
+
+**Found live, not by inspection.** On 2026-09-02 I restarted a dev instance and
+then sent a routine work message to an agent in it. Three sends failed. Routing
+was fine — the cross-instance forward reached the target srv and returned 200,
+and the target's own log recorded `reactive inject request received`. It then
+refused to deliver. The agent only became reachable after its pane was reopened
+by hand.
+
+## 2. Mechanism, traced
+
+Three separate pieces, each individually correct:
+
+**2.1 Controllers register lazily.** On startup a persistent controller
+registers without a process:
+
+```
+persistent controller registered (spawns on first message)
+```
+
+(`blockcontroller/persistent.rs:4021`.) The process spawns on the first
+`send_message`, which carries a `PersistentSpawnConfig`.
+
+**2.2 `inject_message` cannot spawn — by design.**
+`persistent.rs:2154` writes to a live `stdin_tx` or fails:
+
+```rust
+let tx = inner.stdin_tx.as_ref().ok_or("persistent process not running")?;
+```
+
+Its own comment says why: *"this function has no spawn config."* Injection is a
+mid-turn **steer** into a running process, not a way to start one. That is the
+right primitive; it is simply not sufficient on its own.
+
+**2.3 The reactive path deliberately refuses to fall back to PTY.**
+`backend/reactive/handler.rs:667`:
+
+```rust
+Err(e) => {
+    // Structured controller but delivery failed (e.g. persistent
+    // process not running). Do NOT fall back to PTY keystrokes — the
+    // persistent controller rejects raw input. Surface the error.
+```
+
+Also correct: keystrokes genuinely cannot reach a stream-json agent.
+
+**2.4 The gap.** There was a third option, and nothing took it: *start a turn*.
+PR #2930 built exactly that — `run_agent_turn`, which re-reads spawn config from
+block metadata, dispatches to the right controller, and reports honestly whether
+the turn started. It already handles persistent controllers
+(`agent_handlers/input.rs:498-529` → `persistent_ctrl.send_message(message, config)`,
+the spawn-capable call). But its caller gated it to one controller kind
+(`bootstrap.rs`):
+
+```rust
+if !is_subprocess {
+    return match deliver_agent_message(block_id, message) { ... };   // ← cannot spawn
+}
+// subprocess only: run_agent_turn, which CAN spawn
+```
+
+with the comment *"Only the subprocess case changes."* A registered-but-unspawned
+persistent controller lands in that branch and gets the non-spawning path.
+
+This does not appear in #2930's own "what this PR does not change" list, so it
+reads as unnoticed rather than deferred — understandable, since that PR was
+chasing subprocess/container agents specifically.
+
+## 3. Why it matters more than it looks
+
+- **The window is every restart, for every persistent agent** — not a rare edge.
+- **It fails first contact specifically.** An agent that has been talked to is
+  fine; one that hasn't is unreachable. That is the worst possible shape for
+  agent-to-agent coordination, and it silently blocked the cross-channel trust
+  work (`SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md`) that prompted this: those
+  changes make messages *verifiable*, and this made them *undeliverable*.
+- **A human has to intervene** in what is supposed to be agent-to-agent
+  automation, and nothing says so — the target agent has no idea a message was
+  attempted.
+
+## 4. Fix
+
+Widen #2930's turn-start path to the one other controller kind that needs it,
+and only in the state that needs it.
+
+**4.1 New predicate** — `PersistentSubprocessController::needs_spawn()`
+(`persistent.rs`):
+
+```rust
+pub fn needs_spawn(&self) -> bool {
+    let inner = self.inner.lock().unwrap();
+    inner.stdin_tx.is_none() && !inner.spawning_in_progress
+}
+```
+
+`&& !spawning_in_progress` is load-bearing, not defensive tidying. A caller that
+has already claimed the spawn owns that round — see `spawning_in_progress`'s own
+doc comment on the concurrent-spawn TOCTOU race (reagentx P1 on #2360). Reporting
+"needs spawn" inside that window would invite a second, racing spawn and orphan a
+child process. That window instead surfaces as `"still starting up — try again
+shortly"`, which is retryable by design.
+
+The predicate is inherently racy — the process can exit the instant after it
+returns `false` — and that is fine. It is a routing hint; the spawn claim inside
+`send_message` is what actually serialises spawners.
+
+**4.2 Fall through on a recoverable error** (`bootstrap.rs`): on `Err` from
+`deliver_agent_message`, if the controller is persistent *and* `needs_spawn()`,
+fall through to the existing `run_agent_turn` block instead of returning. Every
+other error still returns unchanged.
+
+**No double-delivery risk:** `inject_message` returns its error *before* the
+blockfile append that would make the message visible, so nothing was written or
+persisted on the failing path.
+
+**4.3 Wording.** Four log/error strings on the now-shared path said "subprocess
+agent turn"; generalised, with a `kind` field distinguishing the two callers.
+
+**Deliberately unchanged:** the three constraints #2930 documented all still hold
+and are inherited rather than re-litigated — no optimistic `Ok(true)` before the
+fallible work runs (`cloud_subscriber` treats `success` as final and only retries
+on `!success`, so an optimistic success permanently loses the message);
+`block_in_place` under the reactive `Handler` mutex, so a slow spawn serialises
+other injections; and `TurnRegistration::Skip`, which prevents re-locking a
+non-reentrant mutex the thread already holds.
+
+## 5. Tests
+
+Three unit tests on the predicate, which is where the correctness lives (the
+wiring is a two-line branch on it):
+
+| Test | Asserts |
+|---|---|
+| `needs_spawn_is_true_for_a_freshly_registered_controller` | the post-restart state routes to a turn start |
+| `needs_spawn_is_false_once_a_process_is_live` | a running agent keeps the mid-turn steer, no second turn |
+| `needs_spawn_is_false_while_a_spawn_is_already_in_flight` | no second racing spawn; that window stays retryable |
+
+Full suite: 2963 `agentmux-srv` tests passing.
+
+Note the pre-existing test at `backend/reactive/tests.rs:1435-1453`, which
+asserts that a `"persistent process not running"` error is surfaced rather than
+swallowed, is **unaffected and still correct** — it mocks the message sender
+directly, and the fall-through lives in the real sender. Surfacing a genuine
+failure is still the required behaviour; this change only adds a recovery ahead
+of it.
+
+## 6. Verification
+
+**The failure is confirmed observed** (§1) — three real sends, with matching srv
+logs on both sides.
+
+**The fix is unit-tested but not yet confirmed end-to-end at the time of
+writing.** The repro is: restart an instance, then send a jekt to an agent in it
+whose pane has *not* been opened. Before: permanent `"persistent process not
+running"`. Expected after: the controller spawns and the message is delivered.
+This section will be updated with the observed result — it is deliberately not
+claimed until it has actually been run, since the whole point of this report is
+a case where the machinery existed and the real path never exercised it.
+
+## 7. Out of scope
+
+- **The PTY fallback decision** (§2.3) stays as-is. Correct for stream-json.
+- **ACP controllers.** `acp.rs` has its own `is_running()` and its own
+  turn-start semantics; whether it has the same gap was not investigated here.
+  Worth a look — the shape of the bug would be identical.
+- **The duplicate spawn-config logic** in `app_api/agent_io.rs` that #2930
+  flagged as a follow-up. Still a third copy; still not folded in.

--- a/docs/reports/REPORT_JEKT_DELIVERY_DROPS_UNSPAWNED_PERSISTENT_AGENTS_2026_09_03.md
+++ b/docs/reports/REPORT_JEKT_DELIVERY_DROPS_UNSPAWNED_PERSISTENT_AGENTS_2026_09_03.md
@@ -2,7 +2,9 @@
 
 **Date:** 2026-09-03
 **Author:** Agent4
-**Status:** Fixed — verified end-to-end 2026-09-03 (§6)
+**Status:** implemented — fixed in #2960 and verified end-to-end against a
+running instance on 2026-09-03 (§6). The §6.1 caveat (a slow spawn can surface
+to the caller as a transport timeout) is a separate open follow-up.
 **Repo state:** main @ `25664855` (v0.55.32)
 
 **Sibling:** `REPORT_JEKT_DELIVERY_DROPS_SUBPROCESS_AGENTS_2026_09_02.md` (PR


### PR DESCRIPTION
## Summary

After **any** srv restart, a persistent (stream-json) agent could not receive agent-to-agent messages until a human sent it one from the UI. Every jekt failed with `persistent process not running`.

Found live, not by inspection: three sends to an agent in a freshly restarted instance all failed, while the forward itself was fine — it reached the target srv, returned 200, and the target logged `reactive inject request received` before refusing to deliver.

## Mechanism

Three individually-correct pieces with a gap between them:

1. Controllers register lazily — `persistent controller registered (spawns on first message)`.
2. `inject_message` writes to a live `stdin_tx` or fails — deliberately; its own comment says *"this function has no spawn config."* It is a mid-turn **steer**, not a way to start a process.
3. The reactive path rightly refuses to fall back to PTY keystrokes, which a stream-json agent rejects outright.

The third option nobody took was to **start a turn**. #2930 built exactly that machinery — `run_agent_turn` re-reads spawn config from block meta and already dispatches to persistent controllers via the spawn-capable `send_message` — but gated its caller to subprocess controllers (*"Only the subprocess case changes"*). A registered-but-unspawned persistent controller fell into the other branch. It is **not** in #2930's "what this PR does not change" list, so it reads as unnoticed rather than deferred.

## Fix

Widen that path to the one other controller kind that needs it, and only in the state that needs it:

```rust
pub fn needs_spawn(&self) -> bool {
    let inner = self.inner.lock().unwrap();
    inner.stdin_tx.is_none() && !inner.spawning_in_progress
}
```

**The second half is load-bearing.** A caller that has already claimed the spawn owns that round; reporting "needs spawn" inside that window would invite a second racing spawn and orphan a child — the bug `spawning_in_progress` exists to prevent (reagentx P1 on #2360). That window stays retryable (`"still starting up"`) rather than becoming spawnable. There is a test for exactly this.

No double-delivery: `inject_message` returns its error *before* the blockfile append, so nothing was written on the failing path.

#2930's three constraints are inherited unchanged — no optimistic `Ok(true)` before the fallible work runs, `block_in_place` under the reactive `Handler` mutex, and `TurnRegistration::Skip`.

## Verified end-to-end, not inferred

Precondition established and checked rather than assumed — instance restarted, controller registered with no process, pane not opened by anyone. Then a cross-channel jekt:

```
07:52:27  persistent controller registered (spawns on first message)
07:52:49.089  reactive inject request received
07:52:49.090  reactive delivery: persistent controller not yet spawned — starting a turn instead
07:52:49.258  persistent process spawned
07:52:56      blockfile:line_count            ← message landed in the agent's conversation
```

169 ms, no `structured delivery failed`. The message that previously would have been dropped is what started the agent.

## Known caveat this PR does NOT fix

The sending client can see a **transport timeout even though delivery succeeded** — the spawn is synchronous under `block_in_place` (#2930's deliberate "bounded stalling beats silent loss" trade) and a cold CLI spawn can outlast the caller's HTTP timeout. Strictly better than losing the message, but a retry-on-timeout would now **duplicate** it rather than error, and a transport timeout is not the `success: false` that `cloud_subscriber`'s retry path keys on.

Recorded in §6.1 with two candidate designs (async accept, or longer timeout + idempotency key). Left unfixed deliberately — picking wrong turns a lost message into a doubled one.

## Testing

3 unit tests on the predicate (including the racing-spawn window); 2987 `agentmux-srv` tests pass. The pre-existing test asserting `persistent process not running` is surfaced rather than swallowed is unaffected and still correct — it mocks the message sender, and surfacing a genuine failure is still required; this only adds a recovery ahead of it.

Report: `docs/reports/REPORT_JEKT_DELIVERY_DROPS_UNSPAWNED_PERSISTENT_AGENTS_2026_09_03.md`

<!-- agentmux:agent_id=agent4 -->