### PR TITLE
fix(agent): show hover-to-peek time/token panel on expanded tool calls

### DIFF
--- a/.changesets/1788563253-fix-agent-show-the-hover-to-peek-time-token-panel-on-expande-0ezs.md
+++ b/.changesets/1788563253-fix-agent-show-the-hover-to-peek-time-token-panel-on-expande-0ezs.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): show the hover-to-peek time/token panel on expanded tool calls too

--- a/docs/reports/REPORT_TOOL_CALL_PEEK_SUPPRESSED_WHEN_EXPANDED_2026_09_04.md
+++ b/docs/reports/REPORT_TOOL_CALL_PEEK_SUPPRESSED_WHEN_EXPANDED_2026_09_04.md
@@ -1,0 +1,126 @@
+# Report: hover-to-peek time/token panel is missing on expanded tool calls
+
+**Date:** 2026-09-04
+**Author:** agent3
+**Repo state:** `agentmuxai/agentmux` main @ `b2fbf8bd1`
+**Trigger:** User report — the hover-to-peek panel (pinned to the right,
+tracks the mouse vertically, shows exact time + token estimate) works on
+agent thinking text, but not on the body/preview of tool calls.
+
+---
+
+## 1. Confirmed: real, and scoped to exactly one condition
+
+All three document-node kinds that use the shared `PeekOverlay` +
+`useNodePeek()` infrastructure were compared directly:
+
+| Component | `show=` condition |
+|---|---|
+| `MarkdownBlock.tsx:146` (thinking/assistant text) | `isPeeking() && (peekTimeText() != null \|\| peekEstimateText() != null)` |
+| `UserMessageBlock.tsx:219` (regular user input) | `isPeeking() && (peekTimeText() != null \|\| peekEstimateText() != null)` |
+| `ToolBlock.tsx:493` (tool calls) | `isPeeking() && hasAnyPeekContent() && !expanded()` |
+
+**Only `ToolBlock.tsx` adds `&& !expanded()`.** Neither `MarkdownBlock`
+nor `UserMessageBlock` has any equivalent "already showing its body, so
+suppress the hover panel" condition — they show the time/token peek on
+hover unconditionally, regardless of any expand/pin state.
+
+`expanded()` is true whenever a tool call's panel is showing its body —
+pinned open by the user, auto-expanded (running / pending-approval /
+just-completed hold-open), or manually toggled open. In every one of
+those states, hovering the tool call currently shows **no** peek panel at
+all — confirmed by reading `ToolBlock.tsx:314` (`panelMode()`) and the
+panel's own render at `:517-535`, which renders only `<ToolBlockOverlay>`
+(the command/output/diff body) with no time or token display anywhere in
+it.
+
+## 2. Why this happened (not a regression — a deliberate, now-stale call)
+
+The suppression is original design intent, per the comment at
+`ToolBlock.tsx:487-492`:
+
+> "Suppressed once the panel is already expanded, since the command/time
+> are visible in context there — same condition the old Tooltip-based
+> version used."
+
+This is **half right, half wrong**, and the wrong half is what the user
+is hitting:
+
+- `cmdText()` (the bare command) genuinely *is* redundant once
+  expanded — the same command is visible in the panel body
+  (`ToolBlockOverlay`).
+- `peekTimeText()` (exact timestamp + "time ago") and `peekEstimateText()`
+  (token estimate) are **not** shown anywhere in the expanded panel body.
+  The comment's claim that "time... are visible in context there" does
+  not hold — `ToolBlockOverlay` renders tool output, not a timestamp or
+  token count. This was true at the time of the original (pre-Portal)
+  Tooltip implementation this comment cites, or was simply wrong even
+  then; either way, on current `main` it is not accurate.
+
+Net effect: the moment a tool call's panel opens for any reason (running,
+pending approval, pinned, or just finished and held open), the ONLY
+surface that ever shows that node's time/token info becomes permanently
+unavailable, with no alternate way to see it, for exactly as long as the
+panel stays open — while `MarkdownBlock`/`UserMessageBlock` never lose
+that surface regardless of their own expand states.
+
+## 3. Fix
+
+Keep suppressing `cmdText` when expanded (that part of the original
+rationale is correct), but stop suppressing the whole overlay — let
+`peekTimeText`/`peekEstimateText` show regardless of `expanded()`:
+
+```tsx
+<PeekOverlay show={isPeeking() && hasAnyPeekContent()} rowEl={peekRowEl}>
+    <Show when={peekTimeText()}>
+        <div class="agent-node-peek-tooltip-meta">{peekTimeText()}</div>
+    </Show>
+    <Show when={peekEstimateText()}>
+        <div class="agent-node-peek-tooltip-meta">{peekEstimateText()}</div>
+    </Show>
+    <Show when={cmdText() && !expanded()}>
+        <div class="agent-node-peek-tooltip-body">{cmdText()}</div>
+    </Show>
+</PeekOverlay>
+```
+
+- `show=` drops `&& !expanded()` entirely — the peek now appears on hover
+  regardless of panel state, matching `MarkdownBlock`/`UserMessageBlock`.
+- `hasAnyPeekContent()` (`:360-362`) already checks `cmdText() !== "" ||
+  props.node.timestamp != null || peekEstimateText() != null` — unchanged,
+  since a node with only a command and no timestamp/estimate should still
+  peek-content-gate correctly (rare, but the existing logic already
+  handles it).
+- The `cmdText` `<Show>` inside the overlay body gets `&& !expanded()`
+  moved onto it specifically, so the one genuinely-redundant line (the
+  bare command, already visible in the open panel) stays hidden while
+  expanded, but time/estimate now always show.
+
+This is a minimal, targeted change — one condition moved from the
+overlay's `show` gate to the one child that was actually redundant. No
+change to `MarkdownBlock.tsx`, `UserMessageBlock.tsx`, `PeekOverlay.tsx`,
+or `useNodePeek.ts` — the shared infrastructure (including the mouse-Y
+tracking behavior from `SPEC_PEEK_OVERLAY_MOUSE_Y_TRACKING_2026_09_03.md`)
+already works correctly for every node kind; `ToolBlock.tsx` alone had
+its own extra gate.
+
+## 4. What this does not change
+
+- Collapsed tool calls: already worked, unaffected.
+- Thinking/message blocks, user messages: already worked, unaffected.
+- The peek's positioning/mouse-tracking/pointer-gap behavior
+  (`PeekOverlay.tsx`): unchanged, this report is purely about the `show`
+  condition and one child's visibility in `ToolBlock.tsx`.
+
+## 5. Testing plan
+
+- Existing test `ToolBlock.test.tsx` — "command tooltip > expanded
+  (pinned): hovering the name shows no overlay — command is visible in
+  the panel already" currently asserts the OLD (buggy) behavior and will
+  need updating to assert the overlay DOES show, but WITHOUT the command
+  body line, once pinned/expanded.
+- New test: hovering an expanded/pinned tool call shows
+  `peekTimeText`/`peekEstimateText` but not `cmdText`.
+- Manual: pin a tool call open, hover it, confirm the time/token panel
+  now appears (tracking the mouse per the existing mouse-Y behavior) and
+  does not duplicate the command text already shown in the body.

--- a/docs/reports/REPORT_TOOL_CALL_PEEK_SUPPRESSED_WHEN_EXPANDED_2026_09_04.md
+++ b/docs/reports/REPORT_TOOL_CALL_PEEK_SUPPRESSED_WHEN_EXPANDED_2026_09_04.md
@@ -1,5 +1,6 @@
 # Report: hover-to-peek time/token panel is missing on expanded tool calls
 
+**Status:** implemented — fix + updated tests in PR #2972.
 **Date:** 2026-09-04
 **Author:** agent3
 **Repo state:** `agentmuxai/agentmux` main @ `b2fbf8bd1`

--- a/frontend/app/view/agent/components/ToolBlock.test.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.test.tsx
@@ -182,8 +182,11 @@ describe("ToolBlock — panel mode", () => {
     });
 
     // ── Command tooltip — narrower than the removed hover-to-peek system:
-    // static text only (the bare command), no expansion, suppressed once
-    // the panel is already expanded. See ToolBlock.tsx's header comment.
+    // static text only (the bare command), no expansion. Only the command
+    // LINE is suppressed once the panel is already expanded (redundant with
+    // the visible body) — the overlay itself, and its time/estimate lines,
+    // show regardless of expand state. See ToolBlock.tsx's header comment
+    // and REPORT_TOOL_CALL_PEEK_SUPPRESSED_WHEN_EXPANDED_2026_09_04.md.
     describe("command tooltip", () => {
         // The peek overlay is Portal-rendered at document.body (PeekOverlay.tsx
         // — escapes each virtualized row's own CSS stacking context, see that
@@ -252,14 +255,24 @@ describe("ToolBlock — panel mode", () => {
             }
         });
 
-        it("expanded (pinned): hovering the name shows no overlay — command is visible in the panel already", () => {
+        // REPORT_TOOL_CALL_PEEK_SUPPRESSED_WHEN_EXPANDED_2026_09_04.md: the
+        // overlay used to be fully suppressed while expanded, on the (wrong)
+        // premise that time/estimate were "visible in context" in the panel
+        // body — they aren't, only the command is. Only the command line
+        // stays suppressed now; time/estimate still show.
+        it("expanded (pinned): hovering still shows the overlay's time/estimate, but not the redundant command line", () => {
             vi.useFakeTimers();
             try {
                 const { container } = render(() => (
                     <ToolBlock node={baseTool} pinned={true} onTogglePin={() => {}} />
                 ));
                 hoverToolName(container);
-                expect(document.body.querySelector(".agent-node-peek-overlay")).toBeNull();
+                expect(document.body.querySelector(".agent-node-peek-overlay")).not.toBeNull();
+                expect(document.body.querySelector(".agent-node-peek-tooltip-body")).toBeNull();
+                // baseTool has no timestamp, so just the token estimate line.
+                const metaLines = document.body.querySelectorAll(".agent-node-peek-tooltip-meta");
+                expect(metaLines.length).toBe(1);
+                expect(metaLines[0].textContent).toMatch(/~\d+ tok \(est\.\)/);
             } finally {
                 vi.useRealTimers();
             }
@@ -307,8 +320,8 @@ describe("ToolBlock — panel mode", () => {
 
         // ToolBlock instances are reused across status transitions via
         // index-based virtualization (no remount) -- this asserts the
-        // suppression is reactive to a live status/pin change on an
-        // ALREADY-MOUNTED instance, not just correct on first render.
+        // command-line suppression is reactive to a live status/pin change
+        // on an ALREADY-MOUNTED instance, not just correct on first render.
         //
         // Behavior change from SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25:
         // the peek anchor used to be a narrow inner span, separate from the
@@ -320,14 +333,15 @@ describe("ToolBlock — panel mode", () => {
         // show. Now that peek fires from anywhere in the row (the whole
         // point of "always fires"), the SAME hover also engages
         // `userHolding` while the panel is auto-expanded — so it now stays
-        // held open (correctly: the user is visibly still reading it) and
-        // the peek correctly stays suppressed the whole time, per the
-        // existing "peek is redundant once the detail is already visible in
-        // the expanded panel" rule. Leaving and re-hovering afterward (a
-        // genuinely fresh hover over the now-collapsed row) still shows the
-        // peek — the "always fires" contract holds for real hover, not for
-        // a use hovering session that never actually revisits the row.
-        it("keeps a running tool's panel held open through completion when the cursor never moves, so the peek stays suppressed until a fresh hover", () => {
+        // held open (correctly: the user is visibly still reading it).
+        //
+        // REPORT_TOOL_CALL_PEEK_SUPPRESSED_WHEN_EXPANDED_2026_09_04.md: only
+        // the command LINE stays suppressed while held open (redundant with
+        // the visible panel body) — the overlay itself, and its time/
+        // estimate lines, now show throughout. Leaving and re-hovering
+        // afterward (a genuinely fresh hover over the now-collapsed row)
+        // shows the command line too, since the panel is no longer expanded.
+        it("keeps a running tool's command line suppressed through completion when the cursor never moves, revealing it again only on a fresh hover", () => {
             const [node, setNode] = createSignal<ToolNode>({ ...baseTool, status: "running" });
             vi.useFakeTimers();
             try {
@@ -337,17 +351,20 @@ describe("ToolBlock — panel mode", () => {
                 const row = container.querySelector(".agent-tool-block") as HTMLElement;
                 fireEvent.mouseEnter(row); // cursor arrives while still running (panel auto-expanded)
                 vi.advanceTimersByTime(100);
-                expect(document.body.querySelector(".agent-node-peek-overlay")).toBeNull();
+                expect(document.body.querySelector(".agent-node-peek-overlay")).not.toBeNull();
+                expect(document.body.querySelector(".agent-node-peek-tooltip-body")).toBeNull();
                 setNode({ ...baseTool, status: "success" }); // completes; cursor never moves
                 // Held open by userHolding (engaged at the mouseenter above,
-                // since the panel WAS auto-expanded at that moment) — no
-                // peek while the detail is already visible in-flow.
+                // since the panel WAS auto-expanded at that moment) — command
+                // line stays suppressed while the detail is visible in-flow,
+                // but the overlay itself (time/estimate) keeps showing.
                 const panel = container.querySelector(".agent-tool-panel") as HTMLElement;
                 expect(panel.classList.contains("agent-tool-panel--flow")).toBe(true);
-                expect(document.body.querySelector(".agent-node-peek-overlay")).toBeNull();
+                expect(document.body.querySelector(".agent-node-peek-overlay")).not.toBeNull();
+                expect(document.body.querySelector(".agent-node-peek-tooltip-body")).toBeNull();
 
                 // A genuine fresh hover (leave, then re-enter) after the row
-                // has actually collapsed still shows the peek.
+                // has actually collapsed shows the command line again too.
                 fireEvent.mouseLeave(row);
                 fireEvent.mouseEnter(row);
                 vi.advanceTimersByTime(100);
@@ -359,7 +376,7 @@ describe("ToolBlock — panel mode", () => {
             }
         });
 
-        it("hides the overlay the instant an already-hovered tool gets pinned open, with no mouseleave", () => {
+        it("hides only the command line — not the whole overlay — the instant an already-hovered tool gets pinned open, with no mouseleave", () => {
             const [pinned, setPinned] = createSignal(false);
             vi.useFakeTimers();
             try {
@@ -368,8 +385,10 @@ describe("ToolBlock — panel mode", () => {
                 ));
                 hoverToolName(container);
                 expect(document.body.querySelector(".agent-node-peek-overlay")).not.toBeNull();
+                expect(document.body.querySelector(".agent-node-peek-tooltip-body")).not.toBeNull();
                 setPinned(true); // user clicks elsewhere to pin the panel open; cursor stays put
-                expect(document.body.querySelector(".agent-node-peek-overlay")).toBeNull();
+                expect(document.body.querySelector(".agent-node-peek-overlay")).not.toBeNull();
+                expect(document.body.querySelector(".agent-node-peek-tooltip-body")).toBeNull();
             } finally {
                 vi.useRealTimers();
             }

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -486,18 +486,22 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                 </div>
                 {/* Peek overlay — SPEC_TRANSCRIPT_NODE_HOVER_PEEK_2026_08_03.md,
                 styled to match UserMessageBlock.tsx's "Session context"
-                hover-to-peek (see PeekOverlay.tsx). Suppressed once the
-                panel is already expanded, since the command/time are
-                visible in context there — same condition the old
-                Tooltip-based version used. */}
-                <PeekOverlay show={isPeeking() && hasAnyPeekContent() && !expanded()} rowEl={peekRowEl}>
+                hover-to-peek (see PeekOverlay.tsx). Time/estimate show
+                regardless of expand state — MarkdownBlock/UserMessageBlock
+                never suppressed these either, and unlike the command text
+                below, they're not shown anywhere in the expanded panel body
+                (REPORT_TOOL_CALL_PEEK_SUPPRESSED_WHEN_EXPANDED_2026_09_04.md).
+                Only the bare command line stays gated on !expanded() — that
+                one genuinely is redundant once the panel shows it in
+                context. */}
+                <PeekOverlay show={isPeeking() && hasAnyPeekContent()} rowEl={peekRowEl}>
                     <Show when={peekTimeText()}>
                         <div class="agent-node-peek-tooltip-meta">{peekTimeText()}</div>
                     </Show>
                     <Show when={peekEstimateText()}>
                         <div class="agent-node-peek-tooltip-meta">{peekEstimateText()}</div>
                     </Show>
-                    <Show when={cmdText()}>
+                    <Show when={cmdText() && !expanded()}>
                         <div class="agent-node-peek-tooltip-body">{cmdText()}</div>
                     </Show>
                 </PeekOverlay>


### PR DESCRIPTION
## Summary
`ToolBlock.tsx` was the only one of the three document-node kinds (thinking/message blocks, user messages, tool calls) sharing `PeekOverlay`/`useNodePeek()` that fully suppressed its hover panel whenever the row was expanded (pinned, running, pending-approval, or held-open post-completion). The stated rationale — "command and time are visible in context there" — doesn't hold: the expanded panel body (`ToolBlockOverlay`) shows the command/output, but never a timestamp or token count. So a tool call's time/token info became completely unavailable for as long as its panel stayed open, while thinking text and user messages never lost that surface regardless of their own expand state.

## Fix
Only the redundant command line (`cmdText`) now suppresses on expand; the overlay itself — and its time/token-estimate lines — show regardless of `expanded()`, matching `MarkdownBlock.tsx`/`UserMessageBlock.tsx`'s existing (correct) behavior.

## Report
`docs/reports/REPORT_TOOL_CALL_PEEK_SUPPRESSED_WHEN_EXPANDED_2026_09_04.md` — full investigation, including a side-by-side of all three components' `show=` conditions confirming this was the one outlier.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — ToolBlock/MarkdownBlock/UserMessageBlock/PeekOverlay suites (73 tests) pass; 3 existing tests updated to assert the corrected behavior (overlay + time/estimate show while expanded, only the command line stays gated)
- [ ] Manual verification with real mouse input — not yet confirmed by a human

<!-- agentmux:agent_id=agent3 -->