### PR TITLE
Manoz@Area54: fix(agent-pane): hide the tab strip entirely on a fresh pane

### DIFF
--- a/.changesets/1788623152-fix-agent-pane-hide-the-tab-strip-entirely-on-a-fresh-pane-s-cu3l.md
+++ b/.changesets/1788623152-fix-agent-pane-hide-the-tab-strip-entirely-on-a-fresh-pane-s-cu3l.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): hide the tab strip entirely on a fresh pane, so the picker isn't overlaid by a lone +

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -119,6 +119,7 @@ import { lastLinkedAccountId } from "./providers/provider-id-aliases";
 import { buildStartupPayload, resolveAccounts } from "./startup/buildStartupPayload";
 import type { SignalPair } from "./state";
 import { createAgentAtoms } from "./state";
+import { shouldShowTabStrip } from "./tab-strip-visibility";
 import type { DocumentNode } from "./types";
 import { useAgentStream } from "./useAgentStream";
 
@@ -545,33 +546,45 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
                         so the conversation renders, and can be scrolled,
                         underneath the rest of this row — unobstructed except
                         for wherever a real tab or the "+" actually sits. The
-                        "+" always renders — that's how you'd get to a second
-                        tab — but the tab pill itself stays hidden until
-                        there's something to switch BETWEEN (see visibleTabs
-                        above). */}
-                    <PaneTabStrip
-                        tabs={visibleTabs()}
-                        activeId={activeBlockId()}
-                        zoomFactor={tabStripZoomFactor}
-                        getId={(t) => t.blockId}
-                        getLabel={(t) => t.label}
-                        onActivate={handleTabSwitch}
-                        onClose={handleTabClose}
-                        onTabDoubleClick={(t) => t.definitionId && setRenamingBlockId(t.blockId)}
-                        renderLabel={(t) =>
-                            renamingBlockId() === t.blockId && t.definitionId ? (
-                                <PaneTabRenameInput
-                                    initialValue={t.label}
-                                    onConfirm={(title) => void handleTabRenameConfirm(t, title)}
-                                    onCancel={() => setRenamingBlockId(null)}
-                                />
-                            ) : (
-                                <span class="pane-tab-label">{t.label}</span>
-                            )
-                        }
-                        onAdd={() => void handleNewAgentTab()}
-                        addTitle="New agent"
-                    />
+                        tab pill itself stays hidden until there's something to
+                        switch BETWEEN (see visibleTabs above), and on a FRESH
+                        pane — picker showing, no agent launched yet — the
+                        whole strip (including its "+") is gone rather than
+                        floating a lone button over the picker. The "+" comes
+                        back the moment the pane is a real conversation; see
+                        shouldShowTabStrip for why a 2nd blank tab still keeps
+                        the strip up. */}
+                    <Show
+                        when={shouldShowTabStrip({
+                            visibleTabCount: visibleTabs().length,
+                            hasAgent: !!agentId(),
+                            isHistoryTab: isHistoryTab(),
+                        })}
+                    >
+                        <PaneTabStrip
+                            tabs={visibleTabs()}
+                            activeId={activeBlockId()}
+                            zoomFactor={tabStripZoomFactor}
+                            getId={(t) => t.blockId}
+                            getLabel={(t) => t.label}
+                            onActivate={handleTabSwitch}
+                            onClose={handleTabClose}
+                            onTabDoubleClick={(t) => t.definitionId && setRenamingBlockId(t.blockId)}
+                            renderLabel={(t) =>
+                                renamingBlockId() === t.blockId && t.definitionId ? (
+                                    <PaneTabRenameInput
+                                        initialValue={t.label}
+                                        onConfirm={(title) => void handleTabRenameConfirm(t, title)}
+                                        onCancel={() => setRenamingBlockId(null)}
+                                    />
+                                ) : (
+                                    <span class="pane-tab-label">{t.label}</span>
+                                )
+                            }
+                            onAdd={() => void handleNewAgentTab()}
+                            addTitle="New agent"
+                        />
+                    </Show>
                     <Show
                         when={isHistoryTab()}
                         fallback={

--- a/frontend/app/view/agent/tab-strip-visibility.test.ts
+++ b/frontend/app/view/agent/tab-strip-visibility.test.ts
@@ -1,0 +1,37 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * A fresh agent pane (picker showing, no agent launched) should render no
+ * tab strip at all — not even the collapsed "+" box it used to always
+ * show. The "+" comes back as soon as the pane is a real conversation, and
+ * pills appear as soon as there's a second tab to switch to.
+ */
+
+import { describe, expect, it } from "vitest";
+import { shouldShowTabStrip } from "./tab-strip-visibility";
+
+describe("shouldShowTabStrip", () => {
+    it("hides the strip entirely on a fresh pane (picker, no agent, lone tab)", () => {
+        expect(shouldShowTabStrip({ visibleTabCount: 0, hasAgent: false, isHistoryTab: false })).toBe(false);
+    });
+
+    it("shows the strip (just the +) once the lone tab has launched an agent", () => {
+        expect(shouldShowTabStrip({ visibleTabCount: 0, hasAgent: true, isHistoryTab: false })).toBe(true);
+    });
+
+    it("shows the strip for a lone read-only history tab", () => {
+        expect(shouldShowTabStrip({ visibleTabCount: 0, hasAgent: false, isHistoryTab: true })).toBe(true);
+    });
+
+    // The + on a launched pane opens a SECOND, blank picker tab. That new
+    // tab has no agentId of its own — but the strip must stay up, or the
+    // user lands on a blank pane with no way back to the first tab.
+    it("keeps the strip up when a 2nd tab exists, even with no agent on the active tab", () => {
+        expect(shouldShowTabStrip({ visibleTabCount: 2, hasAgent: false, isHistoryTab: false })).toBe(true);
+    });
+
+    it("keeps the strip up for a multi-tab pane with an agent", () => {
+        expect(shouldShowTabStrip({ visibleTabCount: 3, hasAgent: true, isHistoryTab: false })).toBe(true);
+    });
+});

--- a/frontend/app/view/agent/tab-strip-visibility.ts
+++ b/frontend/app/view/agent/tab-strip-visibility.ts
@@ -1,0 +1,41 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Whether an agent pane should render its tab strip at all.
+ *
+ * Until now the strip always rendered: with a single conversation open it
+ * collapsed to just the 28×28px "+" box, floating over the content
+ * (SPEC_AGENT_PANE_TAB_STRIP_OVERLAY_2026_08_10.md,
+ * SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md). That "+"
+ * is dead weight on a **fresh** pane, though — one that hasn't launched an
+ * agent yet and is still showing the picker ("My Agents"). There is nothing
+ * to switch between, and adding a second blank tab before choosing a first
+ * agent isn't a real flow. So a fresh pane now renders no strip at all, and
+ * the "+" reappears the moment the pane actually has an agent.
+ *
+ * Kept as a pure predicate (rather than inline JSX) so it can be tested
+ * without mounting `agent-view.tsx` — the same extract-and-test pattern the
+ * rest of this directory already uses.
+ */
+export interface TabStripVisibilityInput {
+    /** `visibleTabs().length` — already 0 for a lone tab, since a single
+     *  conversation shows no pill for itself. */
+    visibleTabCount: number;
+    /** This pane has launched an agent (block meta `agentId` is set). */
+    hasAgent: boolean;
+    /** A read-only history-reader tab — never a "fresh" pane, even though
+     *  it may not carry a live `agentId` of its own. */
+    isHistoryTab: boolean;
+}
+
+export function shouldShowTabStrip(input: TabStripVisibilityInput): boolean {
+    // Real pills to switch between — always show, regardless of whether
+    // the *active* tab happens to be a blank picker (adding a 2nd tab to a
+    // launched pane leaves exactly that state, and hiding the strip there
+    // would strand the user with no way back to the first tab).
+    if (input.visibleTabCount > 0) return true;
+    // Lone tab: the strip is just the "+". Worth showing only once this
+    // pane is actually a conversation.
+    return input.hasAgent || input.isHistoryTab;
+}


### PR DESCRIPTION
## Summary

A fresh agent pane — picker showing ("My Agents"), no agent launched yet — rendered the tab strip anyway. With a single conversation the strip collapses to just the "+" button, but since `SPEC_PANE_TAB_STRIP_TRAILING_BLUR_2026_08_12.md` it also spans the full pane width as a frosted-glass panel, so a fresh pane got a glass bar and a lone "+" floating over the top of the picker.

The strip is now gated on a `shouldShowTabStrip()` predicate:

| Pane state | Strip |
|---|---|
| Fresh — picker, no agent, lone tab | **hidden entirely** (new) |
| Lone tab, agent launched | shown (just the "+") |
| Lone read-only history tab | shown |
| 2+ tabs — including a blank 2nd tab opened via "+" | shown, with pills |

That last row is the case worth calling out: the "+" on a launched pane opens a second, still-blank picker tab with no `agentId` of its own. Keying purely off "does this tab have an agent" would hide the strip exactly there and strand the user on a blank pane with no way back to the first tab — so the predicate checks visible tab count first.

The strip is `position: absolute` and reserves no space (`agent-view.scss`), so hiding it shifts no layout — the picker just gets its top edge back.

## On the second half of the request (double-click to rename)

**Already implemented — no code change needed here.** `agent-view.tsx:572` wires `onTabDoubleClick` → `setRenamingBlockId`, rendering `PaneTabRenameInput` inline, and `handleTabRenameConfirm` renames the authoritative `AgentDefinition` with an optimistic local override plus rollback-on-failure. `PaneTabStrip.test.tsx` covers the dispatch ("fires onTabDoubleClick with the tab item").

It's just been hard to *reach*: a lone conversation renders no tab pill at all, so there's nothing to double-click until a 2nd tab exists. That's pre-existing behavior and unchanged by this PR.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run frontend/app/view/agent/tab-strip-visibility.test.ts frontend/app/element/PaneTabStrip.test.tsx` — 25/25 pass
- New `tab-strip-visibility.test.ts` covers all five states in the table above
- Extracted as a pure predicate rather than an inline JSX condition, matching how the rest of this directory is tested (`agent-view.tsx` has no render tests)

<!-- agentmux:agent_id=manoz -->