### PR TITLE
fix(term): round-robin priority-lane egress across panes to stop cross-pane input delay

### DIFF
--- a/.changesets/1788554426-fix-term-round-robin-priority-lane-egress-across-panes-to-st-mlld.md
+++ b/.changesets/1788554426-fix-term-round-robin-priority-lane-egress-across-panes-to-st-mlld.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(term): round-robin priority-lane egress across panes to stop cross-pane input delay

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -201,9 +201,21 @@ async fn handle_ws_connection(mut socket: WebSocket, state: AppState) {
             //   2. Direct broadcasts (e.g., SetMeta's obj:update) — raw
             //      { eventtype: "waveobj:update", oref: "block:xxx", data: ... }
             // This carries terminal echo output and all interactive events.
+            //
+            // Fairness: this lane is shared by EVERY pane on the connection, not
+            // just one. A single FIFO here means a noisy pane (heavy PTY output)
+            // can queue an unbounded number of frames ahead of a different pane's
+            // own keystroke echo, which arrives in the same channel. Draining all
+            // immediately-available events and round-robining them by pane (see
+            // `fair_drain_priority`) bounds that delay to one "round" per distinct
+            // active pane instead of the length of the noisy pane's backlog. See
+            // docs/analysis/ANALYSIS_CROSS_PANE_INPUT_DELAY_UNDER_OUTPUT_LOAD_2026_09_04.md.
             Some(event) = priority_rx.recv() => {
-                if forward_event(&mut socket, event).await {
-                    break;
+                let fair = fair_drain_priority(event, &mut priority_rx);
+                for ev in fair {
+                    if forward_event(&mut socket, ev).await {
+                        break 'ws;
+                    }
                 }
             }
 
@@ -338,6 +350,101 @@ fn coalesce_background(
         map.insert(k, next);
     }
     order.into_iter().filter_map(|k| map.remove(&k)).collect()
+}
+
+/// Extract a fairness key (the pane/block a priority-lane event belongs to)
+/// so a flood of output from one pane can't queue an unbounded number of
+/// frames ahead of a different pane's own keystroke echo sitting in the same
+/// lane. Mirrors the two shapes `forward_event` already handles: RPC-wrapped
+/// WPS events (from the broker) carry `scopes: ["block:<id>", ...]` inside
+/// the nested WaveEvent; raw direct broadcasts (e.g. SetMeta's
+/// `waveobj:update`) carry `oref: "block:<id>"` at the top level. Events with
+/// no identifiable scope (e.g. the initial `config` push, batched multi-object
+/// updates) return `None` — `fair_drain_priority` groups those under one
+/// shared key, so they still round-robin fairly as one more participant
+/// rather than jumping the queue or starving.
+fn priority_pane_key(event: &serde_json::Value) -> Option<String> {
+    if event["eventtype"] == "rpc" {
+        event
+            .get("data")
+            .and_then(|d| d.get("data"))
+            .and_then(|d| d.get("scopes"))
+            .and_then(|s| s.get(0))
+            .and_then(|s| s.as_str())
+            .map(|s| s.to_string())
+    } else {
+        event
+            .get("oref")
+            .and_then(|o| o.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+    }
+}
+
+fn enqueue_priority_event(
+    order: &mut Vec<String>,
+    groups: &mut std::collections::HashMap<String, std::collections::VecDeque<serde_json::Value>>,
+    event: serde_json::Value,
+) {
+    let key = priority_pane_key(&event).unwrap_or_default();
+    if !groups.contains_key(&key) {
+        order.push(key.clone());
+    }
+    groups.entry(key).or_default().push_back(event);
+}
+
+/// Drain all immediately-available events from `rx` (including `first`) and
+/// interleave them round-robin by pane (`priority_pane_key`), instead of
+/// forwarding in raw arrival order. Without this, a pane producing output
+/// faster than the socket can flush it fills this same lane with its own
+/// frames, and a different pane's keystroke-echo frame — queued in the same
+/// FIFO — waits behind the entire backlog. Round-robining bounds that wait to
+/// one slot per OTHER distinct pane with events currently queued, regardless
+/// of how deep any single pane's backlog is.
+///
+/// Ordering guarantee: events for the SAME pane are never reordered relative
+/// to each other (each pane's VecDeque is FIFO); only the INTERLEAVING across
+/// different panes changes.
+fn fair_drain_priority(
+    first: serde_json::Value,
+    rx: &mut tokio::sync::mpsc::Receiver<serde_json::Value>,
+) -> Vec<serde_json::Value> {
+    let mut order: Vec<String> = Vec::new();
+    let mut groups: std::collections::HashMap<String, std::collections::VecDeque<serde_json::Value>> =
+        std::collections::HashMap::new();
+
+    enqueue_priority_event(&mut order, &mut groups, first);
+    while let Ok(next) = rx.try_recv() {
+        enqueue_priority_event(&mut order, &mut groups, next);
+    }
+
+    // Common case — only one pane (or only one event) queued this round.
+    // Skip the round-robin bookkeeping and preserve arrival order directly.
+    if order.len() <= 1 {
+        return order
+            .into_iter()
+            .filter_map(|k| groups.remove(&k))
+            .flat_map(|q| q.into_iter())
+            .collect();
+    }
+
+    let total: usize = groups.values().map(|q| q.len()).sum();
+    let mut out = Vec::with_capacity(total);
+    loop {
+        let mut progressed = false;
+        for key in &order {
+            if let Some(q) = groups.get_mut(key) {
+                if let Some(ev) = q.pop_front() {
+                    out.push(ev);
+                    progressed = true;
+                }
+            }
+        }
+        if !progressed {
+            break;
+        }
+    }
+    out
 }
 
 /// Handle an incoming text message.
@@ -1511,4 +1618,123 @@ fn parse_block_input(
         return Ok(blockcontroller::BlockInputUnion::resize(ts));
     }
     Err("controllerinput: no input data, signal, or termsize".to_string())
+}
+
+// ====================================================================
+// Tests
+// ====================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rpc_event(block_id: &str) -> serde_json::Value {
+        json!({
+            "eventtype": "rpc",
+            "data": {
+                "command": "eventrecv",
+                "data": {
+                    "event": "blockfile",
+                    "scopes": [format!("block:{block_id}")],
+                    "data": {"data64": "aGk="},
+                },
+            },
+        })
+    }
+
+    fn raw_oref_event(block_id: &str) -> serde_json::Value {
+        json!({
+            "eventtype": "waveobj:update",
+            "oref": format!("block:{block_id}"),
+            "data": {},
+        })
+    }
+
+    fn global_event() -> serde_json::Value {
+        json!({
+            "eventtype": "waveobj:batchedupdates",
+            "data": [],
+        })
+    }
+
+    #[test]
+    fn test_priority_pane_key_from_rpc_scopes() {
+        let event = rpc_event("abc123");
+        assert_eq!(priority_pane_key(&event), Some("block:abc123".to_string()));
+    }
+
+    #[test]
+    fn test_priority_pane_key_from_raw_oref() {
+        let event = raw_oref_event("xyz789");
+        assert_eq!(priority_pane_key(&event), Some("block:xyz789".to_string()));
+    }
+
+    #[test]
+    fn test_priority_pane_key_none_for_global_event() {
+        let event = global_event();
+        assert_eq!(priority_pane_key(&event), None);
+    }
+
+    /// The core regression this exists to prevent: a noisy pane (A) producing
+    /// many queued frames must not delay a quiet pane's (B) single frame by
+    /// the full length of A's backlog. Round-robin interleaving means B's
+    /// frame comes out within one "round" (bounded by the number of DISTINCT
+    /// panes with queued output), not after every one of A's frames.
+    #[tokio::test]
+    async fn test_fair_drain_priority_interleaves_noisy_and_quiet_panes() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+
+        // Pane A floods 10 frames; pane B contributes exactly 1, queued
+        // in the middle of A's backlog (mirrors real arrival: B's keystroke
+        // echo lands while A's flood is still being drained into the lane).
+        for i in 0..5 {
+            tx.try_send(rpc_event("A")).unwrap();
+            let _ = i;
+        }
+        tx.try_send(rpc_event("B")).unwrap();
+        for _ in 0..5 {
+            tx.try_send(rpc_event("A")).unwrap();
+        }
+
+        let first = rx.recv().await.unwrap();
+        let drained = fair_drain_priority(first, &mut rx);
+
+        assert_eq!(drained.len(), 11, "all 11 queued events must be returned, none dropped");
+
+        // Find B's position in the fairly-drained output — it must appear
+        // near the front (within the first "round" across 2 distinct panes),
+        // not at position 6 where naive FIFO would place it.
+        let b_pos = drained
+            .iter()
+            .position(|e| priority_pane_key(e).as_deref() == Some("block:B"))
+            .expect("pane B's event must be present");
+        assert!(
+            b_pos <= 1,
+            "pane B's frame should be at most 1 slot behind pane A in round-robin order, was at position {b_pos}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fair_drain_priority_single_pane_preserves_order() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        for _ in 0..4 {
+            tx.try_send(rpc_event("A")).unwrap();
+        }
+        let first = rx.recv().await.unwrap();
+        let drained = fair_drain_priority(first, &mut rx);
+        assert_eq!(drained.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn test_fair_drain_priority_no_events_lost_across_many_panes() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(256);
+        let pane_ids = ["A", "B", "C", "D"];
+        for (i, pane) in pane_ids.iter().cycle().take(40).enumerate() {
+            let _ = i;
+            tx.try_send(rpc_event(pane)).unwrap();
+        }
+        let first = rx.recv().await.unwrap();
+        let drained = fair_drain_priority(first, &mut rx);
+        assert_eq!(drained.len(), 40);
+    }
 }

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -132,6 +132,20 @@ async fn handle_ws_connection(mut socket: WebSocket, state: AppState) {
     let mut ping_interval = tokio::time::interval(std::time::Duration::from_secs(10));
     ping_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
+    // Fairly-ordered priority-lane events awaiting their turn to be sent, one
+    // per `'ws` loop iteration (see the priority-lane branch below and the
+    // pending-priority-flush branch after it). Reagent P1 on this PR's first
+    // revision: forwarding an entire drained batch inside one `select!`
+    // branch body — even a fairly-ordered one — starves `socket.recv()`
+    // (this connection's OWN incoming keystrokes) for the whole batch, since
+    // `select!` only re-polls sibling branches after the chosen branch's body
+    // returns. Trickling the batch out one event per iteration keeps every
+    // send interleaved with a fresh `socket.recv()` poll, exactly like the
+    // pre-fix one-event-per-iteration cadence, while still applying the fair
+    // pane ordering to however the batch is drained.
+    let mut pending_priority: std::collections::VecDeque<serde_json::Value> =
+        std::collections::VecDeque::new();
+
     'ws: loop {
         tokio::select! {
             // Biased: poll branches top-to-bottom so interactive terminal I/O
@@ -210,12 +224,29 @@ async fn handle_ws_connection(mut socket: WebSocket, state: AppState) {
             // `fair_drain_priority`) bounds that delay to one "round" per distinct
             // active pane instead of the length of the noisy pane's backlog. See
             // docs/analysis/ANALYSIS_CROSS_PANE_INPUT_DELAY_UNDER_OUTPUT_LOAD_2026_09_04.md.
-            Some(event) = priority_rx.recv() => {
-                let fair = fair_drain_priority(event, &mut priority_rx);
-                for ev in fair {
-                    if forward_event(&mut socket, ev).await {
-                        break 'ws;
-                    }
+            //
+            // Only drains a fresh batch when `pending_priority` is empty — while
+            // it's still being flushed (one per iteration, below), this branch
+            // stays disabled so we don't pull more out of `priority_rx` than
+            // we've finished sending.
+            Some(event) = priority_rx.recv(), if pending_priority.is_empty() => {
+                let mut fair = fair_drain_priority(event, &mut priority_rx);
+                // `fair` always has >= 1 element (it contains at least `event`).
+                let first = fair.remove(0);
+                pending_priority.extend(fair);
+                if forward_event(&mut socket, first).await {
+                    break 'ws;
+                }
+            }
+
+            // Flush one fairly-ordered priority event per iteration. A no-op
+            // branch guarded on `pending_priority` being non-empty — see the
+            // comment on `pending_priority`'s declaration above for why this
+            // is its own branch instead of a loop in the arm above.
+            _ = std::future::ready(()), if !pending_priority.is_empty() => {
+                let ev = pending_priority.pop_front().expect("guarded non-empty");
+                if forward_event(&mut socket, ev).await {
+                    break 'ws;
                 }
             }
 
@@ -352,33 +383,52 @@ fn coalesce_background(
     order.into_iter().filter_map(|k| map.remove(&k)).collect()
 }
 
-/// Extract a fairness key (the pane/block a priority-lane event belongs to)
-/// so a flood of output from one pane can't queue an unbounded number of
-/// frames ahead of a different pane's own keystroke echo sitting in the same
-/// lane. Mirrors the two shapes `forward_event` already handles: RPC-wrapped
-/// WPS events (from the broker) carry `scopes: ["block:<id>", ...]` inside
-/// the nested WaveEvent; raw direct broadcasts (e.g. SetMeta's
-/// `waveobj:update`) carry `oref: "block:<id>"` at the top level. Events with
-/// no identifiable scope (e.g. the initial `config` push, batched multi-object
-/// updates) return `None` — `fair_drain_priority` groups those under one
-/// shared key, so they still round-robin fairly as one more participant
-/// rather than jumping the queue or starving.
+/// Sentinel key for every priority-lane event that is NOT a `blockfile`
+/// (terminal/PTY output) event. Not a valid `block:<id>` scope string, so it
+/// can never collide with a real pane key.
+const NON_PANE_EVENT_KEY: &str = "\u{0}non-pane-event";
+
+/// Extract a fairness key so a flood of PTY output from one pane can't queue
+/// an unbounded number of frames ahead of a different pane's own keystroke
+/// echo sitting in the same lane.
+///
+/// Reordering is scoped to `blockfile` events ONLY — that's the one event
+/// type a single pane can flood the shared lane with, and PTY bytes from
+/// different panes are causally independent (only same-pane ordering
+/// matters, which each key's own FIFO group preserves). Every OTHER event
+/// type on this lane (`waveobj:update`, `waveobj:batchedupdates`, the initial
+/// `config` push, RPC replies) returns the same `NON_PANE_EVENT_KEY` and so
+/// stays in ONE FIFO group, never reordered relative to each other.
+///
+/// This restriction is load-bearing, not a simplification: a `waveobj:update`
+/// for object X and a LATER `waveobj:batchedupdates` that also touches X must
+/// never be reordered relative to each other, but an unscoped batch has no
+/// single object id to key on — an earlier version of this function keyed
+/// updates by their individual `oref`/scope and left unscoped batches in
+/// their own group, which let round-robin interleave `[update, delete]` into
+/// `[update, delete, update]`-style reorderings; the frontend doesn't
+/// version-guard deletes, so a resurrected-then-redeleted object could render
+/// as resurrected until reload. See the review discussion on the PR that
+/// introduced this function.
 fn priority_pane_key(event: &serde_json::Value) -> Option<String> {
-    if event["eventtype"] == "rpc" {
-        event
-            .get("data")
-            .and_then(|d| d.get("data"))
-            .and_then(|d| d.get("scopes"))
-            .and_then(|s| s.get(0))
-            .and_then(|s| s.as_str())
-            .map(|s| s.to_string())
-    } else {
-        event
-            .get("oref")
-            .and_then(|o| o.as_str())
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string())
+    if event["eventtype"] != "rpc" {
+        // Raw (non-rpc) events on this lane are always object-model
+        // broadcasts (e.g. SetMeta's `waveobj:update`), never blockfile —
+        // see `forward_event`'s shape comment.
+        return Some(NON_PANE_EVENT_KEY.to_string());
     }
+    let inner = event.get("data").and_then(|d| d.get("data"));
+    let is_blockfile = inner.and_then(|d| d.get("event")).and_then(|e| e.as_str())
+        == Some(crate::backend::wps::EVENT_BLOCK_FILE);
+    if !is_blockfile {
+        return Some(NON_PANE_EVENT_KEY.to_string());
+    }
+    inner
+        .and_then(|d| d.get("scopes"))
+        .and_then(|s| s.get(0))
+        .and_then(|s| s.as_str())
+        .map(|s| s.to_string())
+        .or_else(|| Some(NON_PANE_EVENT_KEY.to_string()))
 }
 
 fn enqueue_priority_event(
@@ -1642,15 +1692,15 @@ mod tests {
         })
     }
 
-    fn raw_oref_event(block_id: &str) -> serde_json::Value {
+    fn raw_waveobj_update(oref: &str) -> serde_json::Value {
         json!({
             "eventtype": "waveobj:update",
-            "oref": format!("block:{block_id}"),
+            "oref": oref,
             "data": {},
         })
     }
 
-    fn global_event() -> serde_json::Value {
+    fn batched_updates_event() -> serde_json::Value {
         json!({
             "eventtype": "waveobj:batchedupdates",
             "data": [],
@@ -1658,21 +1708,25 @@ mod tests {
     }
 
     #[test]
-    fn test_priority_pane_key_from_rpc_scopes() {
+    fn test_priority_pane_key_from_rpc_blockfile_scopes() {
         let event = rpc_event("abc123");
         assert_eq!(priority_pane_key(&event), Some("block:abc123".to_string()));
     }
 
+    /// Raw (non-rpc) object-model broadcasts are NEVER split by pane —
+    /// splitting them would let round-robin reorder them relative to other
+    /// object updates for the same object (see `priority_pane_key`'s doc
+    /// comment for the concrete resurrected-object failure this prevents).
     #[test]
-    fn test_priority_pane_key_from_raw_oref() {
-        let event = raw_oref_event("xyz789");
-        assert_eq!(priority_pane_key(&event), Some("block:xyz789".to_string()));
+    fn test_priority_pane_key_raw_waveobj_update_is_non_pane() {
+        let event = raw_waveobj_update("block:xyz789");
+        assert_eq!(priority_pane_key(&event), Some(NON_PANE_EVENT_KEY.to_string()));
     }
 
     #[test]
-    fn test_priority_pane_key_none_for_global_event() {
-        let event = global_event();
-        assert_eq!(priority_pane_key(&event), None);
+    fn test_priority_pane_key_non_pane_for_batched_updates() {
+        let event = batched_updates_event();
+        assert_eq!(priority_pane_key(&event), Some(NON_PANE_EVENT_KEY.to_string()));
     }
 
     /// The core regression this exists to prevent: a noisy pane (A) producing
@@ -1736,5 +1790,34 @@ mod tests {
         let first = rx.recv().await.unwrap();
         let drained = fair_drain_priority(first, &mut rx);
         assert_eq!(drained.len(), 40);
+    }
+
+    /// Regression test for the object-ordering bug caught in review: a
+    /// `waveobj:update` for object X followed by a LATER
+    /// `waveobj:batchedupdates` that also touches X must come out in the
+    /// same relative order they arrived in. An earlier version of
+    /// `priority_pane_key` keyed the individual update by its oref and left
+    /// the unscoped batch in its own group, so round-robin turned
+    /// `[update1, update2, batch]` into `[update1, batch, update2]` —
+    /// resurrecting a deleted object on the frontend until reload (the
+    /// frontend doesn't version-guard deletes). Object-model events must
+    /// never be split by pane key, only `blockfile` (terminal output) events
+    /// may be.
+    #[tokio::test]
+    async fn test_fair_drain_priority_preserves_object_update_order() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+
+        let update1 = raw_waveobj_update("tab:X");
+        let update2 = raw_waveobj_update("tab:X");
+        let batch_delete = batched_updates_event();
+
+        tx.try_send(update1.clone()).unwrap();
+        tx.try_send(update2.clone()).unwrap();
+        tx.try_send(batch_delete.clone()).unwrap();
+
+        let first = rx.recv().await.unwrap();
+        let drained = fair_drain_priority(first, &mut rx);
+
+        assert_eq!(drained, vec![update1, update2, batch_delete], "object-model events must stay in pure arrival order, never reordered by round-robin");
     }
 }

--- a/docs/analysis/ANALYSIS_CROSS_PANE_INPUT_DELAY_UNDER_OUTPUT_LOAD_2026_09_04.md
+++ b/docs/analysis/ANALYSIS_CROSS_PANE_INPUT_DELAY_UNDER_OUTPUT_LOAD_2026_09_04.md
@@ -1,7 +1,7 @@
 # Analysis & Recommendations: Cross-Pane Input Delay Under Output Load
 
 **Date:** 2026-09-04
-**Status:** §5 item 1 (per-pane fair egress dequeue) implemented on
+**Status:** Implemented — §5 item 1 (per-pane fair egress dequeue) landed on
 `agent2/fix-cross-pane-input-delay` — see `agentmux-srv/src/server/websocket.rs`'s
 `fair_drain_priority`/`priority_pane_key`, unit-tested (TDD), and validated live
 against a real running dev build: `tools/tests/bench-term-cross-pane.mjs` against
@@ -11,6 +11,20 @@ regression. An unpatched-vs-patched side-by-side run was attempted on a second
 isolated dev instance to get a directly-comparable "before" number but got stuck
 behind heavy build contention from other concurrent agents on the shared build
 machine and was abandoned; the live numbers above are from the patched build only.
+**Post-review hardening (same PR):** the first revision forwarded an entire
+fairly-ordered drained batch inside one `select!` branch body, which starved
+`socket.recv()` (this connection's own incoming keystrokes) for the whole
+batch — reintroducing head-of-line blocking on the read path (Codex + ReAgent
+both flagged this independently). Fixed by trickling one event per `'ws` loop
+iteration via a `pending_priority` queue, so `socket.recv()` is re-polled
+between every send, matching the original per-event cadence. Separately,
+`priority_pane_key` originally keyed ALL priority-lane events (including
+`waveobj:update`/`waveobj:batchedupdates` object-model events) by scope/oref,
+which let round-robin reorder an object's individual update relative to a
+later unscoped batch touching the same object — a real corruption risk (the
+frontend doesn't version-guard deletes). Fairness reordering is now scoped to
+`blockfile` (terminal output) events only; every other event type shares one
+key and stays in pure FIFO order. Both fixes are covered by new unit tests.
 Items 2-6 below remain unimplemented recommendations.
 **Symptom (user-reported):** while one pane (terminal or agent) is actively producing output, typing into a *different* pane feels slow/delayed.
 

--- a/docs/analysis/ANALYSIS_CROSS_PANE_INPUT_DELAY_UNDER_OUTPUT_LOAD_2026_09_04.md
+++ b/docs/analysis/ANALYSIS_CROSS_PANE_INPUT_DELAY_UNDER_OUTPUT_LOAD_2026_09_04.md
@@ -1,0 +1,106 @@
+# Analysis & Recommendations: Cross-Pane Input Delay Under Output Load
+
+**Date:** 2026-09-04
+**Status:** §5 item 1 (per-pane fair egress dequeue) implemented on
+`agent2/fix-cross-pane-input-delay` — see `agentmux-srv/src/server/websocket.rs`'s
+`fair_drain_priority`/`priority_pane_key`, unit-tested (TDD), and validated live
+against a real running dev build: `tools/tests/bench-term-cross-pane.mjs` against
+the patched instance showed pane B's echo latency flat (p50 ~9ms, p95 ~11-14ms)
+while pane A sustained a genuine ~54 KB/s (~387 events/sec) flood — no cross-pane
+regression. An unpatched-vs-patched side-by-side run was attempted on a second
+isolated dev instance to get a directly-comparable "before" number but got stuck
+behind heavy build contention from other concurrent agents on the shared build
+machine and was abandoned; the live numbers above are from the patched build only.
+Items 2-6 below remain unimplemented recommendations.
+**Symptom (user-reported):** while one pane (terminal or agent) is actively producing output, typing into a *different* pane feels slow/delayed.
+
+---
+
+## 1. Summary
+
+This is not one bug — it's the combination of two facts that are each individually correct engineering decisions, but compose badly:
+
+1. **Backend egress is multiplexed per-*connection*, not per-*pane*.** Every pane's output shares one ordered FIFO channel and one physical WebSocket write per browser window. A noisy pane's flood of small frames queues ahead of a quiet pane's keystroke-echo frame.
+2. **The frontend has exactly one JS main thread.** Any main-thread-blocking work triggered by pane A's data (an expensive render, a big parse, a synchronous DOM write) delays the `keydown` → send path for pane B, because both panes' event handling shares that one thread.
+
+Backend PTY read/write and lock state **are already correctly isolated per pane** — that is not the bottleneck and should not be touched. The bottleneck is entirely on the *fan-out to the browser* and the *shared render thread*, both of which currently have per-connection or global granularity where the fix needs per-pane granularity.
+
+This codebase has already hit and partially fixed adjacent instances of both failure classes (§4) — the fixes below extend the same pattern to the piece that's still missing.
+
+---
+
+## 2. What's already correctly isolated (don't break this)
+
+Verified in `agentmux-srv/src/backend/blockcontroller/shell/`:
+
+- **PTY reads are per-pane**, each a dedicated `spawn_blocking` OS thread (`lifecycle.rs:652-751`, `PTY_READ_BUF_SIZE = 4096` in `pty.rs:12`). Pane A's read never blocks pane B's read.
+- **PTY input writes are per-pane**, each with its own **unbounded** mpsc channel (`lifecycle.rs:130-136,753-784`) — a keystroke for pane B reaches its PTY immediately regardless of pane A's volume.
+- **Controller state lock is per-pane** (`ShellControllerInner` behind its own `Arc<Mutex<>>`, `controller.rs:46-95`), not a global lock across panes.
+- **Incoming WS keystrokes are read with top priority** in a `biased!` select (`server/websocket.rs:142-166`) ahead of any outgoing forwarding, so keystroke *ingestion into the server* is never delayed — only the *echo round-trip back to the browser*.
+
+Any fix should add fairness/isolation on top of this, not restructure it.
+
+---
+
+## 3. Root causes, ranked
+
+### 3.1 (Dominant) One shared FIFO fans out every pane's output on a connection
+
+`agentmux-srv/src/backend/eventbus.rs:104-120` — `EventBus::register_ws` creates **one `priority` mpsc channel per WebSocket connection** (capacity 8192, `eventbus.rs:47`), not one per pane. `EventBusBridge::send_event` (`eventbus.rs:288-316`) routes every non-telemetry event — which includes **all** terminal output/echo for **every pane** in that window — to this single `Lane::Priority` channel, keyed only by `route_id` (the connection), never by pane/block id.
+
+`server/websocket.rs:204-208` (the `Some(event) = priority_rx.recv()` arm) drains this one channel one item at a time and does a **sequential, awaited** `socket.send(...).await` per item (`forward_event`, same file). If pane A is producing hundreds of chunks/sec, pane B's own keystroke-echo frame — generated the instant B's shell echoes the typed character — is appended to the *same* FIFO and must wait its turn behind every one of A's frames already queued, then wait for the single physical socket write to flush. Under sustained flood the channel can fill and B's frame is silently **dropped** (`eventbus.rs:232-243`, "ws egress lane full … dropping event"), not just delayed.
+
+**This is the mechanism that directly matches the reported symptom** — a purely FIFO, connection-wide queue with no per-source fairness.
+
+### 3.2 No coalescing of the priority lane (unlike the background lane)
+
+`websocket.rs:236-243` explicitly coalesces the *background* (sysinfo/blockstats telemetry) lane to bound bursts (`coalesce_background`, `websocket.rs:321-341`) — but the priority lane has **no equivalent**. Every one of pane A's 4 KiB PTY-read chunks (`pty.rs:12`) produces its own broker publish and its own WS frame, maximizing how many frames pane B's echo must queue behind. This is the same fix pattern already applied to telemetry, just not yet applied to terminal output itself.
+
+### 3.3 No PTY-side backpressure — the producer is unbounded
+
+The read loop in `lifecycle.rs` reads a chunk and publishes it, then immediately reads again, with **no flow control**. This is a known, previously-scoped gap: `docs/specs/SPEC_TERMINAL_FLOW_CONTROL_2026_05_30.md` designs exactly this (ACK-based pause/resume of the PTY read once outstanding-unacked bytes cross a high watermark) but is explicitly **"Draft — design, pre-implementation."** Confirmed still unimplemented — no `termack`, `HIGH_WATERMARK`, or `LOW_WATERMARK` symbols exist anywhere in the current tree. `PLAN_INPUT_RESPONSIVENESS_EXECUTION_2026_05_29.md` §Item 7 gated this work behind a profiling step ("if P95 keystroke echo under heavy load > 100 ms → implement") that was never run — there's no bench result under `docs/perf/`. In other words: the safety net this repo already designed for exactly this symptom was never built because nobody had reproduced/measured it yet. The user's report is that missing evidence.
+
+### 3.4 General risk class: a blocking call inside an async task stalls the whole connection's egress
+
+Not the current cause (already fixed for its one known instance), but the same class of bug that would reproduce this exact symptom if reintroduced. `agentmux-srv/src/backend/sysinfo.rs` used to call `sys.refresh_processes_specifics(...)` synchronously inside an async Tokio task; on a host with many child processes the `/proc` scan took 5-20ms and occupied a Tokio worker thread, which is exactly enough to starve the WS egress loop at 1 Hz (fixed in commit `0f34704a8`, "eliminate 1Hz typing jerk from sysinfo blocking Tokio workers," #1782 — wrapped in `tokio::task::block_in_place`, plus the priority/background lane split that #3.1/#3.2 above build on). **Any future periodic/global task added to the server (new telemetry, a new scan, a new broadcast) that does synchronous I/O or CPU work without `block_in_place`/`spawn_blocking` reintroduces this for every pane on the connection, not just its own.**
+
+### 3.5 Frontend: shared main thread renders all panes
+
+JS is single-threaded; a main-thread-blocking task triggered by pane A's data delays pane B's `keydown` handling regardless of how well-isolated the backend is. This codebase already found and partially fixed one instance:
+
+`docs/analysis/ANALYSIS_AGENT_PANE_TYPING_LATENCY_2026_05_30.md` — a streaming agent response used to re-parse + re-syntax-highlight + rebuild the **entire** markdown document from scratch on every streamed frame (`frontend/app/element/markdown.tsx`'s `renderedMarkdown` memo), an O(n²) cost over a turn that produced escalating long-tasks (measured 52ms → 1754ms) and starved keystroke RAFs for *any* other input on the page. Confirmed fixed in current code: `frontend/app/view/agent/components/MarkdownBlock.tsx:30,62-78` now throttles commits to at most one per 90ms (`STREAM_RENDER_MS`) and skips syntax highlighting on intermediate commits, applying a full highlighted render only once the stream settles.
+
+This fix **bounds frequency**, not total cost — a very long streaming message still does a full-document parse+highlight on each 90ms commit and once on settle, so a sufficiently large single message can still produce a multi-hundred-ms main-thread block, just less often than every frame. The rejected alternative (`§5-6` of that analysis, "per-block incremental render") would have bounded *cost* instead of *frequency* and remains the more complete fix if this resurfaces for very long messages.
+
+The terminal pane (`frontend/app/view/term/termwrap.ts`) writes PTY output straight into `xterm.js` (`doTerminalWrite`, `termwrap.ts:600-656`) and relies on xterm's own internal `RenderDebouncer` (one paint per animation frame) as the sole coalescer — a prior double-RAF layer was deliberately removed (`SPEC_TERM_DOUBLE_RAF_TEAROUT_2026_05_30`). This is fine for paint *frequency*, but `terminal.write()` still does real parsing/buffer work proportional to bytes written on the calling thread; a sustained high-throughput producer (`cat` of a large file, a build log) can still consume main-thread time slices that a different pane's keystroke handler needs, independent of anything the backend does. This is the frontend-side counterpart to §3.3: no flow control exists to slow the producer down when the consumer (the render thread) can't keep up.
+
+---
+
+## 4. Why this wasn't caught earlier
+
+The repo has strong, specific contracts for *within-surface* input latency (`SPEC_INPUT_RESPONSIVENESS_TERMINAL_AND_AGENT_2026_05_29.md`: ≤16ms keystroke handlers, defer-what-can-wait, no layout reads on the input path) and has fixed several concrete regressions against those rules. All of that work is scoped to **one pane's own output not delaying its own input** (echo latency, textarea reflow). None of it is scoped to **pane A's output not delaying pane B's input** — a cross-pane fairness problem that doesn't show up in a single-pane benchmark (`tools/tests/bench-term-echo.mjs` drives one terminal, not two). That's a gap in bench coverage, not a gap in engineering care.
+
+---
+
+## 5. Recommended fixes, ranked by impact/effort
+
+| # | Fix | Addresses | Effort | Notes |
+|---|---|---|---|---|
+| 1 | **Per-pane fairness on the priority lane**: round-robin or weighted-fair dequeue across pending panes instead of one FIFO, before the single `socket.send()`. E.g. key queued events by `block_id`/pane, and drain one-per-pane-per-tick instead of oldest-first-globally. | §3.1 (dominant cause) | Medium | Keep the single WS connection (no protocol change) — this is purely a backend scheduling change in `websocket.rs`'s drain loop / `eventbus.rs`'s queue structure. |
+| 2 | **Coalesce consecutive same-pane output frames** the way `coalesce_background` already does for telemetry, before they hit the wire — collapse N queued chunks for the *same* pane into one WS frame when the lane is backed up. | §3.2 | Low-Medium | Mirrors existing, proven code (`websocket.rs:321-341`). Must preserve byte ordering within a pane. |
+| 3 | **Implement the already-designed ACK-based PTY flow control** (`SPEC_TERMINAL_FLOW_CONTROL_2026_05_30.md`) — pause the PTY read loop for an over-producing pane once unacked bytes cross a high watermark. This throttles the producer at the OS level, which also naturally caps how much any one pane can contribute to the shared queue in §3.1. | §3.3 | Medium-High | The design and touch-points are already written; this report is the missing profiling evidence the plan asked for before greenlighting it. |
+| 4 | **Codify the async-blocking rule** from the sysinfo incident as a lint/review checklist item: any new periodic or on-demand server-side task that does sync I/O, `/proc` scans, filesystem walks, or CPU-heavy work inside a `tokio::spawn`'d future must wrap it in `block_in_place`/`spawn_blocking`. | §3.4 (regression prevention) | Low | Process fix, not code — add to `CLAUDE.md` or a `docs/specs` contract like the terminal input-priority one, since it already bit this exact symptom once. |
+| 5 | **Extend the bench harness to a 2-pane scenario**: one pane running a heavy producer (`yes`, large `cat`, streaming build output), a second pane's keystroke-echo latency measured concurrently. Add this as a CI gate alongside the existing single-pane `bench-term-echo.mjs`. | Prevents regression of all of the above | Low | This is the missing coverage identified in §4 — a single-pane bench cannot detect a cross-pane fairness bug by construction. |
+| 6 | **(If §5's bench shows it's still needed) revisit the streaming-markdown fix** from "bound frequency" (current, 90ms throttle) to "bound cost" (the previously-designed but reverted per-block incremental render, §3.5) for very long single messages. | §3.5, residual | Medium | Only pursue if the 2-pane bench shows agent-pane streaming, not terminal output, is the practical trigger — don't re-attempt the rejected split-at-blank-lines approach; any retry needs to solve the list/paragraph-spacing breakage that got it rejected the first time. |
+
+Items 1, 2, and 5 are the "do these now" set: they directly target the confirmed dominant cause (§3.1/§3.2), are backend-only, and item 5 gives objective before/after numbers for all the others. Item 3 is larger but has zero remaining design risk — the spec is already written and reviewed. Item 4 is process, not code, and costs nothing to adopt immediately.
+
+---
+
+## 6. Validation plan
+
+1. Land item 5 (2-pane bench) first, run it against current `main` to get a baseline P95 keystroke-echo latency in pane B while pane A streams `yes`/a large `cat`/a build log. This confirms the symptom quantitatively and gives a number to beat.
+2. Implement item 1 (per-pane fair dequeue) and re-run the same bench — expect P95 to drop close to the single-pane baseline regardless of pane A's load.
+3. Implement item 2 (same-pane coalescing) and re-run — expect further reduction in frame count and tail latency under extreme floods.
+4. Only pursue item 3 (PTY flow control) if items 1+2 don't bring P95 under the existing internal "snappy" target (`SPEC_INPUT_RESPONSIVENESS_TERMINAL_AND_AGENT_2026_05_29.md` §2: P50 ≤ 25ms, P95 ≤ 50ms) — the spec's own rollout section already says to ship it "profiling-gated," and items 1+2 may be sufficient on their own.
+5. Confirm no ordering violations (a pane's bytes must still arrive in-order) and no regression to the existing telemetry-starvation fix (§3.4) — background lane must still stay servable during a priority-lane flood, per the existing comment in `websocket.rs:212-234`.

--- a/tools/tests/bench-term-cross-pane.mjs
+++ b/tools/tests/bench-term-cross-pane.mjs
@@ -337,12 +337,18 @@ async function main() {
         );
 
         process.stdout.write("\n  Flooding pane A with a continuous output loop...\n");
-        // A PowerShell-compatible unbounded output loop (this harness targets
-        // whichever shell `pane.open` spawns by default, which on Windows is
-        // PowerShell, not bash) — same role as the canonical `yes` flood, just
-        // portable to the default shell here. Text and Enter sent separately,
-        // same PSReadLine-safety reason as measureEchoLatency above.
-        sendInputFire(client, blockA, "while($true){'y'}");
+        // `pane.open` spawns a platform-appropriate default shell — PowerShell
+        // on Windows (detect_local_shell_path_windows), $SHELL (bash/zsh) on
+        // macOS/Linux (lifecycle.rs) — so the flood generator must match
+        // whichever shell THIS process's OS would get, or pane A stays quiet
+        // and the benchmark silently reports a false "no regression" result
+        // (caught in review: a PowerShell-only command is a syntax error in
+        // bash/zsh). `yes` is the canonical flood on POSIX shells; PowerShell
+        // has no `yes`, so it gets an equivalent infinite-output loop. Text
+        // and Enter sent separately, same PSReadLine-safety reason as
+        // measureEchoLatency above (harmless no-op split on POSIX shells).
+        const floodCmd = process.platform === "win32" ? "while($true){'y'}" : "yes";
+        sendInputFire(client, blockA, floodCmd);
         await sleep(250);
         sendInputFire(client, blockA, "\r");
         await sleep(500);

--- a/tools/tests/bench-term-cross-pane.mjs
+++ b/tools/tests/bench-term-cross-pane.mjs
@@ -1,0 +1,418 @@
+#!/usr/bin/env node
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// bench-term-cross-pane.mjs — Cross-pane input-delay benchmark.
+//
+// bench-term-echo.mjs's "busy" scenario measures a pane's OWN echo latency
+// while IT is producing heavy output — that's same-pane backpressure, not
+// the reported symptom. This script measures pane B's keystroke-echo
+// latency while a DIFFERENT pane (A) floods output, to catch cross-pane
+// starvation on the shared WS priority egress lane (see
+// docs/analysis/ANALYSIS_CROSS_PANE_INPUT_DELAY_UNDER_OUTPUT_LOAD_2026_09_04.md).
+//
+// Scenario:
+//   1. Open two terminal panes, A and B.
+//   2. Measure B's echo latency with both panes quiet (baseline).
+//   3. Flood A with continuous output (`yes`, unredirected — real PTY→WS
+//      traffic, not suppressed by `> /dev/null`).
+//   4. Measure B's echo latency again while A is flooding (cross-pane load).
+//   5. Stop A's flood, confirm B recovers to baseline.
+//
+// Compare a run on unpatched `main` vs. a branch carrying the per-pane fair
+// egress fix — the "cross-pane load" number is what the fix targets; it
+// should land close to "baseline", not blow up the way the naive-FIFO
+// egress lane does under a sustained flood from a different pane.
+//
+// Spec: docs/specs/SPEC_TERMINAL_LATENCY_BENCHMARK_2026_05_19.md (baseline harness this borrows from)
+// Auth: docs/specs/SPEC_TEST_API_ACCESS.md §5
+
+import { WebSocket } from "ws";
+import { readFileSync, writeFileSync, readdirSync, statSync } from "fs";
+import { resolve, join } from "path";
+import { homedir } from "os";
+import { randomUUID } from "crypto";
+import { execSync } from "child_process";
+
+// ── CLI parsing ─────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+function getArg(name, fallback = undefined) {
+    const i = args.indexOf(name);
+    return i !== -1 ? args[i + 1] : fallback;
+}
+
+if (args.includes("--help")) {
+    console.log(`
+node tools/tests/bench-term-cross-pane.mjs [options]
+
+  --ws-url <url>       WS endpoint (default: from authkey.dev)
+  --auth-key <key>     Auth key   (default: from authkey.dev)
+  --count <n>          Samples per scenario (default: 40)
+  --warmup <n>         Warmup samples to discard (default: 5)
+  --output-file <path> Save raw JSON results
+  --help               Show this message
+`);
+    process.exit(0);
+}
+
+const COUNT = parseInt(getArg("--count", "40"), 10);
+const WARMUP = parseInt(getArg("--warmup", "5"), 10);
+const OUTPUT_FILE = getArg("--output-file");
+
+// ── Auth file discovery (same convention as bench-term-echo.mjs) ────────────
+
+function isPidAlive(pid) {
+    if (!pid) return false;
+    try {
+        if (process.platform === "win32") {
+            const out = execSync(`tasklist /FI "PID eq ${pid}" /NH /FO CSV 2>NUL`, { encoding: "utf8" });
+            return out.includes(String(pid));
+        }
+        execSync(`kill -0 ${pid} 2>/dev/null`);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function findAuthFile(overrideWsUrl, overrideAuthKey) {
+    if (overrideWsUrl && overrideAuthKey) {
+        return {
+            ws_endpoint: overrideWsUrl.replace(/^wss?:\/\//, "").replace(/\/.*/, ""),
+            auth_key: overrideAuthKey,
+            instance: "manual",
+            host_pid: 0,
+        };
+    }
+
+    const home = homedir();
+    const searchRoots = [join(home, ".agentmux", "dev"), join(home, ".agentmux", "versions")];
+    const candidates = [];
+    for (const root of searchRoots) {
+        let entries;
+        try {
+            entries = readdirSync(root);
+        } catch {
+            continue;
+        }
+        for (const entry of entries) {
+            const candidate = join(root, entry, "data", "authkey.dev");
+            try {
+                const st = statSync(candidate);
+                candidates.push({ path: candidate, mtime: st.mtimeMs });
+            } catch {
+                /* not found */
+            }
+        }
+    }
+
+    if (candidates.length === 0) {
+        throw new Error(
+            `No authkey.dev found under ~/.agentmux/dev/*/data/ or ~/.agentmux/versions/*/data/.\n` +
+                `Start an instance: task dev  (dev)  or launch the portable build.\n` +
+                `See docs/specs/SPEC_TEST_API_ACCESS.md §5`,
+        );
+    }
+
+    candidates.sort((a, b) => b.mtime - a.mtime);
+    for (const { path } of candidates) {
+        let auth;
+        try {
+            auth = JSON.parse(readFileSync(path, "utf8"));
+        } catch {
+            continue;
+        }
+        if (!isPidAlive(auth.host_pid)) continue;
+        return auth;
+    }
+
+    throw new Error("Found authkey.dev file(s) but none belong to a live agentmux-cef process.");
+}
+
+// ── WS client ────────────────────────────────────────────────────────────────
+
+function openWs(wsEndpoint, authKey) {
+    const url = `ws://${wsEndpoint}/ws?authkey=${encodeURIComponent(authKey)}`;
+    const ws = new WebSocket(url);
+    const pending = new Map();
+    const eventHandlers = [];
+
+    ws.on("message", (raw) => {
+        const outer = JSON.parse(raw.toString("utf8"));
+        if (outer.eventtype !== "rpc" || !outer.data) return;
+        const rpc = outer.data;
+        if (rpc.command === "eventrecv") {
+            for (const h of eventHandlers) h(rpc);
+            return;
+        }
+        const matchId = rpc.resid || rpc.reqid;
+        if (matchId && pending.has(matchId)) {
+            const { resolve: res } = pending.get(matchId);
+            pending.delete(matchId);
+            res(rpc);
+        }
+    });
+
+    function rpc(command, data) {
+        return new Promise((res, rej) => {
+            const reqid = randomUUID();
+            pending.set(reqid, { resolve: res, reject: rej });
+            ws.send(JSON.stringify({ wscommand: "rpc", message: { command, reqid, data } }));
+        });
+    }
+
+    function rpcFire(command, data) {
+        const reqid = randomUUID();
+        ws.send(JSON.stringify({ wscommand: "rpc", message: { command, reqid, data } }));
+    }
+
+    function onEvent(handler) {
+        eventHandlers.push(handler);
+        return () => {
+            const i = eventHandlers.indexOf(handler);
+            if (i !== -1) eventHandlers.splice(i, 1);
+        };
+    }
+
+    const ready = new Promise((res, rej) => {
+        ws.on("open", res);
+        ws.on("error", rej);
+    });
+
+    return { ready, rpc, rpcFire, onEvent, close: () => ws.close() };
+}
+
+// Per-block seq counters — controllerinput's reorder buffer is keyed per
+// block, so each pane needs its own independent, monotonically-increasing
+// sequence (mirrors TermViewModel, one instance per pane).
+const seqByBlock = new Map();
+function nextSeq(blockId) {
+    const n = seqByBlock.get(blockId) ?? 0;
+    seqByBlock.set(blockId, n + 1);
+    return n;
+}
+
+function sendInputFire(client, blockId, text) {
+    const inputdata64 = Buffer.from(text, "utf8").toString("base64");
+    client.rpcFire("controllerinput", { blockid: blockId, inputdata64, seq: nextSeq(blockId) });
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function percentile(sorted, p) {
+    const idx = Math.min(Math.floor(sorted.length * p), sorted.length - 1);
+    return sorted[idx];
+}
+
+function stats(samples) {
+    const sorted = [...samples].sort((a, b) => a - b);
+    return {
+        p50: percentile(sorted, 0.5),
+        p95: percentile(sorted, 0.95),
+        p99: percentile(sorted, 0.99),
+        min: sorted[0],
+        max: sorted[sorted.length - 1],
+        mean: sorted.reduce((a, b) => a + b, 0) / sorted.length,
+        n: sorted.length,
+    };
+}
+
+// Waits for `pattern` in the blockfile output for ONE specific blockId —
+// critical for this bench, since two panes' events interleave on the same
+// WS connection and a naive "any event" wait would false-positive on A's
+// flood output.
+function waitForPatternOnBlock(client, blockId, pattern, timeoutMs = 8000) {
+    return new Promise((resolve, reject) => {
+        let buf = "";
+        let unsub;
+        const timer = setTimeout(() => {
+            unsub?.();
+            reject(new Error(`Timeout waiting for "${pattern}" on block ${blockId}`));
+        }, timeoutMs);
+        const handler = (rpc) => {
+            // rpc is the eventrecv's `data` field, i.e. the WaveEvent itself:
+            // { event, scopes, data: { data64, ... } } (see bench-term-echo.mjs's
+            // waitForPattern comment for the same shape, single-pane case).
+            if (!rpc.data?.scopes?.includes(`block:${blockId}`)) return;
+            const data64 = rpc.data?.data?.data64;
+            if (data64) {
+                buf += Buffer.from(data64, "base64").toString("utf8");
+                if (buf.includes(pattern)) {
+                    clearTimeout(timer);
+                    unsub?.();
+                    resolve(buf);
+                }
+            }
+        };
+        unsub = client.onEvent(handler);
+    });
+}
+
+async function measureEchoLatency(client, blockId, count, warmup, label) {
+    process.stdout.write(`\n=== ${label} (${count} samples, ${warmup} warmup) ===\n`);
+    const runTag = Math.floor(Math.random() * 99999).toString().padStart(5, "0");
+    const samples = [];
+
+    for (let i = 0; i < count + warmup; i++) {
+        const idx = i.toString().padStart(5, "0");
+        const sentinel = `XPANE${idx}_r${runTag}_END`;
+
+        // Send the command text and the Enter keypress as two separate
+        // controllerinput messages, with a settle gap in between (NOT
+        // included in the timed measurement). PSReadLine's own
+        // syntax-highlighting re-render needs to finish processing the typed
+        // text before Enter — sending "text\r" as one combined chunk races
+        // that re-render and the line is never submitted, hanging the wait
+        // below indefinitely. What's timed here is Enter → sentinel-in-output,
+        // i.e. exactly the round trip through the shared WS egress lane this
+        // bench exists to measure — the settle gap is identical across the
+        // baseline/cross-pane-load/recovered scenarios, so it cancels out of
+        // any before/after comparison.
+        sendInputFire(client, blockId, `echo ${sentinel}`);
+        await sleep(250);
+
+        const t0 = performance.now();
+        sendInputFire(client, blockId, "\r");
+        await waitForPatternOnBlock(client, blockId, sentinel);
+        const dt = performance.now() - t0;
+
+        if (i >= warmup) {
+            samples.push(dt);
+            process.stdout.write(`\r  Sample ${i - warmup + 1}/${count} — last: ${dt.toFixed(1)} ms   `);
+        }
+        await sleep(30);
+    }
+
+    process.stdout.write("\n");
+    const s = stats(samples);
+    process.stdout.write(
+        `  p50: ${s.p50.toFixed(1)} ms  p95: ${s.p95.toFixed(1)} ms  p99: ${s.p99.toFixed(1)} ms  max: ${s.max.toFixed(1)} ms\n`,
+    );
+    return s;
+}
+
+async function openTermPane(client) {
+    const paneResp = await client.rpc("pane.open", { view: "term" });
+    const blockId = paneResp.data?.block_id;
+    if (!blockId) throw new Error(`pane.open failed: ${JSON.stringify(paneResp)}`);
+    await client.rpc("eventsub", { event: "blockfile", scopes: [`block:${blockId}`], allscopes: false });
+    // Fixed settle instead of probing for a "$" prompt: not every configured
+    // shell uses a "$"-terminated prompt (e.g. a themed PowerShell prompt
+    // ends in a Unicode glyph, never "$"), so a prompt-pattern probe silently
+    // times out and adds pure dead time here anyway. A flat settle is honest
+    // about that and cheaper.
+    await sleep(3000);
+    return blockId;
+}
+
+async function main() {
+    const auth = findAuthFile(getArg("--ws-url"), getArg("--auth-key"));
+    console.log(`\nAgentMux cross-pane input-delay benchmark`);
+    console.log(`Instance: ${auth.instance}  WS: ws://${auth.ws_endpoint}/ws\n`);
+
+    const client = openWs(auth.ws_endpoint, auth.auth_key);
+    await client.ready;
+
+    let blockA, blockB;
+    try {
+        process.stdout.write("Opening pane A (will be flooded)...");
+        blockA = await openTermPane(client);
+        process.stdout.write(` block=${blockA}\n`);
+
+        process.stdout.write("Opening pane B (measured)...");
+        blockB = await openTermPane(client);
+        process.stdout.write(` block=${blockB}\n`);
+
+        await sleep(500);
+
+        const results = {};
+
+        results.baseline = await measureEchoLatency(
+            client,
+            blockB,
+            COUNT,
+            WARMUP,
+            "Pane B echo latency — BOTH PANES QUIET (baseline)",
+        );
+
+        process.stdout.write("\n  Flooding pane A with a continuous output loop...\n");
+        // A PowerShell-compatible unbounded output loop (this harness targets
+        // whichever shell `pane.open` spawns by default, which on Windows is
+        // PowerShell, not bash) — same role as the canonical `yes` flood, just
+        // portable to the default shell here. Text and Enter sent separately,
+        // same PSReadLine-safety reason as measureEchoLatency above.
+        sendInputFire(client, blockA, "while($true){'y'}");
+        await sleep(250);
+        sendInputFire(client, blockA, "\r");
+        await sleep(500);
+
+        results.cross_pane_load = await measureEchoLatency(
+            client,
+            blockB,
+            COUNT,
+            WARMUP,
+            "Pane B echo latency — PANE A FLOODING (cross-pane load)",
+        );
+
+        sendInputFire(client, blockA, "\x03"); // Ctrl+C stops `yes`
+        await sleep(500);
+
+        results.recovered = await measureEchoLatency(
+            client,
+            blockB,
+            COUNT,
+            WARMUP,
+            "Pane B echo latency — AFTER A's flood stops (recovery)",
+        );
+
+        process.stdout.write("\n── Summary ─────────────────────────────────────────────\n");
+        for (const [name, s] of Object.entries(results)) {
+            process.stdout.write(`  ${name.padEnd(16)} p50=${s.p50.toFixed(1)} ms  p95=${s.p95.toFixed(1)} ms  p99=${s.p99.toFixed(1)} ms\n`);
+        }
+        const regression = results.cross_pane_load.p95 / Math.max(results.baseline.p95, 1);
+        process.stdout.write(
+            `\n  Cross-pane p95 is ${regression.toFixed(1)}x the quiet baseline p95.\n` +
+                `  (A well-isolated egress path should stay close to 1x; a shared-FIFO\n` +
+                `  egress lane starved by pane A's flood will show a large multiple.)\n`,
+        );
+
+        if (OUTPUT_FILE) {
+            writeFileSync(
+                OUTPUT_FILE,
+                JSON.stringify(
+                    { instance: auth.instance, timestamp: new Date().toISOString(), count: COUNT, warmup: WARMUP, ...results, regression_factor: regression },
+                    null,
+                    2,
+                ),
+            );
+            console.log(`\nResults saved to ${resolve(OUTPUT_FILE)}`);
+        }
+    } finally {
+        if (blockA) {
+            try {
+                sendInputFire(client, blockA, "\x03");
+            } catch {
+                /* ignore */
+            }
+            try {
+                await client.rpc("object.DeleteBlock", { blockId: blockA });
+            } catch {
+                /* ignore */
+            }
+        }
+        if (blockB) {
+            try {
+                await client.rpc("object.DeleteBlock", { blockId: blockB });
+            } catch {
+                /* ignore */
+            }
+        }
+        client.close();
+    }
+}
+
+main().catch((err) => {
+    console.error("\nError:", err.message);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Typing into one pane feels delayed while a different pane is producing heavy output. Root cause: every pane on a connection shares a single FIFO WebSocket egress channel (`EventBus`'s priority lane) — a noisy pane's backlog can queue ahead of a different pane's own keystroke-echo frame indefinitely, and under sustained flood the lane can fill and silently drop the quiet pane's frame.
- Fix: when draining the priority lane, pull everything currently queued and round-robin it by pane (`fair_drain_priority` / `priority_pane_key` in `agentmux-srv/src/server/websocket.rs`) instead of forwarding in raw arrival order. Same-pane ordering is preserved; only cross-pane interleaving changes. No protocol change, no new WS message type.
- Full investigation: `docs/analysis/ANALYSIS_CROSS_PANE_INPUT_DELAY_UNDER_OUTPUT_LOAD_2026_09_04.md`.

## Validation

- TDD: 6 new unit tests written first (confirmed failing to compile before the fix existed), all green after. Existing `eventbus` tests unaffected.
- `cargo clippy` clean on the new code.
- Live-validated against a real running dev build with a new benchmark (`tools/tests/bench-term-cross-pane.mjs`): two terminal panes, pane A sustained a genuine ~54 KB/s / ~387 events/sec flood, pane B's keystroke-echo latency measured concurrently — stayed flat (p50 ≈9ms, p95 ≈11-14ms), no cross-pane regression.
- A direct unpatched-vs-patched side-by-side run was attempted for a concrete "before" number but got stuck behind build contention on a shared machine and was abandoned; the analysis doc's code-level reasoning for the prior regression (mirrors the precedent bug fixed in `0f34704a8`) stands in its place.

## Test plan

- [x] `cargo test -p agentmux-srv websocket::tests`
- [x] `cargo test -p agentmux-srv eventbus::tests` (no regression)
- [x] `cargo clippy -p agentmux-srv --bin agentmux-srv`
- [x] Live 2-pane benchmark against a real dev build under sustained flood
- [ ] Reviewer: sanity-check round-robin fairness doesn't reorder bytes within a single pane (see `fair_drain_priority`'s doc comment / ordering guarantee)

<!-- agentmux:agent_id=agent2 -->