### PR TITLE
fix(agent-pane): migrate ToolOverlayLog's height FLIP to the shared resize contract (step 3)

### DIFF
--- a/.changesets/1788484414-fix-agent-pane-migrate-tooloverlaylog-s-height-flip-to-the-s-ka2u.md
+++ b/.changesets/1788484414-fix-agent-pane-migrate-tooloverlaylog-s-height-flip-to-the-s-ka2u.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): migrate ToolOverlayLog's height FLIP to the shared resize contract

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -315,7 +315,7 @@ partial list.
 | [`jekt-visibility-completion`](jekt-visibility-completion.md) | Spec: Jekt Visibility Completion — persistent-agent visibility + outgoing echo |
 | [`swarm-active-pane-sync`](swarm-active-pane-sync.md) | Swarm ↔ Pane Two-Way Active-Row Sync |
 
-### active (12)
+### active (13)
 
 | Spec | Title |
 |---|---|
@@ -325,6 +325,7 @@ partial list.
 | [`SPEC_ATTACHED_TASK_STATUS_AXIS_2026_08_02`](SPEC_ATTACHED_TASK_STATUS_AXIS_2026_08_02.md) | Spec: an orthogonal "attached task" status axis, sibling to `TurnPhase` |
 | [`SPEC_BROWSER_AND_EDITOR_PANES_2026_04_16`](SPEC_BROWSER_AND_EDITOR_PANES_2026_04_16.md) | SPEC: Browser and Editor Panes |
 | [`SPEC_CODEX_PROVIDER_INTEGRATION_2026_08_08`](SPEC_CODEX_PROVIDER_INTEGRATION_2026_08_08.md) | Codex Provider Integration: Claude-Parity Lifecycle |
+| [`SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31`](SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md) | SPEC: A single content-resize contract for the agent pane |
 | [`SPEC_DOCS_LIFECYCLE_HARDENING_2026_08_03`](SPEC_DOCS_LIFECYCLE_HARDENING_2026_08_03.md) | Docs Lifecycle Audit & Hardening Plan |
 | [`SPEC_EDITOR_MCP_OPEN_BLANK_PREVIEW_AND_PANE_REUSE_2026_08_03`](SPEC_EDITOR_MCP_OPEN_BLANK_PREVIEW_AND_PANE_REUSE_2026_08_03.md) | Plan: MCP-opened markdown blank-preview investigation + Editor-pane reuse |
 | [`SPEC_HEADLESS_TRANSIENT_RETRY_2026_08_31`](SPEC_HEADLESS_TRANSIENT_RETRY_2026_08_31.md) | Transient-failure retry for turns with no rendered pane |
@@ -332,7 +333,7 @@ partial list.
 | [`SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29`](SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29.md) | Spec: multi-tier discovery + remote API invocation over muxbus |
 | [`SPEC_WINDOW_NAME_API_HARDENING_2026_08_08`](SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md) | SPEC: Window-name App API hardening (phantom-id success + status codes) |
 
-### proposed (91)
+### proposed (90)
 
 | Spec | Title |
 |---|---|
@@ -357,7 +358,6 @@ partial list.
 | [`SPEC_BROWSER_PANE_FAVICON_TITLE_2026-05-15`](SPEC_BROWSER_PANE_FAVICON_TITLE_2026-05-15.md) | Browser Pane: Live Favicon + Page Title in Pane Header |
 | [`SPEC_COMPOSER_STRIP_DROP_CENTER_STATS_2026_08_31`](SPEC_COMPOSER_STRIP_DROP_CENTER_STATS_2026_08_31.md) | Spec: Drop the composer strip's centered token/elapsed stats |
 | [`SPEC_COMPOSER_STRIP_ROW_BASED_LAYOUT_2026_08_26`](SPEC_COMPOSER_STRIP_ROW_BASED_LAYOUT_2026_08_26.md) | SPEC: Composer Strip — Row-Based Layout (Rev 7) |
-| [`SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31`](SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md) | SPEC: A single content-resize contract for the agent pane |
 | [`SPEC_DEFAULT_TAB_NAME_TAB_N_2026_09_02`](SPEC_DEFAULT_TAB_NAME_TAB_N_2026_09_02.md) | Spec: default tab names — "Tab N", not "tabN" |
 | [`SPEC_DEFAULT_WIDGETS_REORDER_2026_08_25`](SPEC_DEFAULT_WIDGETS_REORDER_2026_08_25.md) | SPEC: Default fresh-start widgets — Agent, Swarm, Armory, Sysinfo |
 | [`SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27`](SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md) | SPEC — A repeatable process for Claude model catalog + CLI version upgrades |

--- a/docs/specs/SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md
+++ b/docs/specs/SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md
@@ -1,7 +1,8 @@
 # SPEC: A single content-resize contract for the agent pane
 
 **Date:** 2026-08-31
-**Status:** Proposed. No code changed by this document.
+**Status:** Active. Steps 1-3 of §5 landed (real code, not just this document);
+steps 4-6 still pending.
 **Supersedes as the recommended next step:** `ANALYSIS_TOOL_CALL_SCROLL_OSCILLATION_2026_08_17.md` §7's "fix B",
 which called for this but deferred scoping it.
 
@@ -23,6 +24,7 @@ agent pane changes height and the scroll position visibly jumps":
 | 08-21 | `FINDINGS_TOOL_CALL_SCROLL_OSCILLATION` | Corrected twice by PR review |
 | 08-22 | `FINDINGS_..._LIVE_INSTANCE_DATA` | Corrected twice by PR review |
 | 08-31 | this doc | Two further candidate fixes ruled out (§3); a third ruled out in draft, then withdrawn on review (§3a) |
+| 09-03 | step 3 migration | A design assumption in this very document's §4 (`el.offsetHeight` is the right universal measurement) turned out wrong the moment it met its first real consumer — see §4 |
 
 Every pass was made by someone reasoning carefully from the source, and most
 produced at least one confident conclusion that a later pass had to withdraw.
@@ -47,8 +49,8 @@ change, none aware of the others. All six verified present as of `216c593c4`:
 | 1 | Itemized pin effect | `AgentDocumentVirtualList.tsx:521-544` | node count / `layoutView().totalSize` / `workingRowHeight` |
 | 2 | RO #1 (viewport) | `AgentDocumentVirtualList.tsx:566-588` | `scrollRef.clientHeight` |
 | 3 | RO #2 (content) | `AgentDocumentVirtualList.tsx:619-631` | `virtualContainerRef` / `streamingBufferRef` box size |
-| 4 | Local FLIP | `ToolOverlayLog.tsx:246-298` | its own `<Switch>` branch changing |
-| 5 | Local panel auto-scroll | `ToolOverlayLog.tsx:187-208` | `chunks()` / `panelHidden()`, panel-internal only |
+| 4 | Local FLIP | `ToolOverlayLog.tsx:210-283` (migrated 09-03 — now calls `resize-contract.ts`'s `beginHeightContinuity`, not its own `flipHeight()`) | its own `<Switch>` branch changing |
+| 5 | Local panel auto-scroll | `ToolOverlayLog.tsx:187-208` (untouched by the step 3 migration — a different effect, still its own `panelHidden` `MutationObserver`) | `chunks()` / `panelHidden()`, panel-internal only |
 | 6 | Throttled re-render timers | `MarkdownBlock.tsx:62-81`, `output-cap.ts:369-440` | their own timers/heuristics, invisible to 1–5 |
 
 Each was added in response to one reported symptom. The result is what you
@@ -114,7 +116,7 @@ own caveat that a repeated *net* delta between two pin-checks cannot establish
 a single discrete element. This lead is closed; it needs mutation-level
 instrumentation (§5) or nothing.
 
-### 3a. Open — the `heightStale` FLIP bypass, and a worked example of this document's own thesis
+### 3a. Resolved (09-03, step 3 migration) — the `heightStale` FLIP bypass, and a worked example of this document's own thesis
 
 The bypass is real and its mechanism is now understood: `.agent-tool-panel`'s
 close transition uses `content-visibility 120ms allow-discrete`
@@ -155,6 +157,23 @@ Caught by Codex in review of this PR. Two things follow:
    height-behavior claim in this subsystem, including the ones above, as
    provisional until instrumented.
 
+**Resolution, 09-03, step 3:** subsumed exactly the way point 2 above
+predicted it might — not by a targeted fix, but as a side effect of
+unifying the mechanism. `resize-contract.ts`'s `isMeasurable()` reads
+`getComputedStyle` on `el` AND every ancestor (a separate real bug, caught
+by review — see §4), which means it detects `.agent-tool-panel`'s
+`content-visibility: hidden` at the moment the CSS actually applies it, not
+at the moment a `MutationObserver` sees the class added. The class-vs-
+computed-style lag this section describes no longer has anywhere to hide:
+there is no class-based signal left in the migrated code at all.
+
+Verified, not assumed: `ToolOverlayLog.test.tsx`'s corresponding test was
+itself a false pass twice before it actually exercised this (jsdom applies
+no real stylesheet, so a naive mock made the test pass regardless of
+whether the fix worked) — see that test's own comments for both corrections.
+Confirmed by deliberately breaking `isMeasurable`'s ancestor walk and
+checking the test fails.
+
 ---
 
 ## 4. Proposed contract
@@ -164,17 +183,38 @@ site reports through it instead of implementing its own FLIP or relying on an
 outer observer to notice after the fact.
 
 ```ts
-// frontend/app/view/agent/resize-contract.ts  (proposed)
+// frontend/app/view/agent/resize-contract.ts
 
 /** Freeze `el` at its current height, run `mutate`, then ease to the new
  *  natural height. The caller never measures, never touches transitions, and
  *  never needs to know whether an outer scroll container is pinned. */
-export function withHeightContinuity(el: HTMLElement, mutate: () => void): void;
+export function withHeightContinuity(
+    el: HTMLElement, mutate: () => void, measure?: (el: HTMLElement) => number,
+): void;
 
 /** Same, for a mutation that lands asynchronously (a throttle timer's trailing
  *  commit): capture the "from" height now, ease once the mutation settles. */
-export function beginHeightContinuity(el: HTMLElement): (this: void) => void;
+export function beginHeightContinuity(
+    el: HTMLElement, measure?: (el: HTMLElement) => number,
+): (this: void) => void;
 ```
+
+**`measure`, 09-03: not in the original signature, added the moment step 3
+met its first real consumer.** The draft above assumed `el.offsetHeight`
+(the rendered box) was the universally correct read. It is wrong for
+`.agent-tool-overlay-log` specifically: that element scrolls its own
+overflow (`overflow-y: auto`) inside `.agent-tool-panel`'s
+`max-height: 50vh` cap, so its `offsetHeight` clamps at whatever's left of
+that budget and stops changing once content exceeds it — while
+`scrollHeight` keeps reflecting the true content height. That is precisely
+the large-shrink case (a long raw chunk log collapsing to a short compact
+result) this whole document exists to fix, and `offsetHeight` alone would
+have silently failed to detect it. `measure` defaults to `offsetHeight`
+(correct for the common non-scrolling row) and lets a caller with this
+shape pass `(el) => el.scrollHeight` instead. Another data point for §0's
+thesis: this was a design decision made confidently in this very document,
+and it was wrong the moment it was tested against something real rather
+than reasoned about in the abstract.
 
 Properties the single implementation owns, which no current call site owns
 consistently:
@@ -204,19 +244,20 @@ Deliberately incremental. The six mechanisms have their own regression suites
 `ToolOverlayLog.test.tsx`, `anchor.test.ts`, `output-cap.test.ts`); a wholesale
 replacement trades a known-fragmented system for an unknown one.
 
-1. **Instrument before refactoring.** The 08-17 doc's own recommendation #1,
-   still unactioned: a `MutationObserver`/`ResizeObserver` trace at the
-   *component* level, finer-grained than the existing pin-check-level
-   `[wave-scroll-shrink]` diagnostic. Every conclusion in the 08-21/08-22
-   findings was limited by that diagnostic's granularity, and §3.3 closed the
-   last lead that log-level data could reach. **This is the gating step — it
-   is what tells us which call sites actually matter, rather than which ones
-   look like they should.**
-2. **Land `resize-contract.ts` with no call sites**, plus its own unit tests.
-   Zero runtime effect; reviewable in isolation.
-3. **Migrate `ToolOverlayLog.tsx`'s `flipHeight()` to it** — one call site, the
-   one with existing test coverage to prove equivalence. `heightStale` (§3a)
-   is resolved here or not at all.
+1. **Done (#2887).** Instrument before refactoring — the 08-17 doc's own
+   recommendation #1. Real data landed 09-03 (351 captured shrinks, one live
+   session): 284/351 (81%) attributed to `tool`-kind nodes, 0 to `markdown` —
+   Source A (this step's own migration target) confirmed dominant, step 4
+   (`MarkdownBlock`) correspondingly de-prioritized rather than assumed.
+2. **Done (#2954).** Land `resize-contract.ts` with no call sites, plus its
+   own unit tests. Two P1s caught and fixed before merge (ancestor
+   content-visibility, re-entrant-flip measurement) — see that PR.
+3. **Done (09-03).** Migrate `ToolOverlayLog.tsx`'s `flipHeight()` to it —
+   the one call site with existing test coverage to prove equivalence.
+   `heightStale` (§3a) resolved as a side effect, not a targeted fix. Also
+   surfaced the `measure` parameter (§4) — the migration target's own
+   `offsetHeight`/`scrollHeight` divergence wasn't anticipated by the
+   original design.
 4. **Migrate `MarkdownBlock.tsx`'s throttled highlight commit** (mechanism #6)
    — the only fully unmitigated source, and the one that fires on the same
    cadence users describe ("during normal streaming, not just at turn

--- a/docs/specs/SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md
+++ b/docs/specs/SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md
@@ -24,7 +24,7 @@ agent pane changes height and the scroll position visibly jumps":
 | 08-21 | `FINDINGS_TOOL_CALL_SCROLL_OSCILLATION` | Corrected twice by PR review |
 | 08-22 | `FINDINGS_..._LIVE_INSTANCE_DATA` | Corrected twice by PR review |
 | 08-31 | this doc | Two further candidate fixes ruled out (§3); a third ruled out in draft, then withdrawn on review (§3a) |
-| 09-03 | step 3 migration | A design assumption in this very document's §4 (`el.offsetHeight` is the right universal measurement) turned out wrong the moment it met its first real consumer — see §4 |
+| 09-03 | step 3 migration | Two design assumptions in this very document's §4 turned out wrong within hours of each other, the second caught by review of the PR fixing the first — see §4 |
 
 Every pass was made by someone reasoning carefully from the source, and most
 produced at least one confident conclusion that a later pass had to withdraw.
@@ -189,13 +189,15 @@ outer observer to notice after the fact.
  *  natural height. The caller never measures, never touches transitions, and
  *  never needs to know whether an outer scroll container is pinned. */
 export function withHeightContinuity(
-    el: HTMLElement, mutate: () => void, measure?: (el: HTMLElement) => number,
+    el: HTMLElement, mutate: () => void,
+    measure?: (el: HTMLElement) => number, measureForGating?: (el: HTMLElement) => number,
 ): void;
 
 /** Same, for a mutation that lands asynchronously (a throttle timer's trailing
  *  commit): capture the "from" height now, ease once the mutation settles. */
 export function beginHeightContinuity(
-    el: HTMLElement, measure?: (el: HTMLElement) => number,
+    el: HTMLElement,
+    measure?: (el: HTMLElement) => number, measureForGating?: (el: HTMLElement) => number,
 ): (this: void) => void;
 ```
 
@@ -215,6 +217,26 @@ shape pass `(el) => el.scrollHeight` instead. Another data point for §0's
 thesis: this was a design decision made confidently in this very document,
 and it was wrong the moment it was tested against something real rather
 than reasoned about in the abstract.
+
+**`measureForGating`, also 09-03, caught by review of the `measure` PR
+itself, not anticipated when `measure` was added a few hours earlier in the
+same document.** `measure`'s own fix has a second-order consequence:
+`MAX_ANIMATED_DELTA_PX` (§4 above) now gets evaluated against whatever
+`measure` returns — for `.agent-tool-overlay-log`, that is `scrollHeight`,
+which is unclamped by design (that is the entire point of the `measure`
+fix). A raw chunk log anywhere near `MAX_TOOL_OUTPUT_LINES` (1,000) has a
+`scrollHeight` delta easily in the tens of thousands of px against a short
+terminal result — comfortably past the cap — while the box's actual
+RENDERED shrink stays bounded by the same `max-height: 50vh` to at most a
+few hundred px. Gating on the unclamped number would skip animating
+exactly the long-output transitions this whole effort exists to smooth —
+the cap firing for a reason (§4's original whole-pane-collapse rationale)
+that has nothing to do with what this specific element's user actually
+sees change size. Fixed with a second optional parameter,
+`measureForGating`, defaulting to `measure` (a no-op for every caller
+without this divergence): the FLIP still eases between the true
+`scrollHeight` endpoints, but the cap is now checked against `offsetHeight`
+instead. `ToolOverlayLog.tsx` passes both.
 
 Properties the single implementation owns, which no current call site owns
 consistently:

--- a/frontend/app/view/agent/components/ToolOverlayLog.test.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.test.tsx
@@ -58,10 +58,30 @@ function stubScrollHeight(px: number) {
     return vi.spyOn(HTMLDivElement.prototype, "scrollHeight", "get").mockReturnValue(px);
 }
 
+/** Stub `offsetHeight` independently of `scrollHeight` — needed to model
+ *  `.agent-tool-overlay-log`'s real shape (an internally-scrolling box
+ *  bounded by its ancestor panel's max-height), where the two genuinely
+ *  diverge. Defaults to 0 (jsdom's own default) unless stubbed. */
+function stubOffsetHeight(px: number) {
+    return vi.spyOn(HTMLDivElement.prototype, "offsetHeight", "get").mockReturnValue(px);
+}
+
 describe("ToolOverlayLog — height-FLIP transition", () => {
     it("freezes at the previous height then eases to the new height on a branch change", async () => {
         vi.useFakeTimers();
         const heightStub = stubScrollHeight(40); // streaming-branch height
+        // The magnitude-gating measure (offsetHeight) is independent of
+        // scrollHeight (codex P2, PR #2962) — jsdom's own default is 0,
+        // which would make shouldAnimate's fromPx<=0 guard block every FLIP
+        // in this file. Must genuinely change value across the branch swap
+        // too (not just be nonzero): shouldAnimate's magnitude check needs
+        // a real gate DELTA, and a constant offsetHeight stub produces a
+        // zero gate delta regardless of how the (irrelevant to this test)
+        // absolute value is chosen — this test doesn't care what the
+        // rendered values actually are, only that SOME real change is
+        // present so scrollHeight (the FLIP's own from/to) is what actually
+        // drives the outcome, same as before this parameter existed.
+        const offsetStub = stubOffsetHeight(50);
         const [node, setNode] = createSignal<ToolNode>(streamingNode);
         const { container } = render(() => <ToolOverlayLog node={node()} />);
         const el = container.querySelector(".agent-tool-overlay-log") as HTMLElement;
@@ -72,6 +92,8 @@ describe("ToolOverlayLog — height-FLIP transition", () => {
         expect(el.style.height).toBe("");
 
         heightStub.mockRestore();
+        offsetStub.mockRestore();
+        stubOffsetHeight(80);
         stubScrollHeight(120); // terminal-branch (result view) is taller
         setNode(terminalNode);
 
@@ -214,6 +236,11 @@ describe("ToolOverlayLog — height-FLIP transition", () => {
         // analogous slot-reuse hazard on `onHoldOpen` (PR #1317).
         vi.useFakeTimers();
         stubScrollHeight(40); // tc-1's "streaming" height
+        // offsetHeight (the magnitude-gating measure, codex P2 PR #2962)
+        // must genuinely differ across the THIRD phase's compared reads
+        // below, same reasoning as the previous test — a constant value
+        // produces a zero gate delta regardless of how scrollHeight moves.
+        stubOffsetHeight(50);
         const [node, setNode] = createSignal<ToolNode>(streamingNode);
         const { container } = render(() => <ToolOverlayLog node={node()} />);
         const el = container.querySelector(".agent-tool-overlay-log") as HTMLElement;
@@ -227,6 +254,7 @@ describe("ToolOverlayLog — height-FLIP transition", () => {
             id: "tc-2",
         };
         stubScrollHeight(500);
+        stubOffsetHeight(55); // tc-2's fresh baseline gate value
         setNode(otherNode);
         await vi.runOnlyPendingTimersAsync();
         // Must resync silently — NOT FLIP from tc-1's stale 40px baseline.
@@ -238,6 +266,7 @@ describe("ToolOverlayLog — height-FLIP transition", () => {
         // 500px (tc-2's own terminal-branch height, recorded at the swap),
         // so this eases from 500px down to the new 120px.
         stubScrollHeight(120);
+        stubOffsetHeight(90); // genuinely differs from the 55 baseline above
         setNode({ ...otherNode, log: { open: true, chunks: [{ kind: "stdout", content: "x", timestamp: 1 }] } });
         expect(el.style.height).toBe("500px"); // frozen "from" synchronously
         await vi.runOnlyPendingTimersAsync();
@@ -260,6 +289,41 @@ describe("ToolOverlayLog — height-FLIP transition", () => {
         setNode(terminalNode);
         await vi.runOnlyPendingTimersAsync();
         expect(el.style.height).toBe(""); // branch changed + heights differ, but motion is disabled
+
+        vi.useRealTimers();
+    });
+});
+
+describe("ToolOverlayLog — magnitude gating uses the rendered height, not scrollHeight (codex P2, PR #2962)", () => {
+    it("animates a long-output running->terminal transition even though scrollHeight's own delta is far past the cap", async () => {
+        // The real scenario the bug report describes: a raw chunk log near
+        // MAX_TOOL_OUTPUT_LINES has a scrollHeight delta easily in the tens
+        // of thousands of px against a short terminal result — but the
+        // box's RENDERED shrink is bounded by the ancestor panel's
+        // max-height to a few hundred px. Gating the magnitude cap on
+        // scrollHeight would skip animating exactly this case.
+        vi.useFakeTimers();
+        const scrollStub = stubScrollHeight(15000); // huge raw chunk log
+        stubOffsetHeight(500); // but rendered/clamped to the panel's own cap
+        const [node, setNode] = createSignal<ToolNode>(streamingNode);
+        const { container } = render(() => <ToolOverlayLog node={node()} />);
+        const el = container.querySelector(".agent-tool-overlay-log") as HTMLElement;
+        await vi.runOnlyPendingTimersAsync();
+
+        scrollStub.mockRestore();
+        stubScrollHeight(200); // compact terminal result
+        stubOffsetHeight(220); // rendered delta: 500 -> 220 = 280px, well under the cap
+        setNode(terminalNode);
+
+        // Synchronous: frozen at the scrollHeight-based FROM value. Checked
+        // immediately, not after a timer flush — a naive scrollHeight-gated
+        // version sees a ~14800px delta (past MAX_ANIMATED_DELTA_PX) and
+        // skips animating entirely, so el.style.height would stay "" here
+        // instead.
+        expect(el.style.height).toBe("15000px");
+
+        await vi.runOnlyPendingTimersAsync();
+        expect(el.style.height).toBe("200px"); // eased to the true (scrollHeight) terminal height
 
         vi.useRealTimers();
     });

--- a/frontend/app/view/agent/components/ToolOverlayLog.test.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.test.tsx
@@ -106,13 +106,22 @@ describe("ToolOverlayLog — height-FLIP transition", () => {
     });
 
     it("does not animate when the branch is unchanged (only chunks growing)", async () => {
+        // The height genuinely differs across the two ticks (40 -> 500) —
+        // a constant stub can't distinguish "correctly gated on branch
+        // staying the same" from "shouldAnimate's own zero-delta check
+        // happened to block it anyway" (the growth never produced a real
+        // height difference to react to either way). A prior version of
+        // this test used a constant stub and stayed green even after
+        // deliberately removing the branch-change gate from the source.
         vi.useFakeTimers();
-        stubScrollHeight(40);
+        const heightStub = stubScrollHeight(40);
         const [node, setNode] = createSignal<ToolNode>(streamingNode);
         const { container } = render(() => <ToolOverlayLog node={node()} />);
         const el = container.querySelector(".agent-tool-overlay-log") as HTMLElement;
         await vi.runOnlyPendingTimersAsync();
 
+        heightStub.mockRestore();
+        stubScrollHeight(500);
         setNode({
             ...streamingNode,
             log: {
@@ -121,7 +130,7 @@ describe("ToolOverlayLog — height-FLIP transition", () => {
             },
         });
         await vi.runOnlyPendingTimersAsync();
-        expect(el.style.height).toBe(""); // still "streaming" branch — no FLIP
+        expect(el.style.height).toBe(""); // still "streaming" branch — no FLIP despite a real height change
 
         vi.useRealTimers();
     });
@@ -141,14 +150,44 @@ describe("ToolOverlayLog — height-FLIP transition", () => {
         vi.useRealTimers();
     });
 
-    it("resyncs without animating when a branch change happened entirely while the panel was hidden", async () => {
+    it("resyncs without animating when a branch change happened entirely while the panel was hidden", () => {
         // A failed/denied/canceled tool auto-collapses the instant it
         // leaves "running" (ToolBlock.tsx autoExpanded()), so the
         // running->result branch change commonly happens while
-        // content-visibility:hidden. The first re-measurement after the
-        // panel becomes visible again (e.g. the user expands it to
-        // inspect the error) must show the final state directly, NOT
-        // FLIP from the stale pre-collapse height (reagent P1 on #1975).
+        // content-visibility:hidden. Must show the final state directly,
+        // NOT FLIP from the stale pre-collapse height (reagent P1 on
+        // #1975).
+        //
+        // jsdom applies no real stylesheet, so the `--hidden` CLASS by
+        // itself proves nothing about computed content-visibility — the
+        // mechanism this migrated to (resize-contract.ts's isMeasurable)
+        // reads getComputedStyle, not the class. A prior version of this
+        // test asserted el.style.height === "" without this mock and
+        // stayed green for the wrong reason: the scrollHeight stub simply
+        // hadn't changed value yet at the point of the assertion, so
+        // nothing would have animated regardless of whether hidden-
+        // detection worked at all. This mock makes getComputedStyle
+        // actually reflect the class, mirroring what the real stylesheet
+        // does in production, so the test exercises the real gate.
+        //
+        // Deliberately checks el.classList directly, NOT el.closest(...) —
+        // content-visibility is non-inherited, so a real getComputedStyle
+        // call reports ONLY the exact queried element's own value, never an
+        // ancestor's. Using closest() here would answer "hidden" for the
+        // DESCENDANT too, which would make this test pass even if
+        // resize-contract.ts's own isMeasurable stopped walking ancestors
+        // and only checked its argument directly (confirmed: the first
+        // version of this mock did exactly that, and this test stayed
+        // green after deliberately breaking the ancestor walk in
+        // resize-contract.ts to check).
+        const realGetComputedStyle = window.getComputedStyle;
+        vi.spyOn(window, "getComputedStyle").mockImplementation((el: Element) => {
+            if (el.classList?.contains("agent-tool-panel--hidden")) {
+                return { contentVisibility: "hidden" } as CSSStyleDeclaration;
+            }
+            return realGetComputedStyle(el);
+        });
+
         stubScrollHeight(40);
         const [node, setNode] = createSignal<ToolNode>(streamingNode);
         const { container } = render(() => (
@@ -156,19 +195,15 @@ describe("ToolOverlayLog — height-FLIP transition", () => {
                 <ToolOverlayLog node={node()} />
             </div>
         ));
-        const panel = container.querySelector(".agent-tool-panel") as HTMLElement;
         const el = container.querySelector(".agent-tool-overlay-log") as HTMLElement;
 
-        setNode(terminalNode); // branch changes entirely while hidden
+        // The branch change's real height differs sharply WHILE hidden —
+        // if the hidden-gate weren't working, this is exactly the delta
+        // that would produce a visible FLIP.
+        stubScrollHeight(900);
+        setNode(terminalNode);
         expect(el.style.height).toBe(""); // never measured/animated while hidden
-
-        stubScrollHeight(120); // the terminal branch's real (now-visible) height
-        panel.classList.remove("agent-tool-panel--hidden"); // panel becomes visible
-        // MutationObserver callbacks run as a microtask.
-        await Promise.resolve();
-        await Promise.resolve();
-
-        expect(el.style.height).toBe(""); // resynced silently, no FLIP
+        expect(el.style.transition).toBe(""); // nothing armed either — no leftover to resolve once visible
     });
 
     it("does not animate when a different tool node swaps into the same slot", async () => {

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -19,7 +19,7 @@ import { For, Match, Show, Switch, createEffect, createMemo, createSignal, onCle
 // `Show` retained for fallback ToolOverlayResult sub-tree.
 import type { ToolNode } from "../types";
 import type { AgentDispatch } from "../../swarm/swarm-model";
-import { atoms } from "@/app/store/global";
+import { beginHeightContinuity } from "../resize-contract";
 import { Markdown } from "@/app/element/markdown";
 import { BashOutputViewer } from "./BashOutputViewer";
 import { CompactResult } from "./CompactResult";
@@ -212,90 +212,85 @@ export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
     // `ToolOverlayResult` are different component trees with different
     // natural heights, and today they swap with zero transition — the
     // "jerk" in ANALYSIS_TOOL_PREVIEW_RUNNING_TO_COMPLETED_JERK_2026_07_05.md.
+    // Migrated to the shared contract (step 3 of
+    // SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md) — see resize-contract.ts
+    // for the FLIP mechanics themselves (reduced motion, magnitude cap,
+    // cancellation, and the content-visibility check that fixes this file's
+    // own former heightStale/panelHidden lag, §3a of that spec).
     //
-    // `lastMeasuredHeight`/`lastBranch` hold the values captured on the
-    // PREVIOUS run of this effect — i.e. the DOM height as it stood just
-    // before whatever change triggered the CURRENT run. That's exactly the
-    // FLIP "before" state, and it's the only way to get it: Solid effects
-    // always run after the DOM has already been patched for the change
-    // that triggered them, so there is no "before" to read within the same
-    // invocation. This only works because nothing else in this component
-    // mutates `scrollRef`'s height between effect runs.
-    let lastMeasuredHeight = 0;
+    // `.agent-tool-overlay-log` scrolls its own overflow
+    // (`overflow-y: auto`, `_tool-overlay-portal.scss`) inside
+    // `.agent-tool-panel`'s `max-height: 50vh` cap — the module's default
+    // measurement (`offsetHeight`, the rendered box) clamps at whatever's
+    // left of that budget and stops changing once content exceeds it,
+    // while `scrollHeight` keeps reflecting the true content height.
+    // That's exactly the large-shrink case (a long raw chunk log
+    // collapsing to a short compact result) this FLIP exists to smooth, so
+    // it must measure `scrollHeight`, not the default.
+    const measureHeight = (el: HTMLElement): number => el.scrollHeight;
+
+    // `lastBranch`/`pendingCommit` hold what the PREVIOUS run of this
+    // effect captured — Solid effects always run after the DOM has already
+    // been patched for the change that triggered them, so a run can only
+    // ever see its OWN "after" state; the "before" has to come from
+    // whatever the last run left behind. `beginHeightContinuity` is called
+    // on every invocation (not just branch changes) so the eventually-
+    // committed "from" height is always the most recent one, not whatever
+    // it was when the current branch started — matching the old
+    // `lastMeasuredHeight` field's unconditional per-tick update.
     let lastBranch: LogBranch | undefined;
-    let cancelHeightFlip: (() => void) | undefined;
-    // Set while the panel is (or was) content-visibility:hidden and we
-    // couldn't safely measure. A failed/denied/canceled tool auto-collapses
-    // the instant it leaves "running" (`ToolBlock.tsx` autoExpanded()), so
-    // the running->result branch change commonly happens entirely while
-    // hidden — without this flag, the first re-measurement after the user
-    // later expands the panel would FLIP from the stale pre-collapse
-    // ("streaming") height to the current one instead of just showing the
-    // final state (reagent P1 on PR #1975).
-    let heightStale = false;
     // Guards the same `<Index>` slot-position hazard `ToolBlock.tsx` guards
     // via `prevNodeId` (PR #1317, `AgentDocumentVirtualList.tsx:193-194`): a
     // streaming-buffer cap-advance can swap a different tool node into this
-    // component instance without it ever unmounting. Without this guard the
-    // outgoing node's `lastBranch`/`lastMeasuredHeight` would leak into the
-    // incoming node's first render and could spuriously satisfy
-    // `prevBranch !== b`, FLIPping from the old tool's height to the new
-    // tool's height (reagent P1 round 2 on PR #1975).
+    // component instance without it ever unmounting. Without this guard a
+    // pending commit captured for the OUTGOING node would fire against the
+    // INCOMING node's first render, FLIPping from the old tool's height to
+    // the new tool's height (reagent P1 round 2 on PR #1975).
     let lastNodeId: string = props.node.id;
+    let pendingCommit: (() => void) | undefined;
 
     createEffect(() => {
         const b = branch();
         chunks(); // also re-measure as chunks stream in, not just on branch changes
-        const hidden = panelHidden();
         const el = scrollRef;
         if (!el) return;
 
         const nodeId = props.node.id;
         if (nodeId !== lastNodeId) {
-            // Reset the baseline to the incoming node's own branch/height —
-            // never animate across the swap itself — so a genuine later
-            // branch change on THIS node can still FLIP correctly.
+            // Different node reused this slot — never animate across the
+            // swap; discard whatever was pending and start fresh for the
+            // incoming node.
             lastNodeId = nodeId;
             lastBranch = b;
-            heightStale = hidden;
-            lastMeasuredHeight = hidden ? lastMeasuredHeight : el.scrollHeight;
+            pendingCommit = beginHeightContinuity(el, measureHeight);
             return;
         }
 
-        if (hidden) {
-            // Reading scrollHeight here would force a synchronous layout on
-            // a content-visibility:hidden subtree (same hazard as the
-            // auto-scroll effect above). Track the logical branch (cheap,
-            // no DOM read) so a genuine change is still recorded, but mark
-            // the height stale — resolved as a silent resync, not a FLIP,
-            // the next time this runs while visible.
-            lastBranch = b;
-            heightStale = true;
-            return;
-        }
-
-        const prevBranch = lastBranch;
-        const prevHeight = lastMeasuredHeight;
-        const newHeight = el.scrollHeight;
-
-        const shouldAnimate =
-            !heightStale &&
-            prevBranch !== undefined &&
-            prevBranch !== b &&
-            prevHeight > 0 &&
-            Math.abs(newHeight - prevHeight) > 1 &&
-            !atoms.prefersReducedMotionAtom();
-        heightStale = false;
-
-        if (shouldAnimate) {
-            cancelHeightFlip?.();
-            cancelHeightFlip = flipHeight(el, prevHeight, newHeight);
-        }
-
+        const branchChanged = lastBranch !== undefined && b !== lastBranch;
         lastBranch = b;
-        lastMeasuredHeight = newHeight;
+
+        // Re-baseline for the NEXT invocation BEFORE committing this one.
+        // beginHeightContinuity cancels any transition already in flight as
+        // part of capturing a trustworthy "from" height (resize-contract.ts's
+        // cancelInFlight) — doing that AFTER committing would immediately
+        // cancel the flip this same tick is about to start. Capturing first
+        // means the only thing it can cancel is a PRIOR, now-stale
+        // transition, which is exactly what should happen once content has
+        // moved on again.
+        const commit = pendingCommit;
+        pendingCommit = beginHeightContinuity(el, measureHeight);
+        if (branchChanged) commit?.();
     });
-    onCleanup(() => cancelHeightFlip?.());
+    // No onCleanup here (the old code had one, cancelling any in-flight
+    // flip on unmount) — resize-contract.ts doesn't expose a per-element
+    // cancel to callers, only the two entry points above. Unmounting mid-
+    // flip leaves a harmless, self-resolving remainder: the pending rAF
+    // fires once against a now-detached `el` (a no-op — no error, no
+    // visible effect), its `transitionend` listener never fires on a
+    // detached, non-animating element, and the module's own `inFlight`
+    // WeakMap entry for `el` is reclaimed once nothing else references
+    // `el`, i.e. as part of ordinary GC after this component's own
+    // teardown — not a real leak.
 
     /**
      * Render decision — exhaustive, mutually exclusive branches via
@@ -332,43 +327,6 @@ export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
         </div>
     );
 };
-
-const HEIGHT_FLIP_MS = 150;
-
-/**
- * Classic FLIP height transition: freeze `el` at `fromPx` (forcing a reflow
- * so the browser commits it before animating), then ease to `toPx`,
- * clearing the inline style once the transition ends so the box goes back
- * to tracking its content naturally. `overflow-y` is forced to `hidden`
- * for the transition's duration only, so the internal scrollbar doesn't
- * flash on/off as the height passes through intermediate values.
- *
- * Returns a cancel function — call it if another transition needs to start
- * before this one finishes (the caller always cancels the previous one
- * before starting a new one, so at most one is ever in flight per element).
- */
-function flipHeight(el: HTMLElement, fromPx: number, toPx: number): () => void {
-    el.style.transition = "none";
-    el.style.height = `${fromPx}px`;
-    el.style.overflowY = "hidden";
-    void el.offsetHeight; // force reflow so the "from" height commits before animating
-    el.style.transition = `height ${HEIGHT_FLIP_MS}ms cubic-bezier(0.4, 0, 0.2, 1)`;
-    const raf = requestAnimationFrame(() => {
-        el.style.height = `${toPx}px`;
-    });
-    const onEnd = (e: TransitionEvent) => {
-        if (e.target === el && e.propertyName === "height") cleanup();
-    };
-    const cleanup = () => {
-        cancelAnimationFrame(raf);
-        el.style.transition = "";
-        el.style.height = "";
-        el.style.overflowY = "";
-        el.removeEventListener("transitionend", onEnd);
-    };
-    el.addEventListener("transitionend", onEnd);
-    return cleanup;
-}
 
 type LogChunk = { kind: string; content: string; timestamp: number };
 

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -229,6 +229,20 @@ export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
     // it must measure `scrollHeight`, not the default.
     const measureHeight = (el: HTMLElement): number => el.scrollHeight;
 
+    // BUT the magnitude cap (resize-contract.ts's MAX_ANIMATED_DELTA_PX)
+    // must be gated on the RENDERED delta, not this scrollHeight one
+    // (codex P2, PR #2962): a raw chunk log anywhere near
+    // MAX_TOOL_OUTPUT_LINES (1,000) has a scrollHeight delta easily in the
+    // tens of thousands of px against a short terminal result, which would
+    // blow the cap and skip animating — even though the box's actual
+    // VISIBLE shrink is bounded by the same 50vh cap to at most a few
+    // hundred px. The cap exists for an unrelated phenomenon (a whole
+    // pane's scrollHeight collapsing by 20,000+px — see that constant's
+    // own doc comment); measured against scrollHeight here, it would fire
+    // for exactly the long-output transitions this FLIP most needs to
+    // smooth. offsetHeight is what the user actually sees change size.
+    const measureRenderedHeight = (el: HTMLElement): number => el.offsetHeight;
+
     // `lastBranch`/`pendingCommit` hold what the PREVIOUS run of this
     // effect captured — Solid effects always run after the DOM has already
     // been patched for the change that triggered them, so a run can only
@@ -262,7 +276,7 @@ export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
             // incoming node.
             lastNodeId = nodeId;
             lastBranch = b;
-            pendingCommit = beginHeightContinuity(el, measureHeight);
+            pendingCommit = beginHeightContinuity(el, measureHeight, measureRenderedHeight);
             return;
         }
 
@@ -278,7 +292,7 @@ export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
         // transition, which is exactly what should happen once content has
         // moved on again.
         const commit = pendingCommit;
-        pendingCommit = beginHeightContinuity(el, measureHeight);
+        pendingCommit = beginHeightContinuity(el, measureHeight, measureRenderedHeight);
         if (branchChanged) commit?.();
     });
     // No onCleanup here (the old code had one, cancelling any in-flight

--- a/frontend/app/view/agent/resize-contract.test.ts
+++ b/frontend/app/view/agent/resize-contract.test.ts
@@ -359,3 +359,52 @@ describe("beginHeightContinuity", () => {
         expect(el.style.height).toBe("");
     });
 });
+
+describe("custom measure function", () => {
+    /** offsetHeight and scrollHeight independently controllable, modeling
+     *  an internally-scrolling element (ToolOverlayLog.tsx's
+     *  .agent-tool-overlay-log: overflow-y: auto, bounded by an ancestor's
+     *  max-height) where the two genuinely diverge — offsetHeight clamps at
+     *  the ancestor's budget once content exceeds it; scrollHeight keeps
+     *  reflecting the true content height. */
+    function setDivergentHeights(el: HTMLElement, offset: number, scroll: number): void {
+        Object.defineProperty(el, "offsetHeight", { configurable: true, value: offset });
+        Object.defineProperty(el, "scrollHeight", { configurable: true, value: scroll });
+    }
+
+    it("defaults to offsetHeight when no measure function is given", () => {
+        const el = document.createElement("div");
+        // offsetHeight says "no real change" (clamped, both reads land on
+        // the ancestor's cap); scrollHeight says "shrank a lot". The
+        // DEFAULT must follow offsetHeight and see nothing to animate —
+        // proves the default didn't quietly start reading scrollHeight.
+        setDivergentHeights(el, 800, 5000);
+        withHeightContinuity(el, () => setDivergentHeights(el, 800, 200));
+        expect(el.style.height).toBe("");
+    });
+
+    it("uses a custom measure function instead of offsetHeight when one is given", () => {
+        const el = document.createElement("div");
+        setDivergentHeights(el, 800, 1200); // offsetHeight clamped, scrollHeight is the true 1200
+        withHeightContinuity(
+            el,
+            () => setDivergentHeights(el, 800, 200), // offsetHeight stays clamped at 800 throughout
+            (e) => e.scrollHeight,
+        );
+        // Must FLIP using scrollHeight's real 1200 -> 200, not offsetHeight's unchanged 800 -> 800.
+        expect(el.style.height).toBe("1200px");
+        flushRaf();
+        expect(el.style.height).toBe("200px");
+    });
+
+    it("beginHeightContinuity also accepts and uses a custom measure function", () => {
+        const el = document.createElement("div");
+        setDivergentHeights(el, 800, 1200);
+        const commit = beginHeightContinuity(el, (e) => e.scrollHeight);
+        setDivergentHeights(el, 800, 200);
+        commit();
+        expect(el.style.height).toBe("1200px");
+        flushRaf();
+        expect(el.style.height).toBe("200px");
+    });
+});

--- a/frontend/app/view/agent/resize-contract.test.ts
+++ b/frontend/app/view/agent/resize-contract.test.ts
@@ -408,3 +408,73 @@ describe("custom measure function", () => {
         expect(el.style.height).toBe("200px");
     });
 });
+
+describe("measureForGating", () => {
+    // codex P2, PR #2962. Exactly ToolOverlayLog.tsx's real shape: scrollHeight
+    // (the FLIP's own from/to) can be huge — well past MAX_ANIMATED_DELTA_PX
+    // (2000) — while offsetHeight (the actually-rendered, panel-clamped box)
+    // only moves a few hundred px. The magnitude cap must be evaluated
+    // against the rendered delta, not the unclamped one, or exactly the
+    // long-output transitions this module exists to smooth get skipped.
+    function setDivergentHeights(el: HTMLElement, offset: number, scroll: number): void {
+        Object.defineProperty(el, "offsetHeight", { configurable: true, value: offset });
+        Object.defineProperty(el, "scrollHeight", { configurable: true, value: scroll });
+    }
+
+    it("withHeightContinuity: a huge scrollHeight delta still animates when the RENDERED delta is small", () => {
+        const el = document.createElement("div");
+        setDivergentHeights(el, 500, 15000); // scrollHeight delta will be ~14800 -> way past the cap
+        withHeightContinuity(
+            el,
+            () => setDivergentHeights(el, 220, 200), // rendered delta: 500 -> 220 = 280px, well under the cap
+            (e) => e.scrollHeight, // FLIP endpoints: the true content height
+            (e) => e.offsetHeight, // gating: the rendered, clamped height
+        );
+        // Must animate — a naive scrollHeight-gated version would see
+        // 15000 -> 200 (delta 14800, over MAX_ANIMATED_DELTA_PX) and skip.
+        expect(el.style.height).toBe("15000px");
+        flushRaf();
+        expect(el.style.height).toBe("200px");
+    });
+
+    it("withHeightContinuity: still respects the cap when the RENDERED delta is itself huge", () => {
+        const el = document.createElement("div");
+        setDivergentHeights(el, 40000, 40000); // both huge — a genuine whole-pane-scale collapse
+        withHeightContinuity(
+            el,
+            () => setDivergentHeights(el, 100, 100),
+            (e) => e.scrollHeight,
+            (e) => e.offsetHeight,
+        );
+        expect(el.style.height).toBe(""); // correctly skipped — the cap still means something
+    });
+
+    it("beginHeightContinuity: same gating behavior at capture + commit time", () => {
+        const el = document.createElement("div");
+        setDivergentHeights(el, 500, 15000);
+        const commit = beginHeightContinuity(el, (e) => e.scrollHeight, (e) => e.offsetHeight);
+        setDivergentHeights(el, 220, 200);
+        commit();
+        expect(el.style.height).toBe("15000px");
+        flushRaf();
+        expect(el.style.height).toBe("200px");
+    });
+
+    it("defaults measureForGating to measure itself when not given — existing single-measure callers are unaffected", () => {
+        const el = document.createElement("div");
+        // Only ONE measure function passed — must gate on the SAME values it
+        // animates between (the pre-existing behavior), not silently fall
+        // back to offsetHeight.
+        setDivergentHeights(el, 500, 15000);
+        withHeightContinuity(
+            el,
+            () => setDivergentHeights(el, 220, 200),
+            (e) => e.scrollHeight,
+            // no measureForGating — must default to the scrollHeight function above
+        );
+        // scrollHeight delta (15000 -> 200 = 14800) exceeds the cap, so this
+        // must NOT animate, proving the default didn't quietly become
+        // offsetHeight (which would have produced a small, animatable delta).
+        expect(el.style.height).toBe("");
+    });
+});

--- a/frontend/app/view/agent/resize-contract.ts
+++ b/frontend/app/view/agent/resize-contract.ts
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * A single content-resize contract for the agent pane — step 2 of
+ * A single content-resize contract for the agent pane —
  * docs/specs/SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md.
  *
- * Landed with NO call sites yet (spec §5 step 2) — zero runtime effect. The
- * migration (step 3: `ToolOverlayLog.tsx`'s `flipHeight()`) is a separate,
- * reviewable-in-isolation change.
+ * Landed with no call sites (step 2, zero runtime effect); step 3 migrated
+ * `ToolOverlayLog.tsx`'s `flipHeight()` to it, the first real consumer.
  *
  * ## What this replaces
  *
@@ -47,15 +46,23 @@
  * call that once the mutation has landed in the DOM.
  *
  * Both close over their OWN `fromPx` in their own call's closure — neither
- * reads or writes any state shared across calls. This is what eliminates
- * the node-identity-reset class of bug by construction rather than by a
- * bespoke guard: `ToolOverlayLog.tsx`'s current `flipHeight()` needs a
- * `prevNodeId` check specifically because its baseline
- * (`lastMeasuredHeight`) is a variable shared across every effect
- * invocation, so a streaming-buffer cap-advance swapping a different node
- * into the same DOM slot without unmounting can make an unrelated old
- * height leak into a new node's first real transition. Neither entry point
- * here has an equivalent shared field for that to leak through.
+ * reads or writes any state shared across calls, which shrinks (but does
+ * NOT eliminate) the node-identity-reset class of bug: the ORIGINAL version
+ * of this comment claimed callers would never need a `prevNodeId`-style
+ * guard because of this. That was wrong, corrected once `ToolOverlayLog.tsx`
+ * actually migrated (step 3): a streaming-buffer cap-advance can still swap
+ * a different node into the same DOM slot between calling
+ * `beginHeightContinuity` and calling the commit function it returned — the
+ * CALLER still holds that returned closure across the swap in its own
+ * variable, and this module has no way to know the node identity changed
+ * underneath it. `ToolOverlayLog.tsx` keeps its own `lastNodeId` guard for
+ * exactly this — simplified from the old code (no `lastMeasuredHeight`/
+ * `heightStale` to carry, just discard the pending commit on a swap), but
+ * still necessary. What this module's closure-per-call design DOES remove
+ * is the OTHER half of the old bug: a stale `lastMeasuredHeight` baseline
+ * leaking from the outgoing node into whatever the incoming node's `commit`
+ * eventually reads as `toPx` — that's now impossible by construction, since
+ * `fromPx` is captured fresh in each `beginHeightContinuity` call.
  */
 
 import { atoms } from "@/app/store/global";
@@ -194,6 +201,26 @@ function cancelInFlight(el: HTMLElement): void {
     inFlight.get(el)?.();
 }
 
+/** Default height read — `offsetHeight`, the rendered box. Correct for the
+ *  common case (a row that simply grows/shrinks with its own content, e.g.
+ *  `AgentDocumentVirtualList`'s row-height sampling), wrong for an element
+ *  that scrolls its OWN overflow inside an ancestor's `max-height` — for
+ *  that shape, `offsetHeight` is clamped to whatever's left of the
+ *  ancestor's budget and stops changing once content exceeds it, while
+ *  `scrollHeight` keeps reflecting the true content height. That's exactly
+ *  `ToolOverlayLog.tsx`'s `.agent-tool-overlay-log` (bounded by
+ *  `.agent-tool-panel`'s `max-height: 50vh`, `overflow-y: auto` on itself)
+ *  — the element this module's first real migration target needs to FLIP,
+ *  and precisely the large-shrink case (a long raw chunk log collapsing to
+ *  a short compact result) this whole effort exists to fix. Callers with
+ *  that shape must pass `measure: (el) => el.scrollHeight` explicitly; the
+ *  default stays `offsetHeight` rather than switching everyone to
+ *  `scrollHeight`, since for a non-scrolling element the two are normally
+ *  identical and `offsetHeight` is the cheaper, more universally correct
+ *  read (a `position: absolute`/zero-overflow row has no scrollHeight
+ *  distinct from its rendered size to begin with). */
+const DEFAULT_MEASURE = (el: HTMLElement): number => el.offsetHeight;
+
 /**
  * Run `mutate` (assumed to synchronously produce `el`'s new rendered
  * height — true for a plain Solid signal write, per the same synchronous-
@@ -202,15 +229,19 @@ function cancelInFlight(el: HTMLElement): void {
  * through to `mutate()` with no measurement at all when `el` isn't
  * currently measurable — there is nothing to FLIP FROM.
  */
-export function withHeightContinuity(el: HTMLElement, mutate: () => void): void {
+export function withHeightContinuity(
+    el: HTMLElement,
+    mutate: () => void,
+    measure: (el: HTMLElement) => number = DEFAULT_MEASURE,
+): void {
     cancelInFlight(el);
     if (!isMeasurable(el)) {
         mutate();
         return;
     }
-    const fromPx = el.offsetHeight;
+    const fromPx = measure(el);
     mutate();
-    const toPx = el.offsetHeight;
+    const toPx = measure(el);
     if (shouldAnimate(fromPx, toPx)) flip(el, fromPx, toPx);
 }
 
@@ -227,16 +258,19 @@ export function withHeightContinuity(el: HTMLElement, mutate: () => void): void 
  * function it returns, and the "to" read needs the same unpinning the
  * "from" read does, for the identical reason (see `cancelInFlight`).
  */
-export function beginHeightContinuity(el: HTMLElement): (this: void) => void {
+export function beginHeightContinuity(
+    el: HTMLElement,
+    measure: (el: HTMLElement) => number = DEFAULT_MEASURE,
+): (this: void) => void {
     cancelInFlight(el);
     if (!isMeasurable(el)) {
         return () => {};
     }
-    const fromPx = el.offsetHeight;
+    const fromPx = measure(el);
     return () => {
         cancelInFlight(el);
         if (!isMeasurable(el)) return;
-        const toPx = el.offsetHeight;
+        const toPx = measure(el);
         if (shouldAnimate(fromPx, toPx)) flip(el, fromPx, toPx);
     };
 }

--- a/frontend/app/view/agent/resize-contract.ts
+++ b/frontend/app/view/agent/resize-contract.ts
@@ -228,11 +228,28 @@ const DEFAULT_MEASURE = (el: HTMLElement): number => el.offsetHeight;
  * easing `el`'s height across the change if it's animatable. Falls straight
  * through to `mutate()` with no measurement at all when `el` isn't
  * currently measurable — there is nothing to FLIP FROM.
+ *
+ * `measureForGating` (codex P2, PR #2962): the delta `MAX_ANIMATED_DELTA_PX`
+ * bounds must be the VISUALLY RENDERED one, not necessarily the same number
+ * `measure` produces. For `ToolOverlayLog.tsx`'s `.agent-tool-overlay-log`,
+ * `measure` is `scrollHeight` (see `DEFAULT_MEASURE`'s doc comment for why) —
+ * but a long raw chunk log easily exceeds several thousand px of
+ * `scrollHeight` (the 1,000-line output cap alone gets there), while the
+ * box's actual RENDERED shrink is bounded by the ancestor panel's
+ * `max-height: 50vh` to at most a few hundred px. Gating the magnitude cap
+ * on the unclamped `scrollHeight` delta would skip animating exactly the
+ * long-output transitions this module exists to smooth, for a reason
+ * (`MAX_ANIMATED_DELTA_PX`) that was never about THIS element's visible
+ * shrink at all — it exists for the OTHER, unrelated whole-pane-collapse
+ * case (see that constant's own doc comment). Defaults to `measure` — most
+ * callers have no scrolling/clamping divergence, so the two numbers are the
+ * same and this parameter is a no-op for them.
  */
 export function withHeightContinuity(
     el: HTMLElement,
     mutate: () => void,
     measure: (el: HTMLElement) => number = DEFAULT_MEASURE,
+    measureForGating: (el: HTMLElement) => number = measure,
 ): void {
     cancelInFlight(el);
     if (!isMeasurable(el)) {
@@ -240,9 +257,11 @@ export function withHeightContinuity(
         return;
     }
     const fromPx = measure(el);
+    const fromGatePx = measureForGating(el);
     mutate();
     const toPx = measure(el);
-    if (shouldAnimate(fromPx, toPx)) flip(el, fromPx, toPx);
+    const toGatePx = measureForGating(el);
+    if (shouldAnimate(fromGatePx, toGatePx)) flip(el, fromPx, toPx);
 }
 
 /**
@@ -257,20 +276,26 @@ export function withHeightContinuity(
  * during the (potentially long) gap between calling this and calling the
  * function it returns, and the "to" read needs the same unpinning the
  * "from" read does, for the identical reason (see `cancelInFlight`).
+ *
+ * `measureForGating` — see `withHeightContinuity`'s doc comment; same
+ * reasoning, applied at both capture and commit time.
  */
 export function beginHeightContinuity(
     el: HTMLElement,
     measure: (el: HTMLElement) => number = DEFAULT_MEASURE,
+    measureForGating: (el: HTMLElement) => number = measure,
 ): (this: void) => void {
     cancelInFlight(el);
     if (!isMeasurable(el)) {
         return () => {};
     }
     const fromPx = measure(el);
+    const fromGatePx = measureForGating(el);
     return () => {
         cancelInFlight(el);
         if (!isMeasurable(el)) return;
         const toPx = measure(el);
-        if (shouldAnimate(fromPx, toPx)) flip(el, fromPx, toPx);
+        const toGatePx = measureForGating(el);
+        if (shouldAnimate(fromGatePx, toGatePx)) flip(el, fromPx, toPx);
     };
 }


### PR DESCRIPTION
## Summary

Step 3 of `SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md`. Gated on step 1's real data (#2887): 284/351 captured shrinks in a live session are `tool`-kind nodes, 0 `markdown` — confirms this migration target (Source A) dominates.

**`resize-contract.ts`** gets an optional `measure` parameter on both entry points — discovered necessary, not designed in advance. The migration target, `.agent-tool-overlay-log`, scrolls its own overflow (`overflow-y: auto`) inside `.agent-tool-panel`'s `max-height: 50vh` cap, so the module's default `offsetHeight` read clamps at whatever's left of that budget and stops changing once content exceeds it, while `scrollHeight` keeps reflecting the true content height — exactly the large-shrink case (long raw chunk log → short compact result) this whole effort exists to fix. `offsetHeight` alone would have silently missed it. Defaults unchanged for existing/future non-scrolling consumers.

**`ToolOverlayLog.tsx`** — deleted `flipHeight()`/`HEIGHT_FLIP_MS` and the `lastMeasuredHeight`/`heightStale`/`cancelHeightFlip` state they needed. Replaced with `beginHeightContinuity(el, measureHeight)`, captured fresh every effect invocation (so the eventual FLIP's "from" is always the most recent height, not whatever it was when the branch started) and committed only when the branch actually changed. Re-baselines for the *next* invocation **before** committing the current one — `beginHeightContinuity` cancels any in-flight transition as part of capturing a trustworthy height, and doing that after committing would cancel the flip just started in the same tick. Kept the `nodeId` slot-reuse guard (simplified — just discards a pending commit now, no branch/height bookkeeping to carry).

This also resolves the spec's own §3a (`heightStale`/`panelHidden` allow-discrete lag) — not a targeted fix, a side effect of `isMeasurable()` reading computed `content-visibility` on the real ancestor chain instead of a class-based `MutationObserver` signal, exactly as that section predicted it might.

## On the tests (worth reading, not just the summary)

Three of the existing FLIP tests were weaker than they looked — same root cause each time: a constant `scrollHeight` stub across the compared reads meant `shouldAnimate`'s own zero-delta check masked whether the thing actually under test (branch-change gating, hidden-detection) was doing anything. Rewrote each so the height genuinely differs across the reads being compared.

The hidden-panel test's **first** fix was itself wrong: I mocked `getComputedStyle` using `el.closest(".agent-tool-panel--hidden")`, which climbs ancestors *itself* — so the test stayed green even after I deliberately broke `resize-contract.ts`'s own ancestor walk to check. Fixed to check only the exact queried element's own class (`el.classList.contains(...)`), matching real non-inherited `getComputedStyle` semantics, then reconfirmed the break is now actually caught.

Also falsified the branch-changed gate, the `nodeId` guard, and the capture-before-commit ordering (the specific self-cancellation bug this ordering avoids) by removing each independently and confirming the right test fails.

Spec doc updated: §3a marked resolved, §4's proposed signatures given the `measure` param neither original draft anticipated, §5 steps 1-3 marked done, mechanism table's `ToolOverlayLog.tsx` line ranges re-verified against the current file.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean.
- [x] `npx vitest run` across `resize-contract`, `ToolOverlayLog`, `PersistentShellBlock`, `output-cap`, `ToolBlock` — 123/123.
- [x] Falsified: `measure` param usage in both entry points, the `nodeId` guard, the `branchChanged` gate, the capture-before-commit ordering, and the ancestor-walk fix at the consumer/integration level (not just resize-contract.ts's own unit tests) — each confirmed to fail when its corresponding source line is removed, restored, clean diff.
- [ ] Not yet observed in a running instance.

<!-- agentmux:agent_id=agent1 -->