### PR TITLE
docs(retro): task dev killed 4x by Bash-tool SIGINT + mid-build worktree mutation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,24 @@ On Windows, `task dev` builds a production-parallel layout in `dist/cef-dev/` (l
 
 #### Launching `task dev` from an agent / MCP Shell (Windows)
 
+**Use `mcp__agentmux__Shell`. The Bash tool CANNOT launch `task dev`** — not
+with `&`, not with `run_in_background`, not with `nohup`/`disown`. A Bash-tool
+background job belongs to that tool call's process group, and the group is
+terminated when the call returns (seconds), while `task dev` needs minutes.
+`mcp__agentmux__Shell` runs server-side via `ShellNodeRunner` with an
+independent lifetime, which is the whole reason it exists.
+
+This fails **intermittently**, which is the trap: an orphaned child sometimes
+survives long enough to come up, so one success does not mean the method
+works. See the `^C` + `exit status 58` signature under "Diagnosing failed
+shells" below and
+`docs/retro/retro-task-dev-bash-tool-sigint-and-worktree-mutation-2026-09-05.md`.
+
+**Also: never `git checkout` / `git merge` / `gh pr merge` while a build is
+running against the same worktree.** Merging swaps tracked files out from under
+a live `cargo build` / `npm install` and corrupts it (same retro). Stop the
+build first, or use a separate `git worktree`.
+
 `task dev` requires `bash.exe` to be on the Windows PATH (go-task's Taskfile calls `bash -c '...'` for build steps via cmd.exe). The registry PATH has `Git\cmd` (shims) but not `Git\bin` (bash.exe). Two additional traps exist when launching from an agent's MCP Shell:
 
 - **Gap A:** MSYS2 bash won't resolve `.cmd` files from bare command names — `bash -c "task dev"` exits with "command not found".
@@ -85,7 +103,17 @@ diagnoses:
 grep "shell\." ~/.agentmux/logs/agentmuxsrv-*.log.$(date +%Y-%m-%d)
 # line_count:2  + exit:1   + <100ms  → Gap A (bash cmd not found in MSYS2)
 # line_count:53 + exit:200 + <500ms  → AMBIGUOUS, see below
+# ^C in log   + exit:58  + MINUTES  → build was SIGNALLED, not broken (see below)
 ```
+
+**`^C` in the log + `exit status 58`, minutes in** — the build started fine and
+was **killed**, not rejected. Distinguishing feature: a bare `error: could not
+compile` with **no `error[EXXXX]:` diagnostic above it**. A real compile error
+always names a file and line; a signalled one doesn't. Near-always means the
+build was launched from the Bash tool (see the top of this section) or the
+worktree was mutated mid-build by a merge/checkout. To confirm the build itself
+is healthy, run `cargo build --release -p agentmux-srv` directly — it either
+reproduces a real diagnostic or exits 0 and proves the failure was external.
 
 `line_count:53 + exit:200` was previously documented as meaning Gap B
 (`bash.exe` not in cmd.exe PATH). It has (at least) **two** causes: an invalid

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,23 +51,37 @@ On Windows, `task dev` builds a production-parallel layout in `dist/cef-dev/` (l
 
 #### Launching `task dev` from an agent / MCP Shell (Windows)
 
-**Use `mcp__agentmux__Shell`. The Bash tool CANNOT launch `task dev`** — not
-with `&`, not with `run_in_background`, not with `nohup`/`disown`. A Bash-tool
-background job belongs to that tool call's process group, and the group is
-terminated when the call returns (seconds), while `task dev` needs minutes.
-`mcp__agentmux__Shell` runs server-side via `ShellNodeRunner` with an
-independent lifetime, which is the whole reason it exists.
+**Never append a shell `&` when launching `task dev` from the Bash tool.** This
+is the single most common way to lose the build. Two launch paths DO work —
+pick either:
 
-This fails **intermittently**, which is the trap: an orphaned child sometimes
-survives long enough to come up, so one success does not mean the method
-works. See the `^C` + `exit status 58` signature under "Diagnosing failed
-shells" below and
+- **`mcp__agentmux__Shell`** (preferred for `task dev`) — runs server-side via
+  `ShellNodeRunner`, independent lifetime, and gives you a `shell_id` for
+  `ShellStatus`/`ShellStop`.
+- **The Bash tool with `run_in_background: true` and NO `&`** — also genuinely
+  detached: `agentmux-bashwrap` threads the flag through as
+  `--declared-background` (`hook.rs`), which `setsid()`s into a brand-new
+  session with no controlling terminal and exempts the task from the idle-kill
+  timeout (`bash_wrap.rs::effective_idle_timeout`).
+
+**Why `&` breaks both of them:** `cmd &` returns immediately, so the
+*tracked/detached* process is the trivial launcher shell that exits in
+milliseconds — the real `task dev` is orphaned out from under the very
+protection you asked for. Without `run_in_background` it's worse: the job stays
+in the tool call's process group and is **signalled** when the call returns
+(seconds), while `task dev` needs minutes.
+
+This fails **intermittently**, which is the trap: an orphan sometimes survives
+long enough to come up, so one success does not mean the method works. See the
+`^C` + `exit status 58` signature under "Diagnosing failed shells" below and
 `docs/retro/retro-task-dev-bash-tool-sigint-and-worktree-mutation-2026-09-05.md`.
 
-**Also: never `git checkout` / `git merge` / `gh pr merge` while a build is
-running against the same worktree.** Merging swaps tracked files out from under
-a live `cargo build` / `npm install` and corrupts it (same retro). Stop the
-build first, or use a separate `git worktree`.
+**Separately — never `git checkout` / `git merge` / `gh pr merge` while a build
+is running against the same worktree.** Merging swaps tracked files out from
+under a live `cargo build` / `npm install` and corrupts it (same retro). This is
+a *different* failure from the signal case above and does **not** produce a
+`^C`; expect inconsistent-input errors instead. Stop the build first, or use a
+separate `git worktree`.
 
 `task dev` requires `bash.exe` to be on the Windows PATH (go-task's Taskfile calls `bash -c '...'` for build steps via cmd.exe). The registry PATH has `Git\cmd` (shims) but not `Git\bin` (bash.exe). Two additional traps exist when launching from an agent's MCP Shell:
 
@@ -107,13 +121,16 @@ grep "shell\." ~/.agentmux/logs/agentmuxsrv-*.log.$(date +%Y-%m-%d)
 ```
 
 **`^C` in the log + `exit status 58`, minutes in** — the build started fine and
-was **killed**, not rejected. Distinguishing feature: a bare `error: could not
-compile` with **no `error[EXXXX]:` diagnostic above it**. A real compile error
-always names a file and line; a signalled one doesn't. Near-always means the
-build was launched from the Bash tool (see the top of this section) or the
-worktree was mutated mid-build by a merge/checkout. To confirm the build itself
-is healthy, run `cargo build --release -p agentmux-srv` directly — it either
-reproduces a real diagnostic or exits 0 and proves the failure was external.
+was **signalled**, not rejected. Distinguishing feature: a bare `error: could
+not compile` with **no `error[EXXXX]:` diagnostic above it**. A real compile
+error always names a file and line; a signalled one doesn't. The `^C` means
+something delivered an interrupt — in practice, a Bash-tool launch using `&`
+(see the top of this section). A mid-build `git checkout`/`merge` is a
+*separate* hazard that cannot inject this signal: it corrupts build inputs and
+surfaces as inconsistent-state errors, with **no** `^C`. Don't read one
+signature as evidence of the other. To confirm the build itself is healthy, run
+`cargo build --release -p agentmux-srv` directly — it either reproduces a real
+diagnostic or exits 0 and proves the failure was external.
 
 `line_count:53 + exit:200` was previously documented as meaning Gap B
 (`bash.exe` not in cmd.exe PATH). It has (at least) **two** causes: an invalid

--- a/docs/retro/retro-task-dev-bash-tool-sigint-and-worktree-mutation-2026-09-05.md
+++ b/docs/retro/retro-task-dev-bash-tool-sigint-and-worktree-mutation-2026-09-05.md
@@ -1,6 +1,9 @@
 # Retro: `task dev` killed 4× — Bash-tool SIGINT + mid-build worktree mutation
 
 **Date:** 2026-09-05
+**Status:** Implemented — root-caused, verified live (`task dev` launched
+successfully via `mcp__agentmux__Shell`), and the CLAUDE.md guidance hardened
+in the same PR. No code change was needed: the build system was never broken.
 **Severity:** Low (build system was never broken) / Medium as a time sink — ~50 minutes of agent time burned, and the agent wrongly told the user the build system was at fault
 **Observed by:** Agent2 (Claude agent) during the cross-pane-input-delay session (PRs #2973, #2976)
 **Related retros:**

--- a/docs/retro/retro-task-dev-bash-tool-sigint-and-worktree-mutation-2026-09-05.md
+++ b/docs/retro/retro-task-dev-bash-tool-sigint-and-worktree-mutation-2026-09-05.md
@@ -22,14 +22,17 @@ contention from other agents on a shared machine," told the user so, and gave up
 `cargo build --release -p agentmux-srv` directly succeeded on the first try
 (exit 0, 4m39s). The real causes were two things the agent itself did:
 
-1. **Launching via the Bash tool with `&`** instead of `mcp__agentmux__Shell`.
-   When the Bash tool call returns, the harness terminates that call's process
-   group — the detached `task dev` gets **SIGINT**. Signature: a literal `^C` in
-   the redirected log, then `error: could not compile` and go-task
-   `exit status 58`.
+1. **Appending a shell `&` to every launch.** `cmd &` returns immediately, so
+   whatever protection was requested applies to a launcher shell that exits in
+   milliseconds, orphaning the real `task dev`. Without `run_in_background` it's
+   worse: the job stays in the tool call's process group and is **signalled**
+   when the call returns. Signature: a literal `^C` in the redirected log, then
+   `error: could not compile` and go-task `exit status 58`.
 2. **Merging a PR while a build was running against the same worktree.**
    `gh pr merge --delete-branch` checks out `main` and fast-forwards it,
-   swapping files out from under an in-flight `cargo build`.
+   swapping files out from under an in-flight `cargo build`. Note this is a
+   *distinct* failure mode that corrupts build inputs — it cannot deliver the
+   `^C` signal in cause 1, and the two must not be conflated when diagnosing.
 
 Relaunching through `mcp__agentmux__Shell` — **exactly what CLAUDE.md already
 documents** — worked first try: full build, Vite up, host PID 64584, authkey
@@ -55,12 +58,36 @@ contained the correct instructions, and the agent didn't follow them.**
 
 ---
 
-## Root cause 1 — Bash-tool `&` does not detach; the process group is SIGINT'd
+## Root cause 1 — the shell `&`, not the Bash tool as such
 
-The Bash tool's shell is harness-managed. A background job started with `&`
-inside a tool call belongs to that call's process group, and the group is
-terminated when the call returns. `task dev` is a multi-minute build; every
-tool call returns in seconds. The build is always killed mid-flight.
+**Correction (post-review, same day):** the first draft of this retro claimed
+"the Bash tool cannot launch `task dev`, with or without `run_in_background`."
+That is wrong, and Codex's review on PR #2985 caught it with citations. The
+common factor in every failure here was an appended shell **`&`** — a variable
+never isolated, because all six attempts had it.
+
+`run_in_background: true` **without** `&` is a genuinely supported detach path,
+and the code says so unambiguously:
+
+- `agentmux-bashwrap/src/hook.rs:95,107` threads the flag through as
+  `--declared-background`.
+- `bash_wrap.rs:322-328` (`effective_idle_timeout`) exempts such a task from the
+  idle-kill timeout entirely (`Duration::from_secs(u64::MAX)`).
+- `bash_wrap.rs:330+` `setsid()`s the process into a **brand-new session with no
+  controlling terminal**, with a long comment explaining that this exists
+  precisely so the wrapped command survives its invoker's death or signals.
+- `Controller::stop_for_replace` preserves such tasks across session replacement.
+- `docs/status/STATUS_COMPOSER_STRIP_ZONE_BALANCE_HANDOFF_2026_08_25.md:17-19`
+  records a successful Windows `task dev` launch using exactly that mode.
+
+**Why `&` defeats it anyway:** `cmd &` returns immediately, so the process that
+gets tracked and `setsid()`-protected is the trivial launcher shell — which
+exits in milliseconds. The real `task dev` is orphaned out from under the very
+protection that was requested. Without `run_in_background` it degrades further:
+the job stays in the tool call's process group and is *signalled* when the call
+returns (seconds), while `task dev` needs minutes.
+
+So the accurate rule is **"never append `&`"**, not "never use the Bash tool."
 
 **Diagnostic signature** (all three of these together):
 
@@ -80,12 +107,16 @@ task: Failed to run task "dev": ... exit status 58
   returned) — which superficially *looks* like a deterministic compile error and
   is what misled the diagnosis for three attempts.
 
-**Why attempts 1–3 look different (0-byte logs, no `^C`):** with
-`run_in_background: true` the wrapper returns in ~0.1s, so the child is orphaned
-rather than signalled — sometimes it survives (attempt 1 did), sometimes it dies
-before flushing anything to the redirect (attempts 2–3, 0-byte logs). **This
+**Why attempts 1–3 look different (0-byte logs, no `^C`):** those combined
+`run_in_background: true` **with** `&`. The wrapper returns in ~0.1s having
+protected only the launcher shell, so the real build is orphaned rather than
+signalled — sometimes it survives (attempt 1 did), sometimes it dies before
+flushing anything to the redirect (attempts 2–3, 0-byte logs). **This
 non-determinism is the trap**: attempt 1 succeeding is what made the agent
 believe the method was sound and look for an external cause when it later failed.
+
+Note the experiment that was never run: `run_in_background: true` with **no**
+`&`. Six attempts, one uncontrolled variable present in all of them.
 
 ### The fix (already documented, not followed)
 
@@ -165,18 +196,22 @@ Worth recording, because the technical bugs are the cheap part:
 
 ### Immediate (docs)
 
-- Add the **`^C` + `exit status 58`** signature to CLAUDE.md's existing
-  "Diagnosing failed shells" list — the current table covers `line_count:2`/
-  `exit:1` and `line_count:53`/`exit:200` (both *instant* failures) but has no
-  entry for a build that starts fine and is killed minutes in, which is what a
-  Bash-tool launch produces.
-- State explicitly in that section: **the Bash tool cannot launch `task dev`,
-  with or without `&`, with or without `run_in_background`.** The current wording
-  says to use `scripts\dev-agent.cmd` but doesn't say the Bash tool is a dead end
-  — and attempt 1 proves it fails *intermittently*, which is worse than failing
-  reliably.
-- Add a "don't mutate the worktree during a build" note next to the `gh pr merge`
-  guidance in the Git Workflow section.
+All three shipped in the same PR as this retro (#2985):
+
+- Added the **`^C` + `exit status 58`** signature to CLAUDE.md's existing
+  "Diagnosing failed shells" list — the table covered `line_count:2`/`exit:1`
+  and `line_count:53`/`exit:200` (both *instant* failures) but had no entry for
+  a build that starts fine and is killed minutes in. Scoped explicitly to a
+  signal source, with a note that mid-build worktree mutation is a different
+  failure that does **not** produce `^C`.
+- Stated the rule as **never append a shell `&`**, and named the two launch
+  paths that do work (`mcp__agentmux__Shell`, or the Bash tool with
+  `run_in_background: true` and no `&`), with the mechanism for why `&` defeats
+  both. The first draft said "the Bash tool cannot launch `task dev`" — an
+  over-generalisation from six attempts that all shared the `&`; corrected after
+  Codex's review pointed at the `--declared-background`/`setsid()` code.
+- Added the "don't mutate the worktree during a build" rule next to the launch
+  guidance.
 
 ### Behavioural (for agents)
 
@@ -186,6 +221,10 @@ Worth recording, because the technical bugs are the cheap part:
   compile failure.** Look for `^C` / signal evidence.
 - **Grep CLAUDE.md and `docs/retro/` before declaring an infrastructure problem
   novel.** Both the tool to use and two adjacent retros were already on disk.
+- **Isolate one variable before generalising from repeated failures.** Six
+  attempts all carried an appended `&`; the conclusion drawn ("the Bash tool
+  can't do this") indicted the wrong component because the actual common factor
+  was never removed and retested. Repetition is not isolation.
 
 ### Possible follow-up (code)
 
@@ -202,8 +241,14 @@ Root cause confirmed, not merely theorised:
 
 - `cargo build --release -p agentmux-srv` standalone → **exit 0**, 4m39s, no error.
   Proves the build is healthy and the failures were external to it.
-- Same command via Bash tool + `&` → `^C`, `exit status 58`, 3/3 reproductions,
-  always at the point the tool call returned.
+- Same command via Bash tool + `&` (no `run_in_background`) → `^C`,
+  `exit status 58`, 3/3 reproductions, always at the point the tool call
+  returned.
+- **Not tested:** `run_in_background: true` with no `&`. Asserted supported on
+  the strength of the `--declared-background` / `setsid()` implementation and a
+  prior recorded Windows success, not on a run made here — flagged so the next
+  reader knows which claims in this retro are observed and which are read from
+  code.
 - Same command via `mcp__agentmux__Shell` → survived multiple tool-call
   boundaries, 84KB of clean log, **0 occurrences of `^C`**, build completed,
   Vite ready on `localhost:5297`, authkey written to

--- a/docs/retro/retro-task-dev-bash-tool-sigint-and-worktree-mutation-2026-09-05.md
+++ b/docs/retro/retro-task-dev-bash-tool-sigint-and-worktree-mutation-2026-09-05.md
@@ -1,0 +1,211 @@
+# Retro: `task dev` killed 4× — Bash-tool SIGINT + mid-build worktree mutation
+
+**Date:** 2026-09-05
+**Severity:** Low (build system was never broken) / Medium as a time sink — ~50 minutes of agent time burned, and the agent wrongly told the user the build system was at fault
+**Observed by:** Agent2 (Claude agent) during the cross-pane-input-delay session (PRs #2973, #2976)
+**Related retros:**
+`retro-task-dev-agent-shell-path-2026-06-27.md` (Gap A/B — MSYS2 `.cmd` resolution, cmd.exe PATH),
+`retro-task-package-mcp-timeout-and-shell-output-gap-2026-08-06.md` (Bash-tool timeout, `nohup` not detaching)
+
+---
+
+## TL;DR
+
+An agent tried to launch `task dev` four times so the user could test a UI change.
+All four died. The agent concluded the build was being killed by "resource
+contention from other agents on a shared machine," told the user so, and gave up.
+
+**That diagnosis was wrong, and the build system was never at fault.** Running
+`cargo build --release -p agentmux-srv` directly succeeded on the first try
+(exit 0, 4m39s). The real causes were two things the agent itself did:
+
+1. **Launching via the Bash tool with `&`** instead of `mcp__agentmux__Shell`.
+   When the Bash tool call returns, the harness terminates that call's process
+   group — the detached `task dev` gets **SIGINT**. Signature: a literal `^C` in
+   the redirected log, then `error: could not compile` and go-task
+   `exit status 58`.
+2. **Merging a PR while a build was running against the same worktree.**
+   `gh pr merge --delete-branch` checks out `main` and fast-forwards it,
+   swapping files out from under an in-flight `cargo build`.
+
+Relaunching through `mcp__agentmux__Shell` — **exactly what CLAUDE.md already
+documents** — worked first try: full build, Vite up, host PID 64584, authkey
+written.
+
+The most important finding is not either bug. It is that **CLAUDE.md already
+contained the correct instructions, and the agent didn't follow them.**
+
+---
+
+## Timeline
+
+| # | Launch method | Outcome |
+|---|---|---|
+| 1 | Bash tool, `&`, `run_in_background: true` | Instance came up. Used successfully for the cross-pane benchmark. |
+| 2 | Bash tool, `&`, `run_in_background: true` (baseline build, fix stashed) | Never came up. Abandoned after ~30 min; blamed on "build contention." |
+| 3 | Bash tool, `&`, `run_in_background: true` (`TITLE=Agent2`) | Never came up. Log stayed 0 bytes. |
+| 4 | Bash tool, `&` + `sleep 3`, **no** `run_in_background` | Died at `Compiling agentmux-srv`. Log ends `^C` + `exit status 58`. |
+| 5 | Bash tool, `&` + `sleep 3`, no background | Same failure, same place. |
+| 6 | Bash tool, `&` + `sleep 3`, no background | Same failure, same place. |
+| — | **Direct `cargo build --release -p agentmux-srv`** | **Exit 0. 4m39s. Clean.** |
+| 7 | **`mcp__agentmux__Shell` + `scripts\dev-agent.cmd`** | **Worked. Vite ready, host PID 64584.** |
+
+---
+
+## Root cause 1 — Bash-tool `&` does not detach; the process group is SIGINT'd
+
+The Bash tool's shell is harness-managed. A background job started with `&`
+inside a tool call belongs to that call's process group, and the group is
+terminated when the call returns. `task dev` is a multi-minute build; every
+tool call returns in seconds. The build is always killed mid-flight.
+
+**Diagnostic signature** (all three of these together):
+
+```
+task: [build:backend:rust:windows] cargo build --release -p agentmux-srv
+   Compiling agentmux-srv v0.55.34 (...)
+^Cerror: could not compile `agentmux-srv` (bin "agentmux-srv")
+task: Failed to run task "dev": ... exit status 58
+```
+
+- A literal **`^C`** immediately before the error — this is the tell. A real
+  compile error is preceded by a `error[EXXXX]:` diagnostic with a file/line.
+  A bare `error:` with no diagnostic above it means the compiler was *signalled*,
+  not that it *rejected* anything.
+- **`exit status 58`** from go-task.
+- Failure always at the same place (whatever was compiling when the call
+  returned) — which superficially *looks* like a deterministic compile error and
+  is what misled the diagnosis for three attempts.
+
+**Why attempts 1–3 look different (0-byte logs, no `^C`):** with
+`run_in_background: true` the wrapper returns in ~0.1s, so the child is orphaned
+rather than signalled — sometimes it survives (attempt 1 did), sometimes it dies
+before flushing anything to the redirect (attempts 2–3, 0-byte logs). **This
+non-determinism is the trap**: attempt 1 succeeding is what made the agent
+believe the method was sound and look for an external cause when it later failed.
+
+### The fix (already documented, not followed)
+
+`CLAUDE.md` → "Launching `task dev` from an agent / MCP Shell (Windows)":
+
+```json
+{ "cmd": "C:\\<repo>\\scripts\\dev-agent.cmd TITLE=my-branch > C:\\<repo>\\devrun.log 2>&1" }
+```
+
+`mcp__agentmux__Shell` runs server-side via `ShellNodeRunner` — a genuinely
+detached process with an independent lifetime, unaffected by tool-call
+boundaries. The `Shell` tool's own description states its purpose plainly:
+*"Use for build systems, watchers, dev servers — anything that should run in the
+background without blocking the conversation."*
+
+Verified: launched via MCP Shell, survived multiple tool-call boundaries, zero
+`^C` in an 84KB log, completed the full build, Vite ready, instance live.
+
+---
+
+## Root cause 2 — `gh pr merge` mutates the worktree an in-flight build is reading
+
+Attempt 4's log opened with a *different* failure than 5 and 6:
+
+```
+task: [npm:install] npm install
+^Cerror: could not compile `agentmux-srv`
+task: Failed to run task "npm:install": exit status 58
+```
+
+`gh pr merge --squash --delete-branch` (run while that build was live) does a
+local `checkout main` + fast-forward + branch delete. Rewriting tracked files
+under a running `cargo build` / `npm install` corrupts the build. It also left a
+stray 133-line `package-lock.json` diff in the worktree that had to be reverted.
+
+**Rule:** never run `git merge` / `git checkout` / `gh pr merge` while a build is
+running against the same worktree. Either stop the build first, or use a
+separate worktree (`git worktree add`) — the repo already recommends worktrees
+for concurrent work in the commit-hygiene guidance.
+
+This is distinct from root cause 1 and would have broken the build even from a
+correctly-detached MCP Shell.
+
+---
+
+## Why the wrong conclusion was reached
+
+Worth recording, because the technical bugs are the cheap part:
+
+1. **A plausible-but-unverified theory was adopted early.** "Shared machine,
+   other agents building, ~28GB free but something's killing it" fit the
+   evidence loosely and was never tested. It became the working assumption for
+   three attempts.
+2. **The `^C` was visible in the log and read past — twice.** It appears in the
+   first failing log and again in a `tail -c 2000`. It is the single most
+   diagnostic character in the whole output.
+3. **The obvious control experiment was run last, not first.** Running
+   `cargo build` directly takes 5 minutes and immediately separates "build is
+   broken" from "something is killing the build." It was the step that solved
+   it, and it should have been step one — this is exactly what the
+   systematic-debugging skill's *"reproduce it / read the actual error"* steps
+   prescribe.
+4. **The project's own docs were not consulted.** CLAUDE.md has a section with
+   this literal title: *"Launching `task dev` from an agent / MCP Shell
+   (Windows)"*. Two prior retros cover adjacent failures in the same area. The
+   agent had `mcp__agentmux__Shell` available the whole time and used the Bash
+   tool instead.
+5. **The user was given a wrong root cause and told to work around it.** The
+   agent recommended the user run `task dev` themselves — externalizing a
+   self-inflicted problem. The user's pushback (*"we've done a lot to make sure
+   task dev runs robust and isolated"*) was correct and was the thing that
+   forced a real diagnosis.
+
+---
+
+## Prevention
+
+### Immediate (docs)
+
+- Add the **`^C` + `exit status 58`** signature to CLAUDE.md's existing
+  "Diagnosing failed shells" list — the current table covers `line_count:2`/
+  `exit:1` and `line_count:53`/`exit:200` (both *instant* failures) but has no
+  entry for a build that starts fine and is killed minutes in, which is what a
+  Bash-tool launch produces.
+- State explicitly in that section: **the Bash tool cannot launch `task dev`,
+  with or without `&`, with or without `run_in_background`.** The current wording
+  says to use `scripts\dev-agent.cmd` but doesn't say the Bash tool is a dead end
+  — and attempt 1 proves it fails *intermittently*, which is worse than failing
+  reliably.
+- Add a "don't mutate the worktree during a build" note next to the `gh pr merge`
+  guidance in the Git Workflow section.
+
+### Behavioural (for agents)
+
+- **Before concluding a build is externally broken, run the build command
+  directly.** One 5-minute control run beats three 10-minute guesses.
+- **A bare `error:` with no `error[EXXXX]` diagnostic above it is a signal, not a
+  compile failure.** Look for `^C` / signal evidence.
+- **Grep CLAUDE.md and `docs/retro/` before declaring an infrastructure problem
+  novel.** Both the tool to use and two adjacent retros were already on disk.
+
+### Possible follow-up (code)
+
+- `scripts/dev-agent.cmd` could detect it's been signalled and print a one-line
+  hint (`"interrupted — if launched from an agent, use mcp__agentmux__Shell"`)
+  rather than letting go-task's generic `exit status 58` be the last word. Low
+  effort, would have collapsed this whole episode into one attempt.
+
+---
+
+## Verification
+
+Root cause confirmed, not merely theorised:
+
+- `cargo build --release -p agentmux-srv` standalone → **exit 0**, 4m39s, no error.
+  Proves the build is healthy and the failures were external to it.
+- Same command via Bash tool + `&` → `^C`, `exit status 58`, 3/3 reproductions,
+  always at the point the tool call returned.
+- Same command via `mcp__agentmux__Shell` → survived multiple tool-call
+  boundaries, 84KB of clean log, **0 occurrences of `^C`**, build completed,
+  Vite ready on `localhost:5297`, authkey written to
+  `~/.agentmux/dev/main/71037a8bbd2cda52/data/`, host PID 64584 confirmed alive
+  in `tasklist`.
+
+The isolation/robustness work in `task dev` itself needed no changes — it did
+its job correctly every time it was allowed to run to completion.


### PR DESCRIPTION
## Summary

`task dev` failed to launch four times during the previous session. I diagnosed it as external resource contention, told the user the build system was at fault, and gave up. **That was wrong** — running `cargo build --release -p agentmux-srv` directly succeeded first try (exit 0, 4m39s). Both real causes were self-inflicted:

1. **Launching via the Bash tool with `&`** instead of `mcp__agentmux__Shell`. A Bash-tool background job belongs to that tool call's process group, which is terminated when the call returns (seconds) — while `task dev` needs minutes. Signature: a literal `^C` in the log, a bare `error: could not compile` with **no `error[EXXXX]` diagnostic above it**, and go-task `exit status 58`. It fails *intermittently* (an orphaned child sometimes survives), which is what made one early success look like the method worked.
2. **Running `gh pr merge --delete-branch` while a build was live against the same worktree**, swapping tracked files out from under `cargo build` / `npm install`.

`task dev`'s own isolation/robustness work needed no changes — it worked correctly every time it was allowed to run to completion.

## The main finding isn't either bug

CLAUDE.md already had a section literally titled *"Launching `task dev` from an agent / MCP Shell (Windows)"* with the correct invocation, and two adjacent retros already existed. They weren't consulted. The retro records that plainly, along with the other process failures (adopting an unverified theory early, reading past the `^C` twice, running the obvious control experiment last, and handing the user a wrong root cause to work around).

## Changes

- **New retro:** `docs/retro/retro-task-dev-bash-tool-sigint-and-worktree-mutation-2026-09-05.md`
- **CLAUDE.md:**
  - States outright that the Bash tool *cannot* launch `task dev` (with the intermittency warning — one success doesn't validate the method)
  - Adds the `^C` + `exit:58` + *minutes* signature to the failed-shell diagnostic table, including the "bare `error:` with no `error[EXXXX]` = signalled, not broken" tell and the direct-`cargo build` control experiment
  - Adds the don't-mutate-the-worktree-during-a-build rule

## Verification

- `cargo build --release -p agentmux-srv` standalone → exit 0, 4m39s (proves the build is healthy)
- Bash tool + `&` → `^C`, exit 58, 3/3 reproductions, always at the point the tool call returned
- `mcp__agentmux__Shell` + `scripts\dev-agent.cmd` → survived multiple tool-call boundaries, **0 occurrences of `^C`** in an 84KB log, build completed, Vite ready on `localhost:5297`, host PID 64584 confirmed alive in `tasklist`
- `bash scripts/check-doc-status.sh` on the new retro → ok

Note: a dev instance from this verification is currently running against this worktree, so **don't merge this until the user is done testing** — that's the exact mutation cause #2 describes.

<!-- agentmux:agent_id=agent2 -->