### PR TITLE
Manoz@Area54: chore: release v0.55.35

### DIFF
--- a/.changesets/1788496460-fix-toolchain-persist-system-tool-install-success-across-sta-59u0.md
+++ b/.changesets/1788496460-fix-toolchain-persist-system-tool-install-success-across-sta-59u0.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(toolchain): persist system-tool install success across stale-PATH refresh, show live version and collapsible install details

--- a/.changesets/1788536076-feat-launcher-show-a-reassurance-message-in-the-splash-scree-qyah.md
+++ b/.changesets/1788536076-feat-launcher-show-a-reassurance-message-in-the-splash-scree-qyah.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(launcher): show a reassurance message in the splash screen when host startup runs long (first-run Defender scan, issue #2940)

--- a/.changesets/1788540062-fix-startup-port-the-linux-paint-gate-to-windows-so-the-wind-8qrl.md
+++ b/.changesets/1788540062-fix-startup-port-the-linux-paint-gate-to-windows-so-the-wind-8qrl.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(startup): port the Linux paint gate to Windows so the window never shows blank, and report the gap in splash telemetry

--- a/.changesets/1788554426-fix-term-round-robin-priority-lane-egress-across-panes-to-st-mlld.md
+++ b/.changesets/1788554426-fix-term-round-robin-priority-lane-egress-across-panes-to-st-mlld.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(term): round-robin priority-lane egress across panes to stop cross-pane input delay

--- a/.changesets/1788556270-fix-agent-pane-stop-showing-queued-copy-after-a-turn-ends-lo-8i5u.md
+++ b/.changesets/1788556270-fix-agent-pane-stop-showing-queued-copy-after-a-turn-ends-lo-8i5u.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): stop showing 'Queued' copy after a turn ends; log the attached-task axis for diagnosis

--- a/.changesets/1788556302-feat-agent-auto-unblock-on-external-auth-bind-one-click-bind-qsh9.md
+++ b/.changesets/1788556302-feat-agent-auto-unblock-on-external-auth-bind-one-click-bind-qsh9.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent): auto-unblock on external auth bind, one-click Bind account

--- a/.changesets/1788563253-fix-agent-show-the-hover-to-peek-time-token-panel-on-expande-0ezs.md
+++ b/.changesets/1788563253-fix-agent-show-the-hover-to-peek-time-token-panel-on-expande-0ezs.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): show the hover-to-peek time/token panel on expanded tool calls too

--- a/.changesets/1788563593-fix-agent-pane-skip-the-blank-gap-between-thinking-and-tool--lmw4.md
+++ b/.changesets/1788563593-fix-agent-pane-skip-the-blank-gap-between-thinking-and-tool--lmw4.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): skip the blank gap between Thinking… and tool output

--- a/.changesets/1788581353-fix-agent-revert-the-tab-strip-s-button-to-a-bare-glyph-keep-72wy.md
+++ b/.changesets/1788581353-fix-agent-revert-the-tab-strip-s-button-to-a-bare-glyph-keep-72wy.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): revert the tab strip's + button to a bare glyph, keep the tooltip

--- a/.changesets/1788581665-feat-swarm-larger-select-checkboxes-select-all-hide-stop-dur-wutc.md
+++ b/.changesets/1788581665-feat-swarm-larger-select-checkboxes-select-all-hide-stop-dur-wutc.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(swarm): larger select checkboxes, select-all, hide Stop during broadcast, fix groups dropdown overflow

--- a/.changesets/1788584625-docs-propose-an-optional-cross-platform-tray-persistent-back-l6u9.md
+++ b/.changesets/1788584625-docs-propose-an-optional-cross-platform-tray-persistent-back-l6u9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: propose an optional cross-platform tray + persistent background service

--- a/.changesets/1788586185-fix-swarm-re-resolve-and-re-point-subagent-watcher-config-di-uab0.md
+++ b/.changesets/1788586185-fix-swarm-re-resolve-and-re-point-subagent-watcher-config-di-uab0.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(swarm): re-resolve and re-point subagent-watcher config dir after identity rebind

--- a/.changesets/1788586424-docs-propose-a-formal-shutdown-countdown-modal-splash-style--h74s.md
+++ b/.changesets/1788586424-docs-propose-a-formal-shutdown-countdown-modal-splash-style--h74s.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-docs: propose a formal shutdown countdown modal + splash-style progress narration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.34"
+version = "0.55.35"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.34"
+version = "0.55.35"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.34"
+version = "0.55.35"
 dependencies = [
  "base64",
  "dirs",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.34"
+version = "0.55.35"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.34"
+version = "0.55.35"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.34"
+version = "0.55.35"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.34"
+version = "0.55.35"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,22 @@
 # AgentMux Version History
 
+## 0.55.35 — 2026-09-04
+
+- fix(toolchain): persist system-tool install success across stale-PATH refresh, show live version and collapsible install details
+- feat(launcher): show a reassurance message in the splash screen when host startup runs long (first-run Defender scan, issue #2940)
+- fix(startup): port the Linux paint gate to Windows so the window never shows blank, and report the gap in splash telemetry
+- fix(term): round-robin priority-lane egress across panes to stop cross-pane input delay
+- fix(agent-pane): stop showing 'Queued' copy after a turn ends; log the attached-task axis for diagnosis
+- feat(agent): auto-unblock on external auth bind, one-click Bind account
+- fix(agent): show the hover-to-peek time/token panel on expanded tool calls too
+- fix(agent-pane): skip the blank gap between Thinking… and tool output
+- fix(agent): revert the tab strip's + button to a bare glyph, keep the tooltip
+- feat(swarm): larger select checkboxes, select-all, hide Stop during broadcast, fix groups dropdown overflow
+- docs: propose an optional cross-platform tray + persistent background service
+- fix(swarm): re-resolve and re-point subagent-watcher config dir after identity rebind
+- docs: propose a formal shutdown countdown modal + splash-style progress narration
+
+
 ## 0.55.34 — 2026-09-03
 
 - fix(agent-pane): tool-preview code previews waste half their width on indentation

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -16,7 +16,6 @@
 - fix(swarm): re-resolve and re-point subagent-watcher config dir after identity rebind
 - docs: propose a formal shutdown countdown modal + splash-style progress narration
 
-
 ## 0.55.34 — 2026-09-03
 
 - fix(agent-pane): tool-preview code previews waste half their width on indentation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.34",
+  "version": "0.55.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.34",
+      "version": "0.55.35",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.34",
+  "version": "0.55.35",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -165,7 +165,10 @@ TODAY="$(date +%Y-%m-%d)"
     for d in "${DESCRIPTIONS[@]}"; do
         echo "- $d"
     done
-    echo
+    # No extra `echo` here: `tail -n +2` below already reproduces the blank
+    # line that separated the old heading from its first entry — an extra
+    # one here doubles it before every subsequent "## " heading (reagent
+    # P2 on PR #2982).
     tail -n +2 "$HISTORY"
 } >"$TMP"
 mv "$TMP" "$HISTORY"


### PR DESCRIPTION
## Summary

Release v0.55.35, forced patch bump (`--as patch`) consuming all 13 pending changesets — the computed bump was `minor` (two docs-only spec proposals + a couple of `feat` changesets); forcing `patch` ships them all under this patch release per explicit request.

## Changes

- fix(toolchain): persist system-tool install success across stale-PATH refresh, show live version and collapsible install details
- feat(launcher): show a reassurance message in the splash screen when host startup runs long (first-run Defender scan, issue #2940)
- fix(startup): port the Linux paint gate to Windows so the window never shows blank, and report the gap in splash telemetry
- fix(term): round-robin priority-lane egress across panes to stop cross-pane input delay
- fix(agent-pane): stop showing 'Queued' copy after a turn ends; log the attached-task axis for diagnosis
- feat(agent): auto-unblock on external auth bind, one-click Bind account
- fix(agent): show the hover-to-peek time/token panel on expanded tool calls too
- fix(agent-pane): skip the blank gap between Thinking… and tool output
- fix(agent): revert the tab strip's + button to a bare glyph, keep the tooltip
- feat(swarm): larger select checkboxes, select-all, hide Stop during broadcast, fix groups dropdown overflow
- docs: propose an optional cross-platform tray + persistent background service
- fix(swarm): re-resolve and re-point subagent-watcher config dir after identity rebind
- docs: propose a formal shutdown countdown modal + splash-style progress narration

## Verification

- `task release -- --as patch` — all 5 version-consistency locations agree at 0.55.35 (package.json, Cargo.toml, Cargo.lock, package-lock.json, VERSION_HISTORY.md)
- 13 changesets consumed and deleted

<!-- agentmux:agent_id=manoz -->