### PR TITLE
fix(agent): provider_flags were dropped from cmd:args on every send

### DIFF
--- a/.changesets/1788496373-fix-agent-provider-flags-were-dropped-from-cmd-args-on-every-zk5t.md
+++ b/.changesets/1788496373-fix-agent-provider-flags-were-dropped-from-cmd-args-on-every-zk5t.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): provider_flags were dropped from cmd:args on every send

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -25,7 +25,7 @@ import { parseSeedZoom } from "./agent-zoom-seed";
 import { resolveForkSessionArgs } from "./fork-session-args";
 import { HISTORY_TAB_FOR_META_KEY, openOrFocusHistoryTab } from "./open-history-tab";
 import { quickForkAgent } from "./quick-fork";
-import { isPersistentLaunch, selectLaunchArgs } from "./launch-args";
+import { isPersistentLaunch, PROVIDER_FLAGS_META_KEY, selectLaunchArgs } from "./launch-args";
 
 export class AgentViewModel implements ViewModel {
     viewType = "agent";
@@ -688,6 +688,13 @@ export class AgentViewModel implements ViewModel {
                 // expression, so the controller/args choice and the mode this
                 // block advertises can never disagree.
                 agentMode,
+                // Persisted so the per-turn cmd:args rebuild can reapply it.
+                // That rebuild starts from the provider catalog, which knows
+                // nothing about what the launch path appended, so without this
+                // the user's flags are dropped on the first send and never come
+                // back (#2872). `--fork-session` is deliberately NOT persisted
+                // here — it is a one-shot launch intent, not a durable arg.
+                [PROVIDER_FLAGS_META_KEY]: agent.provider_flags ?? "",
                 ...(overrides?.containerImage || agent.container_image ? { "agent:container_image": overrides?.containerImage || agent.container_image } : {}),
                 controller: isPersistent ? "persistent" : "subprocess",
                 cmd: cliBin,

--- a/frontend/app/view/agent/commands/global/runtime.ts
+++ b/frontend/app/view/agent/commands/global/runtime.ts
@@ -42,7 +42,7 @@ async function updateRuntime(
         // the change applies to the running agent. Shared with the GUI control
         // bar via applyRuntimeChange — the persistent rebuild/restart used to
         // live only here (#1503), so the dropdown silently no-op'd.
-        await applyRuntimeChange(ctx.blockId, ctx.provider(), updated, ctx.block()?.meta?.["agentMode"] as string | undefined);
+        await applyRuntimeChange(ctx.blockId, ctx.provider(), updated, ctx.block()?.meta);
         return { ok: true, updated };
     } catch (err: any) {
         return { ok: false, error: err?.message ?? String(err) };

--- a/frontend/app/view/agent/components/AgentRuntimeDropup.tsx
+++ b/frontend/app/view/agent/components/AgentRuntimeDropup.tsx
@@ -110,7 +110,7 @@ export const AgentRuntimeDropup = (props: AgentRuntimeDropupProps): JSX.Element 
                 props.blockId,
                 getProvider(props.providerId),
                 { ...runtime(), ...patch },
-                props.blockAtom()?.meta?.["agentMode"] as string | undefined,
+                props.blockAtom()?.meta,
             );
         } catch {
             // Silent — settings retry on next change (matches the prior

--- a/frontend/app/view/agent/hooks/useAgentCommands.test.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.test.ts
@@ -2787,8 +2787,8 @@ describe("useAgentCommands — pre-turn cmd:args honours agentMode, not just con
         ],
     } as any;
 
-    /** Run one send with the given agentMode and return the persisted cmd:args. */
-    const argsWrittenFor = async (agentMode: string | undefined): Promise<string[]> => {
+    /** Run one send with the given block meta and return the persisted cmd:args. */
+    const argsWrittenForMeta = async (meta: Record<string, unknown>): Promise<string[]> => {
         const model = registerPane(BLOCK_ID, fullRegistration());
         model.dispatchPane({ type: "InitReady", at: Date.now() }, "system");
         model.dispatchPane({ type: "StreamSubscribe", at: Date.now() }, "system");
@@ -2800,7 +2800,7 @@ describe("useAgentCommands — pre-turn cmd:args honours agentMode, not just con
             const commands = useAgentCommands({
                 blockId: BLOCK_ID,
                 model,
-                block: () => ({ meta: { agentMode } }) as any,
+                block: () => ({ meta }) as any,
                 provider: () => claudeProvider,
                 documentAtom: [() => [], () => {}] as any,
                 log: () => {},
@@ -2826,6 +2826,9 @@ describe("useAgentCommands — pre-turn cmd:args honours agentMode, not just con
         return written;
     };
 
+    const argsWrittenFor = (agentMode: string | undefined): Promise<string[]> =>
+        argsWrittenForMeta({ agentMode });
+
     /** The whole point: this is the flag that killed every container agent. */
     it("never writes --input-format for a container agent", async () => {
         expect(await argsWrittenFor("container")).not.toContain("--input-format");
@@ -2843,6 +2846,38 @@ describe("useAgentCommands — pre-turn cmd:args honours agentMode, not just con
     /** Blocks predating the agentMode meta key must keep host behaviour. */
     it("treats a block with no agentMode as a host agent", async () => {
         expect(await argsWrittenFor(undefined)).toContain("--input-format");
+    });
+
+    /** #2872: this rebuild runs before EVERY send and derives its base from the
+     *  provider catalog, so the agent's own provider_flags — appended by the
+     *  launch path, which the catalog knows nothing about — were dropped on the
+     *  first send and never came back, for host agents as much as container
+     *  ones. */
+    it("reapplies the agent's provider_flags on every send", async () => {
+        const args = await argsWrittenForMeta({
+            agentMode: "host",
+            "agent:provider_flags": "--my-flag 7",
+        });
+        expect(args).toContain("--my-flag");
+        expect(args[args.indexOf("--my-flag") + 1]).toBe("7");
+    });
+
+    /** …and must not resurrect the one-shot launch intent alongside them.
+     *  `--fork-session` forks the session being resumed; reapplying it every
+     *  turn would fork again on each one. */
+    it("does NOT reapply --fork-session", async () => {
+        const args = await argsWrittenForMeta({
+            agentMode: "host",
+            "agent:provider_flags": "--my-flag",
+        });
+        expect(args).not.toContain("--fork-session");
+    });
+
+    /** A pane launched before the meta key existed must still send. */
+    it("sends normally when provider_flags meta is absent", async () => {
+        const args = await argsWrittenForMeta({ agentMode: "host" });
+        expect(args).toContain("--input-format");
+        expect(args.some((a) => a.startsWith("--my"))).toBe(false);
     });
 });
 

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -32,7 +32,7 @@ import { snapshot as paneSnapshot } from "@/app/store/agent-pane-state-store";
 import { workingFromPhase, type PaneFailure } from "@/app/store/agent-pane-state/types";
 import type { AgentPaneModel } from "@/app/store/agent-pane-registration";
 import { buildRuntimeArgs, getRuntimeConfig } from "../buildRuntimeArgs";
-import { selectLaunchArgs } from "../launch-args";
+import { PROVIDER_FLAGS_META_KEY, selectLaunchArgs, withProviderFlags } from "../launch-args";
 import { dispatchSlashCommand } from "../commands/dispatch";
 import { buildRegistry } from "../commands/registry";
 import type { SlashCommand, SlashCommandContext, SlashPickerSpec } from "../commands/types";
@@ -1311,9 +1311,19 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
             // it rewrote the bad flags into cmd:args on every turn regardless
             // of what launch time had chosen (reagent P1 on PR #2867 — the
             // fourth copy of this rule, and the one that fires most often).
-            const agentMode = opts.block()?.meta?.["agentMode"] as string | undefined;
+            const meta = opts.block()?.meta;
+            const agentMode = meta?.["agentMode"] as string | undefined;
             const baseArgs = selectLaunchArgs(prov, agentMode);
-            const updatedArgs = buildRuntimeArgs(baseArgs, runtimeConfig, prov.id);
+            // Reapply the agent's own provider_flags. This rebuild starts from
+            // the provider CATALOG, so anything the launch path appended is
+            // otherwise dropped here — permanently, on the very first send
+            // (#2872). `--fork-session` is intentionally not restored: it is a
+            // one-shot launch intent, and reapplying it every turn would fork
+            // the session again on each one.
+            const updatedArgs = withProviderFlags(
+                buildRuntimeArgs(baseArgs, runtimeConfig, prov.id),
+                meta?.[PROVIDER_FLAGS_META_KEY],
+            );
             try {
                 await RpcApi.SetMetaCommand(TabRpcClient, {
                     oref: WOS.makeORef("block", opts.blockId),

--- a/frontend/app/view/agent/launch-args.test.ts
+++ b/frontend/app/view/agent/launch-args.test.ts
@@ -12,7 +12,13 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { isPersistentLaunch, selectLaunchArgs, type LaunchArgsProvider } from "./launch-args";
+import {
+    isPersistentLaunch,
+    parseProviderFlags,
+    selectLaunchArgs,
+    withProviderFlags,
+    type LaunchArgsProvider,
+} from "./launch-args";
 
 /** Claude's real shape, copied from providers/catalog.ts. */
 const claude: LaunchArgsProvider = {
@@ -87,5 +93,66 @@ describe("selectLaunchArgs", () => {
         expect(args).not.toBe(claude.persistentLaunchArgs);
         args.push("--mutated");
         expect(claude.persistentLaunchArgs).not.toContain("--mutated");
+    });
+});
+
+/**
+ * The per-turn `cmd:args` rebuild derives its base from the provider CATALOG,
+ * so anything the launch path appended afterwards is dropped unless something
+ * puts it back. Two things get appended, and they are NOT the same kind of
+ * thing (#2872):
+ *
+ *   provider_flags   durable  — how this agent always runs → reapply every turn
+ *   --fork-session   one-shot — fork the session being resumed AT LAUNCH
+ *
+ * Reapplying `--fork-session` would pair it with the `--resume <sid>` srv adds
+ * on every later turn, forking again each time instead of once. So the fix is
+ * deliberately asymmetric, and that asymmetry is the part worth pinning.
+ */
+describe("provider_flags are durable; --fork-session is not", () => {
+    it("splits provider_flags on whitespace, the way the launch path always has", () => {
+        expect(parseProviderFlags("--foo --bar=1")).toEqual(["--foo", "--bar=1"]);
+        expect(parseProviderFlags("  --a   --b  ")).toEqual(["--a", "--b"]);
+    });
+
+    /** A pane launched before the meta key existed, or an agent with none. */
+    it("treats absent or non-string provider_flags as no flags", () => {
+        expect(parseProviderFlags(undefined)).toEqual([]);
+        expect(parseProviderFlags("")).toEqual([]);
+        expect(parseProviderFlags(null)).toEqual([]);
+        expect(parseProviderFlags(42)).toEqual([]);
+    });
+
+    /** The bug: the user's flags must survive a rebuild. */
+    it("reapplies provider_flags onto a rebuilt argv", () => {
+        const rebuilt = ["-p", "--model", "opus"];
+        expect(withProviderFlags(rebuilt, "--my-flag 7")).toEqual([
+            "-p", "--model", "opus", "--my-flag", "7",
+        ]);
+    });
+
+    it("returns the argv untouched when there are no flags to reapply", () => {
+        const rebuilt = ["-p", "--model", "opus"];
+        expect(withProviderFlags(rebuilt, "")).toEqual(rebuilt);
+        expect(withProviderFlags(rebuilt, undefined)).toEqual(rebuilt);
+    });
+
+    /** The asymmetry. `--fork-session` must NOT come back: this helper only
+     *  ever knows about provider_flags, so a future caller can't accidentally
+     *  route a one-shot launch intent through it. */
+    it("never reintroduces --fork-session", () => {
+        const rebuilt = ["-p", "--model", "opus"];
+        expect(withProviderFlags(rebuilt, "--my-flag")).not.toContain("--fork-session");
+        // Even if it were somehow stored there, it is the caller's job not to —
+        // this documents that the helper is not a general "restore everything".
+        expect(parseProviderFlags("--fork-session")).toEqual(["--fork-session"]);
+    });
+
+    /** Appends, never rewrites — the catalog base can't already carry these. */
+    it("does not mutate the argv it is given", () => {
+        const rebuilt = ["-p"];
+        const out = withProviderFlags(rebuilt, "--x");
+        expect(rebuilt).toEqual(["-p"]);
+        expect(out).not.toBe(rebuilt);
     });
 });

--- a/frontend/app/view/agent/launch-args.ts
+++ b/frontend/app/view/agent/launch-args.ts
@@ -56,3 +56,42 @@ export function selectLaunchArgs(provider: LaunchArgsProvider, agentMode: string
         ? [...provider.persistentLaunchArgs]
         : [...provider.launchArgs];
 }
+
+/**
+ * Block-meta key holding the agent definition's `provider_flags` verbatim.
+ *
+ * Persisted at launch so the per-turn `cmd:args` rebuild can reapply it. The
+ * rebuild derives its base from the provider CATALOG, which by construction
+ * knows nothing the launch path appended afterwards — so without this the
+ * user's flags survive exactly until the first send and are then gone for the
+ * life of the pane (#2872).
+ */
+export const PROVIDER_FLAGS_META_KEY = "agent:provider_flags";
+
+/**
+ * Split an agent definition's `provider_flags` into argv tokens.
+ *
+ * Whitespace-separated, matching how the launch path has always split it.
+ * Anything non-string (absent meta on a pane launched before the key existed)
+ * is no flags rather than an error.
+ */
+export function parseProviderFlags(raw: unknown): string[] {
+    return typeof raw === "string" ? raw.split(/\s+/).filter(Boolean) : [];
+}
+
+/**
+ * Reapply the user's `provider_flags` to a freshly rebuilt argv.
+ *
+ * These are DURABLE args: they describe how this agent always runs, so every
+ * turn needs them. That is what distinguishes them from `--fork-session`, the
+ * other thing the launch path appends — which is a ONE-SHOT intent (fork the
+ * session being resumed at launch) and is deliberately NOT reapplied. Carrying
+ * it forward would pair `--fork-session` with the `--resume <sid>` srv adds on
+ * every subsequent turn, forking again each time instead of once.
+ *
+ * Appends only; the catalog base can never already contain these.
+ */
+export function withProviderFlags(args: string[], raw: unknown): string[] {
+    const flags = parseProviderFlags(raw);
+    return flags.length > 0 ? [...args, ...flags] : args;
+}

--- a/frontend/app/view/agent/runtime-apply.ts
+++ b/frontend/app/view/agent/runtime-apply.ts
@@ -38,7 +38,7 @@ import { TabRpcClient } from "@/app/store/rpc-util";
 import * as WOS from "@/app/store/wos";
 import { staticTabId } from "@/app/store/global";
 import { buildRuntimeArgs } from "./buildRuntimeArgs";
-import { isPersistentLaunch, selectLaunchArgs } from "./launch-args";
+import { isPersistentLaunch, PROVIDER_FLAGS_META_KEY, selectLaunchArgs, withProviderFlags } from "./launch-args";
 import type { AgentRuntimeConfig } from "./types";
 import type { ProviderDefinition } from "./providers";
 
@@ -52,19 +52,26 @@ export async function applyRuntimeChange(
     provider: ProviderDefinition | undefined,
     updated: AgentRuntimeConfig,
     /**
-     * `block.meta["agentMode"]` — "host" or "container". REQUIRED for
-     * correctness on container agents, defaulted only so existing callers
-     * that predate it keep compiling.
+     * The block's own `meta`. Two things are read from it, and both are
+     * REQUIRED for correctness — it takes the whole object rather than one
+     * extracted field so a third such fact doesn't mean a third parameter:
      *
-     * This function used to branch on `provider.controllerType === "persistent"`
-     * alone — a third, unmigrated copy of the rule `launch-args.ts` now owns
-     * (reagent P1 on PR #2867). On a container agent that rewrote
-     * `--input-format stream-json` straight back into persisted `cmd:args` on
-     * every /model, /effort or /mode change, undoing the launch-time fix, and
-     * forced a controller restart the container path never needed.
+     * - `agentMode` ("host" / "container"). This function used to branch on
+     *   `provider.controllerType === "persistent"` alone — an unmigrated copy
+     *   of the rule `launch-args.ts` now owns (reagent P1 on PR #2867). On a
+     *   container agent that rewrote `--input-format stream-json` straight back
+     *   into persisted `cmd:args` on every /model, /effort or /mode change,
+     *   undoing the launch-time fix, and forced a controller restart the
+     *   container path never needed.
+     * - `agent:provider_flags`. The rebuild below starts from the provider
+     *   catalog, so without reapplying these the user's flags are dropped from
+     *   `cmd:args` by the first runtime change (#2872).
+     *
+     * Optional only so callers predating it keep compiling.
      */
-    agentMode?: string,
+    blockMeta?: Record<string, unknown>,
 ): Promise<void> {
+    const agentMode = blockMeta?.["agentMode"] as string | undefined;
     const oref = WOS.makeORef("block", blockId);
     await RpcApi.SetMetaCommand(TabRpcClient, {
         oref,
@@ -77,7 +84,13 @@ export async function applyRuntimeChange(
     // one with no controller churn at all.
     if (provider && isPersistentLaunch(provider, agentMode)) {
         const baseArgs = selectLaunchArgs(provider, agentMode);
-        const updatedArgs = buildRuntimeArgs(baseArgs, updated, provider.id);
+        // `--fork-session` is deliberately not reapplied — it is a one-shot
+        // launch intent, unlike provider_flags which describe how this agent
+        // always runs. See withProviderFlags' own doc.
+        const updatedArgs = withProviderFlags(
+            buildRuntimeArgs(baseArgs, updated, provider.id),
+            blockMeta?.[PROVIDER_FLAGS_META_KEY],
+        );
         await RpcApi.SetMetaCommand(TabRpcClient, {
             oref,
             meta: { "cmd:args": updatedArgs },


### PR DESCRIPTION
Closes #2872.

## The bug

The per-turn `cmd:args` rebuild derives its base from the provider **catalog**, so anything the launch path appended afterwards is dropped:

```ts
const baseArgs = selectLaunchArgs(prov, agentMode);      // catalog
const updatedArgs = buildRuntimeArgs(baseArgs, runtimeConfig, prov.id);
```

`agent.provider_flags` is a real, user-configurable field appended at `agent-model.ts:446`. It was gone from the **first send** onward, for the life of the pane.

Not container-specific, and not new: host agents lost it identically, ever since the runtime controls landed in `f702ceae4` — which predates `provider_flags` itself. The two features were built independently and the rebuild simply never knew about anything appended after the base args.

## The part that isn't mechanical

The launch path appends **two** things, and they are not the same kind of thing:

| | kind | per-turn |
|---|---|---|
| `provider_flags` | durable — how this agent always runs | reapply |
| `--fork-session` | one-shot — fork the session being resumed **at launch** | do **not** reapply |

`--fork-session` is paired with a specific `continueSessionId` (`fork-session-args.ts`). Once forked, the agent has its own session and later turns resume it normally — so reapplying the flag would pair it with the `--resume <sid>` srv adds on every subsequent turn, forking again each time instead of once.

That is why this is fixed **where the args are appended**, rather than by having the rebuild preserve whatever it finds in the live argv. "Just use the existing `cmd:args` as the base" works mechanically — `buildRuntimeArgs` is idempotent — but it would carry the one-shot intent forward too, which is plausibly worse than the bug. That reasoning is why I filed #2872 instead of folding this into #2867 at the time.

## Change

- `provider_flags` is persisted at launch under `agent:provider_flags` and reapplied by both rebuild sites: the pre-send rebuild in `useAgentCommands`, and `applyRuntimeChange` (`/model`, `/effort`, `/mode`).
- `withProviderFlags` / `parseProviderFlags` live in `launch-args.ts`, next to the rule they belong with. `withProviderFlags` only ever knows about provider_flags, so a future caller can't route a one-shot intent through it by accident.
- `applyRuntimeChange` now takes the block's `meta` rather than one extracted field — it needs two of them now, and a third would otherwise mean a third positional parameter.
- srv's `container_argv` already preserves unknown tokens (it subtracts persistent-only flags rather than rebuilding), so a container agent's flags survive its self-heal too.

## Limits, stated plainly

Panes launched **before** this meta key exists have no flags to restore — theirs were already dropped and are not recoverable from the argv. They pick it up on next launch.

## Tests

The send-path test fails on the old code with `expected [ '--input-format', …(9) ] to include '--my-flag'`. Alongside it: the whitespace split, absent/non-string meta (a pane predating the key), argv not mutated, and that `--fork-session` is never reintroduced.

1705 passing in `app/view/agent`, `tsc --noEmit` clean.

<!-- agentmux:agent_id=agent2 -->