### PR TITLE
Camper@claudius: Persist system-tool install success, show live version, collapse install log

### DIFF
--- a/.changesets/1788496460-fix-toolchain-persist-system-tool-install-success-across-sta-59u0.md
+++ b/.changesets/1788496460-fix-toolchain-persist-system-tool-install-success-across-sta-59u0.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(toolchain): persist system-tool install success across stale-PATH refresh, show live version and collapsible install details

--- a/agentmux-srv/src/server/system_install_handlers.rs
+++ b/agentmux-srv/src/server/system_install_handlers.rs
@@ -72,6 +72,16 @@ struct SystemInstallStep {
     /// before the caller's own immediate re-probe shows "still not
     /// found" — Codex P1, PR #2790.
     verify_bin: String,
+    /// Version this exact command would install, queried live from the
+    /// package manager's own catalog at resolve time — never hardcoded.
+    /// A hardcoded "v24" here would repeat the exact staleness bug this
+    /// repo already hit once (Taskfile.yml's VERSION var pinned to a
+    /// specific `node@20` brew formula that outlived that major version
+    /// — see #2942). `None` when the query itself fails or isn't
+    /// implemented for this package manager (most Linux managers below);
+    /// the frontend falls back to unversioned copy in that case, never a
+    /// stale guess.
+    resolved_version: Option<String>,
 }
 
 /// Linux package managers this module knows how to drive, in detection
@@ -152,17 +162,49 @@ fn verify_bin_for_tool(tool_id: &str, windows: bool) -> Option<&'static str> {
     }
 }
 
-fn resolve_windows_step(tool_id: &str) -> Option<SystemInstallStep> {
-    // winget package identifiers — see https://github.com/microsoft/winget-pkgs.
-    // `node`/`npm` share one identifier: npm ships bundled with Node, so
-    // there is no separate winget package for it (mirrors the frontend
-    // catalog's existing node/npm-both-resolve-to-node modeling).
-    let winget_id = match tool_id {
-        "git" => "Git.Git",
-        "node" | "npm" => "OpenJS.NodeJS.LTS",
-        "python" => "Python.Python.3.12",
-        _ => return None,
-    };
+/// Parses `winget show --id <id> -e`'s `Version:` line. Best-effort: any
+/// failure (winget missing/erroring, unexpected output format) returns
+/// `None` and the frontend falls back to unversioned copy — never a
+/// guess. Deliberately a separate call from the actual install, not a
+/// flag on it: `show` never mutates anything, so it's safe to run purely
+/// for display even before the user has consented to installing.
+async fn query_winget_version(winget_id: &str) -> Option<String> {
+    let mut c = tokio::process::Command::new("winget");
+    c.args(["show", "--id", winget_id, "-e"]);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        c.creation_flags(CREATE_NO_WINDOW);
+    }
+    let output = c.output().await.ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout.lines().find_map(|line| {
+        line.strip_prefix("Version:").map(|v| v.trim().to_string())
+    })
+}
+
+// winget package identifiers — see https://github.com/microsoft/winget-pkgs.
+// `node`/`npm` share one identifier: npm ships bundled with Node, so there
+// is no separate winget package for it (mirrors the frontend catalog's
+// existing node/npm-both-resolve-to-node modeling). Its own function (not
+// inlined into `resolve_windows_step`) so `resolve_install_step` can look
+// up the same id to query a version from, without a second copy of this
+// match that could drift from the one that builds the actual install args.
+fn windows_winget_id(tool_id: &str) -> Option<&'static str> {
+    match tool_id {
+        "git" => Some("Git.Git"),
+        "node" | "npm" => Some("OpenJS.NodeJS.LTS"),
+        "python" => Some("Python.Python.3.12"),
+        _ => None,
+    }
+}
+
+fn resolve_windows_step(tool_id: &str, resolved_version: Option<String>) -> Option<SystemInstallStep> {
+    let winget_id = windows_winget_id(tool_id)?;
     Some(SystemInstallStep {
         program: "winget".to_string(),
         args: vec![
@@ -183,18 +225,47 @@ fn resolve_windows_step(tool_id: &str) -> Option<SystemInstallStep> {
         // hardware verification item, not yet confirmed.
         needs_elevation: true,
         verify_bin: verify_bin_for_tool(tool_id, true)?.to_string(),
+        resolved_version,
     })
+}
+
+/// Parses `brew info --json=v2 <formula>`'s `versions.stable` field.
+/// Best-effort, same posture as `query_winget_version`.
+async fn query_brew_version(formula: &str) -> Option<String> {
+    let output = tokio::process::Command::new("brew")
+        .args(["info", "--json=v2", formula])
+        .output()
+        .await
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    parsed
+        .get("formulae")?
+        .get(0)?
+        .get("versions")?
+        .get("stable")?
+        .as_str()
+        .map(|s| s.to_string())
+}
+
+/// Homebrew formula names — its own function for the same reason as
+/// `windows_winget_id` above: shared between the install-args builder and
+/// the version query, without a second copy that could drift.
+fn brew_formula(tool_id: &str) -> Option<&'static str> {
+    match tool_id {
+        "git" => Some("git"),
+        "node" | "npm" => Some("node"),
+        "python" => Some("python@3.12"),
+        _ => None,
+    }
 }
 
 /// Only reachable when `brew` is already on PATH (checked by the caller,
 /// `resolve_install_step`) — this module never bootstraps Homebrew itself.
-fn resolve_brew_step(tool_id: &str) -> Option<SystemInstallStep> {
-    let formula = match tool_id {
-        "git" => "git",
-        "node" | "npm" => "node",
-        "python" => "python@3.12",
-        _ => return None,
-    };
+fn resolve_brew_step(tool_id: &str, resolved_version: Option<String>) -> Option<SystemInstallStep> {
+    let formula = brew_formula(tool_id)?;
     Some(SystemInstallStep {
         program: "brew".to_string(),
         args: vec!["install".to_string(), formula.to_string()],
@@ -202,7 +273,47 @@ fn resolve_brew_step(tool_id: &str) -> Option<SystemInstallStep> {
         // with no elevation step to build at all.
         needs_elevation: false,
         verify_bin: verify_bin_for_tool(tool_id, false)?.to_string(),
+        resolved_version,
     })
+}
+
+/// Parses `apt-cache policy <pkg>`'s `Candidate:` line — the version apt
+/// would actually install right now. Scoped to apt only, deliberately:
+/// `dnf`/`pacman`/`zypper`/`apk` each have a genuinely different query
+/// command and output format (`dnf info`, `pacman -Si`, `zypper info`,
+/// `apk policy`/`apk info`), and implementing all five for a display-only
+/// version label isn't worth the surface area in one pass. Returns `None`
+/// for every other manager — the frontend falls back to unversioned copy,
+/// which is honest, not a stale guess pretending to be real.
+async fn query_apt_version(pkg: &str) -> Option<String> {
+    let output = tokio::process::Command::new("apt-cache")
+        .args(["policy", pkg])
+        .output()
+        .await
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout.lines().find_map(|line| {
+        line.trim()
+            .strip_prefix("Candidate:")
+            .map(|v| v.trim().to_string())
+            .filter(|v| v != "(none)")
+    })
+}
+
+/// Primary package name to query a version for on apt specifically — the
+/// actual install still uses `resolve_linux_step`'s full, PM-aware package
+/// list below; this is only the one representative package worth asking
+/// apt "what version would you install" about for display purposes.
+fn apt_primary_package(tool_id: &str) -> Option<&'static str> {
+    match tool_id {
+        "git" => Some("git"),
+        "node" | "npm" => Some("nodejs"),
+        "python" => Some("python3"),
+        _ => None,
+    }
 }
 
 /// Elevated via `pkexec`, which raises the desktop's own native polkit
@@ -221,7 +332,11 @@ fn resolve_brew_step(tool_id: &str) -> Option<SystemInstallStep> {
 /// not a plain package install) and is deliberately NOT implemented
 /// here. `dnf`/`pacman`/`zypper`/`apk`'s Node packages don't have the
 /// same well-known staleness reputation.
-fn resolve_linux_step(tool_id: &str, pm: LinuxPackageManager) -> Option<SystemInstallStep> {
+fn resolve_linux_step(
+    tool_id: &str,
+    pm: LinuxPackageManager,
+    resolved_version: Option<String>,
+) -> Option<SystemInstallStep> {
     let packages: &[&str] = match tool_id {
         "git" => &["git"],
         "node" | "npm" => &["nodejs", "npm"],
@@ -240,6 +355,7 @@ fn resolve_linux_step(tool_id: &str, pm: LinuxPackageManager) -> Option<SystemIn
         args,
         needs_elevation: true,
         verify_bin: verify_bin_for_tool(tool_id, false)?.to_string(),
+        resolved_version,
     })
 }
 
@@ -271,10 +387,18 @@ async fn resolve_install_step(tool_id: &str) -> Option<SystemInstallStep> {
         // gracefully falling back to the existing link+copy-command UI.
         // reagent P1, PR #2790.
         resolve_tool_path("winget").await?;
-        resolve_windows_step(tool_id)
+        let resolved_version = match windows_winget_id(tool_id) {
+            Some(id) => query_winget_version(id).await,
+            None => None,
+        };
+        resolve_windows_step(tool_id, resolved_version)
     } else if cfg!(target_os = "macos") {
         resolve_tool_path("brew").await?;
-        resolve_brew_step(tool_id)
+        let resolved_version = match brew_formula(tool_id) {
+            Some(formula) => query_brew_version(formula).await,
+            None => None,
+        };
+        resolve_brew_step(tool_id, resolved_version)
     } else {
         let pm = detect_linux_package_manager().await?;
         // Same class of check as the Windows/winget and macOS/brew
@@ -286,7 +410,11 @@ async fn resolve_install_step(tool_id: &str) -> Option<SystemInstallStep> {
         // reported with a command that fails to spawn instead of falling
         // back to the link+copy-command UI. reagent P2, PR #2790.
         resolve_tool_path("pkexec").await?;
-        resolve_linux_step(tool_id, pm)
+        let resolved_version = match (pm, apt_primary_package(tool_id)) {
+            (LinuxPackageManager::AptGet, Some(pkg)) => query_apt_version(pkg).await,
+            _ => None,
+        };
+        resolve_linux_step(tool_id, pm, resolved_version)
     }
 }
 
@@ -316,6 +444,7 @@ pub fn register_system_install_handlers(engine: &Arc<WshRpcEngine>, state: &AppS
                         "args": step.args,
                         "needsElevation": step.needs_elevation,
                         "commandPreview": format!("{} {}", step.program, step.args.join(" ")),
+                        "resolvedVersion": step.resolved_version,
                     }))),
                     None => Ok(Some(json!({ "available": false }))),
                 }
@@ -558,56 +687,63 @@ mod tests {
 
     #[test]
     fn resolve_windows_step_covers_the_catalog_and_rejects_unknown_ids() {
-        let git = resolve_windows_step("git").unwrap();
+        let git = resolve_windows_step("git", None).unwrap();
         assert_eq!(git.program, "winget");
         assert!(git.args.contains(&"Git.Git".to_string()));
         assert!(git.needs_elevation);
 
         // node and npm resolve to the SAME winget package — npm ships
         // bundled with Node, there is no separate winget entry for it.
-        let node = resolve_windows_step("node").unwrap();
-        let npm = resolve_windows_step("npm").unwrap();
+        let node = resolve_windows_step("node", None).unwrap();
+        let npm = resolve_windows_step("npm", None).unwrap();
         assert_eq!(node.args, npm.args);
         assert!(node.args.contains(&"OpenJS.NodeJS.LTS".to_string()));
 
-        assert!(resolve_windows_step("python").is_some());
-        assert!(resolve_windows_step("docker").is_none());
-        assert!(resolve_windows_step("").is_none());
+        assert!(resolve_windows_step("python", None).is_some());
+        assert!(resolve_windows_step("docker", None).is_none());
+        assert!(resolve_windows_step("", None).is_none());
+    }
+
+    #[test]
+    fn resolve_windows_step_carries_the_resolved_version_through() {
+        let git = resolve_windows_step("git", Some("2.47.1".to_string())).unwrap();
+        assert_eq!(git.resolved_version.as_deref(), Some("2.47.1"));
     }
 
     #[test]
     fn resolve_brew_step_covers_the_catalog_and_never_needs_elevation() {
         for id in ["git", "node", "npm", "python"] {
-            let step = resolve_brew_step(id).unwrap();
+            let step = resolve_brew_step(id, None).unwrap();
             assert_eq!(step.program, "brew");
             assert!(!step.needs_elevation, "brew must never be modeled as needing elevation");
         }
-        assert!(resolve_brew_step("docker").is_none());
+        assert!(resolve_brew_step("docker", None).is_none());
     }
 
     #[test]
     fn resolve_linux_step_uses_the_correct_flag_syntax_per_manager() {
-        let apt = resolve_linux_step("git", LinuxPackageManager::AptGet).unwrap();
+        let apt = resolve_linux_step("git", LinuxPackageManager::AptGet, None).unwrap();
         assert_eq!(apt.program, "pkexec");
         assert_eq!(apt.args, vec!["apt-get", "install", "-y", "git"]);
 
-        let pacman = resolve_linux_step("git", LinuxPackageManager::Pacman).unwrap();
+        let pacman = resolve_linux_step("git", LinuxPackageManager::Pacman, None).unwrap();
         assert_eq!(pacman.args, vec!["pacman", "-S", "--noconfirm", "git"]);
 
-        let apk = resolve_linux_step("node", LinuxPackageManager::Apk).unwrap();
+        let apk = resolve_linux_step("node", LinuxPackageManager::Apk, None).unwrap();
         assert_eq!(apk.args, vec!["apk", "add", "nodejs", "npm"]);
 
         // python's package list is genuinely different per manager —
         // not just a flag-syntax difference.
-        let python_pacman = resolve_linux_step("python", LinuxPackageManager::Pacman).unwrap();
+        let python_pacman =
+            resolve_linux_step("python", LinuxPackageManager::Pacman, None).unwrap();
         assert_eq!(python_pacman.args, vec!["pacman", "-S", "--noconfirm", "python", "python-pip"]);
-        let python_apt = resolve_linux_step("python", LinuxPackageManager::AptGet).unwrap();
+        let python_apt = resolve_linux_step("python", LinuxPackageManager::AptGet, None).unwrap();
         assert_eq!(
             python_apt.args,
             vec!["apt-get", "install", "-y", "python3", "python3-pip", "python3-venv"]
         );
 
-        assert!(resolve_linux_step("docker", LinuxPackageManager::AptGet).is_none());
+        assert!(resolve_linux_step("docker", LinuxPackageManager::AptGet, None).is_none());
     }
 
     #[test]
@@ -618,14 +754,14 @@ mod tests {
         // "sh"/"bash"/"cmd"/"powershell" wrapping a formatted string.
         let shells = ["sh", "bash", "cmd", "cmd.exe", "powershell", "powershell.exe"];
         for id in ["git", "node", "npm", "python"] {
-            if let Some(s) = resolve_windows_step(id) {
+            if let Some(s) = resolve_windows_step(id, None) {
                 assert!(!shells.contains(&s.program.as_str()));
             }
-            if let Some(s) = resolve_brew_step(id) {
+            if let Some(s) = resolve_brew_step(id, None) {
                 assert!(!shells.contains(&s.program.as_str()));
             }
             for pm in LinuxPackageManager::ALL_IN_PRIORITY_ORDER {
-                if let Some(s) = resolve_linux_step(id, pm) {
+                if let Some(s) = resolve_linux_step(id, pm, None) {
                     assert!(!shells.contains(&s.program.as_str()));
                     assert_eq!(s.program, "pkexec");
                 }

--- a/frontend/app/element/modal-dispatch.tsx
+++ b/frontend/app/element/modal-dispatch.tsx
@@ -174,6 +174,8 @@ export function renderRequest(
                     <AgentPrereqModalPanel
                         agent={req.agent}
                         missing={req.missing}
+                        installedPendingRestart={req.installedPendingRestart}
+                        onToolInstalled={(tool) => req.onToolInstalled(tool)}
                         onRefresh={() => req.onRefresh()}
                         onProceed={() => req.onProceed()}
                         onCancel={() => {

--- a/frontend/app/element/modal-layer.ts
+++ b/frontend/app/element/modal-layer.ts
@@ -129,6 +129,20 @@ export interface AgentPrereqRequest {
         installUrl: string;
         installLinkText: string;
     }>;
+    /** Tools successfully installed via the inline system-tool installer
+     *  in THIS prereq flow, kept alive across `modalLayer.replace()` calls
+     *  by the caller (`AgentPicker.tsx`) — `ModalLayer` remounts the whole
+     *  panel subtree on every `replace`, so any state owned by
+     *  `AgentPrereqModalPanel` itself would be wiped the moment a
+     *  post-install refresh (which routinely still reports the tool
+     *  missing — srv's own PATH is stale until restart) replaces this
+     *  request. reagent + Codex, PR #2966. */
+    installedPendingRestart: ReadonlySet<string>;
+    /** Fires once per successful install (before the caller's own
+     *  `onRefresh` re-probe) so the caller can add the tool to
+     *  `installedPendingRestart` in the SAME persistent set it threads
+     *  through every subsequent `replace` call. */
+    onToolInstalled: (tool: string) => void;
     /** User clicked "Refresh" — caller re-probes and either closes
      *  this modal (no missing) or replaces it with an updated list. */
     onRefresh: () => void;

--- a/frontend/app/store/rpc-api/identity.ts
+++ b/frontend/app/store/rpc-api/identity.ts
@@ -276,7 +276,18 @@ export const IdentityApi = {
         opts?: RpcOpts,
     ): Promise<
         | { available: false }
-        | { available: true; program: string; args: string[]; needsElevation: boolean; commandPreview: string }
+        | {
+              available: true;
+              program: string;
+              args: string[];
+              needsElevation: boolean;
+              commandPreview: string;
+              /** Version this exact command would install, queried live from
+               *  the package manager's own catalog — `null`/absent when the
+               *  query failed or isn't implemented for this platform's
+               *  package manager. Never a hardcoded guess (see #2942). */
+              resolvedVersion?: string | null;
+          }
     > {
         return client.rpcCall("toolchain.resolve_install_command", data, opts);
     },

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -729,6 +729,15 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                         openCreateFromTemplateModal(agent);
                     }
                 };
+                // Lives OUTSIDE `openPrereqModal` (not re-created per call)
+                // specifically so it survives every `modalLayer.replace()`
+                // in the `refresh` loop below — `ModalLayer` remounts the
+                // whole `AgentPrereqModalPanel` subtree on each replace, so
+                // any state the panel owned itself would be wiped right
+                // when a post-install refresh (which routinely still
+                // reports the tool missing — srv's own PATH is stale until
+                // restart) replaces the request. reagent + Codex, PR #2966.
+                const installedPendingRestart = new Set<string>();
                 const openPrereqModal = (currentMissing: typeof missing, op: "open" | "replace"): void => {
                     const refresh = async () => {
                         for (const m of currentMissing) prereqCache.delete(m.tool);
@@ -744,6 +753,11 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                         agent,
                         originBlockId: props.model.blockId,
                         missing: currentMissing,
+                        installedPendingRestart,
+                        onToolInstalled: (tool: string) => {
+                            installedPendingRestart.add(tool);
+                            void refresh();
+                        },
                         onRefresh: () => void refresh(),
                         onProceed: proceedWithFlow,
                         onCancel: () => {},

--- a/frontend/app/view/agent/components/AgentPrereqModal.scss
+++ b/frontend/app/view/agent/components/AgentPrereqModal.scss
@@ -34,6 +34,11 @@
     background: color-mix(in srgb, var(--warning-color, #e9b800) 6%, transparent);
     border: 1px solid color-mix(in srgb, var(--warning-color, #e9b800) 30%, transparent);
     border-radius: 0;
+
+    &.is-ok {
+        background: color-mix(in srgb, var(--success-color, #3ba55d) 6%, transparent);
+        border-color: color-mix(in srgb, var(--success-color, #3ba55d) 30%, transparent);
+    }
 }
 
 .agent-prereq-modal-icon {
@@ -42,6 +47,10 @@
     font-size: 18px;
     line-height: 1;
     padding-top: 2px;
+
+    &.agent-prereq-modal-icon-ok {
+        color: var(--success-color, #3ba55d);
+    }
 }
 
 .agent-prereq-modal-info {
@@ -61,6 +70,10 @@
 .agent-prereq-modal-tool-status {
     font-weight: 400;
     color: var(--secondary-text-color);
+
+    &.agent-prereq-modal-tool-status-ok {
+        color: var(--success-color, #3ba55d);
+    }
 }
 
 .agent-prereq-modal-link {

--- a/frontend/app/view/agent/components/AgentPrereqModal.test.tsx
+++ b/frontend/app/view/agent/components/AgentPrereqModal.test.tsx
@@ -7,6 +7,16 @@
  * so a freshly-installed binary routinely still probes as "missing"
  * right after install — the row must keep saying "installed" instead of
  * silently reverting to the same "not found" state the user just fixed.
+ *
+ * `installedPendingRestart` is deliberately NOT local state in
+ * `AgentPrereqModalPanel` — `AgentPicker.tsx`'s refresh loop calls
+ * `modalLayer.replace()`, which `ModalLayer` remounts the whole panel
+ * subtree for (reagent + Codex, PR #2966). The caller owns this set and
+ * threads it through every `replace`; this component only ever reads it
+ * from props. The tests below exercise that contract directly: they
+ * simulate a full unmount + remount with fresh props, the same thing
+ * `ModalLayer.replace()` does to the real component, instead of relying
+ * on any internal signal surviving.
  */
 
 import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
@@ -57,6 +67,8 @@ describe("AgentPrereqModalPanel", () => {
             <AgentPrereqModalPanel
                 agent={{ name: "Claude" } as any}
                 missing={missing}
+                installedPendingRestart={new Set()}
+                onToolInstalled={() => {}}
                 onRefresh={() => {}}
                 onProceed={() => {}}
                 onCancel={() => {}}
@@ -65,7 +77,7 @@ describe("AgentPrereqModalPanel", () => {
         await screen.findByText("Install v2.47.1 now ↓");
     });
 
-    it("keeps showing 'installed, restart AgentMux to use it' after a successful install, even if refresh still reports it missing", async () => {
+    it("reports a successful install to the caller via onToolInstalled instead of owning the state itself", async () => {
         resolveMock.mockResolvedValue({
             available: true,
             program: "winget",
@@ -75,13 +87,15 @@ describe("AgentPrereqModalPanel", () => {
             resolvedVersion: "2.47.1",
         });
         installMock.mockResolvedValue({ sessionId: "sysinstall-1" });
-        const onRefresh = vi.fn();
+        const onToolInstalled = vi.fn();
         const { AgentPrereqModalPanel } = await import("./AgentPrereqModal");
         render(() => (
             <AgentPrereqModalPanel
                 agent={{ name: "Claude" } as any}
                 missing={missing}
-                onRefresh={onRefresh}
+                installedPendingRestart={new Set()}
+                onToolInstalled={onToolInstalled}
+                onRefresh={() => {}}
                 onProceed={() => {}}
                 onCancel={() => {}}
             />
@@ -95,11 +109,53 @@ describe("AgentPrereqModalPanel", () => {
         await waitFor(() => expect(chunkHandler).not.toBeNull());
         chunkHandler!({ data: { op: "done", ok: true } });
 
+        await waitFor(() => expect(onToolInstalled).toHaveBeenCalledWith("git"));
+    });
+
+    it("keeps showing 'installed, restart AgentMux to use it' across a full remount, purely from installedPendingRestart props — even though the stale-PATH re-probe still lists the tool as missing", async () => {
+        resolveMock.mockResolvedValue({
+            available: true,
+            program: "winget",
+            args: ["install", "--id", "Git.Git"],
+            needsElevation: true,
+            commandPreview: "winget install --id Git.Git",
+            resolvedVersion: "2.47.1",
+        });
+        const { AgentPrereqModalPanel } = await import("./AgentPrereqModal");
+
+        // Mount 1: nothing installed yet — normal "not found" row.
+        const { unmount } = render(() => (
+            <AgentPrereqModalPanel
+                agent={{ name: "Claude" } as any}
+                missing={missing}
+                installedPendingRestart={new Set()}
+                onToolInstalled={() => {}}
+                onRefresh={() => {}}
+                onProceed={() => {}}
+                onCancel={() => {}}
+            />
+        ));
+        await screen.findByText(/— not found/);
+
+        // Simulate exactly what `ModalLayer.replace()` does to the real
+        // component: destroy this instance entirely and mount a fresh one.
+        // `missing` still lists git (the stale-PATH re-probe outcome this
+        // PR exists to handle) but `installedPendingRestart` — owned by
+        // the caller, not this component — now contains it.
+        unmount();
+        render(() => (
+            <AgentPrereqModalPanel
+                agent={{ name: "Claude" } as any}
+                missing={missing}
+                installedPendingRestart={new Set(["git"])}
+                onToolInstalled={() => {}}
+                onRefresh={() => {}}
+                onProceed={() => {}}
+                onCancel={() => {}}
+            />
+        ));
+
         await screen.findByText(/installed, restart AgentMux to use it/);
-        expect(onRefresh).toHaveBeenCalledTimes(1);
-        // The stale-PATH re-probe in the real app would still report "not
-        // found" here (props.missing is unchanged in this test) — the
-        // persisted success state must win over that, not revert to it.
         expect(screen.queryByText(/— not found/)).toBeNull();
     });
 });

--- a/frontend/app/view/agent/components/AgentPrereqModal.test.tsx
+++ b/frontend/app/view/agent/components/AgentPrereqModal.test.tsx
@@ -1,0 +1,105 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * A successful system-tool install must not revert the row to looking
+ * like nothing happened. srv's own PATH is captured at process startup,
+ * so a freshly-installed binary routinely still probes as "missing"
+ * right after install — the row must keep saying "installed" instead of
+ * silently reverting to the same "not found" state the user just fixed.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const resolveMock = vi.fn();
+const installMock = vi.fn();
+let chunkHandler: ((event: unknown) => void) | null = null;
+
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        ToolchainResolveInstallCommandCommand: (...args: unknown[]) => resolveMock(...args),
+        ToolchainInstallSystemToolCommand: (...args: unknown[]) => installMock(...args),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+vi.mock("@/app/store/wps", () => ({
+    waveEventSubscribe: (sub: { handler: (event: unknown) => void }) => {
+        chunkHandler = sub.handler;
+        return () => { chunkHandler = null; };
+    },
+}));
+vi.mock("@/app/store/global", () => ({ getApi: () => ({ openExternal: vi.fn() }) }));
+
+afterEach(() => {
+    cleanup();
+    resolveMock.mockReset();
+    installMock.mockReset();
+    chunkHandler = null;
+});
+
+const missing = [
+    { tool: "git", label: "Git", installUrl: "https://git-scm.com", installLinkText: "Install Git" },
+];
+
+describe("AgentPrereqModalPanel", () => {
+    it("labels the toggle with the resolved version once resolution completes", async () => {
+        resolveMock.mockResolvedValue({
+            available: true,
+            program: "winget",
+            args: ["install", "--id", "Git.Git"],
+            needsElevation: true,
+            commandPreview: "winget install --id Git.Git",
+            resolvedVersion: "2.47.1",
+        });
+        const { AgentPrereqModalPanel } = await import("./AgentPrereqModal");
+        render(() => (
+            <AgentPrereqModalPanel
+                agent={{ name: "Claude" } as any}
+                missing={missing}
+                onRefresh={() => {}}
+                onProceed={() => {}}
+                onCancel={() => {}}
+            />
+        ));
+        await screen.findByText("Install v2.47.1 now ↓");
+    });
+
+    it("keeps showing 'installed, restart AgentMux to use it' after a successful install, even if refresh still reports it missing", async () => {
+        resolveMock.mockResolvedValue({
+            available: true,
+            program: "winget",
+            args: ["install", "--id", "Git.Git"],
+            needsElevation: true,
+            commandPreview: "winget install --id Git.Git",
+            resolvedVersion: "2.47.1",
+        });
+        installMock.mockResolvedValue({ sessionId: "sysinstall-1" });
+        const onRefresh = vi.fn();
+        const { AgentPrereqModalPanel } = await import("./AgentPrereqModal");
+        render(() => (
+            <AgentPrereqModalPanel
+                agent={{ name: "Claude" } as any}
+                missing={missing}
+                onRefresh={onRefresh}
+                onProceed={() => {}}
+                onCancel={() => {}}
+            />
+        ));
+
+        const toggle = await screen.findByText("Install v2.47.1 now ↓");
+        fireEvent.click(toggle);
+        await screen.findByText("winget install --id Git.Git");
+
+        fireEvent.click(screen.getByText("Install v2.47.1 now"));
+        await waitFor(() => expect(chunkHandler).not.toBeNull());
+        chunkHandler!({ data: { op: "done", ok: true } });
+
+        await screen.findByText(/installed, restart AgentMux to use it/);
+        expect(onRefresh).toHaveBeenCalledTimes(1);
+        // The stale-PATH re-probe in the real app would still report "not
+        // found" here (props.missing is unchanged in this test) — the
+        // persisted success state must win over that, not revert to it.
+        expect(screen.queryByText(/— not found/)).toBeNull();
+    });
+});

--- a/frontend/app/view/agent/components/AgentPrereqModal.tsx
+++ b/frontend/app/view/agent/components/AgentPrereqModal.tsx
@@ -9,11 +9,19 @@
  * SPEC_PROVIDER_SYSTEM_PREREQS_2026_05_18.md.
  */
 
-import { createSignal, For, Show, type JSX } from "solid-js";
+import { createSignal, For, onMount, Show, type JSX } from "solid-js";
 
 import { Button } from "@/element/button";
 import { getApi } from "@/app/store/global";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
 import { SystemToolInstallInline } from "@/app/view/toolchain/SystemToolInstallInline";
+
+interface ResolvedInstallInfo {
+    commandPreview: string;
+    needsElevation: boolean;
+    resolvedVersion?: string | null;
+}
 
 interface MissingPrereq {
     tool: string;
@@ -70,6 +78,43 @@ export const AgentPrereqModalPanel = (props: AgentPrereqModalPanelProps): JSX.El
         setUnavailableInstalls((prev) => new Set(prev).add(tool));
     };
 
+    // Resolved once, up front, per missing+installable tool — lets the
+    // toggle button itself read "Install v<version> now" before the user
+    // ever expands the panel, instead of only the panel's own inner
+    // button knowing the version.
+    const [resolvedInstalls, setResolvedInstalls] = createSignal<ReadonlyMap<string, ResolvedInstallInfo>>(new Map());
+    onMount(() => {
+        for (const req of props.missing) {
+            if (!SYSTEM_INSTALLABLE_IDS.has(req.tool)) continue;
+            void RpcApi.ToolchainResolveInstallCommandCommand(TabRpcClient, { toolId: req.tool })
+                .then((r) => {
+                    if (!r.available) {
+                        markUnavailable(req.tool);
+                        return;
+                    }
+                    setResolvedInstalls((prev) => {
+                        const next = new Map(prev);
+                        next.set(req.tool, {
+                            commandPreview: r.commandPreview,
+                            needsElevation: r.needsElevation,
+                            resolvedVersion: r.resolvedVersion ?? null,
+                        });
+                        return next;
+                    });
+                })
+                .catch(() => markUnavailable(req.tool));
+        }
+    });
+
+    // Once an install genuinely succeeds, keep saying so even if the
+    // post-install refresh's re-probe still reports "missing" — srv's own
+    // PATH is captured at process startup, so a freshly-installed binary
+    // routinely isn't visible to it yet without a restart. Tracked here
+    // (not left to the child's own "done" phase) because `onRefresh()`
+    // re-renders `props.missing` with a new array, which can remount the
+    // child and reset its local phase signal right back to "checking".
+    const [installedPendingRestart, setInstalledPendingRestart] = createSignal<ReadonlySet<string>>(new Set());
+
     return (
         <>
             <header class="modal-panel-header">
@@ -85,44 +130,68 @@ export const AgentPrereqModalPanel = (props: AgentPrereqModalPanelProps): JSX.El
                 <ul class="agent-prereq-modal-list">
                     <For each={props.missing}>
                         {(req) => (
-                            <li class="agent-prereq-modal-row">
-                                <span class="agent-prereq-modal-icon" aria-hidden="true">⚠</span>
-                                <div class="agent-prereq-modal-info">
-                                    <div class="agent-prereq-modal-tool">
-                                        {req.label}
-                                        <span class="agent-prereq-modal-tool-status"> — not found</span>
-                                    </div>
-                                    <a
-                                        class="agent-prereq-modal-link"
-                                        href={req.installUrl}
-                                        onClick={(e) => {
-                                            e.preventDefault();
-                                            open(req.installUrl);
-                                        }}
-                                    >
-                                        {req.installLinkText}
-                                        <span class="agent-prereq-modal-link-arrow" aria-hidden="true"> ↗</span>
-                                    </a>
-                                    <Show when={SYSTEM_INSTALLABLE_IDS.has(req.tool) && !unavailableInstalls().has(req.tool)}>
-                                        <button
-                                            type="button"
+                            <li
+                                class="agent-prereq-modal-row"
+                                classList={{ "is-ok": installedPendingRestart().has(req.tool) }}
+                            >
+                                <Show
+                                    when={!installedPendingRestart().has(req.tool)}
+                                    fallback={
+                                        <>
+                                            <span class="agent-prereq-modal-icon agent-prereq-modal-icon-ok" aria-hidden="true">✓</span>
+                                            <div class="agent-prereq-modal-info">
+                                                <div class="agent-prereq-modal-tool">
+                                                    {req.label}
+                                                    <span class="agent-prereq-modal-tool-status agent-prereq-modal-tool-status-ok">
+                                                        {" "}— installed, restart AgentMux to use it
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </>
+                                    }
+                                >
+                                    <span class="agent-prereq-modal-icon" aria-hidden="true">⚠</span>
+                                    <div class="agent-prereq-modal-info">
+                                        <div class="agent-prereq-modal-tool">
+                                            {req.label}
+                                            <span class="agent-prereq-modal-tool-status"> — not found</span>
+                                        </div>
+                                        <a
                                             class="agent-prereq-modal-link"
-                                            onClick={() => toggleInstallPanel(req.tool)}
+                                            href={req.installUrl}
+                                            onClick={(e) => {
+                                                e.preventDefault();
+                                                open(req.installUrl);
+                                            }}
                                         >
-                                            or install it now ↓
-                                        </button>
-                                        <Show when={expandedInstalls().has(req.tool)}>
-                                            <SystemToolInstallInline
-                                                toolId={req.tool}
-                                                onInstalled={() => {
-                                                    toggleInstallPanel(req.tool);
-                                                    props.onRefresh();
-                                                }}
-                                                onUnavailable={() => markUnavailable(req.tool)}
-                                            />
+                                            {req.installLinkText}
+                                            <span class="agent-prereq-modal-link-arrow" aria-hidden="true"> ↗</span>
+                                        </a>
+                                        <Show when={SYSTEM_INSTALLABLE_IDS.has(req.tool) && !unavailableInstalls().has(req.tool)}>
+                                            <button
+                                                type="button"
+                                                class="agent-prereq-modal-link"
+                                                onClick={() => toggleInstallPanel(req.tool)}
+                                            >
+                                                {(() => {
+                                                    const version = resolvedInstalls().get(req.tool)?.resolvedVersion;
+                                                    return version ? `Install v${version} now ↓` : "or install it now ↓";
+                                                })()}
+                                            </button>
+                                            <Show when={expandedInstalls().has(req.tool)}>
+                                                <SystemToolInstallInline
+                                                    toolId={req.tool}
+                                                    resolvedInfo={resolvedInstalls().get(req.tool)}
+                                                    onInstalled={() => {
+                                                        setInstalledPendingRestart((prev) => new Set(prev).add(req.tool));
+                                                        props.onRefresh();
+                                                    }}
+                                                    onUnavailable={() => markUnavailable(req.tool)}
+                                                />
+                                            </Show>
                                         </Show>
-                                    </Show>
-                                </div>
+                                    </div>
+                                </Show>
                             </li>
                         )}
                     </For>

--- a/frontend/app/view/agent/components/AgentPrereqModal.tsx
+++ b/frontend/app/view/agent/components/AgentPrereqModal.tsx
@@ -39,6 +39,11 @@ const SYSTEM_INSTALLABLE_IDS = new Set(["git", "node", "npm", "python"]);
 interface AgentPrereqModalPanelProps {
     agent: AgentDefinition;
     missing: MissingPrereq[];
+    /** Owned by the caller (`AgentPicker.tsx`), not this component — see
+     *  `AgentPrereqRequest.installedPendingRestart`'s doc comment in
+     *  `modal-layer.ts` for why this can't be local state here. */
+    installedPendingRestart: ReadonlySet<string>;
+    onToolInstalled: (tool: string) => void;
     onRefresh: () => void;
     onProceed: () => void;
     onCancel: () => void;
@@ -106,15 +111,6 @@ export const AgentPrereqModalPanel = (props: AgentPrereqModalPanelProps): JSX.El
         }
     });
 
-    // Once an install genuinely succeeds, keep saying so even if the
-    // post-install refresh's re-probe still reports "missing" — srv's own
-    // PATH is captured at process startup, so a freshly-installed binary
-    // routinely isn't visible to it yet without a restart. Tracked here
-    // (not left to the child's own "done" phase) because `onRefresh()`
-    // re-renders `props.missing` with a new array, which can remount the
-    // child and reset its local phase signal right back to "checking".
-    const [installedPendingRestart, setInstalledPendingRestart] = createSignal<ReadonlySet<string>>(new Set());
-
     return (
         <>
             <header class="modal-panel-header">
@@ -132,10 +128,10 @@ export const AgentPrereqModalPanel = (props: AgentPrereqModalPanelProps): JSX.El
                         {(req) => (
                             <li
                                 class="agent-prereq-modal-row"
-                                classList={{ "is-ok": installedPendingRestart().has(req.tool) }}
+                                classList={{ "is-ok": props.installedPendingRestart.has(req.tool) }}
                             >
                                 <Show
-                                    when={!installedPendingRestart().has(req.tool)}
+                                    when={!props.installedPendingRestart.has(req.tool)}
                                     fallback={
                                         <>
                                             <span class="agent-prereq-modal-icon agent-prereq-modal-icon-ok" aria-hidden="true">✓</span>
@@ -182,10 +178,7 @@ export const AgentPrereqModalPanel = (props: AgentPrereqModalPanelProps): JSX.El
                                                 <SystemToolInstallInline
                                                     toolId={req.tool}
                                                     resolvedInfo={resolvedInstalls().get(req.tool)}
-                                                    onInstalled={() => {
-                                                        setInstalledPendingRestart((prev) => new Set(prev).add(req.tool));
-                                                        props.onRefresh();
-                                                    }}
+                                                    onInstalled={() => props.onToolInstalled(req.tool)}
                                                     onUnavailable={() => markUnavailable(req.tool)}
                                                 />
                                             </Show>

--- a/frontend/app/view/toolchain/SystemToolInstallInline.scss
+++ b/frontend/app/view/toolchain/SystemToolInstallInline.scss
@@ -65,12 +65,39 @@
     color: var(--error-color);
 }
 
-.system-tool-install-spinner {
-    display: inline-block;
+.system-tool-install-progress {
+    height: 3px;
+    overflow: hidden;
+    background: color-mix(in srgb, var(--main-text-color) 10%, transparent);
+}
+
+.system-tool-install-progress-bar {
+    width: 40%;
+    height: 100%;
+    background: var(--accent-color);
+    animation: system-tool-install-progress-slide 1.2s ease-in-out infinite;
+}
+
+@keyframes system-tool-install-progress-slide {
+    0% { transform: translateX(-100%); }
+    100% { transform: translateX(250%); }
+}
+
+.system-tool-install-details {
+    summary {
+        cursor: pointer;
+        font-size: var(--text-xs, 11px);
+        color: var(--secondary-text-color);
+        user-select: none;
+
+        &:hover {
+            color: var(--main-text-color);
+        }
+    }
 }
 
 .system-tool-install-log-body {
-    margin: 0;
+    margin: var(--space-1, 6px) 0 0;
     padding: var(--space-1-5, 10px);
     max-height: 200px;
     overflow-y: auto;

--- a/frontend/app/view/toolchain/SystemToolInstallInline.test.tsx
+++ b/frontend/app/view/toolchain/SystemToolInstallInline.test.tsx
@@ -83,6 +83,33 @@ describe("SystemToolInstallInline", () => {
         expect(installMock).not.toHaveBeenCalled();
     });
 
+    it("labels the install button with the resolved version when the backend reports one", async () => {
+        resolveMock.mockResolvedValue({
+            available: true,
+            program: "brew",
+            args: ["install", "git"],
+            needsElevation: false,
+            commandPreview: "brew install git",
+            resolvedVersion: "2.47.1",
+        });
+        const { SystemToolInstallInline } = await import("./SystemToolInstallInline");
+        render(() => <SystemToolInstallInline toolId="git" onInstalled={() => {}} />);
+        await screen.findByText("Install v2.47.1 now");
+    });
+
+    it("uses caller-provided resolvedInfo instead of self-resolving", async () => {
+        const { SystemToolInstallInline } = await import("./SystemToolInstallInline");
+        render(() => (
+            <SystemToolInstallInline
+                toolId="git"
+                onInstalled={() => {}}
+                resolvedInfo={{ commandPreview: "brew install git", needsElevation: false, resolvedVersion: "2.47.1" }}
+            />
+        ));
+        await screen.findByText("Install v2.47.1 now");
+        expect(resolveMock).not.toHaveBeenCalled();
+    });
+
     it("shows the elevation note only when the resolved step needs it", async () => {
         resolveMock.mockResolvedValue({
             available: true,

--- a/frontend/app/view/toolchain/SystemToolInstallInline.tsx
+++ b/frontend/app/view/toolchain/SystemToolInstallInline.tsx
@@ -31,6 +31,16 @@ import "./SystemToolInstallInline.scss";
 
 type Phase = "checking" | "unavailable" | "idle" | "installing" | "done" | "failed";
 
+interface ResolvedInstallInfo {
+    commandPreview: string;
+    needsElevation: boolean;
+    /** Version this exact command would install, queried live from the
+     *  package manager's own catalog — `null`/absent when the query
+     *  failed or isn't implemented for this platform. Never a hardcoded
+     *  guess (see #2942). */
+    resolvedVersion?: string | null;
+}
+
 interface SystemToolInstallInlineProps {
     toolId: string;
     /** Fires once, on a successful install — the caller re-probes its
@@ -43,12 +53,21 @@ interface SystemToolInstallInlineProps {
      *  blank expanded area with no visible fallback. reagent P2,
      *  PR #2790. */
     onUnavailable?: () => void;
+    /** Pre-resolved install info from the caller (e.g. a parent that
+     *  already resolved every missing tool's command/version up front to
+     *  label its own toggle button) — when provided, this component skips
+     *  its own `toolchain.resolve_install_command` call and uses this
+     *  directly instead. Callers that don't pre-resolve (e.g. the
+     *  Toolchain modal's core-tools list) omit this and keep the
+     *  existing self-resolve-on-mount behavior. */
+    resolvedInfo?: ResolvedInstallInfo;
 }
 
 export const SystemToolInstallInline = (props: SystemToolInstallInlineProps): JSX.Element => {
     const [phase, setPhase] = createSignal<Phase>("checking");
     const [commandPreview, setCommandPreview] = createSignal("");
     const [needsElevation, setNeedsElevation] = createSignal(false);
+    const [resolvedVersion, setResolvedVersion] = createSignal<string | null>(null);
     const [lines, setLines] = createSignal<Array<{ line: string; stream: "stdout" | "stderr" }>>([]);
     const [error, setError] = createSignal<string | null>(null);
 
@@ -65,6 +84,13 @@ export const SystemToolInstallInline = (props: SystemToolInstallInlineProps): JS
     let disposed = false;
 
     onMount(async () => {
+        if (props.resolvedInfo) {
+            setCommandPreview(props.resolvedInfo.commandPreview);
+            setNeedsElevation(props.resolvedInfo.needsElevation);
+            setResolvedVersion(props.resolvedInfo.resolvedVersion ?? null);
+            setPhase("idle");
+            return;
+        }
         try {
             const r = await RpcApi.ToolchainResolveInstallCommandCommand(TabRpcClient, { toolId: props.toolId });
             if (disposed) return;
@@ -75,6 +101,7 @@ export const SystemToolInstallInline = (props: SystemToolInstallInlineProps): JS
             }
             setCommandPreview(r.commandPreview);
             setNeedsElevation(r.needsElevation);
+            setResolvedVersion(r.resolvedVersion ?? null);
             setPhase("idle");
         } catch {
             // Treat a failed probe the same as "unavailable" — the
@@ -151,7 +178,7 @@ export const SystemToolInstallInline = (props: SystemToolInstallInlineProps): JS
                             </p>
                         </Show>
                         <Button onClick={() => void startInstall()} className="green solid">
-                            Install
+                            {resolvedVersion() ? `Install v${resolvedVersion()} now` : "Install"}
                         </Button>
                     </div>
                 </Show>
@@ -159,7 +186,7 @@ export const SystemToolInstallInline = (props: SystemToolInstallInlineProps): JS
                     <div class="system-tool-install-log" classList={{ "is-done": phase() === "done", "is-failed": phase() === "failed" }}>
                         <div class="system-tool-install-log-header">
                             <Show when={phase() === "installing"}>
-                                <span class="system-tool-install-spinner" aria-hidden="true">⏳</span> Installing…
+                                <i class="fa-solid fa-spinner fa-spin" aria-hidden="true" /> Installing…
                             </Show>
                             <Show when={phase() === "done"}>
                                 <span class="system-tool-install-ok" aria-hidden="true">✓</span> Installed
@@ -168,9 +195,17 @@ export const SystemToolInstallInline = (props: SystemToolInstallInlineProps): JS
                                 <span class="system-tool-install-fail" aria-hidden="true">✗</span> Failed
                             </Show>
                         </div>
-                        <pre class="system-tool-install-log-body">
-                            {lines().map((l) => l.line).join("\n")}
-                        </pre>
+                        <Show when={phase() === "installing"}>
+                            <div class="system-tool-install-progress" aria-hidden="true">
+                                <div class="system-tool-install-progress-bar" />
+                            </div>
+                        </Show>
+                        <details class="system-tool-install-details">
+                            <summary>Details</summary>
+                            <pre class="system-tool-install-log-body">
+                                {lines().map((l) => l.line).join("\n")}
+                            </pre>
+                        </details>
                         <Show when={error()}>
                             <div class="system-tool-install-error">{String(error())}</div>
                         </Show>


### PR DESCRIPTION
## Summary
- Fixes a real bug: after successfully installing a system tool (git/node/npm/python) from the AgentPrereqModal, the row reverted to looking like nothing happened. The `onInstalled` handler collapsed the panel and immediately re-probed, but srv's own PATH is captured at process startup, so a freshly-installed binary routinely still probes as "missing" right after a genuinely successful install. The parent modal now tracks installed-pending-restart state itself and shows a persistent "installed, restart AgentMux to use it" row instead of reverting.
- Backend now queries the live version a package manager would actually install (`winget show`, `brew info --json=v2`, `apt-cache policy`) and returns it as `resolvedVersion` — never hardcoded (see #2942 for why a hardcoded version string is a real staleness risk this repo already hit once).
- The install toggle/button now reads "Install v\<version\> now" once resolved, instead of a static "or install it now".
- Replaced the static hourglass emoji with the existing `fa-spinner fa-spin` pattern (already used in recording-section.tsx/swarm-view.tsx) plus a lightweight indeterminate progress bar during install.
- Moved the raw streamed install log behind a collapsed `<details>/<summary>Details</summary>` so the default view stays clean; the status header stays always visible.

## Test plan
- [x] `cargo build --release -p agentmux-srv` (via `task build:backend`) — clean, no errors from `system_install_handlers.rs`
- [x] `npx vitest run frontend/app/view/agent/components/AgentPrereqModal.test.tsx frontend/app/view/toolchain/SystemToolInstallInline.test.tsx` — 11/11 passing, including new coverage for the version-labeled button, the `resolvedInfo` pass-through prop, and the persisted post-install success state
- [x] `npx tsc --noEmit` — clean
- [ ] Manual verification in a running app (not done by the agent — see PR discussion)

<!-- agentmux:agent_id=camper -->