### PR TITLE
Camper@claudius: fix(launcher): widen the Windows splash window (280px -> 460px)

### DIFF
--- a/.changesets/1788484329-fix-launcher-widen-the-windows-splash-window-to-fit-staged-s-ic96.md
+++ b/.changesets/1788484329-fix-launcher-widen-the-windows-splash-window-to-fit-staged-s-ic96.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(launcher): widen the Windows splash window to fit staged status messages

--- a/agentmux-launcher/src/splash.rs
+++ b/agentmux-launcher/src/splash.rs
@@ -49,8 +49,22 @@ use crate::startup_events::{StartupEvent, StartupStatus};
 include!(concat!(env!("OUT_DIR"), "/brain_dims.rs"));
 
 const SPLASH_PADDING: i32 = 12;
-const SPLASH_SIZE: i32 = BRAIN_W + SPLASH_PADDING * 2;
-const BRAIN_X: i32 = SPLASH_PADDING;
+// Vertical size of the brain-logo region only (280px) — was also the
+// window's WIDTH until the fix below (SPLASH_W was `= SPLASH_SIZE`), which
+// left only ~28 monospace characters per stage-telemetry row with no
+// word-wrap (`splash_text.rs` clips silently past the DIB edge). A staged
+// "still starting, first run can take longer" message for the
+// suspend->host-registration wait (see tracking issue #2940 — Windows
+// Defender's on-execution cloud reputation check for newly-extracted
+// binaries can hold this gap open 20+ seconds on a genuinely fresh
+// machine) didn't fit. BRAIN_AREA_H keeps the old value for everything
+// that used to read SPLASH_SIZE as a *height*; SPLASH_W below is now
+// independent and wider.
+const BRAIN_AREA_H: i32 = BRAIN_H + SPLASH_PADDING * 2;
+// Brain logo is centered horizontally in the now-wider window rather than
+// pinned at SPLASH_PADDING — it stays visually centered instead of
+// drifting to the left edge.
+const BRAIN_X: i32 = (SPLASH_W - BRAIN_W) / 2;
 const BRAIN_Y: i32 = SPLASH_PADDING;
 
 // ── Footer ──────────────────────────────────────────────────────────────────
@@ -92,8 +106,11 @@ const SEP_G: u8 = 0x36;
 const SEP_R: u8 = 0x36;
 
 // ── Window geometry ─────────────────────────────────────────────────────────
-const SPLASH_W: i32 = SPLASH_SIZE;
-const SPLASH_H: i32 = SPLASH_SIZE + STAGE_AREA_H + FOOTER_H;
+// Widened from the old `= SPLASH_SIZE` (280px, ~28 chars/row) to comfortably
+// fit a one-line staged status message (~43 chars/row) without word-wrap.
+// See BRAIN_AREA_H's comment above for why.
+const SPLASH_W: i32 = 460;
+const SPLASH_H: i32 = BRAIN_AREA_H + STAGE_AREA_H + FOOTER_H;
 
 const BG_B: u8 = 0x1F;
 const BG_G: u8 = 0x1A;
@@ -422,7 +439,7 @@ fn composite(
     draw_stages(dib, stages, total_ms, restoring);
 
     // Separator line between stage area and footer.
-    let sep_y = SPLASH_SIZE + STAGE_AREA_H - STAGE_PAD_BOTTOM / 2;
+    let sep_y = BRAIN_AREA_H + STAGE_AREA_H - STAGE_PAD_BOTTOM / 2;
     let sep_x0 = STAGE_MARGIN_L;
     let sep_x1 = SPLASH_W - STAGE_MARGIN_R;
     if sep_y >= 0 && sep_y < SPLASH_H {
@@ -485,7 +502,7 @@ fn draw_border(dib: &mut [u8]) {
 fn draw_stages(dib: &mut [u8], stages: &[StageRow], total_ms: Option<u64>, restoring: bool) {
     use crate::splash_text::{draw_text, text_width};
 
-    let y0 = SPLASH_SIZE + STAGE_PAD_TOP;
+    let y0 = BRAIN_AREA_H + STAGE_PAD_TOP;
     let x_label = STAGE_MARGIN_L;
     // Right edge for right-aligned time column.
     let x_time_right = SPLASH_W - STAGE_MARGIN_R;


### PR DESCRIPTION
## Summary

Follow-up to the fresh-PC onboarding investigation (#2940). The first launch on a genuinely clean Windows machine takes ~36s, ~30s of which is Windows Defender's cloud reputation check on newly-extracted, unsigned binaries -- confirmed empirically (closed and relaunched on the same machine: 23s -> 1s for the identical gap). Surfacing that wait as a staged status message in the splash instead of it just sitting there is a small, contained follow-up -- except the splash window was only 280px / ~28 monospace characters wide, with no word-wrap (`splash_text.rs` clips silently past the DIB edge), too narrow to fit a one-line reassurance message.

`SPLASH_SIZE` previously did double duty as both the window's WIDTH (`SPLASH_W = SPLASH_SIZE`) and the brain-logo region's HEIGHT contribution to `SPLASH_H`. Decoupled the two:
- `BRAIN_AREA_H` keeps the old value (280px) for everything that used it as a height (`SPLASH_H`, the stage-area Y offset, the separator line's Y position).
- `SPLASH_W` is now independent at 460px (~43 chars/row), sized to comfortably fit a full status line.
- The brain logo is now centered horizontally in the wider window (`BRAIN_X = (SPLASH_W - BRAIN_W) / 2`) rather than pinned at a fixed left padding, so it doesn't visually drift to one side.

No other layout constant changed -- stage rows, the separator line, the footer, and the border all already read `SPLASH_W`/`SPLASH_H` from the shared constants, so they scale automatically.

## Test plan

- [x] `cargo build -p agentmux-launcher` -- compiles clean, no new warnings
- [ ] **The actual rendered window on screen -- not verified, disclosed honestly rather than claimed.** The splash is a native `WS_EX_TOOLWINDOW` Win32 popup created with no window title text -- by design, excluded from normal window enumeration (so it's not alt-tabbable) -- which is outside what this session's available window-capture tooling can reach. Tried both `DiscoverWindows` and `CaptureWindow` against a live `task dev` launch and neither found it, before or after the change. The constant-math change is small and mechanical enough to review by hand (and the derivation is documented inline), but someone with a normal desktop session should confirm the actual rendered appearance before this ships in a release.

<!-- agentmux:agent_id=camper -->
