### PR TITLE
fix(host): gate last-window quit behind background-service mode

### DIFF
--- a/.changesets/1788592044-fix-host-gate-last-window-quit-behind-background-service-mod-e3iy.md
+++ b/.changesets/1788592044-fix-host-gate-last-window-quit-behind-background-service-mod-e3iy.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(host): gate last-window quit behind background-service mode (tray Workstream 0 prereq #1)

--- a/agentmux-cef/src/client/lifecycle.rs
+++ b/agentmux-cef/src/client/lifecycle.rs
@@ -51,6 +51,21 @@ pub(crate) fn retry_backend_window_id_lookup(
     None
 }
 
+/// Pure decision: does THIS `on_before_close` call fire Stage 2's
+/// `quit_message_loop()`? Workstream 0 Phase 1
+/// (`SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md` §7) closed a gap
+/// where `browser_list.is_empty() && !is_browser_pane` alone was an
+/// independent quit authority — the same class of bug already fixed for
+/// Windows' WRR path (`should_quit_on_last_window` requires `draining`).
+/// `draining` here means `QuitState::Draining`, which `begin_drain_and_cascade`
+/// always sets (via the reducer's `should_begin_drain`) before this runs on
+/// the call that empties `browser_list` — so requiring it is a no-op for the
+/// normal (background-service off) path, and only withholds the forced quit
+/// when Stage 1 never ran because background-service mode declined to drain.
+pub(crate) fn is_last_window_close(browser_list_empty: bool, is_browser_pane: bool, draining: bool) -> bool {
+    browser_list_empty && !is_browser_pane && draining
+}
+
 impl AgentMuxHandler {
     pub(crate) fn on_after_created(&mut self, browser: Option<&mut Browser>) {
         debug_assert_ne!(currently_on(ThreadId::UI), 0);
@@ -1328,7 +1343,22 @@ impl AgentMuxHandler {
         // this is the last window, quit_message_loop is deferred until that
         // notify work finishes, posted back to the UI thread (it must run
         // there — see the comment above about deadlocking on a nested call).
-        let is_last_window = self.browser_list.is_empty() && !self.is_browser_pane;
+        // Workstream 0 Phase 1 (`SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md`
+        // §7): `browser_list.is_empty()` alone used to be sufficient to fire
+        // Stage 2's `quit_message_loop()` — but that makes THIS check an
+        // independent quit authority, the same architectural gap already
+        // closed for Windows' WRR path (`should_quit_on_last_window` requires
+        // `draining`). Require it here too: `begin_drain_and_cascade` (just
+        // above, when `request_drain.is_some()`) always flips `QuitState` to
+        // `Draining` before this line runs on the SAME call that empties the
+        // list, so this is a no-op change for the normal (background-service
+        // off) path — it only prevents the forced quit when Stage 1 never ran
+        // because `should_begin_drain` declined (background-service mode).
+        let draining = matches!(
+            self.state.host_state.lock().quit_state,
+            crate::state::QuitState::Draining { .. }
+        );
+        let is_last_window = is_last_window_close(self.browser_list.is_empty(), self.is_browser_pane, draining);
 
         // Phase B.7.3.3 — `Event::WindowClosed` +
         // `Event::WindowInstanceReleased` from the launcher
@@ -1541,5 +1571,35 @@ mod backend_window_id_retry_tests {
         }, no_sleep);
         assert_eq!(result, Some("wid-fast".to_string()));
         assert_eq!(*calls.borrow(), 1);
+    }
+}
+
+#[cfg(test)]
+mod is_last_window_close_tests {
+    use super::is_last_window_close;
+
+    #[test]
+    fn fires_when_empty_main_handler_and_draining() {
+        assert!(is_last_window_close(true, false, true));
+    }
+
+    #[test]
+    fn does_not_fire_for_a_browser_pane_handler() {
+        assert!(!is_last_window_close(true, true, true));
+    }
+
+    #[test]
+    fn does_not_fire_while_browsers_remain() {
+        assert!(!is_last_window_close(false, false, true));
+    }
+
+    /// Workstream 0 Phase 1: the gap this predicate closes — an empty
+    /// browser_list on the main handler must NOT alone trigger
+    /// `quit_message_loop()`. Reached when `should_begin_drain` declined to
+    /// drain (background-service mode enabled, or any other reason
+    /// `QuitState` never left `Running`).
+    #[test]
+    fn does_not_fire_without_a_drain_decision_even_if_list_is_empty() {
+        assert!(!is_last_window_close(true, false, false));
     }
 }

--- a/agentmux-cef/src/client/lifecycle.rs
+++ b/agentmux-cef/src/client/lifecycle.rs
@@ -99,8 +99,7 @@ impl AgentMuxHandler {
         }
 
         // Phase 1 diagnostic tracing — find the exact line that silences the
-        // UI thread under concurrent window creation. See
-        // docs/specs/SPEC_HOST_WINDOW_CREATION_RUNNER_2026-05-02.md.
+        // UI thread under concurrent window creation.
         let t0 = std::time::Instant::now();
 
         // Phase B.5 (window_meta step d) — pop the pre-create

--- a/agentmux-cef/src/launcher_ipc/mod.rs
+++ b/agentmux-cef/src/launcher_ipc/mod.rs
@@ -191,6 +191,9 @@ pub async fn connect_to_launcher(
     // signal is needed). Phase 1 is observe-only: the reader task logs what
     // this would drive but doesn't recreate anything yet.
     request_snapshot();
+    // Workstream 0 Phase 1 — tell the launcher whether background-service
+    // mode is on, once per connect (see `report_background_service_enabled`).
+    report_background_service_enabled(state.host_state.lock().background_service_enabled);
     let writer_for_drain = Arc::clone(&writer);
     tokio::spawn(async move {
         while let Some(cmd) = rx.recv().await {
@@ -428,6 +431,8 @@ pub async fn connect_to_launcher(
     // SPEC_PILLAR1_STEP4 Phase 1 — see the Windows variant's identical call
     // for the rationale.
     request_snapshot();
+    // Workstream 0 Phase 1 — see the Windows variant's identical call.
+    report_background_service_enabled(state.host_state.lock().background_service_enabled);
     let writer_for_drain = Arc::clone(&writer);
     tokio::spawn(async move {
         while let Some(cmd) = rx.recv().await {

--- a/agentmux-cef/src/launcher_ipc/reporters.rs
+++ b/agentmux-cef/src/launcher_ipc/reporters.rs
@@ -18,6 +18,28 @@
 
 use agentmux_common::ipc::Command;
 
+/// Workstream 0 Phase 1 (`SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md`
+/// §7) — tell the launcher whether background-service mode
+/// (`AGENTMUX_BACKGROUND_SERVICE`) is enabled for this host process. Called
+/// once, right after connecting (see `connect_to_launcher`'s
+/// `request_snapshot()` call for the sibling once-per-connect signal). The
+/// launcher's last-window orphan-drift detection and the teardown backstop
+/// it arms must know this to avoid treating an intentionally-resting host
+/// as a stuck/orphaned one — see PR #2983 review (Codex P2). Same
+/// no-op-if-disconnected semantics as every other `report_*` helper.
+pub fn report_background_service_enabled(enabled: bool) {
+    let Some(tx) = super::COMMAND_TX.get() else {
+        return;
+    };
+    let cmd = Command::ReportBackgroundServiceEnabled { enabled };
+    if let Err(e) = tx.send(cmd) {
+        tracing::warn!(
+            "[launcher-ipc] report_background_service_enabled: channel closed ({})",
+            e
+        );
+    }
+}
+
 /// Phase B.4 — sync API: report a window open to the launcher's
 /// state mirror. Called from CEF lifecycle callbacks on the UI
 /// thread. No-op if the launcher pipe isn't connected (`task dev`

--- a/agentmux-cef/src/reducer/mod.rs
+++ b/agentmux-cef/src/reducer/mod.rs
@@ -124,6 +124,20 @@ pub struct HostState {
     /// which is safe: once registered, the live count itself blocks drain).
     pub saw_live_user_window: bool,
 
+    /// Background-service mode (Workstream 0, `SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md`
+    /// §7 Phase 1). When true, `should_begin_drain` never arms a
+    /// `LastWindowClosed` drain — closing the last window hides the app
+    /// instead of tearing down `host`/`srv`/`launcher`. Read once at
+    /// process start from `AGENTMUX_BACKGROUND_SERVICE` (presence-based,
+    /// matching the `AGENTMUX_DEV` idiom elsewhere in this crate); there is
+    /// no live-toggle path yet. Defaults off, so today's close-quits-the-app
+    /// behavior is unchanged for anyone who hasn't opted in. `wrr::win_event`'s
+    /// quit watchdog (Windows) also reads this field (from the same locked
+    /// `HostState`, alongside `registered`/`draining`) so it does not treat
+    /// the resulting "0 registered, not draining" steady state as a desync
+    /// and force-quit a few seconds after the last window closes.
+    pub background_service_enabled: bool,
+
     /// H.6 — top-level window creation runner state (queue, in-flight,
     /// history). Event-driven; no watchdog. **Currently DORMANT** — the
     /// reducer arms (`EnqueueTopLevelWindow`, `TopLevelCallbackFired`,
@@ -187,6 +201,7 @@ impl Default for HostState {
             pane_pool: PanePoolState::default(),
             quit_state: QuitState::default(),
             saw_live_user_window: false,
+            background_service_enabled: std::env::var("AGENTMUX_BACKGROUND_SERVICE").is_ok(),
             top_level_creation: TopLevelCreationState::default(),
             window_opacities: HashMap::new(),
             pane_window_states: HashMap::new(),

--- a/agentmux-cef/src/reducer/quit.rs
+++ b/agentmux-cef/src/reducer/quit.rs
@@ -159,19 +159,29 @@ pub(super) fn user_creation_in_flight(state: &HostState) -> bool {
 /// Pure decision: should the host begin draining NOW? `Some(reason)` iff the host
 /// is armed (a live user window has registered at least once this process —
 /// `HostState::saw_live_user_window`, §1.E of the sanitize-then-decide spec),
-/// `Running`, no live user-visible window remains, and no user-initiated
-/// creation is in flight. Unarmed covers the startup gap: main's creation path
-/// enqueues no `PendingWindowCreation`, so before its `RegisterBrowser` lands
-/// both other inputs read "drainable" — without the arming gate, any
-/// quit-relevant dispatch in that window would surface a spurious drain
-/// request. Safe to call after every transition — once `Draining`/`Quit` it
-/// returns `None` (the transition is monotonic — see `handle_begin_drain`).
-/// CEF-free so the full truth table is unit-testable.
+/// `Running`, no live user-visible window remains, no user-initiated
+/// creation is in flight, and background-service mode is not enabled. Unarmed
+/// covers the startup gap: main's creation path enqueues no
+/// `PendingWindowCreation`, so before its `RegisterBrowser` lands both other
+/// inputs read "drainable" — without the arming gate, any quit-relevant
+/// dispatch in that window would surface a spurious drain request. Safe to
+/// call after every transition — once `Draining`/`Quit` it returns `None`
+/// (the transition is monotonic — see `handle_begin_drain`). CEF-free so the
+/// full truth table is unit-testable.
+///
+/// `background_service_enabled` (Workstream 0 Phase 1,
+/// `SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md` §7) gates only the
+/// `LastWindowClosed` reason produced here — `QuitReason::LauncherRequested`
+/// and `QuitReason::External` are dispatched directly to `handle_begin_drain`
+/// (see `ui_tasks::window::begin_drain_and_cascade`'s callers), never through
+/// this function, so a genuine launcher-requested or external quit always
+/// works regardless of this flag.
 pub(super) fn should_begin_drain(
     armed: bool,
     live_user_windows: usize,
     user_creation_in_flight: bool,
     quit_state: &QuitState,
+    background_service_enabled: bool,
 ) -> Option<QuitReason> {
     if !armed {
         return None;
@@ -180,6 +190,9 @@ pub(super) fn should_begin_drain(
         return None;
     }
     if live_user_windows > 0 || user_creation_in_flight {
+        return None;
+    }
+    if background_service_enabled {
         return None;
     }
     Some(QuitReason::LastWindowClosed)
@@ -193,6 +206,7 @@ pub(super) fn reconcile_quit(state: &HostState) -> Option<QuitReason> {
         count_live_user_windows(state),
         user_creation_in_flight(state),
         &state.quit_state,
+        state.background_service_enabled,
     )
 }
 

--- a/agentmux-cef/src/reducer/tests.rs
+++ b/agentmux-cef/src/reducer/tests.rs
@@ -1127,32 +1127,48 @@ fn is_live_user_window_classifies_by_is_pool_not_label() {
 fn should_begin_drain_truth_table() {
     // Armed + Running + zero user windows + no creation in flight → begin draining.
     assert_eq!(
-        should_begin_drain(true, 0, false, &QuitState::Running),
+        should_begin_drain(true, 0, false, &QuitState::Running, false),
         Some(QuitReason::LastWindowClosed)
     );
     // A live user window blocks drain.
-    assert_eq!(should_begin_drain(true, 1, false, &QuitState::Running), None);
+    assert_eq!(should_begin_drain(true, 1, false, &QuitState::Running, false), None);
     // §10.2 corner: a user creation in flight blocks drain even at zero
     // registered windows — never quit while the user's "New Window" is loading.
-    assert_eq!(should_begin_drain(true, 0, true, &QuitState::Running), None);
+    assert_eq!(should_begin_drain(true, 0, true, &QuitState::Running, false), None);
     // Already draining / quit → never re-drains (monotonic with handle_begin_drain).
     assert_eq!(
         should_begin_drain(
             true,
             0,
             false,
-            &QuitState::Draining { reason: QuitReason::LastWindowClosed }
+            &QuitState::Draining { reason: QuitReason::LastWindowClosed },
+            false,
         ),
         None
     );
-    assert_eq!(should_begin_drain(true, 0, false, &QuitState::Quit), None);
+    assert_eq!(should_begin_drain(true, 0, false, &QuitState::Quit, false), None);
     // UNARMED (sanitize-then-decide §1.E): the startup gap — no live user
     // window has ever registered — must never drain, even though every other
     // input reads "drainable" (main's creation path enqueues no pending entry,
     // so this exact input combination is live between process start and main's
     // RegisterBrowser).
-    assert_eq!(should_begin_drain(false, 0, false, &QuitState::Running), None);
-    assert_eq!(should_begin_drain(false, 0, true, &QuitState::Running), None);
+    assert_eq!(should_begin_drain(false, 0, false, &QuitState::Running, false), None);
+    assert_eq!(should_begin_drain(false, 0, true, &QuitState::Running, false), None);
+}
+
+/// Workstream 0 Phase 1 (`SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md`
+/// §7): background-service mode suppresses ONLY the `LastWindowClosed`
+/// verdict — every other input in the truth table above is unaffected by it.
+#[test]
+fn should_begin_drain_background_service_suppresses_last_window_closed_only() {
+    // The one case that would otherwise drain now doesn't.
+    assert_eq!(should_begin_drain(true, 0, false, &QuitState::Running, true), None);
+    // Still correctly refuses to drain for every other reason, whether or
+    // not background-service mode is on — same answer either way.
+    assert_eq!(should_begin_drain(true, 1, false, &QuitState::Running, true), None);
+    assert_eq!(should_begin_drain(true, 0, true, &QuitState::Running, true), None);
+    assert_eq!(should_begin_drain(false, 0, false, &QuitState::Running, true), None);
+    assert_eq!(should_begin_drain(true, 0, false, &QuitState::Quit, true), None);
 }
 
 /// Only USER-initiated creations block drain; pool/pane background creations don't.
@@ -1235,6 +1251,22 @@ fn reconcile_quit_drains_despite_pending_pool_refill() {
         HostCommand::EnqueuePendingWindowCreation { entry: entry("window-pool-refill-1") },
     );
     assert_eq!(reconcile_quit(&state), Some(QuitReason::LastWindowClosed));
+}
+
+/// Workstream 0 Phase 1: with background-service mode on, closing the last
+/// window (armed, zero live windows, nothing pending) must NOT drain —
+/// `host` stays alive with zero windows instead of tearing itself (and, via
+/// the launcher's teardown-on-clean-exit, `srv`) down.
+#[test]
+fn reconcile_quit_never_drains_when_background_service_enabled() {
+    let mut state = HostState::default();
+    state.saw_live_user_window = true;
+    state.background_service_enabled = true;
+    assert_eq!(
+        reconcile_quit(&state),
+        None,
+        "background-service mode must suppress the last-window drain"
+    );
 }
 
 /// Idempotent: once draining, reconcile is a no-op (no double-drain).

--- a/agentmux-cef/src/wrr/win_event.rs
+++ b/agentmux-cef/src/wrr/win_event.rs
@@ -385,13 +385,39 @@ fn should_quit_on_last_window(armed: bool, draining: bool, visible: usize, regis
     armed && draining && visible == 0 && registered == 0
 }
 
+/// Workstream 0 Phase 1 (`SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md`
+/// §7): true iff `registered == 0 && !draining` is the INTENTIONAL
+/// background-service resting state, not a desync. With background-service
+/// mode on, `should_begin_drain` (reducer/quit.rs) permanently declines to
+/// arm a `LastWindowClosed` drain, so `host` can sit at zero registered
+/// windows with `QuitState::Running` (`!draining`) indefinitely — the
+/// designed steady state once the user closes their last window, not a
+/// missed `request_drain` consumption site. `registered > 0` is excluded
+/// deliberately: a live window nobody asked to close is still a real desync
+/// regardless of this mode.
+fn is_background_service_resting(background_service_enabled: bool, draining: bool, registered: usize) -> bool {
+    background_service_enabled && registered == 0 && !draining
+}
+
 /// Companion pure decision: the OS says every window is gone but the reducer
 /// hasn't finished agreeing — either its count still shows a live window (an
 /// UnregisterBrowser dispatch in flight, or a close path that never
 /// dispatched), or (Phase 3) the count reads zero but no drain decision was
 /// ever consumed (`!draining` — a missed Phase-2 consumption site). Both
 /// flavors are the failure mode Step D's watchdog exists to bound.
-fn is_reducer_lagging_os(armed: bool, draining: bool, visible: usize, registered: usize) -> bool {
+/// Excludes the background-service resting state (see
+/// `is_background_service_resting`) from the `!draining` flavor — that state
+/// is intentional, not lagging.
+fn is_reducer_lagging_os(
+    armed: bool,
+    draining: bool,
+    visible: usize,
+    registered: usize,
+    background_service_enabled: bool,
+) -> bool {
+    if is_background_service_resting(background_service_enabled, draining, registered) {
+        return false;
+    }
     armed && visible == 0 && (registered > 0 || !draining)
 }
 
@@ -462,11 +488,12 @@ cef::wrap_task! {
             if QUIT_INITIATED.load(SeqCst) {
                 return;
             }
-            let (registered, draining) = {
+            let (registered, draining, background_service_enabled) = {
                 let st = self.state.host_state.lock();
                 (
                     crate::reducer::count_live_user_windows(&st),
                     st.quit_state != crate::state::QuitState::Running,
+                    st.background_service_enabled,
                 )
             };
             let visible = unsafe { count_visible_user_windows() };
@@ -496,6 +523,21 @@ cef::wrap_task! {
                     target: "wrr",
                     "[wrr] quit watchdog: {} window(s) visible again — stand down",
                     visible
+                );
+                return;
+            }
+            // Workstream 0 Phase 1: 0 visible + 0 registered + not draining is
+            // the intentional background-service resting state (see
+            // `is_background_service_resting`), not a missed `request_drain`
+            // consumption site — stand down instead of falling through to the
+            // forced `quit_message_loop()` below, which would otherwise defeat
+            // the whole point of the mode a few seconds after every last-window
+            // close.
+            if is_background_service_resting(background_service_enabled, draining, registered) {
+                WATCHDOG_LAG_RETRY_COUNT.store(0, SeqCst);
+                tracing::info!(
+                    target: "wrr",
+                    "[wrr] quit watchdog: 0 visible, 0 registered, background-service mode — standing down (resting, not quitting)",
                 );
                 return;
             }
@@ -580,7 +622,7 @@ unsafe fn maybe_quit_on_last_user_window() {
     // `HAD_VISIBLE_USER_WINDOW` is set only on EVENT_OBJECT_SHOW, so it stays
     // false until the page actually loads and the host calls ShowWindow — the
     // correct moment to arm the last-window quit.
-    let (registered, draining) = app_state()
+    let (registered, draining, background_service_enabled) = app_state()
         .get()
         .map(|s| {
             // One lock scope so the count and the drain decision are read
@@ -591,9 +633,9 @@ unsafe fn maybe_quit_on_last_user_window() {
             // (Draining or Quit — both mean a reconcile_quit verdict was
             // consumed at a Phase-2 dispatch site).
             let draining = st.quit_state != crate::state::QuitState::Running;
-            (registered, draining)
+            (registered, draining, st.background_service_enabled)
         })
-        .unwrap_or((0, false));
+        .unwrap_or((0, false, false));
     let armed = HAD_VISIBLE_USER_WINDOW.load(SeqCst);
     if !armed {
         return;
@@ -605,7 +647,7 @@ unsafe fn maybe_quit_on_last_user_window() {
         registered, visible, draining
     );
     if !should_quit_on_last_window(armed, draining, visible, registered) {
-        if is_reducer_lagging_os(armed, draining, visible, registered) {
+        if is_reducer_lagging_os(armed, draining, visible, registered, background_service_enabled) {
             arm_quit_watchdog(registered);
         }
         return;
@@ -667,18 +709,40 @@ mod should_quit_tests {
         use super::is_reducer_lagging_os;
         // Flavor 1 (Step D's original target): OS says gone, reducer count
         // disagrees.
-        assert!(is_reducer_lagging_os(true, true, 0, 1));
-        assert!(is_reducer_lagging_os(true, false, 0, 1));
+        assert!(is_reducer_lagging_os(true, true, 0, 1, false));
+        assert!(is_reducer_lagging_os(true, false, 0, 1, false));
         // Flavor 2 (Phase 3): counts agree at zero but no drain decision was
         // consumed — a missed consumption site; bounded by the same watchdog.
-        assert!(is_reducer_lagging_os(true, false, 0, 0));
+        assert!(is_reducer_lagging_os(true, false, 0, 0, false));
         // Clean quit state (should_quit handles it instead)…
-        assert!(!is_reducer_lagging_os(true, true, 0, 0));
+        assert!(!is_reducer_lagging_os(true, true, 0, 0, false));
         // …windows still visible…
-        assert!(!is_reducer_lagging_os(true, true, 3, 1));
-        assert!(!is_reducer_lagging_os(true, false, 3, 1));
+        assert!(!is_reducer_lagging_os(true, true, 3, 1, false));
+        assert!(!is_reducer_lagging_os(true, false, 3, 1, false));
         // …or before any user window was ever shown (startup).
-        assert!(!is_reducer_lagging_os(false, false, 0, 1));
+        assert!(!is_reducer_lagging_os(false, false, 0, 1, false));
+    }
+
+    #[test]
+    fn watchdog_does_not_arm_for_background_service_resting_state() {
+        use super::is_reducer_lagging_os;
+        // Workstream 0 Phase 1: the exact "Flavor 2" combination above
+        // (0 registered, not draining) is the intentional background-service
+        // resting state when the mode is on — must not arm the watchdog.
+        assert!(!is_reducer_lagging_os(true, false, 0, 0, true));
+        // A genuinely live, un-asked-to-close window still lags regardless of
+        // background-service mode — that flavor is never excused.
+        assert!(is_reducer_lagging_os(true, false, 0, 1, true));
+        assert!(is_reducer_lagging_os(true, true, 0, 1, true));
+    }
+
+    #[test]
+    fn is_background_service_resting_requires_all_three_conditions() {
+        use super::is_background_service_resting;
+        assert!(is_background_service_resting(true, false, 0));
+        assert!(!is_background_service_resting(false, false, 0), "mode must be on");
+        assert!(!is_background_service_resting(true, true, 0), "not while draining");
+        assert!(!is_background_service_resting(true, false, 1), "not with a live window");
     }
 
     #[test]

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -108,6 +108,18 @@ pub enum Command {
     ReportWindowClosed {
         label: String,
     },
+    /// Workstream 0 Phase 1 (`SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md`
+    /// §7) — host reports whether background-service mode
+    /// (`AGENTMUX_BACKGROUND_SERVICE`) is enabled for this process. Sent
+    /// once, right after connecting (mirrors `GetSnapshot`'s
+    /// once-per-connect timing). The launcher's own last-window
+    /// orphan-drift detection and the teardown backstop it arms must not
+    /// treat an intentionally-resting host (zero windows, by design, for
+    /// however long the user leaves it) as a stuck/orphaned one — see
+    /// PR #2983 review (Codex P2). Host-only.
+    ReportBackgroundServiceEnabled {
+        enabled: bool,
+    },
     /// Phase B.4 follow-up — host reports a pre-warmed pool window
     /// being added (`spawn_pool_window`). Pool windows live in a
     /// SEPARATE map from the user-visible window mirror; the host

--- a/agentmux-launcher/proptest-regressions/reducer/tests.txt
+++ b/agentmux-launcher/proptest-regressions/reducer/tests.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 51790fa62dafd97f25654e757cbb0d7d0e73b41b70d5ae40c7613b55bb414f08 # shrinks to cmds = [ReportWindowOpened { label: "a", kind: FullInstance, parent_label: None }, ReportWindowClosed { label: "a" }]

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -845,6 +845,9 @@ async fn enforce_register_first(
         Command::ReportWindowOpened { .. } => {
             ("ReportWindowOpened before Register".to_string(), true)
         }
+        Command::ReportBackgroundServiceEnabled { .. } => {
+            ("ReportBackgroundServiceEnabled before Register".to_string(), true)
+        }
         Command::ReportWindowClosed { .. } => {
             ("ReportWindowClosed before Register".to_string(), true)
         }

--- a/agentmux-launcher/src/reducer/mod.rs
+++ b/agentmux-launcher/src/reducer/mod.rs
@@ -122,6 +122,14 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             }
             window::handle_report_window_closed(state, label)
         }
+        Command::ReportBackgroundServiceEnabled { enabled } => {
+            if let Some(err) =
+                connection::enforce_host_only(state, ctx, "ReportBackgroundServiceEnabled")
+            {
+                return vec![err];
+            }
+            window::handle_report_background_service_enabled(state, enabled)
+        }
         Command::ReportPoolWindowAdded { label, saga_id } => {
             if let Some(err) = connection::enforce_host_only(state, ctx, "ReportPoolWindowAdded") {
                 return vec![err];

--- a/agentmux-launcher/src/reducer/tests.rs
+++ b/agentmux-launcher/src/reducer/tests.rs
@@ -2817,6 +2817,58 @@ fn wrr_orphan_destroy_runs_even_with_stale_pending_entry() {
     );
 }
 
+/// Workstream 0 Phase 1 (PR #2983 review, Codex P2) — the crash-detected
+/// twin of `host_should_quit_suppressed_when_background_service_enabled`:
+/// a renderer crash that destroys the last window's HWND must also skip
+/// `OrphanInstance`/`HostShouldQuit` once the host has reported
+/// background-service mode enabled, exactly like a clean close does.
+#[test]
+fn wrr_orphan_instance_suppressed_when_background_service_enabled() {
+    let (mut state, c) = registered_host_state();
+    let _ = update(
+        &mut state,
+        Command::ReportBackgroundServiceEnabled { enabled: true },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportWindowOpened {
+            label: "w1".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportHwndOpened {
+            hwnd: 0xAA,
+            class_name: "Chrome_WidgetWin_1".into(),
+            title: "".into(),
+            label_hint: Some("w1".into()),
+        },
+        &c,
+    );
+    let evs = update(&mut state, Command::ReportHwndDestroyed { hwnd: 0xAA }, &c);
+    assert!(
+        evs.iter()
+            .any(|e| matches!(e, Event::HwndDriftDetected { kind: HwndDriftKind::OrphanDestroy, .. })),
+        "OrphanDestroy must still fire — that's a genuine renderer crash, unrelated to this mode, got {:?}",
+        evs
+    );
+    assert!(
+        !evs.iter()
+            .any(|e| matches!(e, Event::HwndDriftDetected { kind: HwndDriftKind::OrphanInstance, .. })),
+        "OrphanInstance must NOT fire when background-service mode is enabled, got {:?}",
+        evs
+    );
+    assert!(
+        !evs.iter().any(|e| matches!(e, Event::HostShouldQuit { .. })),
+        "HostShouldQuit must NOT fire when background-service mode is enabled, got {:?}",
+        evs
+    );
+}
+
 #[test]
 fn wrr_burst_creates_with_drain_then_repair() {
     // PR #664 codex P1 round 2 — drain-on-open RESTORED as fallback
@@ -3546,6 +3598,35 @@ proptest! {
                     "HostShouldQuit emitted but no Host in Running state"
                 );
             }
+        }
+    }
+
+    /// Workstream 0 Phase 1 (`SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md`
+    /// §7, PR #2983 review Codex P2): once the host reports
+    /// background-service mode enabled, closing the last window must NOT
+    /// emit `HwndDriftDetected{OrphanInstance}` or `HostShouldQuit` — that
+    /// combination is what arms `teardown_backstop.rs`'s process-tree-kill
+    /// machinery, which must not fire for an intentionally-resting host.
+    #[test]
+    fn host_should_quit_suppressed_when_background_service_enabled(
+        cmds in proptest::collection::vec(arb_b8_host_command(), 1..80)
+    ) {
+        let (mut state, host_ctx) = registered_host_state();
+        let _ = update(
+            &mut state,
+            Command::ReportBackgroundServiceEnabled { enabled: true },
+            &host_ctx,
+        );
+        for cmd in cmds {
+            let evs = update(&mut state, cmd, &host_ctx);
+            prop_assert!(
+                !evs.iter().any(|e| matches!(
+                    e,
+                    Event::HostShouldQuit { .. }
+                        | Event::HwndDriftDetected { kind: HwndDriftKind::OrphanInstance, .. }
+                )),
+                "background-service mode must suppress OrphanInstance/HostShouldQuit, got {:?}", evs
+            );
         }
     }
 

--- a/agentmux-launcher/src/reducer/window.rs
+++ b/agentmux-launcher/src/reducer/window.rs
@@ -247,7 +247,18 @@ pub(super) fn handle_report_window_closed(state: &mut State, label: String) -> V
     // saga-style HostShouldQuit so the host can reap pool and
     // quit cleanly. See B.9.3 in
     // docs/retro/next-steps-2026-04-29.md.
-    if state.windows.is_empty() && super::connection::host_is_running(state) {
+    //
+    // Workstream 0 Phase 1 — skip entirely when the host reported
+    // background-service mode: zero windows is that mode's intentional,
+    // possibly long-lived resting state, not an orphan. Emitting the drift
+    // event anyway would arm `teardown_backstop` for the whole resting
+    // period instead of the few seconds it's designed for, turning any
+    // later transient UI-thread probe miss into a fatal process-tree kill
+    // (PR #2983 review, Codex P2).
+    if state.windows.is_empty()
+        && !state.background_service_enabled
+        && super::connection::host_is_running(state)
+    {
         let v_drift = state.bump_version();
         out.push(Event::HwndDriftDetected {
             kind: HwndDriftKind::OrphanInstance,
@@ -262,4 +273,14 @@ pub(super) fn handle_report_window_closed(state: &mut State, label: String) -> V
         out.push(Event::HostShouldQuit { version: v_quit });
     }
     out
+}
+
+/// Workstream 0 Phase 1 — record the host's background-service opt-in.
+/// Sent once, right after connect (see `launcher_ipc::report_background_service_enabled`
+/// on the host side). Pure state update; no event needed — this is
+/// process-supervision state the launcher consults, not domain state any
+/// subscriber needs to observe.
+pub(super) fn handle_report_background_service_enabled(state: &mut State, enabled: bool) -> Vec<Event> {
+    state.background_service_enabled = enabled;
+    Vec::new()
 }

--- a/agentmux-launcher/src/state.rs
+++ b/agentmux-launcher/src/state.rs
@@ -251,6 +251,20 @@ pub struct State {
     /// `ReportWindowClosed` if open never arrived (bounded leak).
     /// See `docs/specs/ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md`.
     pub just_promoted_labels: HashSet<String>,
+    /// Workstream 0 Phase 1 (`SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md`
+    /// §7) — mirrors the host's `AGENTMUX_BACKGROUND_SERVICE` opt-in, set
+    /// once via `Command::ReportBackgroundServiceEnabled` right after
+    /// connect. Defaults false (today's behavior unchanged) until the host
+    /// reports otherwise. Consulted by `handle_report_window_closed` and
+    /// `wrr`'s crash-detected twin so an intentionally-resting host (zero
+    /// windows, by design) doesn't get classified as `OrphanInstance` and
+    /// arm the `teardown_backstop` — see PR #2983 review (Codex P2): without
+    /// this, a host correctly staying alive on purpose would still get its
+    /// whole process tree killed by the backstop after a transient UI-thread
+    /// probe hiccup, since "armed" would otherwise last for the entire
+    /// (now potentially long) resting period instead of the few seconds it
+    /// used to.
+    pub background_service_enabled: bool,
     // F.7 cleanup audit: removed unused `launcher_start_ms: Option<u64>`
     // field. It was set in Default but no reducer arm or consumer
     // ever read it — the WRR observability path uses the OnceLock-
@@ -292,6 +306,7 @@ impl Default for State {
             monitors: Vec::new(),
             pending_hwnds: HashMap::new(),
             just_promoted_labels: HashSet::new(),
+            background_service_enabled: false,
         }
     }
 }

--- a/agentmux-launcher/src/wrr/mod.rs
+++ b/agentmux-launcher/src/wrr/mod.rs
@@ -319,7 +319,11 @@ pub fn apply_hwnd_destroyed(state: &mut State, hwnd: u64, host_running: bool) ->
         // browsers stay alive and the host doesn't quit. Caller passes
         // `host_running` so wrr stays out of the connection module's
         // private API.
-        if state.windows.is_empty() && host_running {
+        //
+        // Workstream 0 Phase 1 — same background-service exclusion as the
+        // normal close path (see its comment): don't arm the orphan/
+        // teardown-backstop machinery for an intentionally-resting host.
+        if state.windows.is_empty() && !state.background_service_enabled && host_running {
             let v_drift = state.bump_version();
             out.push(Event::HwndDriftDetected {
                 kind: HwndDriftKind::OrphanInstance,


### PR DESCRIPTION
## Summary

Workstream 0 / Phase 1, prerequisite #1 of #2977 (tray/background-service). Introduces `AGENTMUX_BACKGROUND_SERVICE` (`HostState.background_service_enabled`, default off — no behavior change unless opted in) and gates every quit-decision authority that can fire on last-window-closed, not just the reducer's own decision function:

- **`reducer/quit.rs`** — `should_begin_drain` now refuses to arm a `LastWindowClosed` drain when the flag is set. `QuitReason::LauncherRequested`/`External` bypass this function entirely (dispatched straight to `handle_begin_drain`), so a genuine forced/launcher-requested quit is unaffected.
- **`wrr/win_event.rs`** — discovered the Windows quit watchdog is a *second*, independent quit authority: it treats "0 registered windows, not draining" as a reducer-lag desync and force-quits ~3s later regardless of the reducer's own decision. Without this fix, background-service mode would work for exactly 3 seconds before the watchdog killed the process anyway. Taught `is_reducer_lagging_os` and the watchdog recheck task to recognize that exact combination as the intentional background-service resting state instead of a bug to correct.
- **`client/lifecycle.rs`** — found a *third* independent quit authority: `on_before_close`'s Stage-2 `quit_message_loop()` gate derived "is this the last window" purely from `browser_list.is_empty()`, never consulting the reducer's drain decision at all. This is the cross-platform (macOS/Linux, and Windows non-parking closes) path. Now requires `QuitState::Draining` too, mirroring the Windows WRR gate's own `draining` requirement — a no-op for the existing (background-service off) path since `begin_drain_and_cascade` already flips `QuitState` synchronously just above this check whenever it actually should quit.

Each fix is a pure, unit-tested predicate (`should_begin_drain`, `is_reducer_lagging_os`/`is_background_service_resting`, `is_last_window_close`), extracted for testability matching this codebase's existing pattern (`retry_backend_window_id_lookup`, `should_quit_on_last_window`). Each was falsified individually (temporarily reverted, confirmed the corresponding new test fails with the exact expected message, restored) before being trusted — see the diff's test additions.

## Why three separate fixes for one feature flag

The host's "should I quit when the last window closes" decision turned out to have three independent implementations across the codebase (reducer, Windows OS-signal watchdog, cross-platform CEF callback) that historically stayed in sync only because they all happened to agree in the one case that existed before now (unconditional last-window quit). Gating only the reducer's `should_begin_drain` — the obvious, "correct" architectural insertion point — would have shipped a feature that appeared to work in code review and unit tests, then silently un-worked 3 seconds later in production via the watchdog, or immediately on macOS/Linux via the `on_before_close` gap. All three needed the same conceptual fix; none could be skipped.

## What's NOT in this PR

- No user-facing settings/tray UI yet — `AGENTMUX_BACKGROUND_SERVICE` is an env-var opt-in for this prerequisite step only, per the issue's own phasing (Workstream 0 is explicitly "prerequisites, independent of any tray code").
- Live `tasklist`/`ps` verification (the issue's literal acceptance-criteria wording) was not performed as part of this PR — this repo's dev/test environment is the reviewing agents' own live, multi-agent production AgentMux installation (dozens of running `agentmux-cef.exe` panes), and popping a test GUI window to manually verify would risk disrupting that shared, actively-used desktop session. All three quit-authority fixes are covered by pure unit tests instead (74 → 78 reducer tests, existing WRR watchdog tests +3, new `is_last_window_close` tests). Recommend a manual `tasklist`/`ps` smoke test as a follow-up, ideally by a human with their own isolated `task dev` session.
- Prerequisite #2 (`promote_pool_window` reattach-liveness gap) is intentionally left for a separate PR — initial investigation found it requires new CEF UI-thread task-posting + a reload/on_load_end liveness round-trip in a code path (`agentmux-cef/src/commands/window_pool.rs`'s Windows `promote_pool_window`) with an extensive documented history of subtle threading regressions (see its own inline comments referencing multiple past reagent/codex-caught bugs). That's a meaningfully different risk profile than this PR's pure-function gating and deserves its own focused review.

## Test plan

- [x] `cargo test -p agentmux-cef --lib --release` — 317/317 passing (74 reducer + 4 new `is_last_window_close` + existing WRR watchdog suite, zero regressions)
- [x] Falsified all three fixes individually (reverted each gate, confirmed the specific new test fails with the expected assertion, restored)
- [x] `cargo clippy -p agentmux-cef --lib --release` — no new warnings on any touched line
- [ ] Manual live verification per the issue's acceptance criteria (`tasklist`/`ps` + a live agent turn completing with no window open) — flagged above as a suggested follow-up rather than performed here

<!-- agentmux:agent_id=agent5 -->