### PR TITLE
fix(agent): revert tab strip + button to bare glyph, keep tooltip

### DIFF
--- a/.changesets/1788581353-fix-agent-revert-the-tab-strip-s-button-to-a-bare-glyph-keep-72wy.md
+++ b/.changesets/1788581353-fix-agent-revert-the-tab-strip-s-button-to-a-bare-glyph-keep-72wy.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): revert the tab strip's + button to a bare glyph, keep the tooltip

--- a/frontend/app/element/PaneTabStrip.scss
+++ b/frontend/app/element/PaneTabStrip.scss
@@ -233,6 +233,18 @@
     }
 }
 
+// Tooltip wrapper for the "+" button — same reasoning as .pane-tab-tip
+// above: the Tooltip component wraps its child in a plain unstyled <div>,
+// which would otherwise sit as the flex child instead of the button itself
+// (breaking .pane-tab-strip-add's own `flex: 0 0 auto`, below). Just the
+// flex passthrough — no min/max-width clamp needed here, unlike the
+// per-tab wrapper, since this button's content never needs truncating.
+.pane-tab-strip-add-tip {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: stretch;
+}
+
 // The far-right "+" — always the strip's last flex child (rendered after
 // the <For> in PaneTabStrip.tsx), so it stays pinned at the visual end of
 // the row regardless of tab count.

--- a/frontend/app/element/PaneTabStrip.test.tsx
+++ b/frontend/app/element/PaneTabStrip.test.tsx
@@ -6,7 +6,7 @@
  * Spec: docs/specs/SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md §3.1.
  */
 
-import { cleanup, render, screen } from "@solidjs/testing-library";
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
 import { createSignal } from "solid-js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -170,11 +170,45 @@ describe("PaneTabStrip", () => {
         // layout as of
         // docs/specs/SPEC_PANE_TAB_STRIP_CHROME_ZOOM_AND_SCROLL_CLEARANCE_2026_08_12.md
         // §A.2 — the outer box now only wraps that one inner layer.
+        // The button itself is wrapped in the Tooltip's own div
+        // (.pane-tab-strip-add-tip, instant delayMs={0} — same reasoning as
+        // the per-tab Tooltip above it), so the flex-last child is that
+        // wrapper, not addBtn directly; assert it CONTAINS addBtn instead.
         const inner = container.querySelector(".pane-tab-strip-inner");
-        expect(inner?.lastElementChild).toBe(addBtn);
+        expect(inner?.lastElementChild).toContainElement(addBtn);
         const user = userEvent.setup();
         await user.click(addBtn);
         expect(onAdd).toHaveBeenCalledTimes(1);
+    });
+
+    // Native `title` is slow/inconsistent in CEF (same reasoning as the
+    // per-tab Tooltip) — the + button's tooltip uses the Portal-based
+    // Tooltip component with delayMs={0} instead, so it shows essentially
+    // immediately rather than after the component's own 300ms default.
+    it("shows the + button's tooltip almost immediately (delayMs={0}), not after the 300ms default", () => {
+        vi.useFakeTimers();
+        try {
+            const { container } = render(() => (
+                <PaneTabStrip
+                    tabs={TABS}
+                    activeId="a"
+                    getId={(t: T) => t.id}
+                    getLabel={(t: T) => t.label}
+                    onActivate={vi.fn()}
+                    onAdd={vi.fn()}
+                    addTitle="New shell tab"
+                />
+            ));
+            const wrapper = container.querySelector(".pane-tab-strip-add-tip") as HTMLElement;
+            expect(wrapper).not.toBeNull();
+            fireEvent.mouseEnter(wrapper);
+            // Advance far less than the Tooltip default (300ms) — if this
+            // still passed the default, the tooltip wouldn't be visible yet.
+            vi.advanceTimersByTime(10);
+            expect(document.body.textContent).toContain("New shell tab");
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     // The agent pane's "+ New Agent". Opt-in per pane so the editor and

--- a/frontend/app/element/PaneTabStrip.test.tsx
+++ b/frontend/app/element/PaneTabStrip.test.tsx
@@ -185,7 +185,17 @@ describe("PaneTabStrip", () => {
     // per-tab Tooltip) — the + button's tooltip uses the Portal-based
     // Tooltip component with delayMs={0} instead, so it shows essentially
     // immediately rather than after the component's own 300ms default.
-    it("shows the + button's tooltip almost immediately (delayMs={0}), not after the 300ms default", () => {
+    //
+    // reagent P2 on PR #2975: the first cut of this test only checked that
+    // the tooltip's text existed in document.body — but tooltip.tsx mounts
+    // that div (`isOpen`) synchronously on hover regardless of `delayMs`;
+    // only its OPACITY (`isVisible`, gated behind a `setTimeout(fn,
+    // delayMs())`) actually depends on the delay. That version would have
+    // passed identically even with the 300ms default, so it verified
+    // nothing. Asserting on the floating div's own `opacity` (via its
+    // `data-pane-overlay` marker, tooltip.tsx's own hook for this exact
+    // node) is what actually distinguishes delayMs={0} from the default.
+    it("shows the + button's tooltip almost immediately (delayMs={0}) — opacity flips well under the 300ms default", () => {
         vi.useFakeTimers();
         try {
             const { container } = render(() => (
@@ -202,10 +212,20 @@ describe("PaneTabStrip", () => {
             const wrapper = container.querySelector(".pane-tab-strip-add-tip") as HTMLElement;
             expect(wrapper).not.toBeNull();
             fireEvent.mouseEnter(wrapper);
-            // Advance far less than the Tooltip default (300ms) — if this
-            // still passed the default, the tooltip wouldn't be visible yet.
+            // isOpen flips synchronously on hover (mounts the Portal'd div),
+            // but isVisible/opacity is still gated behind the delayMs-
+            // scheduled timeout — not visible yet, even at delayMs={0}
+            // (still a real setTimeout(fn, 0), not synchronous).
+            let tip = document.body.querySelector("[data-pane-overlay]") as HTMLElement;
+            expect(tip).not.toBeNull();
+            expect(tip.getAttribute("style")).toContain("opacity: 0");
+            // Advance far less than the Tooltip's own 300ms default — with
+            // delayMs={0} this is enough for the showTimeout to fire; with
+            // the default it would not be, which is exactly what this test
+            // guards against regressing to.
             vi.advanceTimersByTime(10);
-            expect(document.body.textContent).toContain("New shell tab");
+            tip = document.body.querySelector("[data-pane-overlay]") as HTMLElement;
+            expect(tip.getAttribute("style")).toContain("opacity: 1");
         } finally {
             vi.useRealTimers();
         }

--- a/frontend/app/element/PaneTabStrip.tsx
+++ b/frontend/app/element/PaneTabStrip.tsx
@@ -208,21 +208,27 @@ export function PaneTabStrip<T>(props: PaneTabStripProps<T>): JSX.Element {
                     )}
                 </For>
                 <Show when={props.onAdd}>
-                    <button
-                        type="button"
-                        class={`pane-tab-strip-add${props.addLabel ? " pane-tab-strip-add-labeled" : ""}`}
-                        title={props.addTitle ?? "New tab"}
-                        aria-label={props.addLabel ?? props.addTitle ?? "New tab"}
-                        onClick={() => props.onAdd!()}
-                    >
-                        {/* Wrapped so the glyph itself can be nudged (PaneTabStrip.scss's
-                            .pane-tab-strip-add-glyph) without moving the button's own
-                            box/hover-background/border — see that rule's comment. */}
-                        <span class="pane-tab-strip-add-glyph">+</span>
-                        <Show when={props.addLabel}>
-                            <span class="pane-tab-strip-add-label">{props.addLabel}</span>
-                        </Show>
-                    </button>
+                    {/* Tooltip (Portal-based), same reason as the per-tab one
+                        above: native `title` is slow/inconsistent in CEF.
+                        delayMs={0} — instant, matching the status bar's own
+                        tooltip feel (that one's a separate data-tip/Portal
+                        system, but the same "no perceptible delay" intent). */}
+                    <Tooltip divClassName="pane-tab-strip-add-tip" content={props.addTitle ?? "New tab"} delayMs={0}>
+                        <button
+                            type="button"
+                            class={`pane-tab-strip-add${props.addLabel ? " pane-tab-strip-add-labeled" : ""}`}
+                            aria-label={props.addLabel ?? props.addTitle ?? "New tab"}
+                            onClick={() => props.onAdd!()}
+                        >
+                            {/* Wrapped so the glyph itself can be nudged (PaneTabStrip.scss's
+                                .pane-tab-strip-add-glyph) without moving the button's own
+                                box/hover-background/border — see that rule's comment. */}
+                            <span class="pane-tab-strip-add-glyph">+</span>
+                            <Show when={props.addLabel}>
+                                <span class="pane-tab-strip-add-label">{props.addLabel}</span>
+                            </Show>
+                        </button>
+                    </Tooltip>
                 </Show>
             </div>
         </div>

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -571,7 +571,6 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
                         }
                         onAdd={() => void handleNewAgentTab()}
                         addTitle="New agent"
-                        addLabel="New Agent"
                     />
                     <Show
                         when={isHistoryTab()}


### PR DESCRIPTION
## Summary
- #2944 added a visible "New Agent" text label beside the agent pane's `+` button (`PaneTabStrip`'s opt-in `addLabel` prop). Per request, reverted the visible label back to a bare `+`.
- The hover tooltip is preserved, and now shows **instantly**: switched from native `title` (OS-controlled delay, already documented elsewhere in this file as "slow/inconsistent in CEF") to the same Portal-based `Tooltip` component the per-tab labels already use, with `delayMs={0}`.
- `PaneTabStrip`'s `addLabel` prop itself is left in place (shared, tested, opt-in, no other call site) — this reverts agent-view's usage of it, not the underlying component feature.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run frontend/app/element/PaneTabStrip.test.tsx` — 20 tests pass (1 new: confirms the tooltip shows well under the component's 300ms default; 1 updated: "pinned last" check now accounts for the Tooltip's wrapper div)
- [ ] Manual verification — not yet confirmed by a human

<!-- agentmux:agent_id=agent3 -->