### PR TITLE
Camper@claudius: Show a reassurance message in the splash screen when host startup runs long

### DIFF
--- a/.changesets/1788536076-feat-launcher-show-a-reassurance-message-in-the-splash-scree-qyah.md
+++ b/.changesets/1788536076-feat-launcher-show-a-reassurance-message-in-the-splash-scree-qyah.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(launcher): show a reassurance message in the splash screen when host startup runs long (first-run Defender scan, issue #2940)

--- a/agentmux-launcher/src/host_pipe/mod.rs
+++ b/agentmux-launcher/src/host_pipe/mod.rs
@@ -611,6 +611,19 @@ impl HostPipe {
         self.inner.lock().await.writer.is_some()
     }
 
+    /// Production counterpart of `is_connected` above (which is test-only):
+    /// has a CEF host ever called `set_writer` — i.e. registered as
+    /// `ClientKind::Host` over the IPC pipe — since this `HostPipe` was
+    /// created (or since its writer was last cleared)? Used by the
+    /// splash's delayed "first run can take longer" hint
+    /// (`supervisor/windows.rs`) to distinguish the pre-registration gap
+    /// (host process exists, zero code executed — where that message
+    /// belongs) from ordinary post-registration CEF-init/first-paint time
+    /// (where it would be misleading). Codex P2, PR #2967.
+    pub async fn has_registered_host(&self) -> bool {
+        self.inner.lock().await.writer.is_some()
+    }
+
     /// Test-only: force the disconnect timer back by `delta` so the
     /// 30s timeout fires without sleeping in tests.
     #[cfg(test)]

--- a/agentmux-launcher/src/host_pipe/mod.rs
+++ b/agentmux-launcher/src/host_pipe/mod.rs
@@ -605,22 +605,17 @@ impl HostPipe {
         self.inner.lock().await.pending_buffer.len()
     }
 
-    /// Test-only inspection of whether a writer is currently set.
-    #[cfg(test)]
+    /// Whether a writer is currently set — i.e. a CEF host has called
+    /// `set_writer` (registered as `ClientKind::Host` over the IPC pipe)
+    /// and hasn't since disconnected. Originally test-only inspection;
+    /// also used in production by the splash's delayed "first run can
+    /// take longer" hint (`supervisor/windows.rs`) to distinguish the
+    /// pre-registration gap (host process exists, zero code executed —
+    /// where that message belongs) from ordinary post-registration
+    /// CEF-init/first-paint time (where it would be misleading). reagent
+    /// P2, PR #2967 — was a separate `has_registered_host` method with an
+    /// identical body; merged to avoid keeping two copies in sync.
     pub async fn is_connected(&self) -> bool {
-        self.inner.lock().await.writer.is_some()
-    }
-
-    /// Production counterpart of `is_connected` above (which is test-only):
-    /// has a CEF host ever called `set_writer` — i.e. registered as
-    /// `ClientKind::Host` over the IPC pipe — since this `HostPipe` was
-    /// created (or since its writer was last cleared)? Used by the
-    /// splash's delayed "first run can take longer" hint
-    /// (`supervisor/windows.rs`) to distinguish the pre-registration gap
-    /// (host process exists, zero code executed — where that message
-    /// belongs) from ordinary post-registration CEF-init/first-paint time
-    /// (where it would be misleading). Codex P2, PR #2967.
-    pub async fn has_registered_host(&self) -> bool {
         self.inner.lock().await.writer.is_some()
     }
 

--- a/agentmux-launcher/src/splash.rs
+++ b/agentmux-launcher/src/splash.rs
@@ -89,9 +89,13 @@ const MAX_STAGE_ROWS: usize = 12;
 const STAGE_AREA_H: i32 =
     STAGE_PAD_TOP + MAX_STAGE_ROWS as i32 * STAGE_ROW_H + STAGE_PAD_BOTTOM;
 
-// Stage label character budget (truncated if longer).
+// Stage label character budget (truncated if longer). SUB_LABEL_MAX_CHARS was
+// 14 until the SPLASH_W widening above (PR #2961) — bumped to fit the
+// "First run can take longer" sub-row message (below) at its full length;
+// existing short sub-labels (individual migration names, etc.) are
+// unaffected, this only raises the truncation threshold.
 const LABEL_MAX_CHARS: usize = 16;
-const SUB_LABEL_MAX_CHARS: usize = 14;
+const SUB_LABEL_MAX_CHARS: usize = 28;
 
 // Colors
 const STAGE_COLOR: [u8; 3] = [0xC0, 0xC0, 0xCC];

--- a/agentmux-launcher/src/supervisor/windows.rs
+++ b/agentmux-launcher/src/supervisor/windows.rs
@@ -503,21 +503,33 @@ pub(crate) async fn run_windows(
             // path, while still showing well before this gap's own
             // observed 18-30s+ worst case ends.
             //
-            // Fire-and-forget, no cancellation: if the host registers
-            // (and the splash dismisses) before 5s, this message is sent
-            // into either an already-torn-down channel (silently dropped,
-            // see StartupEventSink's own doc comment) or one whose
-            // consumer has already stopped draining it mid-hold/fade —
-            // both cases are harmless no-ops, never a visible glitch.
+            // Gated on `host_pipe.has_registered_host()`, NOT on splash
+            // dismiss timing — Codex P2, PR #2967: host IPC registration
+            // (this timer's actual target) happens well before the splash
+            // dismisses (that waits for CEF's `on_load_end`, i.e. full
+            // init + first paint). An earlier version of this comment
+            // assumed those two events were close enough together that a
+            // plain fire-and-forget timer would only ever land in the
+            // pre-registration gap or a torn-down channel; that's false
+            // whenever registration succeeds quickly but CEF init/first
+            // paint alone runs past 5s (slow disk, cold caches, etc.) — a
+            // real, if unrelated, delay this message must not be shown
+            // for, since it isn't the first-run-scan gap it exists to
+            // explain. Checking registration state directly, right before
+            // sending, fixes that regardless of how long the splash stays
+            // up afterward.
             if splash_event_name.is_some() {
                 let delayed_sink = startup_sink.clone();
-                std::thread::spawn(move || {
-                    std::thread::sleep(std::time::Duration::from_secs(5));
-                    delayed_sink.sub_begin(
-                        "host",
-                        "first-run-wait",
-                        "First run can take longer",
-                    );
+                let delayed_host_pipe = std::sync::Arc::clone(&host_pipe);
+                tokio::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                    if !delayed_host_pipe.has_registered_host().await {
+                        delayed_sink.sub_begin(
+                            "host",
+                            "first-run-wait",
+                            "First run can take longer",
+                        );
+                    }
                 });
             }
             c

--- a/agentmux-launcher/src/supervisor/windows.rs
+++ b/agentmux-launcher/src/supervisor/windows.rs
@@ -503,7 +503,7 @@ pub(crate) async fn run_windows(
             // path, while still showing well before this gap's own
             // observed 18-30s+ worst case ends.
             //
-            // Gated on `host_pipe.has_registered_host()`, NOT on splash
+            // Gated on `host_pipe.is_connected()`, NOT on splash
             // dismiss timing — Codex P2, PR #2967: host IPC registration
             // (this timer's actual target) happens well before the splash
             // dismisses (that waits for CEF's `on_load_end`, i.e. full

--- a/agentmux-launcher/src/supervisor/windows.rs
+++ b/agentmux-launcher/src/supervisor/windows.rs
@@ -479,6 +479,47 @@ pub(crate) async fn run_windows(
                 startup_events::StartupStatus::Ok,
                 None,
             );
+            // Issue #2940: the gap this is meant to explain — suspended
+            // host process exists, zero instructions executed, up to ~30s
+            // before it registers over the IPC pipe — happens entirely
+            // AFTER this stage already ended (spawn_host_supervised
+            // returning is fast; the actual wait is Windows Defender's
+            // on-execution cloud reputation check on the newly-extracted
+            // exes, confirmed via the Defender operational event log,
+            // 2026-09-04). Nothing else reports progress during that gap
+            // today. Deliberately does NOT claim "Windows Defender is
+            // scanning" — that can't actually be known from here (no
+            // event-log/process-state access in this path), and a wrong
+            // guess is worse than a generic one; see the tracking issue
+            // comment for why detection was ruled out. A launcher-side
+            // timer, not host cooperation: the host executes zero code
+            // during this gap, so it cannot report progress itself.
+            //
+            // 5s threshold: comfortably above a normal launch's ~1s host-
+            // registration time (confirmed via a same-machine relaunch
+            // immediately after a slow first launch — the SAME gap was
+            // 23s on the fresh-machine run vs. 1s on the immediate
+            // relaunch, same binaries) so this never appears on the fast
+            // path, while still showing well before this gap's own
+            // observed 18-30s+ worst case ends.
+            //
+            // Fire-and-forget, no cancellation: if the host registers
+            // (and the splash dismisses) before 5s, this message is sent
+            // into either an already-torn-down channel (silently dropped,
+            // see StartupEventSink's own doc comment) or one whose
+            // consumer has already stopped draining it mid-hold/fade —
+            // both cases are harmless no-ops, never a visible glitch.
+            if splash_event_name.is_some() {
+                let delayed_sink = startup_sink.clone();
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_secs(5));
+                    delayed_sink.sub_begin(
+                        "host",
+                        "first-run-wait",
+                        "First run can take longer",
+                    );
+                });
+            }
             c
         }
         None => {

--- a/agentmux-launcher/src/supervisor/windows.rs
+++ b/agentmux-launcher/src/supervisor/windows.rs
@@ -523,7 +523,7 @@ pub(crate) async fn run_windows(
                 let delayed_host_pipe = std::sync::Arc::clone(&host_pipe);
                 tokio::spawn(async move {
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                    if !delayed_host_pipe.has_registered_host().await {
+                    if !delayed_host_pipe.is_connected().await {
                         delayed_sink.sub_begin(
                             "host",
                             "first-run-wait",


### PR DESCRIPTION
## Summary
Follow-up to the earlier splash-width fix (#2961) and the first-launch-latency findings on issue #2940.

Windows Defender's on-execution cloud reputation check for newly-extracted binaries can hold the splash screen open 18-36s on a genuinely fresh machine, with nothing telling the user anything is happening during that gap — confirmed against the Defender operational event log (Event ID 2010) on a real VM, both on the original 36s first-launch investigation and again just now on a fresh portable build.

- Adds a launcher-side 5s timer (well above a normal ~1s host-registration time) that posts a "First run can take longer" sub-row under the existing "Host startup" splash stage, reusing the splash's existing `SubBegin`/live-elapsed-counter rendering — no new rendering code.
- Deliberately does **not** claim "Windows Defender is scanning" specifically — that can't actually be known from the launcher (no event-log/process-state access in this code path), so a generic, honest message is used instead of a guess that also wouldn't generalize to macOS's own first-run Gatekeeper delay.
- Bumps `SUB_LABEL_MAX_CHARS` 14 → 28 to fit the message at full length without truncation, safe under the `SPLASH_W` widening already shipped in #2961 — only raises the truncation threshold for every sub-row, doesn't change layout.
- Fire-and-forget by design: if the host registers before the 5s threshold, the message is sent into either an already-torn-down channel or one whose consumer stopped draining — both harmless no-ops per `StartupEventSink`'s existing doc comment, never a visible glitch on a normal launch.

**Honest disclosure, same as #2961:** this has not been visually verified on a real Windows machine — the native `WS_EX_TOOLWINDOW` splash has no title text and is excluded from window-enumeration tooling I have access to. The release build compiles clean; the actual rendered result is unconfirmed.

## Test plan
- [x] `cargo build --release -p agentmux-launcher` — clean, no errors
- [ ] Visual confirmation on a real Windows machine (not done by the agent)

<!-- agentmux:agent_id=camper -->