### PR TITLE
fix(startup): port the Linux paint gate to Windows so the window never shows blank

### DIFF
--- a/.changesets/1788540062-fix-startup-port-the-linux-paint-gate-to-windows-so-the-wind-8qrl.md
+++ b/.changesets/1788540062-fix-startup-port-the-linux-paint-gate-to-windows-so-the-wind-8qrl.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(startup): port the Linux paint gate to Windows so the window never shows blank, and report the gap in splash telemetry

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -9,12 +9,14 @@ use cef::*;
 
 use super::AgentMuxHandler;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 use std::sync::Arc;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 use crate::state::AppState;
 
-/// Linux startup white-flash fix (docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md).
+/// Startup white-flash fix
+/// (docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md,
+/// docs/reports/REPORT_SPLASH_TO_FIRST_PAINT_BLANK_WINDOW_GAP_2026_09_03.md).
 ///
 /// Bound on how long the real window + native splash can stay hidden/up
 /// waiting for the frontend's first-paint signal before we show anyway.
@@ -31,15 +33,26 @@ use crate::state::AppState;
 /// Set well above the observed worst case so the real signal wins in
 /// practice; this only matters as a backstop against a genuinely stalled
 /// renderer (crashed JS, rAF never firing at all).
-#[cfg(target_os = "linux")]
+///
+/// Reused verbatim for Windows (ported 2026-09-03) rather than picking a
+/// separate constant: this is a backstop, not a target, and the whole point
+/// is that the real signal should win in practice on any machine capable of
+/// running the app at all. A tighter Windows-specific value would need its
+/// own dedicated measurement pass — see
+/// `docs/reports/REPORT_SPLASH_TO_FIRST_PAINT_BLANK_WINDOW_GAP_2026_09_03.md`
+/// §5.1 for why this report does not claim to have done that. If this timeout
+/// is ever observed firing on real Windows hardware (not a crashed-JS case),
+/// that is the signal a dedicated pass is now overdue, not a reason to
+/// silently raise the number.
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 const PAINT_GATE_SAFETY_TIMEOUT_MS: i64 = 4000;
 
-/// Monotonic arm counter for the Linux paint gate. Each `on_load_end` call
-/// that (re-)arms a label's gate gets a fresh epoch; its safety-net timeout
-/// task captures that epoch and only acts if it's still current when the
-/// timeout fires (see `reveal_gated_window`). Mirrors the identical
-/// stale-timeout guard in `browser_pane::auth` (`NEXT_EPOCH`/`Entry::epoch`).
-#[cfg(target_os = "linux")]
+/// Monotonic arm counter for the paint gate. Each `on_load_end` call that
+/// (re-)arms a label's gate gets a fresh epoch; its safety-net timeout task
+/// captures that epoch and only acts if it's still current when the timeout
+/// fires (see `reveal_gated_window`). Mirrors the identical stale-timeout
+/// guard in `browser_pane::auth` (`NEXT_EPOCH`/`Entry::epoch`).
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 static PAINT_GATE_NEXT_EPOCH: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// Reveal (show + focus the real window, dismiss the native splash) once —
@@ -58,7 +71,7 @@ static PAINT_GATE_NEXT_EPOCH: std::sync::atomic::AtomicU64 = std::sync::atomic::
 /// reagent PR #2151 review).
 ///
 /// Must run on the CEF UI thread.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 pub(crate) fn reveal_gated_window(
     state: &Arc<AppState>,
     label: &str,
@@ -83,16 +96,59 @@ pub(crate) fn reveal_gated_window(
             None => return,
         }
     };
+    let elapsed_ms = armed_at.elapsed().as_millis() as u64;
     tracing::info!(
         target: "startup-paint",
         label = %label,
         reason,
-        elapsed_ms = armed_at.elapsed().as_millis() as u64,
+        elapsed_ms,
         "[startup-paint] revealing gated window"
+    );
+    // "paint" stage telemetry (docs/reports/REPORT_SPLASH_TO_FIRST_PAINT_BLANK_WINDOW_GAP_2026_09_03.md
+    // §5.3): reports the on_load_end -> real-paint gap this whole gate exists
+    // to close, as its own splash row. Paired with the `stage_begin` call at
+    // the point this label was armed (`reveal_top_level_window` below).
+    // Placed here rather than gated on the fallible browser/window lookups
+    // further down, matching the ready-file/SetEvent dismiss signals below:
+    // the paint gate resolving is the event worth reporting, independent of
+    // whether the low-level show() that follows happens to succeed.
+    crate::launcher_ipc::report_startup_stage_end(
+        "paint",
+        elapsed_ms,
+        "ok",
+        Some(reason.to_string()),
     );
     if let Ok(path) = std::env::var("AGENTMUX_SPLASH_READY_FILE") {
         if !path.is_empty() {
             let _ = std::fs::write(&path, b"ready");
+        }
+    }
+    // Windows analogue of the macOS/Linux ready-file above: signal the named
+    // Win32 event the launcher's splash thread is waiting on. Ported from
+    // `on_load_end`'s old unconditional call (2026-09-03) — moving it here
+    // means it now fires only once the window has something real to show,
+    // instead of at bare document-load-complete. This also fixes a latent
+    // bug the move inherits a fix for: the old call ran for EVERY on_load_end
+    // including hidden pool-window prewarms (nothing gated it on
+    // `is_pool_window`, which is checked later in `on_load_end`), so a
+    // background prewarm racing ahead of the real main window during a cold
+    // start could dismiss the splash before the real window had loaded at
+    // all. Pool windows never reach this function (they skip the whole
+    // reveal call — see `on_load_end`), so that race is now closed the same
+    // way Linux's ready-file was already immune to it.
+    #[cfg(target_os = "windows")]
+    {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::System::Threading::{OpenEventW, SetEvent, EVENT_MODIFY_STATE};
+        if let Ok(event_name) = std::env::var("AGENTMUX_SPLASH_EVENT") {
+            let nul: Vec<u16> = format!("{}\0", event_name).encode_utf16().collect();
+            unsafe {
+                let ev = OpenEventW(EVENT_MODIFY_STATE, 0, nul.as_ptr());
+                if !ev.is_null() {
+                    SetEvent(ev);
+                    CloseHandle(ev);
+                }
+            }
         }
     }
     let Some(mut browser) = state.get_browser(label) else { return };
@@ -108,7 +164,7 @@ pub(crate) fn reveal_gated_window(
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 wrap_task! {
     struct PaintGateRevealTask {
         state: Arc<AppState>,
@@ -134,7 +190,7 @@ wrap_task! {
 ///   to the slower safety timeout. Reagent PR #2151 second-round review.
 ///
 /// Must run on the CEF UI thread.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 pub(crate) fn handle_first_paint_signal(state: &Arc<AppState>, label: &str) {
     let already_armed = state.linux_paint_gate_pending.lock().contains_key(label);
     if already_armed {
@@ -144,7 +200,7 @@ pub(crate) fn handle_first_paint_signal(state: &Arc<AppState>, label: &str) {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 wrap_task! {
     struct FirstPaintSignalTask { state: Arc<AppState>, label: String }
     impl Task { fn execute(&self) {
@@ -157,7 +213,7 @@ wrap_task! {
 /// presented a frame. Posts to the UI thread to reveal the window if
 /// `on_load_end` already deferred it, or to record the signal for `on_load_end`
 /// to consume if it hasn't run yet (see `handle_first_paint_signal`).
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 pub(crate) fn on_frontend_first_paint(state: Arc<AppState>, label: String) {
     let mut task = FirstPaintSignalTask::new(state, label);
     post_task(ThreadId::UI, Some(&mut task));
@@ -193,17 +249,25 @@ const SHOW_WINDOW_RETRY_DELAY_MS: i64 = 50;
 /// — matches the pre-existing "can't gate safely on an unknown label"
 /// fallback (immediate show, every platform).
 ///
-/// `state`/`label` are only read inside the `#[cfg(target_os = "linux")]`
-/// branch below — unused on every other platform, hence the `allow`.
-#[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
+/// `state`/`label` are only read inside the `#[cfg(any(target_os = "linux",
+/// target_os = "windows"))]` branch below — unused on macOS, hence the
+/// `allow`. See `docs/reports/REPORT_SPLASH_TO_FIRST_PAINT_BLANK_WINDOW_GAP_2026_09_03.md`
+/// §6 for why macOS is deliberately not included here: it needs its own
+/// live-verified pass, not a blind extension of the Linux/Windows cfg gate.
+#[cfg_attr(target_os = "macos", allow(unused_variables))]
 fn reveal_top_level_window(
     state: &std::sync::Arc<crate::state::AppState>,
     label: Option<&str>,
     window: &cef::Window,
     browser: Option<&mut Browser>,
 ) {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     if let Some(label) = label {
+        // "paint" stage begin — pairs with the stage_end call inside
+        // reveal_gated_window, whichever path below resolves it. Fired once
+        // per arm regardless of which sub-path (early-signal vs timeout)
+        // ends up resolving, by sitting above both.
+        crate::launcher_ipc::report_startup_stage_begin("paint", "Window paint");
         // The real paint signal can race ahead of this call (see
         // handle_first_paint_signal) — if it already arrived, reveal
         // immediately instead of arming a gate + safety timeout for a paint
@@ -432,27 +496,17 @@ impl AgentMuxHandler {
             return;
         }
 
-        // Signal the pre-splash to fade out the moment CEF's first frame
-        // is ready. The launcher created this named event and forwarded
-        // its name via AGENTMUX_SPLASH_EVENT. OpenEventW + SetEvent is
-        // fire-and-forget; missing env var means no splash was running.
-        #[cfg(target_os = "windows")]
-        {
-            use windows_sys::Win32::Foundation::CloseHandle;
-            use windows_sys::Win32::System::Threading::{
-                OpenEventW, SetEvent, EVENT_MODIFY_STATE,
-            };
-            if let Ok(event_name) = std::env::var("AGENTMUX_SPLASH_EVENT") {
-                let nul: Vec<u16> = format!("{}\0", event_name).encode_utf16().collect();
-                unsafe {
-                    let ev = OpenEventW(EVENT_MODIFY_STATE, 0, nul.as_ptr());
-                    if !ev.is_null() {
-                        SetEvent(ev);
-                        CloseHandle(ev);
-                    }
-                }
-            }
-        }
+        // Windows: the old unconditional AGENTMUX_SPLASH_EVENT SetEvent that
+        // used to live here was moved into `reveal_gated_window`
+        // (2026-09-03, docs/reports/REPORT_SPLASH_TO_FIRST_PAINT_BLANK_WINDOW_GAP_2026_09_03.md).
+        // Firing it here — at bare `on_load_end`, before anything has visually
+        // painted — is exactly the too-early dismiss defect A of that report
+        // diagnoses; it also had no `is_pool_window` guard, so a hidden
+        // pool-window prewarm racing ahead of the real main window during a
+        // cold start could dismiss the splash before the real window had even
+        // loaded. See `reveal_top_level_window`/`reveal_gated_window` below,
+        // which now gate this on the same real first-paint confirmation Linux
+        // already used, reached only via the non-pool-window path.
 
         // macOS analogue of the Win32 splash signal: the launcher owns the native
         // splash (see agentmux-launcher/src/splash_mac.rs) and passes a ready-file

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -136,21 +136,17 @@ pub(crate) fn reveal_gated_window(
     // all. Pool windows never reach this function (they skip the whole
     // reveal call — see `on_load_end`), so that race is now closed the same
     // way Linux's ready-file was already immune to it.
+    //
+    // Also called from `reveal_top_level_window`'s `label: None` fallback
+    // branch — that path never arms the paint gate (no label to key it on),
+    // so it must fire this signal itself rather than relying on this
+    // function, which the fallback never reaches. Reagent PR #2968 review:
+    // the signal used to fire unconditionally in `on_load_end` regardless of
+    // label resolution; moving it here alone silently dropped that fallback
+    // case, leaving the launcher's splash wait (no overall timeout,
+    // `agentmux-launcher/src/splash.rs::run_splash`) to hang forever.
     #[cfg(target_os = "windows")]
-    {
-        use windows_sys::Win32::Foundation::CloseHandle;
-        use windows_sys::Win32::System::Threading::{OpenEventW, SetEvent, EVENT_MODIFY_STATE};
-        if let Ok(event_name) = std::env::var("AGENTMUX_SPLASH_EVENT") {
-            let nul: Vec<u16> = format!("{}\0", event_name).encode_utf16().collect();
-            unsafe {
-                let ev = OpenEventW(EVENT_MODIFY_STATE, 0, nul.as_ptr());
-                if !ev.is_null() {
-                    SetEvent(ev);
-                    CloseHandle(ev);
-                }
-            }
-        }
-    }
+    signal_windows_splash_dismiss();
     let Some(mut browser) = state.get_browser(label) else { return };
     if let Some(bv) = browser_view_get_for_browser(Some(&mut browser)) {
         if let Some(window) = bv.window() {
@@ -159,6 +155,29 @@ pub(crate) fn reveal_gated_window(
                 if let Some(host) = browser.host() {
                     host.set_focus(1);
                 }
+            }
+        }
+    }
+}
+
+/// Signal the named Win32 event the launcher's splash thread is waiting on
+/// (`AGENTMUX_SPLASH_EVENT`). Shared by both `reveal_gated_window` (the
+/// normal, label-resolved path) and `reveal_top_level_window`'s `label:
+/// None` fallback (which never arms the paint gate, so it never reaches
+/// `reveal_gated_window` at all) — every code path that can show the
+/// top-level window for the first time must dismiss the splash, or
+/// `run_splash`'s untimed wait hangs forever.
+#[cfg(target_os = "windows")]
+fn signal_windows_splash_dismiss() {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{OpenEventW, SetEvent, EVENT_MODIFY_STATE};
+    if let Ok(event_name) = std::env::var("AGENTMUX_SPLASH_EVENT") {
+        let nul: Vec<u16> = format!("{}\0", event_name).encode_utf16().collect();
+        unsafe {
+            let ev = OpenEventW(EVENT_MODIFY_STATE, 0, nul.as_ptr());
+            if !ev.is_null() {
+                SetEvent(ev);
+                CloseHandle(ev);
             }
         }
     }
@@ -294,6 +313,11 @@ fn reveal_top_level_window(
         }
         return;
     }
+    // No resolvable label — the paint gate above never armed, so this is
+    // also this window's only chance to dismiss the Windows splash (see
+    // `signal_windows_splash_dismiss`'s doc comment).
+    #[cfg(target_os = "windows")]
+    signal_windows_splash_dismiss();
     window.show();
     if let Some(b) = browser {
         if let Some(host) = b.host() {

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -104,18 +104,92 @@ pub(crate) fn reveal_gated_window(
         elapsed_ms,
         "[startup-paint] revealing gated window"
     );
-    // "paint" stage telemetry (docs/reports/REPORT_SPLASH_TO_FIRST_PAINT_BLANK_WINDOW_GAP_2026_09_03.md
-    // §5.3): reports the on_load_end -> real-paint gap this whole gate exists
-    // to close, as its own splash row. Paired with the `stage_begin` call at
-    // the point this label was armed (`reveal_top_level_window` below).
-    // Placed here rather than gated on the fallible browser/window lookups
-    // further down, matching the ready-file/SetEvent dismiss signals below:
-    // the paint gate resolving is the event worth reporting, independent of
-    // whether the low-level show() that follows happens to succeed.
+    finish_gated_reveal(state, label, reason, elapsed_ms, SHOW_WINDOW_MAX_RETRIES);
+}
+
+/// Physically show a window whose paint gate has already fired (label
+/// already removed from `linux_paint_gate_pending`). Returns `true` once
+/// the `browser`/`BrowserView`/`Window` chain resolves — whether or not a
+/// `show()` was actually needed (already-visible counts as resolved) —
+/// `false` if any link in that chain isn't available yet, in which case the
+/// caller should retry rather than treat it as permanent: the same chain
+/// can resolve successfully at arm-time (`try_show_top_level_window`) and
+/// still transiently fail moments later — the same documented CEF Views
+/// quirk `SHOW_WINDOW_MAX_RETRIES` above exists to cover, just hit at a
+/// later point in the gated path. Reagent/Codex PR #2968 review: this used
+/// to be an inline, non-retrying lookup, with the splash dismiss signal
+/// already fired unconditionally before it even ran — a transient failure
+/// here would dismiss the splash while permanently leaving the window
+/// hidden.
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+fn try_show_resolved_window(state: &Arc<AppState>, label: &str) -> bool {
+    let Some(mut browser) = state.get_browser(label) else { return false };
+    let Some(bv) = browser_view_get_for_browser(Some(&mut browser)) else { return false };
+    let Some(window) = bv.window() else { return false };
+    if window.is_visible() == 0 {
+        window.show();
+        if let Some(host) = browser.host() {
+            host.set_focus(1);
+        }
+    }
+    true
+}
+
+/// Finish a gated reveal: retry `try_show_resolved_window` until it
+/// succeeds or `retries_left` is exhausted, THEN fire the "paint" stage-end
+/// telemetry and the ready-file/`SetEvent` splash-dismiss signals — never
+/// before the window is confirmed shown (or retries are genuinely
+/// exhausted). Firing the dismiss signals only at that point, instead of
+/// unconditionally ahead of the fallible lookup, is what makes the retry
+/// meaningful: dismissing early would let the splash close over a window
+/// that never actually appeared. Retries are still exhausted with the
+/// dismiss signals fired anyway (with an error logged) rather than silently
+/// never firing them — `run_splash`'s wait has no overall timeout, so never
+/// dismissing would hang the splash forever even though the underlying
+/// window-show failure is a separate, already-logged problem.
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+fn finish_gated_reveal(
+    state: &Arc<AppState>,
+    label: &str,
+    reason: &'static str,
+    elapsed_ms: u64,
+    retries_left: u32,
+) {
+    if try_show_resolved_window(state, label) {
+        signal_gated_reveal_complete(elapsed_ms, reason, "ok");
+        return;
+    }
+    if retries_left == 0 {
+        tracing::error!(
+            target: "startup-paint",
+            label = %label,
+            max_retries = SHOW_WINDOW_MAX_RETRIES,
+            "[startup-paint] browser_view/window still not resolvable after gate fired — \
+             dismissing splash anyway to avoid hanging it; window will stay hidden"
+        );
+        signal_gated_reveal_complete(elapsed_ms, reason, "error");
+        return;
+    }
+    let mut next = GatedRevealRetryTask::new(
+        state.clone(),
+        label.to_string(),
+        reason,
+        elapsed_ms,
+        retries_left - 1,
+    );
+    post_delayed_task(ThreadId::UI, Some(&mut next), SHOW_WINDOW_RETRY_DELAY_MS);
+}
+
+/// "paint" stage telemetry + the ready-file/`SetEvent` splash-dismiss
+/// signals (docs/reports/REPORT_SPLASH_TO_FIRST_PAINT_BLANK_WINDOW_GAP_2026_09_03.md
+/// §5.3), fired together once `finish_gated_reveal` knows the window is
+/// either shown or permanently unshowable — never any earlier.
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+fn signal_gated_reveal_complete(elapsed_ms: u64, reason: &'static str, status: &str) {
     crate::launcher_ipc::report_startup_stage_end(
         "paint",
         elapsed_ms,
-        "ok",
+        status,
         Some(reason.to_string()),
     );
     if let Ok(path) = std::env::var("AGENTMUX_SPLASH_READY_FILE") {
@@ -147,17 +221,20 @@ pub(crate) fn reveal_gated_window(
     // `agentmux-launcher/src/splash.rs::run_splash`) to hang forever.
     #[cfg(target_os = "windows")]
     signal_windows_splash_dismiss();
-    let Some(mut browser) = state.get_browser(label) else { return };
-    if let Some(bv) = browser_view_get_for_browser(Some(&mut browser)) {
-        if let Some(window) = bv.window() {
-            if window.is_visible() == 0 {
-                window.show();
-                if let Some(host) = browser.host() {
-                    host.set_focus(1);
-                }
-            }
-        }
+}
+
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+wrap_task! {
+    struct GatedRevealRetryTask {
+        state: Arc<AppState>,
+        label: String,
+        reason: &'static str,
+        elapsed_ms: u64,
+        retries_left: u32,
     }
+    impl Task { fn execute(&self) {
+        finish_gated_reveal(&self.state, &self.label, self.reason, self.elapsed_ms, self.retries_left);
+    }}
 }
 
 /// Signal the named Win32 event the launcher's splash thread is waiting on

--- a/agentmux-cef/src/commands/backend.rs
+++ b/agentmux-cef/src/commands/backend.rs
@@ -413,16 +413,20 @@ pub fn set_window_init_status(state: &Arc<AppState>, args: &serde_json::Value) -
     serde_json::Value::Null
 }
 
-/// First-paint signal from the frontend (Linux startup white-flash fix, see
-/// docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md). Sent via a
-/// double-`requestAnimationFrame` at the very top of `bootstrap.ts` — the
-/// earliest reliable proxy for "the compositor actually presented a frame",
-/// as opposed to CEF's `on_load_end` which only means "main-frame HTML
-/// finished loading" and can fire before anything has visually painted.
+/// First-paint signal from the frontend (startup white-flash fix, see
+/// docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md and
+/// docs/reports/REPORT_SPLASH_TO_FIRST_PAINT_BLANK_WINDOW_GAP_2026_09_03.md).
+/// Sent via a double-`requestAnimationFrame` at the very top of
+/// `bootstrap.ts` — the earliest reliable proxy for "the compositor actually
+/// presented a frame", as opposed to CEF's `on_load_end` which only means
+/// "main-frame HTML finished loading" and can fire before anything has
+/// visually painted.
 ///
-/// On Linux this unblocks the window `on_load_end` deferred (see
-/// `client::navigation::reveal_gated_window`). On other platforms it's
-/// currently just logged for telemetry — Windows/macOS aren't gated on it.
+/// On Linux and Windows this unblocks the window `on_load_end` deferred (see
+/// `client::navigation::reveal_gated_window`) — Windows ported 2026-09-03,
+/// same mechanism, not a separate implementation. On macOS it's currently
+/// just logged for telemetry — not gated on it; see that report's §6 for why
+/// macOS is deliberately not included in this pass.
 pub fn report_first_paint(state: &Arc<AppState>, args: &serde_json::Value) -> serde_json::Value {
     let label = args
         .get("label")
@@ -434,7 +438,9 @@ pub fn report_first_paint(state: &Arc<AppState>, args: &serde_json::Value) -> se
         label = %label,
         "[startup-paint] frontend reported first paint"
     );
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     crate::client::navigation::on_frontend_first_paint(state.clone(), label);
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    let _ = state;
     serde_json::Value::Null
 }

--- a/agentmux-cef/src/state/mod.rs
+++ b/agentmux-cef/src/state/mod.rs
@@ -550,9 +550,8 @@ pub struct AppState {
     /// Per-pane Ctrl+Wheel zoom factor, keyed by block_id. Applied as CSS
     /// `zoom` via `ExecuteJavaScript` (`BrowserPaneManager::apply_zoom`),
     /// deliberately NOT Chromium's native page zoom — every browser pane
-    /// shares its parent window's RequestContext (see
-    /// docs/specs/pane-shares-window-request-context-linux-2026-05-13.md),
-    /// so native zoom is scoped to HostZoomMap and shared across every pane
+    /// shares its parent window's RequestContext, so native zoom is scoped
+    /// to HostZoomMap and shared across every pane
     /// on the same host/profile. CSS injection sidesteps that entirely: no
     /// RequestContext/HostZoomMap involvement, so no cookie/session sharing
     /// tradeoff, and it's per-CefFrame by construction. Absent entry means

--- a/agentmux-cef/src/state/mod.rs
+++ b/agentmux-cef/src/state/mod.rs
@@ -115,8 +115,9 @@ pub struct AppState {
     /// Window initialization status ("ready" or "wave-ready")
     pub window_init_status: Mutex<String>,
 
-    /// Linux startup white-flash fix (docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md).
-    /// Window labels whose native `window.show()`/focus + splash-ready-file has
+    /// Startup white-flash fix (docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md,
+    /// docs/reports/REPORT_SPLASH_TO_FIRST_PAINT_BLANK_WINDOW_GAP_2026_09_03.md).
+    /// Window labels whose native `window.show()`/focus + splash dismiss has
     /// been deferred by `on_load_end` pending a real first-paint confirmation
     /// from the frontend (`report_first_paint` IPC command) or a safety-net
     /// timeout, whichever fires first. Value is `(armed_at, epoch)` — `epoch`
@@ -124,21 +125,23 @@ pub struct AppState {
     /// call for the same label (e.g. a reload/retry mid-startup re-arms the
     /// gate) firing at its original, now-too-early deadline and revealing the
     /// window ahead of the *current* navigation's real paint. Mirrors the
-    /// epoch pattern in `browser_pane::auth`. Only populated/consumed on
-    /// Linux; the field exists unconditionally to keep `AppState` un-cfg'd.
+    /// epoch pattern in `browser_pane::auth`. Populated/consumed on Linux
+    /// (original) and Windows (ported 2026-09-03, same field — no reason for
+    /// a second copy); the field exists unconditionally to keep `AppState`
+    /// un-cfg'd, so it stays inert-but-present on macOS too.
     pub linux_paint_gate_pending: Mutex<std::collections::HashMap<String, (std::time::Instant, u64)>>,
 
-    /// Linux startup white-flash fix, second-round race (reagent PR #2151
-    /// review): `report_first_paint` can reach the UI thread before
-    /// `on_load_end` arms `linux_paint_gate_pending` for the same label — CEF's
-    /// main-frame load-complete isn't guaranteed to fire after the frontend's
-    /// first compositor frame (render-blocking stylesheets can resolve, and a
-    /// frame can paint, before other load-blocking resources finish and
+    /// Startup white-flash fix, second-round race (reagent PR #2151 review):
+    /// `report_first_paint` can reach the UI thread before `on_load_end` arms
+    /// `linux_paint_gate_pending` for the same label — CEF's main-frame
+    /// load-complete isn't guaranteed to fire after the frontend's first
+    /// compositor frame (render-blocking stylesheets can resolve, and a frame
+    /// can paint, before other load-blocking resources finish and
     /// `on_load_end` runs). Labels land here when the signal arrives too
     /// early; `on_load_end` checks this set before arming so it can reveal
     /// immediately instead of falling through to the slower safety timeout.
-    /// Only populated/consumed on Linux; unconditional field for the same
-    /// reason as `linux_paint_gate_pending` above.
+    /// Populated/consumed on Linux and Windows (see `linux_paint_gate_pending`
+    /// above); unconditional field for the same reason.
     pub linux_first_paint_seen: Mutex<std::collections::HashSet<String>>,
 
     /// Browser-pane top-level navigation watchdog. Chromium's underlying TCP

--- a/agentmux-launcher/src/splash.rs
+++ b/agentmux-launcher/src/splash.rs
@@ -346,11 +346,29 @@ unsafe fn run_splash(
 
         // Check for dismiss signal from CEF host's on_load_end.
         if WaitForSingleObject(dismiss_ev, 0) == WAIT_OBJECT_0 {
-            // Drain any final events that arrived at the same time.
+            // Drain any final events that arrived at the same time. The
+            // dismiss signal (a synchronous Win32 SetEvent) and the last
+            // stage-end command (an async message queued on the CEF host
+            // side and drained over the launcher IPC pipe by a background
+            // task) are sent moments apart on the same call path — SetEvent
+            // can win that race, in which case a single non-blocking
+            // try_recv() pass here would miss the trailing stage-end and
+            // freeze the summary showing that row as still in progress for
+            // the whole hold. Keep polling briefly, but only while some row
+            // is genuinely still open (`done.is_none()`) — the common case
+            // (every stage already resolved) exits immediately, same as
+            // before. Reagent PR #2968 review.
+            let drain_deadline = Instant::now() + std::time::Duration::from_millis(150);
             loop {
                 match events_rx.try_recv() {
                     Ok(ev) => apply_event(&mut stages, ev),
-                    Err(_) => break,
+                    Err(_) => {
+                        let still_open = stages.iter().any(|s| s.done.is_none());
+                        if !still_open || Instant::now() >= drain_deadline {
+                            break;
+                        }
+                        std::thread::sleep(std::time::Duration::from_millis(10));
+                    }
                 }
             }
 

--- a/docs/reports/REPORT_SPLASH_TO_FIRST_PAINT_BLANK_WINDOW_GAP_2026_09_03.md
+++ b/docs/reports/REPORT_SPLASH_TO_FIRST_PAINT_BLANK_WINDOW_GAP_2026_09_03.md
@@ -1,0 +1,397 @@
+# REPORT — the window is blank for seconds after the splash disappears, and none of that time is in the splash's own timeline
+
+**Date:** 2026-09-03 (diagnosis), implemented and live-verified 2026-09-04
+**Author:** Agent5
+**Status:** implemented — both defects fixed on Windows in this repo's `main`
+(commit history below). Diagnosis (§1-4) is unchanged from the original pass;
+§5 is updated to describe what actually shipped, including one deliberate
+divergence from the original proposed shape (§5.3).
+**Platform:** Windows (reported, fixed, live-verified). macOS shares defect A
+verbatim and is unfixed here by design — see §6. Linux already had the fix
+for A before this report existed; it now also gets defect B's `paint` stage
+for free, since the fix was implemented as a shared, not Windows-only, code
+path.
+
+---
+
+## 1. The report, restated precisely
+
+Two distinct complaints, and they turn out to be two distinct bugs that happen
+to sit next to each other in the startup sequence:
+
+1. **"The splash screen says things are done" — but the main window is then
+   blank for a further stretch before anything real appears.** The splash's
+   own stage list reaches its end and disappears; the window that replaces it
+   shows nothing for seconds.
+2. **The window should show fully painted, not spend seconds blank.**
+
+(1) is a *measurement* gap — real work is happening, but the splash's timeline
+doesn't know about it, so it reports "done" early. (2) is a *rendering* gap —
+the window is being shown before it has anything to show. Both are real, and
+both are verified against the current code below, not inferred.
+
+---
+
+## 2. Defect A — the window is shown before it has painted anything (Windows/macOS)
+
+### 2.1 What actually gates `window.show()` today
+
+`agentmux-cef/src/client/navigation.rs::on_load_end` — CEF's "main-frame HTML
+finished loading" callback. For the top-level window, on every platform
+**except Linux**, the code goes straight to:
+
+```rust
+window.show();
+if let Some(b) = browser { if let Some(host) = b.host() { host.set_focus(1); } }
+```
+
+`on_load_end` is not "the page painted." It is document-load-complete, and the
+code's own doc comments say so, in two places:
+
+> `report_first_paint`'s doc comment: *"as opposed to CEF's `on_load_end` which
+> only means 'main-frame HTML finished loading' and can fire before anything
+> has visually painted."*
+
+> `reveal_top_level_window`'s doc comment, describing the fix Linux got and
+> Windows/macOS didn't: *"the real double-rAF signal for the main window
+> landed ~2.08s after `on_load_end`."*
+
+That 2.08s figure is not a worst case pulled from thin air — it's a measured
+number from `docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md`'s
+own verification run, on the same class of machine this investigation ran on
+(a resource-shared dev box running several concurrent CEF instances). Also
+measured that day: pool-window prewarms (an unrelated code path, so this is a
+baseline reading of compositor-first-frame latency on that environment, not an
+artifact of the gate) landed 1.36–1.84s after their own equivalent starting
+point. **A one-to-two-second gap between "document loaded" and "something is
+actually on screen" is the demonstrated norm on this class of hardware, not a
+tail case.**
+
+### 2.2 The fix already exists — for one platform
+
+`reveal_top_level_window` (same file) has a real paint gate, but it is
+`#[cfg(target_os = "linux")]`:
+
+- The frontend fires a double-`requestAnimationFrame` at the very top of
+  `bootstrap.ts` (`frontend/bootstrap.ts:40-46`) — the standard proxy for "the
+  compositor actually presented a frame" — and reports it via the
+  `report_first_paint` IPC command.
+- On Linux, `on_load_end` **arms a gate instead of showing the window**, with a
+  4000ms safety-net timeout in case the signal never arrives (crashed JS, rAF
+  never firing). The real signal races the timeout; whichever comes first wins,
+  once, per-arm (an `epoch` counter guards against a stale timeout firing after
+  a reload re-armed the same label).
+- `agentmux-cef/src/commands/backend.rs::report_first_paint`'s own doc comment
+  states the gap outright: *"On Linux this unblocks the window `on_load_end`
+  deferred... On other platforms it's currently just logged for telemetry —
+  Windows/macOS aren't gated on it."*
+
+So the signal exists, is already wired end-to-end from the frontend, is
+already received by the host on every platform — and is thrown away on
+Windows and macOS. This is the single largest, most directly actionable
+finding in this report: **the fix for the exact bug reported is already built
+and shipping on one platform.**
+
+### 2.3 Why a click or a resize doesn't fix this one
+
+Worth naming since it's easy to conflate with a different, already-fixed
+issue from this same investigation session (the resize-then-drag report,
+unrelated): this is not a focus/activation problem. The window is genuinely
+empty pixels — nothing has been asked to paint yet — for the whole gap. No
+user action shortens it; only time (and whatever the frontend is doing) does.
+
+---
+
+## 3. Defect B — the splash's timeline stops long before the app is actually usable
+
+### 3.1 What the splash currently measures, exactly
+
+Confirmed by reading every `stage_begin`/`stage_end` call site
+(`agentmux-launcher/src/supervisor/windows.rs`, `agentmux-cef/src/lib.rs`) and
+cross-checked against `docs/specs/PLAN_SPLASH_TELEMETRY_OPEN_ITEMS_2026_07_22.md`
+(items #2 and #7, both explicitly verified there by exhaustive grep — this
+report's own grep reproduces the same result independently):
+
+| Stage key | Covers | Ends at |
+|---|---|---|
+| `migrations` | srv DB migrations | subprocess exit |
+| `backend` | srv spawn | `AGENTMUXSRV-ESTART` on srv stderr |
+| `host` | CEF host **process spawn** | `spawn_host_supervised` returning a live `Child` — **not** first paint. The comment at `windows.rs:453-461` says this explicitly: *"not full first-paint... Extending this stage to span to first-paint is a follow-up once a race-safe signal exists."* That signal (`report_first_paint`) now exists (§2.2) and was never plugged back into this stage. |
+| `dlopen` | Loading `libcef`/`libcef.dll` | framework loaded |
+| `cef_init` | `CefInitialize()` | returns |
+
+**That is the complete list.** Nothing covers:
+
+- Window creation → `on_load_end` (the load itself)
+- `on_load_end` → real compositor first paint (defect A's own gap)
+- Frontend bootstrap: `setupCefApi()` (an async IPC round-trip),
+  `initApp()`, RPC/store hydration, tab/pane mount
+- The tab-content reveal gate's own settle window
+  (`frontend/app/store/tab-reveal.ts`) — up to `MAX_GATE_MS` (800ms) of
+  intentional additional hold, waiting for a window of long-task-free frames
+  after mount, before the in-page "brain" overlay (`#startup-loading`,
+  `frontend/app/init/startup-splash.ts`) cross-fades out
+
+Grep confirms zero frontend-side stage reporting exists at all:
+`frontend/` has no reference to `sendLauncherMsg`, `startup_stage_begin`, or
+`startup_stage_end` anywhere. The original telemetry spec
+(`SPEC_SPLASH_STARTUP_TELEMETRY_2026_06_25.md`, Implementation Order step 7,
+"Frontend events") was never built. `PLAN_SPLASH_TELEMETRY_OPEN_ITEMS_2026_07_22.md`
+already reached this same conclusion in July and correctly logged it as an
+open item rather than a rumor — this report adds nothing new on that point,
+only confirms it still holds two months later and connects it to the live bug
+report that makes it worth acting on now.
+
+### 3.2 Consequently, two separate un-measured stretches are invisible
+
+1. **The `on_load_end` → real-paint gap** (defect A, up to ~2s observed) — the
+   splash has already declared `host` complete by the time this gap even
+   starts, since `host` ends at process-spawn, long before `on_load_end`
+   fires at all.
+2. **The frontend-mount-and-settle gap** — everything from `setupCefApi()`
+   through the tab-reveal gate's 80ms-clean-frames-or-800ms-cap settle
+   detector. This is real, often substantial work (async IPC handshake,
+   store hydration, tab restoration, first render, measured layout reflow)
+   with zero telemetry representation.
+
+The splash's own design already anticipates a live "running clock" row for
+whatever is currently in flight (`SPEC_SPLASH_STARTUP_TELEMETRY_2026_06_25.md`
+§"Running Clock") — the mechanism to show "still working, N seconds and
+counting" exists. It simply has no stage to attach to for either of these two
+gaps, so the splash instead shows nothing in-flight and looks finished.
+
+### 3.3 Why this reads as "says done, but isn't" rather than "runs long"
+
+The splash's summary hold (§"Summary Hold" in the June spec) is meant to fire
+once real first-paint happens and hold briefly to let the user read the
+timeline. Today, because nothing gates on real first-paint on Windows (defect
+A), the hold logic has no correct trigger to attach to either — the closest
+proxy available to it is `on_load_end`, the same too-early signal responsible
+for the blank window in the first place.
+
+---
+
+## 4. These two defects compound, they don't just coexist
+
+Fixing A alone (port the Linux paint gate to Windows/macOS) removes the blank
+window, but the splash would still dismiss and the window would still appear
+to "just be there" with no accounting of the wait — the user would see a
+correctly-painted window arrive after an unexplained pause, rather than a
+blank one. Fixing B alone (wire frontend + real-paint stages into the splash)
+would make the *existing* too-early dismiss more informative but wouldn't stop
+the window itself from flashing blank first — the timeline would show
+"Frontend init ▶ 1.8s..." running *in the splash*, while the *separate* CEF
+window behind it still blanks out before that row even finishes. **Both need
+fixing for the reported experience — "splash says done, then blank window,
+then more loading" — to actually become "splash accurately shows the whole
+wait, then the window arrives already painted."**
+
+---
+
+## 5. What shipped
+
+Ordered by dependency, matching how the existing code was already structured
+to receive each piece. §5.1 matches the original proposal. §5.2 diverges from
+the original two-change proposal (§5.2+§5.3 in the first draft of this
+report) deliberately, once implementing §5.1 first made a cleaner shape
+visible — see §5.2's own explanation. §5.3 remains unimplemented, unchanged
+from the original diagnosis.
+
+### 5.1 Port the Linux paint gate to Windows (defect A) — the core fix
+
+`reveal_top_level_window` isolated the platform-specific behavior behind a
+single `#[cfg(target_os = "linux")]` block with a documented fallback. That
+gate is now `#[cfg(any(target_os = "linux", target_os = "windows"))]` —
+Windows shares the exact same state machine and functions Linux already used
+(`reveal_gated_window`, `handle_first_paint_signal`, `PaintGateRevealTask`,
+`FirstPaintSignalTask`, `on_frontend_first_paint`, `PAINT_GATE_NEXT_EPOCH`),
+not a parallel reimplementation. `linux_paint_gate_pending`/
+`linux_first_paint_seen` (`state/mod.rs`) keep their names — renaming them
+would have touched every call site for no functional gain — but their doc
+comments now say plainly that Windows populates them too.
+
+What actually differs per platform is only the two calling-convention pieces
+`reveal_top_level_window`'s own doc comment already flagged as the seam:
+
+- **Dismiss signal.** Windows' `AGENTMUX_SPLASH_EVENT` `SetEvent` used to fire
+  unconditionally at `on_load_end`, before anything had painted — the same
+  bug in miniature. It now fires from inside `reveal_gated_window`, at the
+  exact moment the gate resolves, right alongside the macOS/Linux
+  ready-file write it sits next to in that function. This also closes a
+  latent bug the move inherits a fix for: the old call had no
+  `is_pool_window` guard (that check happens later in `on_load_end`), so a
+  hidden pool-window prewarm racing ahead of the real main window during a
+  cold start could dismiss the splash before the real window had loaded at
+  all — precisely the class of bug Linux's ready-file placement was already
+  immune to, for the identical reason cited in its own comment.
+- **Safety-timeout value.** Reused Linux's `4000ms` verbatim rather than
+  picking a separate Windows number. The comment on
+  `PAINT_GATE_SAFETY_TIMEOUT_MS` now says why directly: this is a backstop
+  against a genuinely stalled renderer, not a target, so the real signal is
+  expected to win on any machine capable of running the app at all — and the
+  live Windows run below confirms exactly that (`reason="signal"`, nowhere
+  near the timeout).
+
+**Live-verified**, not just compiled: a fresh `task dev` cold start on this
+machine, host log (`agentmux-host-v0.55.34.log.2026-09-04`):
+
+```json
+{"message":"[startup-paint] frontend reported first paint","label":"main"}
+{"message":"[startup-paint] revealing gated window","label":"main","reason":"signal","elapsed_ms":1177}
+```
+
+`reason="signal"` — the real double-rAF paint confirmation resolved the gate,
+not the timeout. `elapsed_ms=1177` is the main window's `on_load_end`-to-
+real-paint gap on this run: **over a full second that the old code would have
+shown as a blank window**, and that now stays hidden behind the (already-
+painted, non-blank) native splash instead. This is the same order of
+magnitude as the Linux measurement in §2.1 (1.36-2.08s on a similar class of
+machine), which is itself the strongest available confirmation that this
+isn't a Linux-specific quirk — the gap is real on Windows too, and the fix
+closes it the same way.
+
+Pool-window prewarms (`floating-pool-...`, `window-pool-...`) also logged
+`report_first_paint`, correctly with **no** matching `revealing gated window`
+line — confirming they still skip the whole reveal path as designed (§2.2's
+pool-window carve-out), rather than the fix accidentally widening its own
+scope to windows that were never meant to go through it.
+
+### 5.2 "paint" stage telemetry (defect B) — one new stage, not two stage changes
+
+The original proposal (§5.2/§5.3 in the first draft of this report) was to
+add a `frontend` stage plus extend `host` to span to first-paint. Implementing
+§5.1 first made a cleaner shape visible, so this diverges from that proposal
+deliberately:
+
+**What shipped instead: one new stage, `paint`**, begun in
+`reveal_top_level_window` at the exact moment the gate arms (i.e. where
+`on_load_end` used to just call `window.show()`), and ended in
+`reveal_gated_window` at the exact moment the gate resolves — the same two
+places already carrying this report's core logic, via
+`launcher_ipc::report_startup_stage_begin`/`report_startup_stage_end`, the
+identical fire-and-forget API `dlopen`/`cef_init` already use successfully
+(confirmed safe to call unconditionally: it's a no-op sender-side when no
+launcher connection exists, e.g. in `task dev`).
+
+Why this is a better fit than the original two-change proposal, not just a
+smaller one:
+
+- `host`'s own comment already defines it as *process-spawn* latency — a
+  genuinely distinct, useful number ("how fast did the OS launch our
+  process"). Extending it to also mean "...and also how long until paint"
+  would have made one row answer two different questions.
+- A separate `frontend` stage measured from the top of `bootstrap()` to the
+  same first-paint signal would have mostly **duplicated** `paint`'s own
+  span — `bootstrap()` starts essentially when `on_load_end` fires (the
+  renderer's own script can't run meaningfully earlier), so a second,
+  differently-named row ending at the identical instant would have added
+  splash noise without adding information.
+- No frontend/`bootstrap.ts` changes were needed at all: `paint`'s begin fires
+  host-side (at `on_load_end`), and its end reuses the *already-existing*
+  `report_first_paint` signal `reveal_gated_window` was already consuming for
+  the reveal itself. One signal, already flowing, now feeding two consumers
+  (the gate AND the stage row) instead of needing a new one invented for
+  telemetry alone.
+
+`apply_event`'s stage-row handling in `splash.rs` is fully key-driven — new
+stage keys need no launcher-side changes, confirmed by `dlopen`/`cef_init`
+already working this way. Nothing in `agentmux-launcher` was touched for this
+half of the fix.
+
+Not observed in the live `task dev` run above: `report_startup_stage_begin`/
+`_end` log at `tracing::debug!`, and `task dev` doesn't connect to a launcher
+IPC socket at all in dev mode (`should_connect_launcher` gates on
+`!is_dev_build_exe`), so the calls fire as designed no-ops there — expected,
+not a gap. Confirming the `paint` row actually renders in a real native
+splash needs a packaged-build run; this pass's packaged-build smoke test
+didn't produce a distinguishable separate window (a single-instance
+collision with another same-day build already running on this shared,
+multi-agent dev machine) and wasn't pursued further rather than risk
+touching another agent's running instance. The core mechanism this stage
+reports on is verified either way (§5.1); what's unverified is only the
+final-mile "does the pixel row draw," which is the same class of gap
+`dlopen`/`cef_init` already closed successfully using the identical API.
+
+### 5.3 Frontend bootstrap / tab-reveal settle window — deliberately still not counted
+
+Still open, unchanged from the original diagnosis. This is a judgment call,
+not an engineering blocker, flagged rather than resolved here. Arguments both
+ways:
+
+- **For:** it's real, sometimes-substantial time the user is waiting with
+  nothing telling them why (the in-page brain overlay is animated, but gives
+  no duration/stage information the way the splash does).
+- **Against:** the brain overlay already exists specifically to cover this
+  exact window (`startup-splash.ts`'s own doc comment: *"must stay up...
+  until the content-reveal gate decides the window has settled"*) — it may be
+  intentional that this phase has its own, different-looking "still working"
+  indicator rather than extending the native splash's lifetime further. Doing
+  so would also mean holding the OS-native splash window open across the
+  hand-off to the in-page one, which is a real architectural change, not a
+  telemetry-only one.
+
+---
+
+## 6. What this fix does not cover
+
+- **§5.3 (frontend bootstrap / tab-reveal settle window) is not implemented.**
+  Deliberately: the brain overlay already covers it visually, and folding it
+  into the native splash's own lifetime would be an architectural change, not
+  a telemetry addition — see §5.3's own for/against.
+- **Windows-specific safety-timeout tuning was not done.** `PAINT_GATE_SAFETY_TIMEOUT_MS`
+  reuses Linux's `4000ms` verbatim (§5.1's own reasoning for why that's
+  the correct conservative choice, not a placeholder). If it's ever observed
+  firing on real Windows hardware outside a genuinely crashed renderer,
+  that's the signal a dedicated measurement pass is now overdue — the
+  comment on the constant says this explicitly.
+- **The `paint` splash row's actual on-screen rendering was not visually
+  confirmed** — §5.2's live run used `task dev`, which never connects to a
+  launcher IPC socket, so the `report_startup_stage_begin`/`_end` calls
+  fired as designed no-ops there. The underlying reveal mechanism they
+  report on IS confirmed live (§5.1's `elapsed_ms=1177` evidence); a
+  packaged-build re-run to watch the row itself draw is the natural
+  follow-up, not blocking given `dlopen`/`cef_init` already prove the same
+  API renders correctly.
+- **macOS is untouched**, deliberately. `reveal_top_level_window`'s cfg gate
+  is `any(linux, windows)`, not widened further — macOS keeps its exact
+  pre-existing behavior (unconditional `window.show()` at `on_load_end`),
+  matching this report's own scope statement in the original diagnosis
+  pass and the "don't touch what you can't verify" discipline
+  `PLAN_SPLASH_TELEMETRY_OPEN_ITEMS_2026_07_22.md` already established for
+  the reverse case (a macOS-only environment declining to touch Windows
+  code blind). Defect A's applicability to macOS is read from the code
+  (identical unconditional fallback), not separately measured; defect B's
+  `paint` stage is Windows/Linux-only by the same cfg gate, so macOS's
+  splash timeline is unchanged by this pass.
+- `PLAN_SPLASH_TELEMETRY_OPEN_ITEMS_2026_07_22.md` items #4 (Windows
+  pre-supervisor "prep" stage — splash doesn't exist yet at that point on
+  Windows, a structural gap), #5 (cross-platform `StageRow` consolidation),
+  #6 (IPC-signal dismiss instead of file-poll, macOS-specific), and #8 (full
+  srv/host spawn parallelization) remain real, already-tracked, and out of
+  scope here — none of them are on the path between `on_load_end` and first
+  paint, which is where this report's two defects lived.
+
+---
+
+## 7. References
+
+- `agentmux-cef/src/client/navigation.rs` — `on_load_end`,
+  `reveal_top_level_window`, `reveal_gated_window`, `handle_first_paint_signal`
+- `agentmux-cef/src/commands/backend.rs::report_first_paint`
+- `frontend/bootstrap.ts:20-46` — the double-rAF signal
+- `frontend/app/init/startup-splash.ts`, `frontend/app/store/tab-reveal.ts`
+- `agentmux-launcher/src/supervisor/windows.rs:258-300,450-490` — splash spawn,
+  `host` stage bounds
+- `agentmux-cef/src/lib.rs:396-415,714-723,1055-1056` — `dlopen`/`cef_init`
+  stage reporting
+- `docs/specs/SPEC_SPLASH_STARTUP_TELEMETRY_2026_06_25.md` — original design,
+  step 7 ("Frontend changes") never implemented
+- `docs/specs/PLAN_SPLASH_TELEMETRY_OPEN_ITEMS_2026_07_22.md` — items #2, #4,
+  #7 independently confirm §3's findings from a prior, separate pass
+- `docs/specs/REPORT_NEW_WINDOW_STARTUP_COLOR_FLASH_2026_07_14.md` — the
+  Linux investigation and fix defect A needed ported (§5.1: now done)
+- `agentmux-cef/src/state/mod.rs` — `linux_paint_gate_pending`/
+  `linux_first_paint_seen`, doc comments updated to say Windows populates
+  them too (names kept to avoid an unrelated-diff rename)
+- Live evidence (§5.1): `agentmux-host-v0.55.34.log.2026-09-04`, a fresh
+  `task dev` cold start on this machine, 2026-09-04


### PR DESCRIPTION
Fixes a live user report: the window loads blank for a long time behind the splash screen, and the splash says things are done well before the window is actually usable.

Full diagnosis: `docs/reports/REPORT_SPLASH_TO_FIRST_PAINT_BLANK_WINDOW_GAP_2026_09_03.md`.

## Root cause

The window was shown at CEF's `on_load_end` ("main-frame HTML finished loading") rather than at real first paint, on every platform **except Linux**. `on_load_end` can fire before anything has visually painted — the code's own doc comments already said so — and a July investigation measured that gap at ~2.08s on a comparable machine.

**Live-verified on this exact fix**, not just compiled: a fresh cold start logged

```json
{"message":"[startup-paint] frontend reported first paint","label":"main"}
{"message":"[startup-paint] revealing gated window","label":"main","reason":"signal","elapsed_ms":1177}
```

`elapsed_ms=1177` between `on_load_end` and the real double-rAF paint signal — over a full second the old code would have shown as a blank window. `reason="signal"` confirms the real signal won the race, not the 4s safety timeout.

## What changed

`reveal_top_level_window`'s existing Linux-only paint gate (`reveal_gated_window`, `handle_first_paint_signal`, `PaintGateRevealTask`, `FirstPaintSignalTask`, `PAINT_GATE_NEXT_EPOCH`) is now `#[cfg(any(linux, windows))]` — **Windows shares the exact state machine, not a parallel reimplementation.** Only the two calling-convention pieces differ per platform, both already flagged as the seam in that function's own doc comment:

- The `AGENTMUX_SPLASH_EVENT` `SetEvent` dismiss signal moved from an unconditional call at `on_load_end` into `reveal_gated_window`, firing only once the gate actually resolves.
- The `4000ms` safety-timeout constant is reused verbatim from Linux rather than picking a separate number — it's a backstop against a stalled renderer, not a target, and the live run confirms the real signal wins in practice.

### A latent bug fixed as a side effect of the move

The old unconditional `SetEvent` call had **no `is_pool_window` guard** (that check happens later in `on_load_end`), so a hidden pool-window prewarm racing ahead of the real main window during a cold start could dismiss the splash before the real window had even loaded — the same class of bug Linux's ready-file placement was already immune to, for the identical reason its own comment cites. Verified live: pool-window first-paint signals (`floating-pool-...`, `window-pool-...`) logged with **no** matching `revealing gated window` line, confirming they still skip the reveal path entirely.

## Splash telemetry (defect B)

Adds one new stage, **`paint`** — begun where `on_load_end` used to just call `window.show()`, ended where the gate resolves — so the gap this fix closes is visible in the splash's own timeline instead of the splash declaring "done" before it actually was.

This **diverges from the report's original two-change proposal** (a separate `frontend` stage plus extending `host` to span to first-paint): implementing the gate first made a cleaner shape visible, since both of those would have mostly duplicated one span already available at the same two call sites. No launcher-side changes needed — stage rows are fully key-driven, the same way `dlopen`/`cef_init` already prove. The report's §5.2 explains the reasoning in full.

## Explicitly out of scope

- **macOS is untouched.** The cfg gate stays `any(linux, windows)`, not widened further. Its applicability is read from the code (identical fallback path) but not separately measured — matching the original investigation's stated scope and the "don't touch what you can't verify" discipline this repo already established for the reverse case.
- **The frontend bootstrap / tab-reveal settle window is deliberately not counted** in splash telemetry — the in-page brain overlay already covers it visually; folding it into the native splash's lifetime would be an architectural change, not a telemetry one. See report §5.3.
- **The `paint` row's on-screen rendering wasn't visually confirmed** — the live run used `task dev`, which never connects to the launcher IPC socket the splash reads from, so those calls fired as designed no-ops there. The underlying reveal mechanism they report on **is** confirmed live; a packaged-build re-run to watch the row draw is the natural follow-up. (A packaged-build smoke test in this pass hit a single-instance collision with another already-running same-day build on this shared, multi-agent dev machine, and wasn't pursued further to avoid touching another agent's running instance.)
- **Windows-specific safety-timeout tuning wasn't done** — `4000ms` is reused from Linux, deliberately, per the reasoning above. If it's ever observed firing on real Windows hardware outside a genuinely crashed renderer, that's the signal a dedicated measurement pass is overdue.

## Testing

`cargo test -p agentmux-cef -p agentmux-launcher` — **521 passed, 0 failed** (308 + 213). Neither suite had prior unit coverage of this OS-coupled logic to extend on any platform — it's tightly bound to real CEF/Win32 state, the same reason Linux's original version shipped with none either. Verification here is the live cold-start run documented above, the same standard the original fix shipped under.

<!-- agentmux:agent_id=agent5 -->
