### PR TITLE
Loap #2@claudius: feat(agent): auto-unblock on external auth bind, one-click Bind account

### DIFF
--- a/.changesets/1788556302-feat-agent-auto-unblock-on-external-auth-bind-one-click-bind-qsh9.md
+++ b/.changesets/1788556302-feat-agent-auto-unblock-on-external-auth-bind-one-click-bind-qsh9.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): auto-unblock on external auth bind, one-click Bind account

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -334,7 +334,7 @@ partial list.
 | [`SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29`](SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29.md) | Spec: multi-tier discovery + remote API invocation over muxbus |
 | [`SPEC_WINDOW_NAME_API_HARDENING_2026_08_08`](SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md) | SPEC: Window-name App API hardening (phantom-id success + status codes) |
 
-### proposed (90)
+### proposed (91)
 
 | Spec | Title |
 |---|---|
@@ -344,6 +344,7 @@ partial list.
 | [`SPEC_AGENT_BUSY_ANTS_REFINEMENT_2026_06_22`](SPEC_AGENT_BUSY_ANTS_REFINEMENT_2026_06_22.md) | Agent Busy Bar (Marching Ants) Refinement |
 | [`SPEC_AGENT_DISPATCH_SUBAGENT_HIERARCHY_2026_07_17`](SPEC_AGENT_DISPATCH_SUBAGENT_HIERARCHY_2026_07_17.md) | SPEC: two-level dispatch/member schema for subagents and workflows |
 | [`SPEC_AGENT_HISTORY_AS_TAB_AND_DRAFT_PRESERVATION_2026_08_11`](SPEC_AGENT_HISTORY_AS_TAB_AND_DRAFT_PRESERVATION_2026_08_11.md) | SPEC: Agent History as a pane tab, composer draft preservation, and a scrolling link row |
+| [`SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04`](SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md) | SPEC — Tighten the agent-pane login flow: auto-unblock on external bind, "Bind account" button |
 | [`SPEC_AGENT_WORKING_ROW_TOOL_BURST_REVEAL_INTERRUPT_2026_08_21`](SPEC_AGENT_WORKING_ROW_TOOL_BURST_REVEAL_INTERRUPT_2026_08_21.md) | SPEC: Tool-call bursts restart the agent-pane "Working…" row's type-out reveal |
 | [`SPEC_AGENT_WORKING_ROW_TYPOGRAPHY_REFRESH_2026_09_03`](SPEC_AGENT_WORKING_ROW_TYPOGRAPHY_REFRESH_2026_09_03.md) | SPEC: `AgentWorkingRow` typography refresh — drop the accent-color text, match the thinking-text font, go bold |
 | [`SPEC_AGENT_ZOOM_PERSISTENCE_2026_06_22`](SPEC_AGENT_ZOOM_PERSISTENCE_2026_06_22.md) | Per-agent zoom persistence |

--- a/docs/specs/SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md
+++ b/docs/specs/SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md
@@ -102,6 +102,22 @@ In `useAgentControllerStatus.ts`:
    rare but is not impossible if a previous mismatched link existed): do
    nothing, leave the row as-is.
 
+**Amended 2026-09-04 (reagentx P1 on the implementation PR):** step 4's
+"if it still fails" is not a rare edge case — it is the FIRST attempt's
+default outcome. `agentidentities:changed` is published by the backend
+synchronously inside `LinkAgentIdentityCommand`'s handler, before it even
+responds to the RPC; RPC responses and WS events share one in-order
+connection, so this subscription fires before `bindAccountToAgent`'s own
+`SetMetaCommand` (which only runs after that same Link RPC resolves
+client-side) has refreshed `cmd:env` to the newly-bound account's dir. A
+single recheck races that refresh and loses almost every time. Fix: a
+short, bounded retry ladder (`recheck-after-bind.ts`,
+`retryRecheckAfterBind` — a few hundred ms to a couple seconds total),
+re-reading block meta fresh on each attempt so it converges the instant
+the real refresh lands, bailing early if the pane becomes unblocked through
+some other path first (e.g. a live turn arriving). Still never retries a
+turn (§2.3 is unaffected) — only the recheck itself is retried.
+
 ### 2.3 Explicit non-goal: do not auto-retry a turn
 
 "Free the user to work" means **unblocking send**, not **auto-resubmitting
@@ -268,6 +284,12 @@ narrowing of the terminal fallback.
 - Regression: `useAgentCommands`'s existing `canRetry`-gating tests
   (`useAgentCommands.test.ts:186,203,326`) still pass unchanged — the fix only
   adds a new writer of `canRetry(false)`, it doesn't change what reads it.
+- Unit (`recheck-after-bind.test.ts`, dependency-injected — no DOM/RPC mocking):
+  retries through N failures and picks up a later success; stops at the first
+  success and never calls `onHealthy` twice; gives up after exhausting the
+  ladder; bails early once `stillBlocked()` turns false mid-ladder; sleeps the
+  exact delay values in order. This is what actually pins the 2026-09-04
+  amendment to step 4 above — without it the race is invisible to any test.
 - Live: reproduce the operator's exact report — start an agent, hit the login
   prompt, bind an account from the Armory's Bind-to-Agent menu in a different
   window, confirm the pane's prompt clears **without switching back to it**

--- a/docs/specs/SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md
+++ b/docs/specs/SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md
@@ -1,0 +1,311 @@
+# SPEC — Tighten the agent-pane login flow: auto-unblock on external bind, "Bind account" button
+
+**Date:** 2026-09-04
+**Status:** proposed — analysis complete, not yet implemented.
+**Repo:** agentmuxai/agentmux
+**Trigger:** Operator report, two related pieces of friction in the same flow:
+1. Starting an agent shows the login-required prompt. The user switches to the
+   Armory and binds an account for that provider (e.g. via the existing
+   Bind-to-Agent context menu). The agent pane does **not** notice — it is
+   still showing the same blocking prompt, and the user is stuck until they
+   manually retry.
+2. When no account is bound yet, the only recovery actions offered are a
+   fresh login ("Log in"/"Login Again"), "Login via terminal", and a link to
+   the Armory. If the user already has a **different, already-authenticated**
+   account for the same provider (e.g. two Claude accounts, one already
+   signed in), there is no one-click way to just use it — they have to leave
+   the pane, go bind it from the Armory, and come back (and today, per issue
+   #1, "come back" doesn't even self-resolve).
+
+---
+
+## 0. Read this first — a closely related bypass was just closed
+
+`docs/analysis/ANALYSIS_PER_CHANNEL_AUTH_BYPASSES_2026_08_31.md` (merged
+2026-08-31, PR #2878) hardened a real invariant:
+
+> **INV-PC (per-channel auth):** an agent running in channel *C* must launch
+> only against a credential that was authenticated **in channel *C***.
+
+As part of that work, **"Use existing login"** — a failure-row action that
+copied the user's personal `~/.claude` credential into the agent's isolated
+dir — was deleted outright (`failure-accessory.ts:125-132`, comment: *"copied
+the user's personal `~/.claude` credential into this agent, which defeated
+per-channel isolation"*).
+
+**This spec's issue #2 is not that feature.** "Use existing login" read from
+the ambient, un-scoped `~/.claude` file — a credential nobody chose and that
+was never authenticated *for this channel*. This spec's "bind to existing
+account" reads from **`db_accounts`**, the per-channel-scoped Armory account
+list — a credential a human explicitly authenticated (in the Armory or in
+another agent pane) *in this channel*, using the exact same link mechanism
+(`LinkAgentIdentityCommand`) the Armory's own Bind-to-Agent menu already
+uses. It is additive to INV-PC, not a regression of it — but anyone
+implementing this must source the candidate list from the channel-safe path
+(§3.3) or they will reopen a shape of the same bug.
+
+## 1. What already exists (do not rebuild)
+
+| Piece | Where | Notes |
+|---|---|---|
+| The one login CTA (post-consolidation) | `frontend/app/view/agent/failure/failure-accessory.ts` `failureToRow()`, `case "auth"` (~line 124) | Ships "Log in"/"Login Again" (primary, `on.loginAgain`), "🖥 Login via terminal" (`on.loginViaTerminal`), "Armory → Accounts" (`on.openArmory`). One surface since `PLAN_LOGIN_CTA_SURFACE_CONSOLIDATION_2026_09_02.md` (PR #2951) — see §2 below, this matters for where new actions go. |
+| The state machine behind those buttons | `frontend/app/view/agent/hooks/useAgentControllerStatus.ts` | Owns `canRetry` (gates `useAgentCommands`'s unauthenticated-send fast-fail), `relogin()`, `loginViaTerminal()`, `existingAccountIdFor(providerId)` (this agent's *own* last-linked account — not a general provider search), `recordRecoveryIntent`/`beginRecoveryFlow`/`endRecoveryFlow` (concurrent-recovery-flow guards, several past P0/P1s live here — read the doc comments at lines ~277-370 before touching this file). |
+| Channel-safe account listing | `agentmux-srv/src/server/agent_handlers/identity.rs:147-161` (`COMMAND_LIST_IDENTITY_ACCOUNTS` / `listidentityaccounts`) | Backed by `state.id_store.identity_list(provider)` — `id_store` is the **per-channel** store (`SPEC_IDENTITY_STORE_SPLIT_2026_08_17.md`). **This is the channel-safe path.** Frontend cache: `frontend/app/view/identity/identity-model.ts` (`loadAccounts()`, `subscribeAccountChanges(fn)`), already consumed the same way by `AgentLaunchModal.tsx` and the Armory's `identity-accounts-tab.tsx`. `frontend/app/store/launch-flow-state/types.ts:184` (`accountsForProvider(state, providerId)`) is the existing "accounts for a provider" filter over that same cache. |
+| The NOT-channel-safe listing (avoid for this feature) | `identity.self.accounts` (`app_api/mod.rs`) | Per `ANALYSIS_PER_CHANNEL_AUTH_BYPASSES_2026_08_31.md` §6, this one still falls back to the global cross-channel mirror (`resolve_account`, not `resolve_account_for_spawn`) for continuity reasons unrelated to this feature. An account it lists can still fail to spawn with `MissingCredentials`. **Do not use this RPC to build the candidate list in §3.** |
+| Bind action | `LinkAgentIdentityCommand` → `agent_handlers/identity.rs:590-611` | Upserts `db_agent_identity_links` (`ON CONFLICT(agent_id, provider) DO UPDATE`) — binding an agent that already has a link for this provider **replaces** it. Already used by the Armory's Bind-to-Agent context menu (`SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md`, PR #2485, implemented) and by the per-agent Identity tab. |
+| Live-apply after a bind, for a *running* pane | `SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md` §2 | Two best-effort steps after the link upsert: (1) `SetMetaCommand` refreshing `cmd:env`'s provider config-dir env var to the newly-bound account's dir, (2) `ControllerResyncCommand{forcerestart:true}` — a persistent controller's already-running CLI process reads env only at spawn, so a forced (session-preserving, `--resume`) respawn is required or the new binding silently doesn't apply until a manual restart. |
+| Bind-change event, scoped per agent | `format!("agentidentities:changed:{agent_id}")` broker event — emitted at `agent_handlers/identity.rs:601-607` (link), `:636-642` (unlink), `:556-562` (cascaded on account delete) | **Fires today on every bind, from every entry point** (Armory context menu, per-agent Identity tab, and this spec's new button). **Nothing in the agent pane currently listens to it.** This is the gap issue #1 closes. |
+| Prior art for "bind to an existing account from a failure state" | `docs/specs/SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md` | Designed a near-identical failure-row "Use existing account" action for a *different* trigger (an unlinked legacy agent, not "no login yet"). **Status: superseded** — the chosen direction at the time was Armory-side-only (the Bind-to-Agent menu), on the reasoning that the failure row already routes users to the Armory. This spec revisits that call because live usage now shows the round-trip (leave pane → Armory → back) is real friction, and because issue #1's auto-unblock removes the main cost of offering it in both places (a stale prompt after binding elsewhere). Reuse this spec's candidate-set rules (§2.3) and adopt-action shape (§2) directly — they were correct and remain so; only the "where does it launch a picker from" chrome (§3.2) is new here. |
+
+## 2. Issue #1 — auto-detect a bind and unblock the pane
+
+### 2.1 What "stuck" means concretely
+
+Two states currently never re-check anything after first render:
+
+- **Pre-launch**: `runLaunchFlow` returns `auth_failed` → `canRetry(true)` →
+  the synthetic `turnAttempted: false` auth failure row renders (per
+  `PLAN_LOGIN_CTA_SURFACE_CONSOLIDATION_2026_09_02.md` Phase 1). `canRetry`
+  also fast-fails any send attempt (`useAgentCommands`). Nothing clears
+  `canRetry` except a click on "Log in" (`relogin()`).
+- **Post-turn-failure**: a real 401/403 mid-turn → backend `FailureClass::Auth`
+  → `state.failure` set (`code: "auth", turnAttempted: true`). Nothing clears
+  it except a click on "Login Again", "Login via terminal", or Dismiss.
+
+In both states, if the user goes and binds a usable account for this
+provider **anywhere else in the app**, this pane has no way to find out.
+
+### 2.2 Fix — subscribe to the per-agent bind event while blocked
+
+In `useAgentControllerStatus.ts`:
+
+1. While `canRetry()` is true **or** `failure()?.code === "auth"`, subscribe
+   to `agentidentities:changed:<agentDefinitionId>` (same `agentDefinitionId`
+   already resolved in `existingAccountIdFor`, via
+   `getBlockMetaKeyAtom(opts.blockId, "agentId")`). Use the same
+   `waveEventSubscribe`/broker-subscription primitive `identity-model.ts`
+   already uses for `identityaccounts:changed` — this is a straight repeat of
+   an existing pattern, not a new one.
+2. On fire, re-run whatever auth pre-flight check the mount-time launch flow
+   already performs (the same check that produced `auth_failed` in the first
+   place — do not invent a second, possibly-divergent check; call the same
+   function). Scope this re-check to the **current channel** (it must use the
+   channel-safe path — see §1's `id_store` row — so a bind from a *different*
+   channel's Armory instance, if that's even reachable, can't false-positive
+   this).
+3. If the re-check now succeeds: clear `canRetry`, clear/replace
+   `state.failure` (the row disappears or updates — see §2.3), and let the
+   sends fast-fail guard re-open (it already reads `canRetry`/`failure`, no
+   change needed there).
+4. If it still fails (e.g. the bind was for a different provider than this
+   agent needs — links are keyed `(agent_id, provider)`, so this should be
+   rare but is not impossible if a previous mismatched link existed): do
+   nothing, leave the row as-is.
+
+### 2.3 Explicit non-goal: do not auto-retry a turn
+
+"Free the user to work" means **unblocking send**, not **auto-resubmitting
+anything**. Do not call `relogin()`/`retryLastTurn` automatically from the
+event handler in §2.2.
+
+This is deliberate, not a missed opportunity, for the same reason
+`retryAfterLogin: false` exists at all
+(`PLAN_LOGIN_CTA_SURFACE_CONSOLIDATION_2026_09_02.md` §2, "A"): a stale
+resend of an old message the user never asked to re-send is the exact bug
+class this codebase has already paid down twice (the pre-launch bar's
+original stale-resend bug, and `inFlightRetryAfterLogin`'s two P1s on PR
+#2951). An external bind event, observed asynchronously, is a strictly
+*less* trustworthy signal of "the user wants this turn re-sent right now"
+than a direct button click — so it gets *less* license to act, not the same.
+Concretely:
+
+- Pre-launch case: clearing `canRetry` is enough — the user types and sends
+  normally, no stale message exists to accidentally resend.
+- Post-turn-failure case: clear the blocking aspect of the row (or downgrade
+  it — e.g. keep a dismissible, non-blocking "Signed in — click Retry to
+  resume" state reusing the existing retry button) but require the explicit
+  click that already exists for actually re-running the failed turn.
+
+### 2.4 Apply the standing design rules from the last time this file changed
+
+`PLAN_LOGIN_CTA_SURFACE_CONSOLIDATION_2026_09_02.md` §"Standing design
+property" recorded five rules earned from two P1s on the *previous* change to
+this exact state machine. They apply verbatim to this new entry point:
+
+1. Guard before you write (don't leave `inFlightRetryAfterLogin` or similar
+   set by a call that no-ops).
+2. Enumerate every flow that reaches the shared handler this fix touches —
+   this is a **fourth** entry point into recovery state (`relogin`,
+   `loginViaTerminal`, `/login`, and now "external bind detected") — update
+   the enumeration comment at `recordRecoveryIntent` accordingly.
+3. Capture what you need before any `await`/teardown.
+4. Prefer carrying intent explicitly over re-deriving it after the fact.
+5. Every entry point must derive shared intent (e.g. `turnAttempted`) the
+   same way the others do.
+
+## 3. Issue #2 — "Bind account" button, replacing "Armory → Accounts"
+
+**Decided (2026-09-04, operator):** "Login via terminal" stays, unconditionally
+— it is the only working path for providers whose in-app OAuth can't complete
+in-app (`SPEC_HOST_CLI_LOGIN_CAPTURE_2026_06_20.md` §5.5 — Claude Code
+v2.1.x's self-driving login TUI is the concrete example already in this
+codebase), so making it conditional on candidate-account availability (this
+spec's original draft) traded a rare "had to use a terminal" annoyance for an
+occasional hard dead end. Instead, the new action takes the slot **"Armory →
+Accounts" occupied** — but only when it has something to offer instead of that
+link (see below); this resolves the open decision that was §3.6 in the prior
+draft of this spec.
+
+### 3.1 What changes in `failure-accessory.ts`
+
+In the `case "auth":` arm (~line 124-150):
+
+- **When ≥1 candidate account exists (§3.3):** replace "🗄 Armory → Accounts"
+  with **"Bind account"** — named to match the vocabulary the Armory side
+  already shipped ("Bind to Agent" context menu,
+  `SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md`), so the same action
+  reads as one concept from both directions instead of a new one. Dynamic
+  label, mirroring the existing "Log in"/"Login Again" swap-by-state pattern:
+  - Exactly one candidate → **"Bind: *\<account name>*"** (e.g. "Bind:
+    work-claude") — binds directly on click, no picker.
+  - More than one candidate → **"Bind account"** — opens the picker (§3.2).
+  - Icon: reuse the `vault` FontAwesome icon `openArmory` used (`icon:
+    "vault"`) — same visual language, since this button now owns the
+    "go interact with your Armory accounts" affordance in this state.
+- **When zero candidates exist: keep "🗄 Armory → Accounts" exactly as it is
+  today.** There is nothing to one-click bind to yet — the user's actual next
+  step is still "go create/authenticate an account," which is what that link
+  is for. Dropping it here would remove the only path to the Armory from this
+  row for the one case that most needs it, trading a real regression for
+  visual tidiness. (`openArmory` is reused verbatim by other failure classes
+  — `usage_limit`, `spawn_failure` — those are untouched either way.)
+- **Keep "Login via terminal" exactly as it is today, always shown,
+  regardless of candidate count.**
+
+Resulting row for `code: "auth"`: `[Login Again / Log in]` (primary) ·
+`[Login via terminal]` · `[Bind: <name> / Bind account]` **or**
+`[Armory → Accounts]` (exactly one of these two, chosen by candidate count) ·
+`[Details]` (when there's expandable content) · `[×]` dismiss. Net effect:
+the row never grows past its current width — "Bind account" and "Armory →
+Accounts" occupy the same slot, never both at once — it only gets more useful
+in the case where a one-click fix is actually available.
+
+### 3.2 Picker chrome for multiple candidates
+
+`PaneRowAction` (`components/PaneRow.tsx`) is a flat button —
+`onClick: () => void`, no submenu. For the single-candidate case this is
+sufficient (label the button with the account name, bind directly on click).
+For the multi-candidate case, do not extend `PaneRowAction` with new menu
+plumbing — reuse the **same** `ContextMenuModel`/`ContextMenuItem`
+(`submenu`/`checked`/`sublabel`) primitive the Armory's Bind-to-Agent context
+menu already uses (`SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md`
+§1), anchored at the button's position on click. This keeps "pick one of N
+accounts to bind" as one component with one set of tests instead of two.
+
+### 3.3 Candidate set — reuse the piggyback spec's rules verbatim
+
+From `SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md` §2.3, unchanged:
+
+- Source: the **channel-safe** cache (`identity-model.ts` / `loadAccounts()`
+  / `accountsForProvider`, backed by `ListIdentityAccountsCommand` →
+  `id_store.identity_list` — see §1's table; **not** `identity.self.accounts`).
+- `resolve_provider_alias(account.provider) == resolve_provider_alias(agent.provider)`,
+  canonicalized on **both** sides (the alias-mismatch class from Codex's P1
+  on PR #2377 applies verbatim).
+- OAuth-class accounts only (`secret_ref.backend == "oauth_config_dir"`).
+  API-key accounts don't gate spawns the same way and are out of scope for
+  this button (they're already handled by direct linking elsewhere).
+- Sort `status == "valid"` first, then most-recently-updated; show the status
+  dot (an expired account is still selectable — adopting then re-logging is
+  still fewer steps than fresh OAuth — but visibly marked).
+- Exclude the account already linked to *this* agent for this provider
+  (nothing to adopt).
+
+### 3.4 Adopt action
+
+Identical to `SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md` §2 (this
+is the same bind, from a different entry point — do not reimplement it):
+
+1. `LinkAgentIdentityCommand { agent_id, account_id, provider }`.
+2. Best-effort live-apply for a running pane: `cmd:env` config-dir refresh,
+   then `ControllerResyncCommand{forcerestart:true}`.
+3. Wrap in `beginRecoveryFlow()`/`endRecoveryFlow()` like every other
+   recovery action in `useAgentControllerStatus.ts`, so the concurrent-flow
+   guards (§2.4) apply uniformly.
+4. **Do not auto-retry the failed turn from here either** — same reasoning as
+   §2.3. The bind fires `agentidentities:changed:<agent_id>`, which issue
+   #1's listener (§2.2) picks up and uses to clear the blocking state; the
+   user (or the row's own now-relevant Retry button) drives anything further.
+   This is the intended convergence: issue #2's button doesn't need its own
+   unblock logic, because issue #1 already provides it for *any* bind source.
+
+### 3.5 Non-goals (repeated from the piggyback spec, still correct)
+
+- **No silent auto-adoption.** Even with exactly one valid candidate, require
+  the click — an agent silently switching to an account the user never chose
+  is the attributability failure `PLAN_LOGIN_SINGLE_PATH_CONSOLIDATION_2026_07_20.md`
+  §7 exists to prevent.
+- No cross-channel or cross-machine adoption (accounts are channel-local by
+  design, per §1's `id_store` row).
+- No API-key-class accounts through this button (out of scope, see §3.3).
+
+### 3.6 Decided (was: open decision for the operator)
+
+Resolved 2026-09-04 — see the callout at the top of §3. "Login via terminal"
+is kept, always. "Armory → Accounts" is what makes room for "Bind account",
+and only when there's a candidate to bind (§3.1) — not a conditional
+narrowing of the terminal fallback.
+
+## 4. Test plan
+
+**Issue #1:**
+- Hook test: while `canRetry()` is true, firing `agentidentities:changed:<agentId>`
+  for this pane's own agent id and a now-passing pre-flight check clears
+  `canRetry` and does **not** call `relogin`/retry.
+- Hook test: same event for a **different** agent id is ignored.
+- Hook test: while `state.failure.code === "auth"`, the same event downgrades/clears
+  the blocking row without dispatching a retry.
+- Regression: `useAgentCommands`'s existing `canRetry`-gating tests
+  (`useAgentCommands.test.ts:186,203,326`) still pass unchanged — the fix only
+  adds a new writer of `canRetry(false)`, it doesn't change what reads it.
+- Live: reproduce the operator's exact report — start an agent, hit the login
+  prompt, bind an account from the Armory's Bind-to-Agent menu in a different
+  window, confirm the pane's prompt clears **without switching back to it**
+  (subscription must fire while the pane is mounted but not necessarily
+  focused).
+
+**Issue #2:**
+- Unit (candidate-set filter): mirrors
+  `SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md` §5's plan verbatim —
+  alias canonicalization both directions, oauth-class-only, exclusion of the
+  already-linked id, status-then-recency sort.
+- Unit (`failureToRow`): "Login via terminal" present in all three cases
+  below (never conditional). Zero candidates → "Armory → Accounts" present,
+  no bind action. One candidate → "Bind: \<name>" present, no "Armory →
+  Accounts". 2+ candidates → "Bind account" (picker-opening) present, no
+  "Armory → Accounts".
+- Unit (adopt action): link RPC called with canonical provider; `cmd:env` +
+  forced-resync fired only when the pane is currently open/running; recovery-
+  flow counter begun/ended; **no** automatic retry dispatched (assert the
+  retry/relogin mock is never called from this path — the regression this
+  spec is most likely to accidentally reintroduce).
+- Live: two Claude accounts in one channel, one already valid. New agent hits
+  the login prompt, "Bind: *work-claude*" appears (replacing "Armory →
+  Accounts") and is clickable in one step, next message runs without a fresh
+  OAuth.
+- Live: zero existing accounts for the provider — confirm "Login via
+  terminal" **and** "Armory → Accounts" both still render and still work,
+  unchanged.
+
+## 5. Explicit non-goals for this spec
+
+- Finishing the `disposable_test`/Store B per-account-scope split tracked in
+  `ANALYSIS_PER_CHANNEL_AUTH_BYPASSES_2026_08_31.md` §1 (out of scope,
+  tracked separately).
+- Building the `usable_in_channel` listing field
+  (`ANALYSIS_PER_CHANNEL_AUTH_BYPASSES_2026_08_31.md` §6) — not needed here
+  because this spec deliberately sources candidates from the already-channel-
+  safe `id_store` path (§1), not from `identity.self.accounts`.
+- Any change to the inline transcript 401/403 CTA (surface C, per
+  `PLAN_LOGIN_CTA_SURFACE_CONSOLIDATION_2026_09_02.md` §2.1) — it is a jump to
+  the same row, not a fourth surface, and is unaffected by either fix here.

--- a/docs/specs/SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md
+++ b/docs/specs/SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md
@@ -231,11 +231,25 @@ From `SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md` §2.3, unchanged:
 - OAuth-class accounts only (`secret_ref.backend == "oauth_config_dir"`).
   API-key accounts don't gate spawns the same way and are out of scope for
   this button (they're already handled by direct linking elsewhere).
-- Sort `status == "valid"` first, then most-recently-updated; show the status
-  dot (an expired account is still selectable — adopting then re-logging is
-  still fewer steps than fresh OAuth — but visibly marked).
 - Exclude the account already linked to *this* agent for this provider
   (nothing to adopt).
+
+**Amended 2026-09-05 (reagentx P1) — `status === "valid"` only, no
+expired-but-selectable allowance.** The piggyback spec's original rule
+("expired account is still selectable — adopting then re-logging is still
+fewer steps than fresh OAuth — but visibly marked") is dropped. Two
+problems: the "visibly marked" status dot was never actually built (no such
+concept exists on `PaneRowAction`), and independent of that gap, issue #1's
+`recheckAuthAfterBind` trusts `CheckCliAuthCommand`'s `authenticated` flag
+— which this codebase already documented as capable of an
+"expired-but-present false positive" (`resolveCliForRecovery`'s doc
+comment, `retro-agent-auth-relogin-noop-2026-07-01` H2 — the exact reason
+`relogin()` never trusts that check for its own success). Offering a
+KNOWN-expired account as a one-click "fix" risked `declareAuthHealthy()`
+clearing the failure row on a false positive while the next real turn
+still failed. Restricting to valid-only removes the self-inflicted case
+entirely; the lost convenience (skip a fresh OAuth for an expired account)
+is a smaller cost than a row that lies about being fixed.
 
 ### 3.4 Adopt action
 
@@ -254,6 +268,15 @@ is the same bind, from a different entry point — do not reimplement it):
    user (or the row's own now-relevant Retry button) drives anything further.
    This is the intended convergence: issue #2's button doesn't need its own
    unblock logic, because issue #1 already provides it for *any* bind source.
+5. **A failed link upsert must surface to the user, not just the logs.**
+   Added 2026-09-05 (reagentx P2): `bindExistingAccount` catches whatever
+   `bindAccountToAgent` throws and reports it via `authNotice` (the same
+   user-visible recovery-failure surface every other action in
+   `useAgentControllerStatus.ts` already uses) — mirroring the Armory's own
+   Bind-to-Agent menu, which passes `onBindError` for the identical case.
+   Without this, `agent-view.tsx`'s `void status.bindExistingAccount(...)`
+   call sites would produce an unhandled promise rejection with no
+   user-facing indication anything went wrong.
 
 ### 3.5 Non-goals (repeated from the piggyback spec, still correct)
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -33,6 +33,7 @@ import {
     atoms,
     createBlock,
     getApi,
+    getBlockMetaKeyAtom,
     openOrFocusPaneByView,
     pushNotification,
     refocusNode,
@@ -41,8 +42,9 @@ import {
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { BlockService, ObjectService } from "@/app/store/services";
+import { waveEventSubscribe } from "@/app/store/wps";
 import { scheduleOnSettle } from "@/app/util/settle-detector";
-import { loadAccounts, type AgentAccounts } from "@/app/view/identity/identity-model";
+import { loadAccounts, subscribeAccountChanges, type Account, type AgentAccounts } from "@/app/view/identity/identity-model";
 import { handleAgentIdChange } from "@/app/view/term/termagent";
 import { makeWindowFocusSignal } from "@/app/window/window-focus";
 import { ConfirmModal } from "@/element/modal";
@@ -93,6 +95,7 @@ import { useAgentControllerStatus } from "./hooks/useAgentControllerStatus";
 import { useAgentDecisions } from "./hooks/useAgentDecisions";
 import { useAgentDropAttach } from "./hooks/useAgentDropAttach";
 import { useAgentFailure } from "./hooks/useAgentFailure";
+import { computeAccountBindCandidates } from "./failure/bind-account-candidates";
 import { decideSyntheticRow } from "./failure/synthetic-row";
 import { useAgentKeyboard } from "./hooks/useAgentKeyboard";
 import { useAgentQuestions } from "./hooks/useAgentQuestions";
@@ -110,6 +113,7 @@ import { buildResumePreflightNode, injectResumePreflight } from "./inject-resume
 import { useResumePreflight } from "./hooks/useResumePreflight";
 import { HISTORY_TAB_FOR_META_KEY, openOrFocusHistoryTab } from "./open-history-tab";
 import { getProvider } from "./providers";
+import { lastLinkedAccountId } from "./providers/provider-id-aliases";
 import { buildStartupPayload, resolveAccounts } from "./startup/buildStartupPayload";
 import type { SignalPair } from "./state";
 import { createAgentAtoms } from "./state";
@@ -1368,8 +1372,8 @@ const AgentPresentationView = ({
             // is valid, and would otherwise silently clear that recovery's
             // own canRetry=true, letting the next message bypass the
             // fast-fail guard and reach the still-known-bad process.
-            status.notifyControllerHealthy();
-            // Also clear a stale live "auth"-classified state.failure —
+            //
+            // Also clears a stale live "auth"-classified state.failure —
             // unlike the OTHER two places in this PR that declare a
             // controller healthy (login.ts's finalizeLoginSuccess,
             // useAgentCommands.ts's flushPendingControllerRefresh success
@@ -1392,9 +1396,12 @@ const AgentPresentationView = ({
             // a turn-active event arrives, even though that unrelated
             // problem was never actually resolved. reagentx P1 on PR #2338
             // (thirty-fifth re-review).
-            if (paneSnapshot(model.blockId)?.failure?.data.code === "auth") {
-                dispatchPane(model.blockId, { type: "FailureCleared" }, "system");
-            }
+            //
+            // Extracted into `declareAuthHealthy` (defined below, in scope
+            // via closure) so the SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md
+            // §2 bind-event listener can reuse the identical logic instead of
+            // duplicating this exact gating a second time.
+            declareAuthHealthy();
         },
     });
 
@@ -1872,6 +1879,109 @@ const AgentPresentationView = ({
         }
     });
 
+    // ---- Bind-account (SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md §2/§3) ----
+    //
+    // Cross-pane/cross-tab live account cache — same subscription pattern
+    // `AgentLaunchModal.tsx` already uses. Seeded synchronously (no network
+    // round trip; the app-wide cache is already warm) then kept live.
+    const [accountCache, setAccountCache] = createSignal<Account[]>(loadAccounts());
+    createEffect(() => {
+        const unsub = subscribeAccountChanges((list) => setAccountCache(list));
+        onCleanup(unsub);
+    });
+
+    // This agent's own currently-linked account for its provider, if any —
+    // excluded from bind candidates (nothing to adopt). Refreshed on mount
+    // and whenever this agent's identity links change (below) — the same
+    // event that also drives the auto-unblock check, since both concerns
+    // become stale for the identical reason.
+    const [linkedAccountId, setLinkedAccountId] = createSignal<string | undefined>(undefined);
+    const refreshLinkedAccountId = async () => {
+        const agentDefinitionId = getBlockMetaKeyAtom(model.blockId, "agentId")() as string | undefined;
+        const prov = provider();
+        if (!agentDefinitionId || !prov) {
+            setLinkedAccountId(undefined);
+            return;
+        }
+        try {
+            const links = await RpcApi.ListAgentIdentitiesCommand(TabRpcClient, { agent_id: agentDefinitionId });
+            setLinkedAccountId(lastLinkedAccountId(links, prov.id));
+        } catch {
+            setLinkedAccountId(undefined);
+        }
+    };
+    void refreshLinkedAccountId();
+
+    const bindCandidates = createMemo(() => {
+        const prov = provider();
+        if (!prov) return [];
+        return computeAccountBindCandidates(prov.id, accountCache(), linkedAccountId());
+    });
+
+    const onBindAccount = (e?: MouseEvent) => {
+        const candidates = bindCandidates();
+        if (candidates.length === 0) return;
+        if (candidates.length === 1) {
+            void status.bindExistingAccount(candidates[0]);
+            return;
+        }
+        // 2+ candidates: a picker, anchored at the click — same
+        // ContextMenuModel primitive the Armory's Bind-to-Agent menu uses
+        // (SPEC_ARMORY_BIND_TO_AGENT_CONTEXT_MENU_2026_08_09.md), just a flat
+        // list here (this button IS the trigger — no outer submenu to nest
+        // under). No event to anchor on (shouldn't happen — PaneRow's render
+        // call site always passes one) → no-op rather than guessing a position.
+        if (!e) return;
+        ContextMenuModel.showContextMenu(
+            candidates.map((acct) => ({
+                label: acct.name,
+                click: () => void status.bindExistingAccount(acct),
+            })),
+            e,
+        );
+    };
+
+    // Declare the auth-blocking state resolved: clears canRetry/authNotice
+    // (notifyControllerHealthy) and, ONLY when the live failure is actually
+    // an auth failure, clears it too — never unconditionally, so an
+    // unrelated concurrent failure (rate_limited, context_exceeded, …) that
+    // happens to be showing isn't silently wiped. Shared by two independent
+    // proofs of health: a live controllerstatus event showing an active turn
+    // (below), and a verified auth re-check after an external bind (below).
+    const declareAuthHealthy = () => {
+        status.notifyControllerHealthy();
+        if (paneSnapshot(model.blockId)?.failure?.data.code === "auth") {
+            dispatchPane(model.blockId, { type: "FailureCleared" }, "system");
+        }
+    };
+
+    // Auto-unblock: a bind can happen from ANYWHERE (the Armory's
+    // Bind-to-Agent menu, the per-agent Identity tab, or this pane's own
+    // "Bind account" above) — this pane must notice regardless of source.
+    // `agentidentities:changed:<agentId>` already fires on every one of
+    // those; nothing previously listened for it here.
+    //
+    // Re-verifies via CheckCliAuth before declaring healthy (a bind event is
+    // not itself proof the new credential works) and NEVER auto-retries a
+    // turn — see recheckAuthAfterBind's and declareAuthHealthy's own doc
+    // comments. SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md §2.
+    createEffect(() => {
+        const agentDefinitionId = getBlockMetaKeyAtom(model.blockId, "agentId")() as string | undefined;
+        if (!agentDefinitionId) return;
+        const unsub = waveEventSubscribe({
+            eventType: `agentidentities:changed:${agentDefinitionId}`,
+            handler: () => {
+                void refreshLinkedAccountId();
+                const blocked = status.canRetry() || paneSnapshot(model.blockId)?.failure?.data.code === "auth";
+                if (!blocked) return;
+                void status.recheckAuthAfterBind().then((ok) => {
+                    if (ok) declareAuthHealthy();
+                });
+            },
+        });
+        onCleanup(unsub);
+    });
+
     const failureUI = useAgentFailure({
         blockId: model.blockId,
         // Per-pane model keeps dispatch sites default-safe; see useAgentStream above.
@@ -1916,6 +2026,8 @@ const AgentPresentationView = ({
             log("auth", "Login via terminal — opening a console window for browser login");
             void status.loginViaTerminal({ retryAfterLogin: turnAttempted });
         },
+        bindCandidates,
+        onBindAccount,
     });
 
     // Deliver queued-while-busy ("send now") messages at the next tool-call

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -59,6 +59,7 @@ import {
 import { holdLeafRevealGate, scheduleLeafRevealLift } from "@/app/store/tab-reveal";
 import { getTrail } from "@/log/render-trail";
 import { writeText as clipboardWriteText } from "@/util/clipboard";
+import { sleep } from "@/util/util";
 import { createEffect, createMemo, createSignal, on, onCleanup, onMount, Show, untrack, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
 import { earliestLiveAttachedStartMs } from "./activity/attached-task";
@@ -96,6 +97,7 @@ import { useAgentDecisions } from "./hooks/useAgentDecisions";
 import { useAgentDropAttach } from "./hooks/useAgentDropAttach";
 import { useAgentFailure } from "./hooks/useAgentFailure";
 import { computeAccountBindCandidates } from "./failure/bind-account-candidates";
+import { retryRecheckAfterBind } from "./failure/recheck-after-bind";
 import { decideSyntheticRow } from "./failure/synthetic-row";
 import { useAgentKeyboard } from "./hooks/useAgentKeyboard";
 import { useAgentQuestions } from "./hooks/useAgentQuestions";
@@ -1955,6 +1957,30 @@ const AgentPresentationView = ({
         }
     };
 
+    // Bounded retry around recheckAuthAfterBind — NOT a stylistic choice, a
+    // correctness fix. `agentidentities:changed` is published by the
+    // backend SYNCHRONOUSLY inside the `LinkAgentIdentityCommand` handler,
+    // before it even responds to the RPC (agent_handlers/identity.rs:590-611);
+    // RPC responses and WS events share one in-order connection, so this
+    // pane's subscription below fires before `bindAccountToAgent`'s own
+    // `SetMetaCommand` — which only runs AFTER that same Link RPC resolves
+    // client-side — has refreshed `cmd:env` to the newly-bound account's
+    // dir. The very first recheck therefore reads STALE env and fails on
+    // essentially every bind, not as an edge case but as the common case —
+    // reagentx P1 on PR #2969. Retry ladder lives in recheck-after-bind.ts,
+    // unit-tested there (dependency-injected, no DOM/RPC mocking needed) —
+    // kept out of this file for the same reason
+    // PLAN_LOGIN_CTA_SURFACE_CONSOLIDATION_2026_09_02.md's retrospective
+    // extracted decideSyntheticRow out of here after several P1s: inline
+    // logic in this component is unassertable by any existing harness.
+    const recheckAuthAfterBindWithRetry = () =>
+        retryRecheckAfterBind({
+            recheck: status.recheckAuthAfterBind,
+            stillBlocked: () => status.canRetry() || paneSnapshot(model.blockId)?.failure?.data.code === "auth",
+            sleep,
+            onHealthy: declareAuthHealthy,
+        });
+
     // Auto-unblock: a bind can happen from ANYWHERE (the Armory's
     // Bind-to-Agent menu, the per-agent Identity tab, or this pane's own
     // "Bind account" above) — this pane must notice regardless of source.
@@ -1974,9 +2000,7 @@ const AgentPresentationView = ({
                 void refreshLinkedAccountId();
                 const blocked = status.canRetry() || paneSnapshot(model.blockId)?.failure?.data.code === "auth";
                 if (!blocked) return;
-                void status.recheckAuthAfterBind().then((ok) => {
-                    if (ok) declareAuthHealthy();
-                });
+                void recheckAuthAfterBindWithRetry();
             },
         });
         onCleanup(unsub);

--- a/frontend/app/view/agent/components/PaneRow.tsx
+++ b/frontend/app/view/agent/components/PaneRow.tsx
@@ -44,7 +44,13 @@ export interface PaneRowAction {
     label?: string;
     /** Accessible name / tooltip. */
     title: string;
-    onClick: () => void;
+    /** Receives the click event — most actions ignore it; actions that need
+     *  to anchor a popover (e.g. a context-menu picker) at the click
+     *  position use it. Optional (not just optionally-ignored) so existing
+     *  callers that invoke `onClick()` directly — every current test in
+     *  `failure-accessory.test.ts` does — keep typechecking without a
+     *  synthetic event; the real render call site always passes one. */
+    onClick: (e?: MouseEvent) => void;
     /** Tints the glyph on hover with the error colour (destructive actions). */
     danger?: boolean;
     /** Emphasise as the primary action (filled accent). */
@@ -103,7 +109,7 @@ export const PaneRow = (props: PaneRowProps): JSX.Element => {
                             aria-label={action.title}
                             disabled={action.disabled}
                             // stopPropagation so an action never also fires onActivate.
-                            onClick={(e) => { e.stopPropagation(); action.onClick(); }}
+                            onClick={(e) => { e.stopPropagation(); action.onClick(e); }}
                         >
                             <Show
                                 when={action.icon}

--- a/frontend/app/view/agent/failure/bind-account-candidates.test.ts
+++ b/frontend/app/view/agent/failure/bind-account-candidates.test.ts
@@ -58,16 +58,19 @@ describe("computeAccountBindCandidates", () => {
         expect(result.map((a) => a.id)).toEqual(["acct-2"]);
     });
 
-    it("sorts valid accounts before expired/invalid ones", () => {
-        const accounts = [
-            mkAccount({ id: "expired", status: "expired", updated_at: "2026-03-01T00:00:00Z" }),
-            mkAccount({ id: "valid", status: "valid", updated_at: "2026-01-01T00:00:00Z" }),
-        ];
-        const result = computeAccountBindCandidates("claude", accounts);
-        expect(result.map((a) => a.id)).toEqual(["valid", "expired"]);
+    it("excludes expired/invalid/unknown/checking accounts entirely, not just deprioritizes them", () => {
+        // Amended 2026-09-05 (reagentx P1): offering a KNOWN-bad account as a
+        // one-click "fix" interacts badly with recheckAuthAfterBind's trust
+        // in CheckCliAuthCommand's expired-but-present false positive — see
+        // this module's own doc comment. An expired candidate must not
+        // appear at all, not just sort after valid ones.
+        const accounts = (["expired", "invalid", "unknown", "checking"] as const).map((status) =>
+            mkAccount({ id: status, status }),
+        );
+        expect(computeAccountBindCandidates("claude", accounts)).toEqual([]);
     });
 
-    it("within the same validity bucket, sorts most-recently-updated first", () => {
+    it("sorts most-recently-updated first among valid accounts", () => {
         const accounts = [
             mkAccount({ id: "older", updated_at: "2026-01-01T00:00:00Z" }),
             mkAccount({ id: "newer", updated_at: "2026-02-01T00:00:00Z" }),

--- a/frontend/app/view/agent/failure/bind-account-candidates.test.ts
+++ b/frontend/app/view/agent/failure/bind-account-candidates.test.ts
@@ -1,0 +1,78 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { computeAccountBindCandidates } from "./bind-account-candidates";
+import type { Account } from "@/app/view/identity/identity-model";
+
+const mkAccount = (overrides: Partial<Account> = {}): Account => ({
+    id: "acct-1",
+    name: "work-claude",
+    // CLI-OAuth accounts (claude/codex/gemini/…) store the canonical AGENT
+    // provider-catalog id here, not one of `AccountProvider`'s narrower
+    // service-account literals — see `ClaudeLoginPanel.tsx`'s "successful
+    // login here links the CANONICAL 'claude' provider" and
+    // `bind-to-agent-menu.ts`'s identical `resolveProviderAlias(account.provider)`
+    // usage, both of which only make sense against real CLI ids. Cast past
+    // the (stale, service-account-oriented) `AccountProvider` union.
+    provider: "claude" as Account["provider"],
+    kind: "oauth",
+    secret_ref: { backend: "oauth_config_dir", dir: "/tmp/acct-1" },
+    context: {},
+    assigned_agents: [],
+    status: "valid",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+});
+
+describe("computeAccountBindCandidates", () => {
+    it("returns an oauth-class account matching the agent's provider", () => {
+        const accounts = [mkAccount()];
+        expect(computeAccountBindCandidates("claude", accounts)).toEqual(accounts);
+    });
+
+    it("canonicalizes provider aliases on both sides", () => {
+        // "claude-code" is a real legacy alias of "claude" in this codebase's
+        // provider catalog (PROVIDER_ALIASES) — an account stored under the
+        // alias must still match an agent declared under the canonical id,
+        // and vice versa.
+        const accounts = [mkAccount({ provider: "claude-code" as Account["provider"] })];
+        expect(computeAccountBindCandidates("claude", accounts)).toHaveLength(1);
+    });
+
+    it("excludes accounts for a different provider", () => {
+        const accounts = [mkAccount({ provider: "codex" as Account["provider"] })];
+        expect(computeAccountBindCandidates("claude", accounts)).toEqual([]);
+    });
+
+    it("excludes non-OAuth (api-key/service) accounts", () => {
+        const accounts = [mkAccount({ secret_ref: { backend: "env", env_var: "GH_TOKEN" } })];
+        expect(computeAccountBindCandidates("claude", accounts)).toEqual([]);
+    });
+
+    it("excludes the account already linked to this agent", () => {
+        const accounts = [mkAccount({ id: "acct-1" }), mkAccount({ id: "acct-2", name: "personal-claude" })];
+        const result = computeAccountBindCandidates("claude", accounts, "acct-1");
+        expect(result.map((a) => a.id)).toEqual(["acct-2"]);
+    });
+
+    it("sorts valid accounts before expired/invalid ones", () => {
+        const accounts = [
+            mkAccount({ id: "expired", status: "expired", updated_at: "2026-03-01T00:00:00Z" }),
+            mkAccount({ id: "valid", status: "valid", updated_at: "2026-01-01T00:00:00Z" }),
+        ];
+        const result = computeAccountBindCandidates("claude", accounts);
+        expect(result.map((a) => a.id)).toEqual(["valid", "expired"]);
+    });
+
+    it("within the same validity bucket, sorts most-recently-updated first", () => {
+        const accounts = [
+            mkAccount({ id: "older", updated_at: "2026-01-01T00:00:00Z" }),
+            mkAccount({ id: "newer", updated_at: "2026-02-01T00:00:00Z" }),
+        ];
+        const result = computeAccountBindCandidates("claude", accounts);
+        expect(result.map((a) => a.id)).toEqual(["newer", "older"]);
+    });
+});

--- a/frontend/app/view/agent/failure/bind-account-candidates.ts
+++ b/frontend/app/view/agent/failure/bind-account-candidates.ts
@@ -1,0 +1,51 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Candidate accounts for the agent-pane failure row's "Bind account" action
+ * — SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md §3.3.
+ *
+ * The inverse of `bind-to-agent-menu.ts`'s `computeBindCandidates` (one
+ * account → many agents, the Armory's perspective): this is one agent → many
+ * accounts, the failure row's perspective. Filtering RULES are the same
+ * ones that spec reuses verbatim from
+ * `SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md` §2.3 — alias
+ * canonicalization on both sides, OAuth-class accounts only, exclude the
+ * already-linked account, sort valid-then-recent.
+ *
+ * Deliberately a separate pure function rather than reusing
+ * `computeBindCandidates` directly — that function's shape (candidate
+ * AGENTS for one account) doesn't invert cleanly, and duplicating this much
+ * smaller filter is cheaper than forcing one function to serve both
+ * directions. It DOES reuse `resolveProviderAlias`, the actual thing that
+ * must not drift between the two.
+ */
+
+import { resolveProviderAlias } from "@/app/view/agent/providers";
+import type { Account } from "@/app/view/identity/identity-model";
+
+/** Compute the accounts this agent's failure row could one-click bind to. */
+export function computeAccountBindCandidates(
+    agentProviderId: string,
+    accounts: Account[],
+    /** The account already linked to this agent for this provider, if any —
+     *  excluded (nothing to adopt). */
+    excludeAccountId?: string,
+): Account[] {
+    const provider = resolveProviderAlias(agentProviderId);
+    return accounts
+        .filter((a) => a.id !== excludeAccountId)
+        // CLI-OAuth accounts only — service (api-key) accounts don't gate
+        // spawns the same way and are handled by direct linking elsewhere,
+        // per the spec's non-goals (§3.5).
+        .filter((a) => a.secret_ref?.backend === "oauth_config_dir")
+        .filter((a) => resolveProviderAlias(a.provider) === provider)
+        .sort((a, b) => {
+            const validA = a.status === "valid" ? 0 : 1;
+            const validB = b.status === "valid" ? 0 : 1;
+            if (validA !== validB) return validA - validB;
+            // Most-recently-updated first among accounts with the same
+            // validity bucket.
+            return b.updated_at.localeCompare(a.updated_at);
+        });
+}

--- a/frontend/app/view/agent/failure/bind-account-candidates.ts
+++ b/frontend/app/view/agent/failure/bind-account-candidates.ts
@@ -7,11 +7,11 @@
  *
  * The inverse of `bind-to-agent-menu.ts`'s `computeBindCandidates` (one
  * account → many agents, the Armory's perspective): this is one agent → many
- * accounts, the failure row's perspective. Filtering RULES are the same
- * ones that spec reuses verbatim from
+ * accounts, the failure row's perspective. Filtering RULES mostly follow
  * `SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md` §2.3 — alias
  * canonicalization on both sides, OAuth-class accounts only, exclude the
- * already-linked account, sort valid-then-recent.
+ * already-linked account — with one deliberate departure: `status === "valid"`
+ * only, not "expired selectable but marked" (see below).
  *
  * Deliberately a separate pure function rather than reusing
  * `computeBindCandidates` directly — that function's shape (candidate
@@ -19,6 +19,24 @@
  * smaller filter is cheaper than forcing one function to serve both
  * directions. It DOES reuse `resolveProviderAlias`, the actual thing that
  * must not drift between the two.
+ *
+ * **Why valid-only (amended 2026-09-05, reagentx P1):** the original design
+ * allowed an expired candidate through ("adopting then re-logging is still
+ * fewer steps"), visibly marked. That marking was never actually built in
+ * `failure-accessory.ts` (no status-dot concept exists on `PaneRowAction`),
+ * and independent of that gap, `useAgentControllerStatus.recheckAuthAfterBind`
+ * (the auto-unblock check that fires right after any bind) trusts
+ * `CheckCliAuthCommand`'s `authenticated` flag — which this same codebase
+ * already documented as capable of an "expired-but-present false positive"
+ * (see `resolveCliForRecovery`'s doc comment,
+ * `retro-agent-auth-relogin-noop-2026-07-01` H2; it's *why* `relogin()`
+ * never trusts that check for its own success). Offering a KNOWN-expired
+ * account as a one-click "fix" then risks `declareAuthHealthy()` clearing
+ * the failure row on a false positive, even though the next real turn still
+ * fails. Restricting to `status === "valid"` removes this self-inflicted
+ * case entirely, at the cost of the (unimplemented) "expired but still
+ * useful" convenience — losing a convenience is a far smaller cost than a
+ * row that silently lies about being fixed.
  */
 
 import { resolveProviderAlias } from "@/app/view/agent/providers";
@@ -40,12 +58,8 @@ export function computeAccountBindCandidates(
         // per the spec's non-goals (§3.5).
         .filter((a) => a.secret_ref?.backend === "oauth_config_dir")
         .filter((a) => resolveProviderAlias(a.provider) === provider)
-        .sort((a, b) => {
-            const validA = a.status === "valid" ? 0 : 1;
-            const validB = b.status === "valid" ? 0 : 1;
-            if (validA !== validB) return validA - validB;
-            // Most-recently-updated first among accounts with the same
-            // validity bucket.
-            return b.updated_at.localeCompare(a.updated_at);
-        });
+        // Valid only — see this module's doc comment for why an expired
+        // candidate is excluded entirely rather than offered-but-marked.
+        .filter((a) => a.status === "valid")
+        .sort((a, b) => b.updated_at.localeCompare(a.updated_at));
 }

--- a/frontend/app/view/agent/failure/failure-accessory.test.ts
+++ b/frontend/app/view/agent/failure/failure-accessory.test.ts
@@ -21,13 +21,14 @@ const mkView = (overrides: Partial<FailureViewState> = {}): FailureViewState => 
 });
 
 const mkActions = (): FailureActions & { _calls: Record<keyof FailureActions, number> } => {
-    const _calls = { retry: 0, loginAgain: 0, loginViaTerminal: 0, openArmory: 0, newSession: 0, toggleDetails: 0, dismiss: 0 };
+    const _calls = { retry: 0, loginAgain: 0, loginViaTerminal: 0, openArmory: 0, bindAccount: 0, newSession: 0, toggleDetails: 0, dismiss: 0 };
     return {
         _calls,
         retry: vi.fn(() => void _calls.retry++),
         loginAgain: vi.fn(() => void _calls.loginAgain++),
         loginViaTerminal: vi.fn(() => void _calls.loginViaTerminal++),
         openArmory: vi.fn(() => void _calls.openArmory++),
+        bindAccount: vi.fn(() => void _calls.bindAccount++),
         newSession: vi.fn(() => void _calls.newSession++),
         toggleDetails: vi.fn(() => void _calls.toggleDetails++),
         dismiss: vi.fn(() => void _calls.dismiss++),
@@ -234,5 +235,56 @@ describe("auth row: pre-launch vs post-turn (PLAN_LOGIN_CTA_SURFACE_CONSOLIDATIO
     it("leaves NON-auth failures on the error accent regardless of turnAttempted", () => {
         const ctx = mkFailure({ code: "context_exceeded", title: "Context full", detail: "" });
         expect(failureToRow(ctx, mkView({ turnAttempted: false }), mkActions()).accent).toBe("error");
+    });
+});
+
+describe("auth row: bind-account vs Armory (SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04)", () => {
+    const authFailure = () =>
+        mkFailure({ code: "auth", title: "Not authenticated", detail: "401", retryable: true });
+
+    it("shows Armory → Accounts and no bind action when there are zero candidates", () => {
+        const row = failureToRow(authFailure(), mkView({ bindCandidates: [] }), mkActions());
+        expect(action(row, "Armory → Accounts")).toBeTruthy();
+        expect(row.actions.some((a) => a.icon === "vault" && a.label !== "Armory → Accounts")).toBe(false);
+    });
+
+    it("shows Armory → Accounts when bindCandidates is omitted (default/back-compat)", () => {
+        const row = failureToRow(authFailure(), mkView(), mkActions());
+        expect(action(row, "Armory → Accounts")).toBeTruthy();
+    });
+
+    it("replaces Armory → Accounts with a named Bind action for exactly one candidate", () => {
+        const on = mkActions();
+        const row = failureToRow(
+            authFailure(),
+            mkView({ bindCandidates: [{ id: "acct-1", name: "work-claude" }] }),
+            on,
+        );
+        expect(action(row, "Armory → Accounts")).toBeUndefined();
+        const bind = action(row, "Bind: work-claude");
+        expect(bind).toBeTruthy();
+        expect(bind?.icon).toBe("vault");
+        bind?.onClick();
+        expect(on._calls.bindAccount).toBe(1);
+    });
+
+    it("shows a generic picker-opening Bind action for 2+ candidates", () => {
+        const on = mkActions();
+        const row = failureToRow(
+            authFailure(),
+            mkView({
+                bindCandidates: [
+                    { id: "acct-1", name: "work-claude" },
+                    { id: "acct-2", name: "personal-claude" },
+                ],
+            }),
+            on,
+        );
+        expect(action(row, "Armory → Accounts")).toBeUndefined();
+        expect(action(row, "Bind: work-claude")).toBeUndefined();
+        const bind = action(row, "Bind account");
+        expect(bind).toBeTruthy();
+        bind?.onClick();
+        expect(on._calls.bindAccount).toBe(1);
     });
 });

--- a/frontend/app/view/agent/failure/failure-accessory.ts
+++ b/frontend/app/view/agent/failure/failure-accessory.ts
@@ -27,6 +27,17 @@ export interface FailureActions {
     loginViaTerminal: () => void;
     /** Open Armory → Accounts. */
     openArmory: () => void;
+    /**
+     * Bind an already-authenticated account (of this agent's provider) to
+     * this agent, replacing the round-trip through the Armory. Receives the
+     * click event so the caller can anchor a picker popover at the click
+     * position when there's more than one candidate — see
+     * SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md §3.2. Never fires a
+     * retry itself (§3.4) — binding only clears the way; the row's own
+     * Retry/Login-Again action (or the auto-unblock in useAgentControllerStatus)
+     * is what acts on it.
+     */
+    bindAccount: (e?: MouseEvent) => void;
     /** Start a fresh agent session — recovery for a context-window overflow,
      *  where resuming the same (full) session would only re-fail. */
     newSession: () => void;
@@ -50,6 +61,16 @@ export interface FailureViewState {
      * See docs/specs/PLAN_LOGIN_CTA_SURFACE_CONSOLIDATION_2026_09_02.md.
      */
     turnAttempted?: boolean;
+    /**
+     * Already-authenticated accounts for this agent's provider that could be
+     * bound in one click, excluding the account already linked here — see
+     * `computeAccountBindCandidates` (bind-account-candidates.ts). Empty or
+     * omitted → the auth row shows "Armory → Accounts" as it always has;
+     * non-empty → it shows "Bind: <name>" (one candidate) or "Bind account"
+     * (2+, opens a picker) instead. See
+     * docs/specs/SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md §3.1.
+     */
+    bindCandidates?: { id: string; name: string }[];
     /** stderr tail revealed. */
     expanded: boolean;
     /** Seconds left on the auto-retry countdown, or null when not armed. */
@@ -121,7 +142,7 @@ export function failureToRow(f: AgentFailure, view: FailureViewState, on: Failur
 
     const actions: PaneRowAction[] = [];
     switch (f.code) {
-        case "auth":
+        case "auth": {
             // "Use existing login" REMOVED 2026-08-31. It copied the user's
             // personal `~/.claude` credential into this agent, which defeated
             // per-channel isolation — see
@@ -130,6 +151,28 @@ export function failureToRow(f: AgentFailure, view: FailureViewState, on: Failur
             // this channel. `canSeed` no longer branches the action list (it
             // only ever meant "provider is Claude"), so both arms collapse into
             // one.
+            //
+            // NOTE: this is a DIFFERENT thing from `bindCandidates` below —
+            // that reuses an existing per-channel Armory account (a real,
+            // channel-local login someone already completed), not the raw
+            // ambient `~/.claude` file. See
+            // SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md §0.
+            const bindCandidates = view.bindCandidates ?? [];
+            // "Login via terminal" stays unconditionally — it's the only
+            // working recovery for providers whose in-app OAuth can't
+            // complete in-app (SPEC_HOST_CLI_LOGIN_CAPTURE_2026_06_20.md
+            // §5.5). What "Bind account" replaces is "Armory → Accounts",
+            // and only when it actually has something to offer instead —
+            // decided 2026-09-04, see the spec's §3 for the full rationale.
+            const armoryOrBind: PaneRowAction =
+                bindCandidates.length === 0
+                    ? openArmory
+                    : {
+                          icon: "vault",
+                          label: bindCandidates.length === 1 ? `Bind: ${bindCandidates[0].name}` : "Bind account",
+                          title: "Bind an already-signed-in account to this agent",
+                          onClick: on.bindAccount,
+                      };
             actions.push(
                 {
                     glyph: "🔑",
@@ -146,9 +189,10 @@ export function failureToRow(f: AgentFailure, view: FailureViewState, on: Failur
                     onClick: on.loginAgain,
                 },
                 { glyph: "🖥", label: "Login via terminal", title: "Open a terminal window where the browser login can complete", onClick: on.loginViaTerminal },
-                openArmory,
+                armoryOrBind,
             );
             break;
+        }
         case "usage_limit":
             actions.push({ ...openArmory, label: "Armory (switch / upgrade)", primary: true });
             break;

--- a/frontend/app/view/agent/failure/recheck-after-bind.test.ts
+++ b/frontend/app/view/agent/failure/recheck-after-bind.test.ts
@@ -1,0 +1,101 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { retryRecheckAfterBind } from "./recheck-after-bind";
+
+const noopSleep = async () => {};
+
+describe("retryRecheckAfterBind", () => {
+    it("succeeds immediately if the first recheck is already true (no sleep needed)", async () => {
+        const recheck = vi.fn().mockResolvedValue(true);
+        const onHealthy = vi.fn();
+        const sleep = vi.fn(noopSleep);
+
+        const result = await retryRecheckAfterBind({
+            recheck,
+            stillBlocked: () => true,
+            sleep,
+            onHealthy,
+        });
+
+        expect(result).toBe(true);
+        expect(recheck).toHaveBeenCalledTimes(1);
+        expect(onHealthy).toHaveBeenCalledTimes(1);
+        expect(sleep).not.toHaveBeenCalled();
+    });
+
+    it("retries through failures and picks up a later success — the actual race this fixes", async () => {
+        // Simulates the real bug: the first recheck races bindAccountToAgent's
+        // cmd:env refresh and reads stale env; a later attempt (after the
+        // refresh has landed) succeeds.
+        const recheck = vi.fn()
+            .mockResolvedValueOnce(false)
+            .mockResolvedValueOnce(false)
+            .mockResolvedValueOnce(true);
+        const onHealthy = vi.fn();
+
+        const result = await retryRecheckAfterBind(
+            { recheck, stillBlocked: () => true, sleep: noopSleep, onHealthy },
+            [10, 10, 10],
+        );
+
+        expect(result).toBe(true);
+        expect(recheck).toHaveBeenCalledTimes(3);
+        expect(onHealthy).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops calling onHealthy after the first success — never fires twice", async () => {
+        const recheck = vi.fn().mockResolvedValue(true);
+        const onHealthy = vi.fn();
+        await retryRecheckAfterBind({ recheck, stillBlocked: () => true, sleep: noopSleep, onHealthy });
+        expect(onHealthy).toHaveBeenCalledTimes(1);
+    });
+
+    it("gives up after exhausting the ladder without ever succeeding", async () => {
+        const recheck = vi.fn().mockResolvedValue(false);
+        const onHealthy = vi.fn();
+
+        const result = await retryRecheckAfterBind(
+            { recheck, stillBlocked: () => true, sleep: noopSleep, onHealthy },
+            [10, 10],
+        );
+
+        expect(result).toBe(false);
+        // 2 delays → 3 total attempts (delays.length + 1 — see the function's
+        // own doc comment on why the final attempt is explicit).
+        expect(recheck).toHaveBeenCalledTimes(3);
+        expect(onHealthy).not.toHaveBeenCalled();
+    });
+
+    it("bails early once stillBlocked() turns false, without exhausting the ladder", async () => {
+        let blocked = true;
+        const recheck = vi.fn().mockResolvedValue(false);
+        const onHealthy = vi.fn();
+
+        const result = await retryRecheckAfterBind(
+            { recheck, stillBlocked: () => blocked, sleep: async () => { blocked = false; }, onHealthy },
+            [10, 10, 10],
+        );
+
+        expect(result).toBe(false);
+        // One attempt, one sleep (which flips stillBlocked to false), then bail
+        // — must NOT continue through the remaining two delays.
+        expect(recheck).toHaveBeenCalledTimes(1);
+        expect(onHealthy).not.toHaveBeenCalled();
+    });
+
+    it("sleeps the exact delay ladder values, in order, between attempts", async () => {
+        const recheck = vi.fn().mockResolvedValue(false);
+        const sleepCalls: number[] = [];
+        const sleep = async (ms: number) => { sleepCalls.push(ms); };
+
+        await retryRecheckAfterBind(
+            { recheck, stillBlocked: () => true, sleep, onHealthy: () => {} },
+            [300, 700, 1500],
+        );
+
+        expect(sleepCalls).toEqual([300, 700, 1500]);
+    });
+});

--- a/frontend/app/view/agent/failure/recheck-after-bind.ts
+++ b/frontend/app/view/agent/failure/recheck-after-bind.ts
@@ -1,0 +1,74 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Bounded retry ladder for the auto-unblock auth recheck fired by
+ * `agentidentities:changed` — SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md
+ * §2.2, and the fix for a P1 caught on PR #2969's first review pass:
+ *
+ * The backend publishes `agentidentities:changed:<agentId>` SYNCHRONOUSLY
+ * inside the `LinkAgentIdentityCommand` handler, before it even responds to
+ * the RPC (`agent_handlers/identity.rs:590-611`). RPC responses and WS
+ * events share one in-order connection, so the frontend's subscription
+ * fires before `bindAccountToAgent`'s own `SetMetaCommand` — which only
+ * runs AFTER that same Link RPC resolves client-side — has refreshed
+ * `cmd:env` to the newly-bound account's dir. A single, immediate recheck
+ * therefore reads STALE env and fails on essentially every bind, not as an
+ * edge case but as the common one.
+ *
+ * `recheck` must re-read fresh state on every call (never a cached
+ * snapshot — `useAgentControllerStatus.recheckAuthAfterBind` already does
+ * this by construction) for retrying to actually converge: each attempt
+ * picks up whatever `cmd:env` holds AT THAT MOMENT, so it naturally
+ * succeeds the instant the real refresh lands, typically within one tick.
+ *
+ * Extracted as a pure, dependency-injected function (rather than left
+ * inline in agent-view.tsx) because that exact "unassertable inline logic"
+ * shape is what `PLAN_LOGIN_CTA_SURFACE_CONSOLIDATION_2026_09_02.md`'s own
+ * retrospective flagged as the reason the synthetic-row effect had to be
+ * extracted to `synthetic-row.ts` after several P1s — no sense re-learning
+ * that lesson on the same file.
+ */
+
+export interface RetryRecheckAfterBindDeps {
+    /** Re-run the auth check against current state; true = now authenticated. */
+    recheck: () => Promise<boolean>;
+    /** Whether the pane is still in a state worth continuing to poll for
+     *  (canRetry, or a live "auth" failure). Checked BETWEEN attempts so a
+     *  ladder in flight bails early if something else already resolved it
+     *  (e.g. a live turn arriving — see agent-view.tsx's
+     *  onActiveTurnConfirmed) or the row was dismissed. */
+    stillBlocked: () => boolean;
+    sleep: (ms: number) => Promise<void>;
+    /** Fired exactly once, the moment `recheck` first returns true. */
+    onHealthy: () => void;
+}
+
+export const DEFAULT_RECHECK_AFTER_BIND_DELAYS_MS = [300, 700, 1500];
+
+/**
+ * Try `recheck` up to `delaysMs.length + 1` times, sleeping `delaysMs[i]`
+ * between attempt `i` and `i+1`, stopping early on success or on
+ * `stillBlocked()` turning false. Returns whether it ended healthy.
+ */
+export async function retryRecheckAfterBind(
+    deps: RetryRecheckAfterBindDeps,
+    delaysMs: number[] = DEFAULT_RECHECK_AFTER_BIND_DELAYS_MS,
+): Promise<boolean> {
+    for (const delay of delaysMs) {
+        if (await deps.recheck()) {
+            deps.onHealthy();
+            return true;
+        }
+        await deps.sleep(delay);
+        if (!deps.stillBlocked()) return false;
+    }
+    // Final attempt after the last delay — kept explicit rather than folded
+    // into the loop so `delaysMs` reads as "N delays between N+1 attempts,"
+    // not "N attempts then N delays."
+    if (await deps.recheck()) {
+        deps.onHealthy();
+        return true;
+    }
+    return false;
+}

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -45,6 +45,8 @@ import { persistAndLinkAccount, runProviderLogin } from "../flows/run-provider-l
 import { LOGIN_LINK_CAPTURE_LABEL_MS, type LaunchPhase } from "../flows/launch-phase";
 import { lastLinkedAccountId } from "../providers/provider-id-aliases";
 import type { ProviderDefinition } from "../providers";
+import { bindAccountToAgent, type BindCandidate } from "@/app/view/identity/bind-to-agent-menu";
+import type { Account } from "@/app/view/identity/identity-model";
 
 import type { LogFn } from "../types";
 export type { LogFn };
@@ -246,6 +248,34 @@ export interface UseAgentControllerStatus {
     beginRecoveryFlow: (retryAfterLogin?: boolean) => void;
     /** Pairs with `beginRecoveryFlow` — see its doc comment. */
     endRecoveryFlow: () => void;
+    /**
+     * Re-run the CLI auth check against this pane's CURRENT `cmd`/`cmd:env`
+     * block meta, without opening any login flow. Used after an external
+     * bind event (a different pane, the Armory's Bind-to-Agent menu, or
+     * this pane's own `bindExistingAccount` below) to verify the newly
+     * bound credential actually works before declaring the pane unblocked.
+     * On success, clears `canRetry`/`authNotice` via `notifyControllerHealthy()`
+     * and returns `true`; the CALLER is responsible for also clearing a
+     * live `state.failure` row if one is showing (reducer-owned, outside
+     * this hook — mirror the exact `paneSnapshot(...).failure?.data.code
+     * === "auth"` guard `agent-view.tsx`'s `onActiveTurnConfirmed` already
+     * uses, so an unrelated concurrent non-auth failure is never silently
+     * wiped). See docs/specs/SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md §2.2.
+     */
+    recheckAuthAfterBind: () => Promise<boolean>;
+    /**
+     * Bind `account` to this pane's agent (link upsert + best-effort live
+     * `cmd:env`/forced-resync apply) — identical sequence to the Armory's
+     * Bind-to-Agent context menu (`bindAccountToAgent`, reused directly, not
+     * reimplemented). Deliberately does NOT retry the failed turn or call
+     * `recheckAuthAfterBind` itself: binding fires the same
+     * `agentidentities:changed:<agentId>` event any other bind source does,
+     * and the pane's own subscription to that event (agent-view.tsx) is
+     * what re-verifies and unblocks — one code path for "how does a pane
+     * recover after a bind," regardless of where the bind came from. See
+     * spec §3.4.
+     */
+    bindExistingAccount: (account: Account) => Promise<void>;
 }
 
 /**
@@ -366,6 +396,13 @@ export function useAgentControllerStatus(
         // the same pending failure. relogin/loginViaTerminal set the value
         // themselves before calling this and pass nothing, so they are
         // unaffected. reagent P1 + manoz on PR #2951.
+        //
+        // `bindExistingAccount` (SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md
+        // §3.4) is a THIRD no-intent caller, same shape as `/login`: it never
+        // retries a turn, so it has no `retryAfterLogin` to declare, and its
+        // `beginRecoveryFlow()` call only participates in the shared
+        // `activeRecoveryFlows`/`loginWaiting()` counter — not the intent
+        // chokepoint.
         if (retryAfterLogin !== undefined) recordRecoveryIntent(retryAfterLogin);
         activeRecoveryFlows += 1;
         setLoginWaiting(true);
@@ -1286,6 +1323,65 @@ export function useAgentControllerStatus(
         setAuthStatus("authenticated");
     };
 
+    const recheckAuthAfterBind = async (): Promise<boolean> => {
+        const prov = opts.provider();
+        if (!prov) return false;
+        // Reuse whatever this pane already has on disk — after a bind's
+        // live-apply step (bindAccountToAgent) refreshed `cmd:env`, this is
+        // the newly-bound account's dir; before any bind, it's whatever the
+        // last launch/recovery attempt wrote. Never re-derive a fresh env
+        // here — that would risk checking a DIFFERENT dir than the one the
+        // running controller will actually use next.
+        const cliPath = getBlockMetaKeyAtom(opts.blockId, "cmd")() as string | undefined;
+        if (!cliPath) return false;
+        const envMeta = getBlockMetaKeyAtom(opts.blockId, "cmd:env")();
+        const authEnv: Record<string, string> = {};
+        if (envMeta && typeof envMeta === "object") {
+            for (const [k, v] of Object.entries(envMeta as Record<string, unknown>)) {
+                if (typeof v === "string") authEnv[k] = v;
+            }
+        }
+        try {
+            const result = await RpcApi.CheckCliAuthCommand(TabRpcClient, {
+                cli_path: cliPath,
+                auth_check_args: prov.authCheckCommand,
+                auth_env: authEnv,
+            }, { timeout: 10000 });
+            if (!result.authenticated) return false;
+            notifyControllerHealthy();
+            return true;
+        } catch {
+            // Transient RPC error — treated as "still blocked," matching
+            // every other best-effort auth check in this hook. The pane
+            // simply stays as it was; the next bind event (or a manual
+            // retry) gets another chance.
+            return false;
+        }
+    };
+
+    const bindExistingAccount = async (account: Account): Promise<void> => {
+        const agentDefinitionId = getBlockMetaKeyAtom(opts.blockId, "agentId")() as string | undefined;
+        if (!agentDefinitionId) return;
+        // No retryAfterLogin declared — this flow never retries a turn (spec
+        // §3.4), so there is no intent to record. Still goes through
+        // beginRecoveryFlow/endRecoveryFlow so loginWaiting()'s shared
+        // counter (and therefore the fast-fail send guard) sees this as an
+        // in-flight recovery, same as every other entry point.
+        beginRecoveryFlow();
+        try {
+            const candidate: BindCandidate = {
+                agentId: agentDefinitionId,
+                agentName: "",
+                runningBlockId: opts.blockId,
+                boundHere: false,
+                boundElsewhereName: null,
+            };
+            await bindAccountToAgent(account, candidate);
+        } finally {
+            endRecoveryFlow();
+        }
+    };
+
     // If the pane is closed while login is in progress, cancel and kill
     // the host CLI process. This onCleanup is registered against the
     // SolidJS owner context that called useAgentControllerStatus — the
@@ -1323,5 +1419,7 @@ export function useAgentControllerStatus(
         resetCancelled: () => { loginCancelled = false; },
         beginRecoveryFlow,
         endRecoveryFlow,
+        recheckAuthAfterBind,
+        bindExistingAccount,
     };
 }

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -1368,6 +1368,7 @@ export function useAgentControllerStatus(
         // counter (and therefore the fast-fail send guard) sees this as an
         // in-flight recovery, same as every other entry point.
         beginRecoveryFlow();
+        setAuthNotice(null);
         try {
             const candidate: BindCandidate = {
                 agentId: agentDefinitionId,
@@ -1377,6 +1378,20 @@ export function useAgentControllerStatus(
                 boundElsewhereName: null,
             };
             await bindAccountToAgent(account, candidate);
+        } catch (e: any) {
+            // bindAccountToAgent throws on a failed link upsert (its own
+            // live-apply steps are already best-effort/non-throwing — see
+            // its doc comment). Surface it the same way every other failed
+            // recovery action in this hook does: `authNotice`, not a
+            // console-only log or an unhandled rejection at the caller
+            // (agent-view.tsx's `void status.bindExistingAccount(...)` call
+            // sites don't — and shouldn't have to — attach their own
+            // `.catch()`). reagentx P2 on PR #2971: the Armory's own
+            // Bind-to-Agent menu surfaces this via `onBindError`; this entry
+            // point had no equivalent until now.
+            const msg = `Couldn't bind "${account.name}": ${e?.message ?? String(e)}`;
+            opts.log("auth", msg, "error");
+            setAuthNotice(msg);
         } finally {
             endRecoveryFlow();
         }

--- a/frontend/app/view/agent/hooks/useAgentFailure.ts
+++ b/frontend/app/view/agent/hooks/useAgentFailure.ts
@@ -115,6 +115,18 @@ export interface UseAgentFailureOptions {
     onOpenArmory: () => void;
     /** Start a fresh agent session (context-window overflow recovery). */
     onNewSession: () => void;
+    /**
+     * Already-authenticated accounts for this agent's provider that could be
+     * bound in one click — see `computeAccountBindCandidates`
+     * (bind-account-candidates.ts). Reactive: the row re-derives its
+     * "Bind: <name>" / "Bind account" vs. "Armory → Accounts" action every
+     * time this changes. Optional so callers that haven't wired the account
+     * cache yet (e.g. tests) fall back to the pre-existing Armory-only
+     * behavior. See docs/specs/SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md §3.
+     */
+    bindCandidates?: Accessor<{ id: string; name: string }[]>;
+    /** Bind one of `bindCandidates` (or open a picker for 2+) to this agent. */
+    onBindAccount?: (e?: MouseEvent) => void;
 }
 
 export interface UseAgentFailureResult {
@@ -290,6 +302,7 @@ export function useAgentFailure(opts: UseAgentFailureOptions): UseAgentFailureRe
                 // Selects the auth arm's "Log in" vs "Login Again" label and
                 // the row's accent — see failure-accessory's FailureViewState.
                 turnAttempted: pf.turnAttempted,
+                bindCandidates: opts.bindCandidates?.(),
             },
             {
                 retry: doRetry,
@@ -301,6 +314,7 @@ export function useAgentFailure(opts: UseAgentFailureOptions): UseAgentFailureRe
                 // Same single-source forwarding as loginAgain above.
                 loginViaTerminal: () => opts.onLoginViaTerminal(pf.turnAttempted ?? true),
                 openArmory: opts.onOpenArmory,
+                bindAccount: opts.onBindAccount ?? (() => {}),
                 newSession: opts.onNewSession,
                 toggleDetails: () => setExpanded((v) => !v),
                 dismiss: endEpisode,


### PR DESCRIPTION
## Summary

Two related fixes to the agent-pane login flow, from a live usage report — see `docs/specs/SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md` for the full analysis and design.

**1. Auto-unblock on an external bind.** If an agent pane is stuck behind a login prompt and the user binds an account for that provider elsewhere (Armory's Bind-to-Agent menu, the per-agent Identity tab, or this PR's new button), the pane now notices via the existing per-agent `agentidentities:changed:<agentId>` event, re-verifies with `CheckCliAuth`, and clears the block — without ever auto-retrying a turn (a bind event is not proof the credential works, and auto-resending an old message is the exact bug class `PLAN_LOGIN_CTA_SURFACE_CONSOLIDATION_2026_09_02.md` already paid down once).

**2. One-click "Bind account".** The auth failure row's "Armory → Accounts" action is replaced by "Bind: `<name>`" (one candidate) / "Bind account" (2+, opens a picker) whenever an already-authenticated account for this agent's provider exists in this channel — reusing the Armory's own `bindAccountToAgent` link+live-apply sequence directly, not reimplemented. "Login via terminal" is unaffected either way (kept unconditionally — it's the only working recovery for providers whose in-app OAuth can't complete in-app).

Explicitly NOT the removed "Use existing login" (`ANALYSIS_PER_CHANNEL_AUTH_BYPASSES_2026_08_31.md`) — that copied the user's personal `~/.claude` file across channel boundaries. This binds to a proper per-channel Armory account someone already authenticated in this channel; candidates are sourced from the channel-safe `id_store`-backed listing, not the flagged cross-channel-leaking one.

No backend changes — everything reuses existing RPCs/events (`LinkAgentIdentityCommand`, `CheckCliAuthCommand`, `agentidentities:changed`).

## Test plan

- [x] 44 new/updated unit tests (candidate-set filter, bind/Armory row-swap logic) — all passing
- [x] Full frontend suite: 3616 tests / 242 files, 0 failures
- [x] `npx tsc --noEmit` — clean
- [ ] Live: bind an account from the Armory while a different pane sits on the login prompt for that provider — confirm it clears without switching back to it
- [ ] Live: "Bind: `<name>`" / "Bind account" appears and works end-to-end when a candidate account exists; "Login via terminal" + "Armory → Accounts" still work unchanged when none exists

Reopened from #2969 (closed — opened under the wrong account). A review already landed there flagging a real P1 (auto-unblock recheck can race `bindAccountToAgent`'s `cmd:env` refresh) — carrying it forward to address next, not dropping it.

<!-- agentmux:agent_id=loap #2 -->