### PR TITLE
Loap #2@claudius: feat(window): Chrome-style drag-to-top maximize and border-drag vertical snap

### DIFF
--- a/.changesets/1788623510-feat-window-chrome-style-drag-to-top-maximize-and-border-dra-r417.md
+++ b/.changesets/1788623510-feat-window-chrome-style-drag-to-top-maximize-and-border-dra-r417.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(window): Chrome-style drag-to-top maximize and border-drag vertical snap

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -58,6 +58,10 @@ mod crash_recovery;
 mod recovery_pages;
 pub(crate) mod error_catalog;
 mod context_menu;
+// Deliberately NOT windows-gated even though both call sites are: it is pure
+// integer geometry with no Win32 types, so its tests run on every CI target
+// instead of only windows-latest. See the module's own doc comment.
+pub(crate) mod window_snap;
 #[cfg(target_os = "windows")]
 mod wndproc;
 #[cfg(target_os = "windows")]

--- a/agentmux-cef/src/client/window_snap.rs
+++ b/agentmux-cef/src/client/window_snap.rs
@@ -1,0 +1,248 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pure geometry for Chrome-style window snapping —
+//! `docs/specs/SPEC_WINDOW_SNAP_MAXIMIZE_2026_09_04.md`.
+//!
+//! Deliberately **not** `#[cfg(target_os = "windows")]` and deliberately free
+//! of any Win32 type: the callers (`client::wndproc`'s `WM_SIZING` arm for
+//! border-drag vertical snap, `ui_tasks::drag`'s move loop for
+//! drag-to-top maximize) are both native message-loop code that no test
+//! harness can drive, so the only way any of this logic gets asserted is by
+//! keeping the decisions here, as plain integer math, and letting the
+//! platform code do nothing but read/apply the answer.
+//!
+//! **All coordinates are PHYSICAL screen pixels.** Both call sites work in
+//! physical px (`GetWindowRect`/`GetCursorPos`/`MONITORINFO.rcWork` all
+//! return physical), and `app::monitor::get_monitor_work_area` is
+//! deliberately NOT used by either — it converts to DIP for CEF's
+//! `Window::set_bounds`, and mixing the two units is a bug class this
+//! codebase has been bitten by before. Nothing here converts anything;
+//! callers must pass one consistent unit.
+
+/// How close (physical px) a dragged edge must get before it snaps. Windows'
+/// own edge magnetism is in this neighbourhood; small enough that a user
+/// deliberately sizing a window near the screen edge isn't fighting it,
+/// large enough to be reachable without pixel-hunting.
+pub(crate) const SNAP_THRESHOLD_PX: i32 = 12;
+
+/// Which horizontal edge of the window a `WM_SIZING` drag is moving.
+/// Corners count as their vertical component — dragging the top-left corner
+/// toward the screen top should still offer the vertical snap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum VerticalEdge {
+    Top,
+    Bottom,
+}
+
+/// Map a `WM_SIZING` `wParam` (`WMSZ_*`) to the vertical edge being dragged,
+/// or `None` for a purely horizontal drag (left/right edge — no vertical
+/// snap applies).
+///
+/// Values are the raw `WMSZ_*` constants, matching the existing `edge`
+/// string mapping in `wndproc::window_edge_resize_wndproc` (which this
+/// intentionally mirrors rather than re-deriving from a shared enum — that
+/// mapping predates this module and is load-bearing for the
+/// `windowresize:tick` payload, so the two are kept side by side and
+/// pinned by `wmsz_mapping_matches_the_tick_event_edges`).
+pub(crate) fn vertical_edge_for_wmsz(wparam: usize) -> Option<VerticalEdge> {
+    match wparam {
+        3 | 4 | 5 => Some(VerticalEdge::Top),    // WMSZ_TOP / TOPLEFT / TOPRIGHT
+        6 | 7 | 8 => Some(VerticalEdge::Bottom), // WMSZ_BOTTOM / BOTTOMLEFT / BOTTOMRIGHT
+        _ => None,                               // WMSZ_LEFT / WMSZ_RIGHT / unknown
+    }
+}
+
+/// Decide whether an in-progress vertical border drag should snap to fill
+/// the monitor vertically, and if so return the `(top, bottom)` the window
+/// should take.
+///
+/// **Fills BOTH edges, not just the dragged one** — this is the behavior the
+/// feature request describes ("the top and bottom should snap to the top and
+/// bottom") and what Windows/Chrome actually do: dragging the top border to
+/// the screen top makes the window full-height, it does not merely stop the
+/// top edge there. The horizontal axis is untouched by construction (this
+/// returns no x/width), which is exactly what distinguishes this from an
+/// accidental full maximize.
+///
+/// Returns `None` when the drag isn't near the relevant work-area edge, or
+/// when the window already exactly fills the work area vertically (nothing
+/// to change — avoids rewriting the rect and re-logging on every one of the
+/// many `WM_SIZING` ticks a single drag produces).
+pub(crate) fn snap_vertical_fill(
+    edge: VerticalEdge,
+    proposed_top: i32,
+    proposed_bottom: i32,
+    work_top: i32,
+    work_bottom: i32,
+    threshold: i32,
+) -> Option<(i32, i32)> {
+    // Only the edge actually under the cursor arms the snap. Checking both
+    // would let a window whose *opposite* edge happens to sit near the
+    // screen edge snap while the user drags the other one — surprising, and
+    // not what either Windows or Chrome do.
+    let near_dragged_edge = match edge {
+        VerticalEdge::Top => (proposed_top - work_top).abs() <= threshold,
+        VerticalEdge::Bottom => (proposed_bottom - work_bottom).abs() <= threshold,
+    };
+    if !near_dragged_edge {
+        return None;
+    }
+    if proposed_top == work_top && proposed_bottom == work_bottom {
+        return None; // already filled — no-op
+    }
+    Some((work_top, work_bottom))
+}
+
+/// Whether a drag-to-top *move* (not resize) is currently in the
+/// maximize-offer zone: the cursor at/above the work area's top edge.
+///
+/// Separate from [`snap_vertical_fill`] because the gestures differ in kind,
+/// not just in threshold — a move gesture tracks the CURSOR (the window
+/// follows it, so the window's own top edge is wherever the grab offset put
+/// it and is not a meaningful signal), whereas a resize gesture tracks the
+/// proposed EDGE. Conflating them would make the maximize offer depend on
+/// where in the title bar the user happened to grab.
+pub(crate) fn cursor_in_top_maximize_zone(
+    cursor_y: i32,
+    work_top: i32,
+    threshold: i32,
+) -> bool {
+    cursor_y <= work_top + threshold
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wmsz_top_family_maps_to_top_including_corners() {
+        assert_eq!(vertical_edge_for_wmsz(3), Some(VerticalEdge::Top)); // WMSZ_TOP
+        assert_eq!(vertical_edge_for_wmsz(4), Some(VerticalEdge::Top)); // TOPLEFT
+        assert_eq!(vertical_edge_for_wmsz(5), Some(VerticalEdge::Top)); // TOPRIGHT
+    }
+
+    #[test]
+    fn wmsz_bottom_family_maps_to_bottom_including_corners() {
+        assert_eq!(vertical_edge_for_wmsz(6), Some(VerticalEdge::Bottom)); // WMSZ_BOTTOM
+        assert_eq!(vertical_edge_for_wmsz(7), Some(VerticalEdge::Bottom)); // BOTTOMLEFT
+        assert_eq!(vertical_edge_for_wmsz(8), Some(VerticalEdge::Bottom)); // BOTTOMRIGHT
+    }
+
+    /// A purely horizontal drag must never arm the vertical snap — this is
+    /// what keeps "drag the left edge near the screen's left" from
+    /// unexpectedly changing the window's height.
+    #[test]
+    fn wmsz_horizontal_and_unknown_map_to_no_vertical_edge() {
+        assert_eq!(vertical_edge_for_wmsz(1), None); // WMSZ_LEFT
+        assert_eq!(vertical_edge_for_wmsz(2), None); // WMSZ_RIGHT
+        assert_eq!(vertical_edge_for_wmsz(0), None);
+        assert_eq!(vertical_edge_for_wmsz(99), None);
+    }
+
+    /// Mirrors `window_edge_resize_wndproc`'s own WMSZ_* → edge-string map,
+    /// so the two can't silently drift apart (the tick event says "topleft"
+    /// for 4; this module must agree that 4 is a Top-family drag).
+    #[test]
+    fn wmsz_mapping_matches_the_tick_event_edges() {
+        let tick_edge = |w: usize| match w {
+            1 => "left",
+            2 => "right",
+            3 => "top",
+            4 => "topleft",
+            5 => "topright",
+            6 => "bottom",
+            7 => "bottomleft",
+            8 => "bottomright",
+            _ => "",
+        };
+        for w in 0..=9usize {
+            let name = tick_edge(w);
+            let expected = if name.starts_with("top") {
+                Some(VerticalEdge::Top)
+            } else if name.starts_with("bottom") {
+                Some(VerticalEdge::Bottom)
+            } else {
+                None
+            };
+            assert_eq!(vertical_edge_for_wmsz(w), expected, "wmsz={w} ({name})");
+        }
+    }
+
+    #[test]
+    fn top_drag_within_threshold_fills_vertically() {
+        // Work area 0..1000; window currently 5..600, dragging its top edge.
+        let got = snap_vertical_fill(VerticalEdge::Top, 5, 600, 0, 1000, 12);
+        assert_eq!(got, Some((0, 1000)), "should fill BOTH edges, not just the dragged one");
+    }
+
+    #[test]
+    fn bottom_drag_within_threshold_fills_vertically() {
+        let got = snap_vertical_fill(VerticalEdge::Bottom, 400, 995, 0, 1000, 12);
+        assert_eq!(got, Some((0, 1000)));
+    }
+
+    #[test]
+    fn snaps_when_the_edge_overshoots_past_the_work_area() {
+        // Dragging above the top of the screen — still within |delta| <= threshold.
+        let got = snap_vertical_fill(VerticalEdge::Top, -8, 600, 0, 1000, 12);
+        assert_eq!(got, Some((0, 1000)));
+    }
+
+    #[test]
+    fn does_not_snap_when_the_dragged_edge_is_far_from_the_work_area() {
+        assert_eq!(snap_vertical_fill(VerticalEdge::Top, 200, 600, 0, 1000, 12), None);
+        assert_eq!(snap_vertical_fill(VerticalEdge::Bottom, 200, 600, 0, 1000, 12), None);
+    }
+
+    /// The opposite edge being near the screen edge must NOT arm the snap —
+    /// only the edge actually being dragged counts.
+    #[test]
+    fn does_not_snap_on_the_edge_that_is_not_being_dragged() {
+        // Bottom is at the work-area bottom, but the user is dragging the TOP,
+        // and the top is nowhere near the work-area top.
+        assert_eq!(snap_vertical_fill(VerticalEdge::Top, 400, 1000, 0, 1000, 12), None);
+        // Mirror: top is at the work-area top, user drags the BOTTOM far away.
+        assert_eq!(snap_vertical_fill(VerticalEdge::Bottom, 0, 500, 0, 1000, 12), None);
+    }
+
+    #[test]
+    fn already_filled_is_a_no_op() {
+        assert_eq!(snap_vertical_fill(VerticalEdge::Top, 0, 1000, 0, 1000, 12), None);
+        assert_eq!(snap_vertical_fill(VerticalEdge::Bottom, 0, 1000, 0, 1000, 12), None);
+    }
+
+    /// Non-zero work-area origin — a secondary monitor placed above/left of
+    /// the primary has negative coordinates, and a taskbar makes rcWork.top
+    /// non-zero even on the primary. Neither may be assumed to be 0.
+    #[test]
+    fn handles_a_non_zero_and_negative_work_area_origin() {
+        // Secondary monitor above the primary: work area -1080..-40.
+        let got = snap_vertical_fill(VerticalEdge::Top, -1075, -500, -1080, -40, 12);
+        assert_eq!(got, Some((-1080, -40)));
+        // Primary with a 40px taskbar at the top: work area 40..1040.
+        let got = snap_vertical_fill(VerticalEdge::Top, 45, 600, 40, 1040, 12);
+        assert_eq!(got, Some((40, 1040)));
+    }
+
+    #[test]
+    fn threshold_boundary_is_inclusive() {
+        assert_eq!(snap_vertical_fill(VerticalEdge::Top, 12, 600, 0, 1000, 12), Some((0, 1000)));
+        assert_eq!(snap_vertical_fill(VerticalEdge::Top, 13, 600, 0, 1000, 12), None);
+    }
+
+    #[test]
+    fn cursor_zone_covers_at_and_above_the_work_area_top() {
+        assert!(cursor_in_top_maximize_zone(0, 0, 12));
+        assert!(cursor_in_top_maximize_zone(12, 0, 12));
+        assert!(cursor_in_top_maximize_zone(-30, 0, 12), "above the screen still counts");
+        assert!(!cursor_in_top_maximize_zone(13, 0, 12));
+    }
+
+    #[test]
+    fn cursor_zone_respects_a_non_zero_work_area_top() {
+        // 40px taskbar at the top: the zone starts at 40, not 0.
+        assert!(cursor_in_top_maximize_zone(45, 40, 12));
+        assert!(!cursor_in_top_maximize_zone(60, 40, 12));
+    }
+}

--- a/agentmux-cef/src/client/window_snap.rs
+++ b/agentmux-cef/src/client/window_snap.rs
@@ -94,6 +94,40 @@ pub(crate) fn snap_vertical_fill(
     Some((work_top, work_bottom))
 }
 
+/// Undo a vertical snap when the drag leaves the snap zone: restore the
+/// **non-dragged** edge to where it was before this drag started.
+///
+/// Without this, backing out of a snap is one-way — [`snap_vertical_fill`]
+/// moved the opposite edge to the work-area edge, and simply declining to
+/// snap on later ticks leaves it stranded there (the native resize only ever
+/// moves the edge under the cursor, so nothing else would ever put it back).
+/// Chrome/Windows both restore it, which is the behavior being matched.
+///
+/// Only the opposite edge is restored — the dragged edge stays wherever the
+/// cursor currently puts it.
+///
+/// Returns the `(top, bottom)` to apply, or `None` when the opposite edge is
+/// already at its pre-drag value (the common case: every tick of a drag that
+/// never snapped at all, where this must be a no-op rather than a redundant
+/// rect write).
+pub(crate) fn unsnap_restore_opposite_edge(
+    edge: VerticalEdge,
+    current_top: i32,
+    current_bottom: i32,
+    origin_top: i32,
+    origin_bottom: i32,
+) -> Option<(i32, i32)> {
+    match edge {
+        VerticalEdge::Top if current_bottom != origin_bottom => {
+            Some((current_top, origin_bottom))
+        }
+        VerticalEdge::Bottom if current_top != origin_top => {
+            Some((origin_top, current_bottom))
+        }
+        _ => None,
+    }
+}
+
 /// Whether a drag-to-top *move* (not resize) is currently in the
 /// maximize-offer zone: the cursor at/above the work area's top edge.
 ///
@@ -229,6 +263,53 @@ mod tests {
     fn threshold_boundary_is_inclusive() {
         assert_eq!(snap_vertical_fill(VerticalEdge::Top, 12, 600, 0, 1000, 12), Some((0, 1000)));
         assert_eq!(snap_vertical_fill(VerticalEdge::Top, 13, 600, 0, 1000, 12), None);
+    }
+
+    /// The reported bug: drag the top edge up to snap (bottom moves to the
+    /// work-area bottom), then drag back down out of the zone — the bottom
+    /// must return to where it was before the drag, not stay stranded at the
+    /// screen edge.
+    #[test]
+    fn dragging_back_out_of_a_snap_restores_the_opposite_edge() {
+        // Pre-drag window was 300..600. A snap moved it to 0..1000. The user
+        // has now dragged the top back down to 250.
+        let got = unsnap_restore_opposite_edge(VerticalEdge::Top, 250, 1000, 300, 600);
+        assert_eq!(got, Some((250, 600)), "bottom must revert to its pre-drag 600");
+    }
+
+    #[test]
+    fn dragging_back_out_of_a_bottom_snap_restores_the_top() {
+        // Mirror: pre-drag 300..600, snapped to 0..1000, bottom dragged to 700.
+        let got = unsnap_restore_opposite_edge(VerticalEdge::Bottom, 0, 700, 300, 600);
+        assert_eq!(got, Some((300, 700)), "top must revert to its pre-drag 300");
+    }
+
+    /// Every tick of an ordinary drag that never snapped hits this path — it
+    /// must be a no-op, not a redundant rect write on every WM_SIZING.
+    #[test]
+    fn restore_is_a_no_op_when_the_opposite_edge_never_moved() {
+        assert_eq!(
+            unsnap_restore_opposite_edge(VerticalEdge::Top, 250, 600, 300, 600),
+            None,
+        );
+        assert_eq!(
+            unsnap_restore_opposite_edge(VerticalEdge::Bottom, 300, 700, 300, 600),
+            None,
+        );
+    }
+
+    /// The dragged edge is never restored — only the opposite one. A top
+    /// drag must keep whatever the cursor currently dictates for `top`, even
+    /// though it differs wildly from the origin.
+    #[test]
+    fn restore_never_touches_the_edge_being_dragged() {
+        let (top, _bottom) =
+            unsnap_restore_opposite_edge(VerticalEdge::Top, 250, 1000, 300, 600).unwrap();
+        assert_eq!(top, 250, "dragged edge must follow the cursor, not the origin");
+
+        let (_top, bottom) =
+            unsnap_restore_opposite_edge(VerticalEdge::Bottom, 0, 700, 300, 600).unwrap();
+        assert_eq!(bottom, 700);
     }
 
     #[test]

--- a/agentmux-cef/src/client/window_snap.rs
+++ b/agentmux-cef/src/client/window_snap.rs
@@ -128,6 +128,48 @@ pub(crate) fn unsnap_restore_opposite_edge(
     }
 }
 
+/// Where to place a window that is being un-maximized because the user
+/// started dragging it — the other half of the drag-to-top gesture, and what
+/// Chrome/Windows both do when you drag a maximized title bar.
+///
+/// The window must land *under the cursor*, or the drag would feel like it
+/// teleported: the restored window is smaller than the maximized one, so
+/// keeping its top-left fixed would leave the cursor somewhere else entirely
+/// (often outside the window). Two rules, matching the OS:
+///
+/// - **Horizontally, proportional.** The cursor keeps the same *fractional*
+///   position along the title bar it had while maximized — grab the middle
+///   of a maximized title bar and you're still holding the middle of the
+///   restored one. Absolute-offset would drop the cursor off the right edge
+///   whenever the restored window is much narrower.
+/// - **Vertically, same absolute offset.** Title bars are a fixed height, so
+///   preserving "N px below the window top" keeps the grab point on the same
+///   part of the chrome. Proportional here would slide the grab off the
+///   title bar entirely for a short window.
+///
+/// All inputs/outputs are PHYSICAL px. Returns the restored window's new
+/// `(x, y)` top-left.
+pub(crate) fn unmaximize_drag_origin(
+    cursor_x: i32,
+    cursor_y: i32,
+    maximized_left: i32,
+    maximized_top: i32,
+    maximized_width: i32,
+    restored_width: i32,
+) -> (i32, i32) {
+    // Guard the degenerate case rather than dividing by zero — a zero-width
+    // maximized rect shouldn't be reachable, but this runs inside a drag
+    // loop where a panic would wedge the UI thread mid-gesture.
+    let ratio = if maximized_width > 0 {
+        (cursor_x - maximized_left) as f64 / maximized_width as f64
+    } else {
+        0.5
+    };
+    let new_x = cursor_x - (restored_width as f64 * ratio).round() as i32;
+    let new_y = cursor_y - (cursor_y - maximized_top);
+    (new_x, new_y)
+}
+
 /// Whether a drag-to-top *move* (not resize) is currently in the
 /// maximize-offer zone: the cursor at/above the work area's top edge.
 ///
@@ -310,6 +352,51 @@ mod tests {
         let (_top, bottom) =
             unsnap_restore_opposite_edge(VerticalEdge::Bottom, 0, 700, 300, 600).unwrap();
         assert_eq!(bottom, 700);
+    }
+
+    #[test]
+    fn unmaximize_keeps_the_cursor_proportionally_along_the_title_bar() {
+        // Maximized 0..1920, cursor at the midpoint (960). Restored width 800
+        // → cursor should still be at the restored window's midpoint, so the
+        // window's left edge lands 400px left of the cursor.
+        let (x, _y) = unmaximize_drag_origin(960, 10, 0, 0, 1920, 800);
+        assert_eq!(x, 560);
+        assert_eq!(960 - x, 400, "cursor stays at the restored midpoint");
+    }
+
+    #[test]
+    fn unmaximize_handles_a_grab_near_the_right_end_of_the_title_bar() {
+        // Grabbed at 90% across. An absolute-offset scheme would put the
+        // window left edge at 1728-... far off-screen and drop the cursor
+        // past the right edge; proportional keeps it at 90% of 800 = 720.
+        let (x, _y) = unmaximize_drag_origin(1728, 10, 0, 0, 1920, 800);
+        assert_eq!(x, 1008);
+        assert_eq!(1728 - x, 720);
+    }
+
+    #[test]
+    fn unmaximize_preserves_the_absolute_vertical_grab_offset() {
+        // Cursor 18px below the maximized window's top → the restored window
+        // must also sit 18px above the cursor, keeping the grab on the title bar.
+        let (_x, y) = unmaximize_drag_origin(500, 58, 0, 40, 1920, 800);
+        assert_eq!(y, 40);
+        assert_eq!(58 - y, 18);
+    }
+
+    #[test]
+    fn unmaximize_respects_a_non_zero_maximized_origin() {
+        // Secondary monitor at x=1920, taskbar making top=40.
+        let (x, y) = unmaximize_drag_origin(2880, 60, 1920, 40, 1920, 800);
+        assert_eq!(x, 2480, "midpoint grab → 400px left of cursor");
+        assert_eq!(y, 40);
+    }
+
+    /// Must not panic or divide by zero inside a modal drag loop.
+    #[test]
+    fn unmaximize_survives_a_degenerate_zero_width_maximized_rect() {
+        let (x, y) = unmaximize_drag_origin(500, 30, 0, 0, 0, 800);
+        assert_eq!(x, 100, "falls back to a centered grab");
+        assert_eq!(y, 0);
     }
 
     #[test]

--- a/agentmux-cef/src/client/wndproc.rs
+++ b/agentmux-cef/src/client/wndproc.rs
@@ -234,6 +234,17 @@ struct WindowEdgeResizeHookEntry {
     original: isize,
     install_label: String,
     session_began: bool,
+    /// The window's `(top, bottom)` in PHYSICAL px as of the start of the
+    /// current native size loop, captured lazily on its first `WM_SIZING`
+    /// tick and cleared on `WM_EXITSIZEMOVE`.
+    ///
+    /// Needed to back OUT of a vertical snap: once
+    /// `window_snap::snap_vertical_fill` has moved the non-dragged edge to
+    /// the work-area edge, nothing would ever move it back (a native resize
+    /// only ever moves the edge under the cursor), so dragging away from the
+    /// screen edge would leave it stranded. See
+    /// `window_snap::unsnap_restore_opposite_edge`.
+    session_origin_top_bottom: Option<(i32, i32)>,
 }
 
 /// Map of top-level HWND -> hook entry for the Shift+window-edge-resize
@@ -367,6 +378,12 @@ unsafe extern "system" fn window_edge_resize_wndproc(
     } else if msg == WM_EXITSIZEMOVE {
         let ended = WINDOW_EDGE_RESIZE_WNDPROCS.lock().ok().and_then(|mut m| {
             m.get_mut(&(hwnd as usize)).and_then(|entry| {
+                // Always drop the snap origin — this loop is over either way,
+                // and a stale origin leaking into the NEXT drag would restore
+                // an edge to a rect that no longer exists. Cleared outside the
+                // session_began branch because a plain move loop never sets
+                // that flag but must still not leave state behind.
+                entry.session_origin_top_bottom = None;
                 if entry.session_began {
                     entry.session_began = false;
                     Some(entry.install_label.clone())
@@ -411,15 +428,52 @@ unsafe extern "system" fn window_edge_resize_wndproc(
         if let Some(edge) = crate::client::window_snap::vertical_edge_for_wmsz(wparam) {
             let rect = lparam as *mut windows_sys::Win32::Foundation::RECT;
             let proposed = *rect;
+            // Remember where this drag STARTED so a snap can be backed out of
+            // (see `session_origin_top_bottom`). Captured lazily from the
+            // live window rect on the first tick rather than from
+            // WM_ENTERSIZEMOVE: the window hasn't been resized yet at this
+            // point, so GetWindowRect is still the pre-drag geometry, and
+            // this doesn't depend on ENTERSIZEMOVE arriving at all.
+            let origin = {
+                let mut guard = WINDOW_EDGE_RESIZE_WNDPROCS.lock().ok();
+                let entry = guard.as_mut().and_then(|m| m.get_mut(&(hwnd as usize)));
+                entry.and_then(|e| {
+                    if e.session_origin_top_bottom.is_none() {
+                        let mut live: windows_sys::Win32::Foundation::RECT = std::mem::zeroed();
+                        if windows_sys::Win32::UI::WindowsAndMessaging::GetWindowRect(
+                            hwnd, &mut live,
+                        ) != 0
+                        {
+                            e.session_origin_top_bottom = Some((live.top, live.bottom));
+                        }
+                    }
+                    e.session_origin_top_bottom
+                })
+            };
             if let Some((work_top, work_bottom)) = work_area_vertical_for_rect(&proposed) {
-                if let Some((top, bottom)) = crate::client::window_snap::snap_vertical_fill(
+                let adjusted = crate::client::window_snap::snap_vertical_fill(
                     edge,
                     proposed.top,
                     proposed.bottom,
                     work_top,
                     work_bottom,
                     crate::client::window_snap::SNAP_THRESHOLD_PX,
-                ) {
+                )
+                .or_else(|| {
+                    // Not (or no longer) in the snap zone. If an earlier tick
+                    // of THIS drag snapped, put the non-dragged edge back
+                    // where it started; otherwise this is a no-op.
+                    origin.and_then(|(origin_top, origin_bottom)| {
+                        crate::client::window_snap::unsnap_restore_opposite_edge(
+                            edge,
+                            proposed.top,
+                            proposed.bottom,
+                            origin_top,
+                            origin_bottom,
+                        )
+                    })
+                });
+                if let Some((top, bottom)) = adjusted {
                     // Vertical axis ONLY — left/right are untouched by
                     // construction, which is what keeps this a vertical snap
                     // rather than an accidental maximize.
@@ -530,6 +584,7 @@ pub(crate) unsafe fn install_window_edge_resize_hook(
                     original,
                     install_label: label.to_string(),
                     session_began: false,
+                    session_origin_top_bottom: None,
                 },
             );
         }

--- a/agentmux-cef/src/client/wndproc.rs
+++ b/agentmux-cef/src/client/wndproc.rs
@@ -290,10 +290,26 @@ fn emit_window_edge_resize_event(
 ///
 /// The renderer computes the pixel delta itself from its own container
 /// rect (no coordinates are forwarded — that sidesteps every
-/// physical-px/DPR/zoom unit question). Pure observer: every message
-/// ALWAYS passes through to the original WndProc.
+/// physical-px/DPR/zoom unit question).
 ///
-/// Spec: `docs/specs/SPEC_RESIZE_DEFAULT_FLIP_AND_WINDOW_EDGE_SHIFT_2026_08_26.md` §3.4.
+/// **No longer a pure observer for `WM_SIZING`.** As of
+/// `SPEC_WINDOW_SNAP_MAXIMIZE_2026_09_04.md` §3 this hook also implements
+/// Chrome-style border-drag vertical snap by CLAMPING the proposed rect
+/// (`lParam`) when a top/bottom drag lands near the monitor's work-area
+/// edge — the documented `WM_SIZING` contract explicitly allows the handler
+/// to adjust that rect, and it is the only per-tick point during a NATIVE
+/// resize loop where the app can influence the outcome. Every message still
+/// always reaches the original WndProc; the clamp is applied to the rect
+/// AFTER that passthrough (see the call site for why that order).
+///
+/// Windows' own Snap Assist does not fire for this window because it is a
+/// CEF Views *frameless* window (`AgentMuxWindowDelegate::is_frameless`),
+/// which hands non-client behavior to Chromium's internal
+/// `HWNDMessageHandler` — hence re-implementing the gesture here.
+///
+/// Specs: `docs/specs/SPEC_RESIZE_DEFAULT_FLIP_AND_WINDOW_EDGE_SHIFT_2026_08_26.md` §3.4
+/// (the observer half), `docs/specs/SPEC_WINDOW_SNAP_MAXIMIZE_2026_09_04.md` §3
+/// (the snap clamp).
 #[cfg(target_os = "windows")]
 unsafe extern "system" fn window_edge_resize_wndproc(
     hwnd: *mut std::ffi::c_void,
@@ -369,17 +385,53 @@ unsafe extern "system" fn window_edge_resize_wndproc(
         }
     }
 
-    // ALWAYS pass through — pure observer, CEF still owns every message.
+    // ALWAYS pass through — CEF still owns every message (the WM_SIZING
+    // rect clamp below adjusts the result, it never swallows the message).
     let original = WINDOW_EDGE_RESIZE_WNDPROCS
         .lock()
         .ok()
         .and_then(|m| m.get(&(hwnd as usize)).map(|e| e.original))
         .unwrap_or(0);
-    let result = if original != 0 {
+    let mut result = if original != 0 {
         CallWindowProcW(Some(std::mem::transmute(original)), hwnd, msg, wparam, lparam)
     } else {
         DefWindowProcW(hwnd, msg, wparam, lparam)
     };
+
+    // Chrome-style border-drag vertical snap (SPEC_WINDOW_SNAP_MAXIMIZE §3).
+    //
+    // Applied AFTER the passthrough, deliberately: Chromium's own WM_SIZING
+    // handling may rewrite the proposed rect (min-size and aspect-ratio
+    // constraints live there), so clamping BEFORE would let it silently
+    // discard the snap. Clamping after makes this the final word for the
+    // vertical axis only. The clamp can only ever move an edge by at most
+    // SNAP_THRESHOLD_PX, so it cannot push the window under Chromium's
+    // minimum height in any realistic configuration.
+    if msg == WM_SIZING && !lparam_is_null(lparam) {
+        if let Some(edge) = crate::client::window_snap::vertical_edge_for_wmsz(wparam) {
+            let rect = lparam as *mut windows_sys::Win32::Foundation::RECT;
+            let proposed = *rect;
+            if let Some((work_top, work_bottom)) = work_area_vertical_for_rect(&proposed) {
+                if let Some((top, bottom)) = crate::client::window_snap::snap_vertical_fill(
+                    edge,
+                    proposed.top,
+                    proposed.bottom,
+                    work_top,
+                    work_bottom,
+                    crate::client::window_snap::SNAP_THRESHOLD_PX,
+                ) {
+                    // Vertical axis ONLY — left/right are untouched by
+                    // construction, which is what keeps this a vertical snap
+                    // rather than an accidental maximize.
+                    (*rect).top = top;
+                    (*rect).bottom = bottom;
+                    // TRUE = "the application processed this message" (and
+                    // adjusted the rect), per WM_SIZING's contract.
+                    result = 1;
+                }
+            }
+        }
+    }
 
     // Prune AFTER passthrough so the original proc still receives
     // WM_NCDESTROY (HWND-reuse safety, same as close_routing_wndproc).
@@ -390,6 +442,49 @@ unsafe extern "system" fn window_edge_resize_wndproc(
     }
 
     result
+}
+
+#[cfg(target_os = "windows")]
+fn lparam_is_null(lparam: isize) -> bool {
+    lparam == 0
+}
+
+/// Work-area top/bottom (PHYSICAL px) of the monitor the proposed rect sits
+/// on, for the `WM_SIZING` snap clamp.
+///
+/// Resolved from the rect's own CENTER rather than a corner: during a
+/// top-edge drag the top corner is exactly the point being dragged past the
+/// screen edge, so keying off it would flip to the monitor *above* right at
+/// the moment the snap should engage. `MONITOR_DEFAULTTONEAREST` then keeps
+/// a rect dragged fully off-screen resolving to something sane.
+///
+/// Deliberately does NOT use `app::monitor::get_monitor_work_area` — that
+/// helper converts to DIP for CEF's `Window::set_bounds`, while `WM_SIZING`
+/// rects are physical px. Mixing the two is the unit-confusion bug class
+/// called out in `client::window_snap`'s doc comment.
+#[cfg(target_os = "windows")]
+unsafe fn work_area_vertical_for_rect(
+    rect: &windows_sys::Win32::Foundation::RECT,
+) -> Option<(i32, i32)> {
+    use windows_sys::Win32::Foundation::POINT;
+    use windows_sys::Win32::Graphics::Gdi::{
+        GetMonitorInfoW, MonitorFromPoint, MONITORINFO, MONITOR_DEFAULTTONEAREST,
+    };
+
+    let center = POINT {
+        x: rect.left + (rect.right - rect.left) / 2,
+        y: rect.top + (rect.bottom - rect.top) / 2,
+    };
+    let hmonitor = MonitorFromPoint(center, MONITOR_DEFAULTTONEAREST);
+    if hmonitor.is_null() {
+        return None;
+    }
+    let mut info: MONITORINFO = std::mem::zeroed();
+    info.cbSize = std::mem::size_of::<MONITORINFO>() as u32;
+    if GetMonitorInfoW(hmonitor, &mut info) == 0 {
+        return None;
+    }
+    Some((info.rcWork.top, info.rcWork.bottom))
 }
 
 /// Subclass a top-level window's WndProc to observe the native size loop

--- a/agentmux-cef/src/client/wndproc.rs
+++ b/agentmux-cef/src/client/wndproc.rs
@@ -450,7 +450,7 @@ unsafe extern "system" fn window_edge_resize_wndproc(
                     e.session_origin_top_bottom
                 })
             };
-            if let Some((work_top, work_bottom)) = work_area_vertical_for_rect(&proposed) {
+            if let Some((work_top, work_bottom)) = work_area_vertical_for_drag(&proposed) {
                 let adjusted = crate::client::window_snap::snap_vertical_fill(
                     edge,
                     proposed.top,
@@ -503,33 +503,50 @@ fn lparam_is_null(lparam: isize) -> bool {
     lparam == 0
 }
 
-/// Work-area top/bottom (PHYSICAL px) of the monitor the proposed rect sits
-/// on, for the `WM_SIZING` snap clamp.
+/// Work-area top/bottom (PHYSICAL px) of the monitor to snap against during
+/// a `WM_SIZING` border drag.
 ///
-/// Resolved from the rect's own CENTER rather than a corner: during a
-/// top-edge drag the top corner is exactly the point being dragged past the
-/// screen edge, so keying off it would flip to the monitor *above* right at
-/// the moment the snap should engage. `MONITOR_DEFAULTTONEAREST` then keeps
-/// a rect dragged fully off-screen resolving to something sane.
+/// Resolved from the **cursor**, not from the rect. An earlier version keyed
+/// off the rect's center, which picks the wrong monitor whenever a window
+/// straddles two side-by-side displays with different work areas: the center
+/// can still be on monitor A while the edge being dragged is already over
+/// monitor B, so the clamp would fill against A's geometry (reagentx P2).
+/// Using a corner instead is no better — during a top-edge drag the top
+/// corner is the very point crossing the screen boundary, so it flips to the
+/// monitor *above* exactly when the snap should engage.
+///
+/// The cursor sidesteps both: it is physically on the edge being dragged, it
+/// is unambiguous when the window spans monitors, and it is what Windows
+/// itself uses to decide snap targets — which also makes this consistent
+/// with the drag-to-top gesture, whose zone detection is cursor-based for
+/// the same reason.
+///
+/// Falls back to the rect's center if the cursor can't be read, so a
+/// GetCursorPos failure degrades to the old behavior rather than disabling
+/// the snap.
 ///
 /// Deliberately does NOT use `app::monitor::get_monitor_work_area` — that
 /// helper converts to DIP for CEF's `Window::set_bounds`, while `WM_SIZING`
 /// rects are physical px. Mixing the two is the unit-confusion bug class
 /// called out in `client::window_snap`'s doc comment.
 #[cfg(target_os = "windows")]
-unsafe fn work_area_vertical_for_rect(
+unsafe fn work_area_vertical_for_drag(
     rect: &windows_sys::Win32::Foundation::RECT,
 ) -> Option<(i32, i32)> {
     use windows_sys::Win32::Foundation::POINT;
     use windows_sys::Win32::Graphics::Gdi::{
         GetMonitorInfoW, MonitorFromPoint, MONITORINFO, MONITOR_DEFAULTTONEAREST,
     };
+    use windows_sys::Win32::UI::WindowsAndMessaging::GetCursorPos;
 
-    let center = POINT {
-        x: rect.left + (rect.right - rect.left) / 2,
-        y: rect.top + (rect.bottom - rect.top) / 2,
-    };
-    let hmonitor = MonitorFromPoint(center, MONITOR_DEFAULTTONEAREST);
+    let mut probe = POINT { x: 0, y: 0 };
+    if GetCursorPos(&mut probe) == 0 {
+        probe = POINT {
+            x: rect.left + (rect.right - rect.left) / 2,
+            y: rect.top + (rect.bottom - rect.top) / 2,
+        };
+    }
+    let hmonitor = MonitorFromPoint(probe, MONITOR_DEFAULTTONEAREST);
     if hmonitor.is_null() {
         return None;
     }

--- a/agentmux-cef/src/commands/window/chrome.rs
+++ b/agentmux-cef/src/commands/window/chrome.rs
@@ -88,11 +88,14 @@ pub(crate) unsafe fn toggle_maximize_hwnd(hwnd: *mut std::ffi::c_void) {
 /// Maximize an already-resolved HWND, with no toggle — a window that is
 /// already maximized stays maximized.
 ///
-/// The drag-to-top gesture needs this rather than [`toggle_maximize_hwnd`]:
-/// the user dragged the title bar to the top of the screen asking to
-/// maximize, and a *toggle* would restore-down instead for the one case
-/// where a maximized window was dragged (which unmaximizes it in Windows,
-/// then re-drags it) — the opposite of what the gesture means.
+/// The drag-to-top gesture needs this rather than [`toggle_maximize_hwnd`].
+/// The gesture means "maximize", unconditionally: a toggle would be a
+/// latent trap, silently restoring-down instead on any path where the
+/// window is still maximized at release. That path is not currently
+/// reachable — `ui_tasks::drag::unmaximize_for_drag` restores a maximized
+/// window at drag START, so by release it is never maximized — but the
+/// gesture's meaning does not depend on that invariant holding, and this
+/// function is what keeps the two independent.
 #[cfg(target_os = "windows")]
 pub(crate) unsafe fn maximize_hwnd(hwnd: *mut std::ffi::c_void) {
     use windows_sys::Win32::UI::WindowsAndMessaging::{ShowWindow, SW_MAXIMIZE};

--- a/agentmux-cef/src/commands/window/chrome.rs
+++ b/agentmux-cef/src/commands/window/chrome.rs
@@ -47,17 +47,9 @@ pub fn maximize_window(state: &Arc<AppState>, args: &serde_json::Value) -> Resul
     let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
     #[cfg(target_os = "windows")]
     unsafe {
-        use windows_sys::Win32::UI::WindowsAndMessaging::*;
         let hwnd = resolve_window_hwnd(state, label);
         if !hwnd.is_null() {
-            let mut placement: WINDOWPLACEMENT = std::mem::zeroed();
-            placement.length = std::mem::size_of::<WINDOWPLACEMENT>() as u32;
-            GetWindowPlacement(hwnd, &mut placement);
-            if placement.showCmd == SW_MAXIMIZE as u32 {
-                ShowWindow(hwnd, SW_RESTORE);
-            } else {
-                ShowWindow(hwnd, SW_MAXIMIZE);
-            }
+            toggle_maximize_hwnd(hwnd);
             return Ok(serde_json::Value::Null);
         }
     }
@@ -65,6 +57,46 @@ pub fn maximize_window(state: &Arc<AppState>, args: &serde_json::Value) -> Resul
     crate::ui_tasks::post_maximize_window(state, label);
     let _ = (state, args, label);
     Ok(serde_json::Value::Null)
+}
+
+/// Toggle maximize/restore on an already-resolved HWND.
+///
+/// Split out of [`maximize_window`] so callers that ALREADY hold the raw
+/// HWND on the UI thread can reuse the exact placement logic without
+/// round-tripping through label resolution and JSON args — specifically the
+/// drag-to-top snap in `ui_tasks::drag`'s move loop
+/// (`SPEC_WINDOW_SNAP_MAXIMIZE_2026_09_04.md` §2.3), which runs inside a
+/// modal message loop where re-resolving a label would be both pointless
+/// and (given `resolve_window_hwnd` takes `&AppState` locks) needless
+/// contention.
+///
+/// Caller must be on the thread owning the window (Win32 `ShowWindow`
+/// rules); both current call sites are.
+#[cfg(target_os = "windows")]
+pub(crate) unsafe fn toggle_maximize_hwnd(hwnd: *mut std::ffi::c_void) {
+    use windows_sys::Win32::UI::WindowsAndMessaging::*;
+    let mut placement: WINDOWPLACEMENT = std::mem::zeroed();
+    placement.length = std::mem::size_of::<WINDOWPLACEMENT>() as u32;
+    GetWindowPlacement(hwnd, &mut placement);
+    if placement.showCmd == SW_MAXIMIZE as u32 {
+        ShowWindow(hwnd, SW_RESTORE);
+    } else {
+        ShowWindow(hwnd, SW_MAXIMIZE);
+    }
+}
+
+/// Maximize an already-resolved HWND, with no toggle — a window that is
+/// already maximized stays maximized.
+///
+/// The drag-to-top gesture needs this rather than [`toggle_maximize_hwnd`]:
+/// the user dragged the title bar to the top of the screen asking to
+/// maximize, and a *toggle* would restore-down instead for the one case
+/// where a maximized window was dragged (which unmaximizes it in Windows,
+/// then re-drags it) — the opposite of what the gesture means.
+#[cfg(target_os = "windows")]
+pub(crate) unsafe fn maximize_hwnd(hwnd: *mut std::ffi::c_void) {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{ShowWindow, SW_MAXIMIZE};
+    ShowWindow(hwnd, SW_MAXIMIZE);
 }
 
 /// Toggle a FLOATING pane's OS-window maximize via the pane-state reducer.

--- a/agentmux-cef/src/ui_tasks/drag.rs
+++ b/agentmux-cef/src/ui_tasks/drag.rs
@@ -394,6 +394,19 @@ wrap_task! {
                 let mut last_hover_emit = std::time::Instant::now()
                     - std::time::Duration::from_millis(50);
 
+                // Drag-to-top maximize (SPEC_WINDOW_SNAP_MAXIMIZE_2026_09_04 §2).
+                // Only for real top-level windows: floaters have their own
+                // top-of-screen semantics (redock / tear-back-in) that this
+                // must not collide with — see the spec's §2.4 scope note.
+                let snap_eligible = !self
+                    .source_label
+                    .as_deref()
+                    .unwrap_or("main")
+                    .starts_with("floating-");
+                // Tracks zone membership so the preview is shown/hidden on
+                // TRANSITIONS only, not re-issued on every mousemove tick.
+                let mut in_snap_zone = false;
+
                 // 3. Modal move loop on the UI thread.
                 let mut msg: MSG = std::mem::zeroed();
                 let mut moves: u32 = 0;
@@ -458,6 +471,38 @@ wrap_task! {
                                     SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
                                 );
                                 moves += 1;
+                                // Drag-to-top maximize: offer the snap while the
+                                // cursor sits in the work area's top zone. Keyed
+                                // off the CURSOR, not the window's own top edge —
+                                // the window is following the cursor at whatever
+                                // offset the user grabbed it, so its edge says
+                                // nothing about intent (see window_snap's
+                                // `cursor_in_top_maximize_zone` doc comment).
+                                if snap_eligible {
+                                    let zone = snap_work_area_for_cursor(cur.x, cur.y)
+                                        .map(|(wx, wy, ww, wh)| {
+                                            (
+                                                crate::client::window_snap::cursor_in_top_maximize_zone(
+                                                    cur.y,
+                                                    wy,
+                                                    crate::client::window_snap::SNAP_THRESHOLD_PX,
+                                                ),
+                                                (wx, wy, ww, wh),
+                                            )
+                                        });
+                                    if let Some((now_in_zone, work)) = zone {
+                                        if now_in_zone != in_snap_zone {
+                                            in_snap_zone = now_in_zone;
+                                            if now_in_zone {
+                                                crate::ui_tasks::snap_preview::show(
+                                                    work.0, work.1, work.2, work.3,
+                                                );
+                                            } else {
+                                                crate::ui_tasks::snap_preview::hide();
+                                            }
+                                        }
+                                    }
+                                }
                                 // Floater: emit redock-hover at 50ms cadence so the
                                 // drop-target highlight tracks the cursor while the
                                 // renderer's mousemove listener is dark (§2.2 / §3.2).
@@ -504,6 +549,12 @@ wrap_task! {
                                 SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
                             );
                             cancelled = true;
+                            // Same for the snap preview: an Esc-cancelled drag
+                            // must not leave a maximize offer on screen, and
+                            // must not maximize on the eventual release (the
+                            // commit below re-checks `cancelled` too).
+                            in_snap_zone = false;
+                            crate::ui_tasks::snap_preview::hide();
                             // Tear down the hover overlay immediately so the
                             // drop-target placeholder doesn't outlive the cancel.
                             let _ = crate::commands::window::clear_floating_redock_hover(
@@ -536,6 +587,25 @@ wrap_task! {
 
                 // 4. Stop the wake tick and release capture.
                 KillTimer(h, DRAG_TICK_ID);
+
+                // Drag-to-top maximize: commit iff the drag ended inside the
+                // zone and wasn't cancelled. Unconditionally hide the preview
+                // FIRST — this is the single exit path every `break` above
+                // funnels through, so clearing here is what guarantees the
+                // overlay can never outlive the drag regardless of how the
+                // loop ended (release, Esc-then-release, WM_QUIT, stolen
+                // capture via the wake-tick safety net).
+                crate::ui_tasks::snap_preview::hide();
+                if in_snap_zone && !cancelled {
+                    tracing::info!(
+                        "[start_window_drag] released in top snap zone — maximizing hwnd={:#x}",
+                        self.hwnd
+                    );
+                    // NOT the toggle variant: the gesture means "maximize",
+                    // and toggling would restore-down a window that was
+                    // already maximized when the drag began.
+                    crate::commands::window::maximize_hwnd(h as *mut std::ffi::c_void);
+                }
                 // Capture cursor position before ReleaseCapture — this is the
                 // actual release point in physical screen px. Included in the
                 // window_drag_ended payload so the renderer can use these
@@ -565,6 +635,36 @@ wrap_task! {
             }
         }
     }
+}
+
+/// Work area (PHYSICAL px, `(x, y, width, height)`) of the monitor under the
+/// cursor, for the drag-to-top snap zone + preview rect.
+///
+/// `MONITOR_DEFAULTTONEAREST` so a cursor dragged slightly past the top of
+/// the screen still resolves to the monitor it just left rather than
+/// failing. Deliberately does NOT use `app::monitor::get_monitor_work_area`
+/// — that converts to DIP for CEF's `Window::set_bounds`, while this whole
+/// move loop is physical px ("no devicePixelRatio math", per its anchor
+/// comment above). Mixing them is the unit-confusion bug class called out in
+/// `client::window_snap`'s doc comment.
+#[cfg(target_os = "windows")]
+unsafe fn snap_work_area_for_cursor(x: i32, y: i32) -> Option<(i32, i32, i32, i32)> {
+    use windows_sys::Win32::Foundation::POINT;
+    use windows_sys::Win32::Graphics::Gdi::{
+        GetMonitorInfoW, MonitorFromPoint, MONITORINFO, MONITOR_DEFAULTTONEAREST,
+    };
+
+    let hmonitor = MonitorFromPoint(POINT { x, y }, MONITOR_DEFAULTTONEAREST);
+    if hmonitor.is_null() {
+        return None;
+    }
+    let mut info: MONITORINFO = std::mem::zeroed();
+    info.cbSize = std::mem::size_of::<MONITORINFO>() as u32;
+    if GetMonitorInfoW(hmonitor, &mut info) == 0 {
+        return None;
+    }
+    let rc = info.rcWork;
+    Some((rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top))
 }
 
 #[cfg(target_os = "windows")]

--- a/agentmux-cef/src/ui_tasks/drag.rs
+++ b/agentmux-cef/src/ui_tasks/drag.rs
@@ -487,9 +487,15 @@ wrap_task! {
                     .as_deref()
                     .unwrap_or("main")
                     .starts_with("floating-");
-                // Tracks zone membership so the preview is shown/hidden on
-                // TRANSITIONS only, not re-issued on every mousemove tick.
-                let mut in_snap_zone = false;
+                // The preview rect currently on screen (None = hidden). Stored
+                // as the RECT rather than a bool so the preview also follows
+                // the cursor onto a different monitor: with side-by-side
+                // displays that share a work-area top, zone membership never
+                // changes as you cross between them, so a bool would leave the
+                // preview stranded on the monitor you left (reagentx P2).
+                // Comparing rects re-issues only when something actually
+                // differs, so this still doesn't fire per mousemove tick.
+                let mut snap_preview_rect: Option<(i32, i32, i32, i32)> = None;
 
                 // 3. Modal move loop on the UI thread.
                 let mut msg: MSG = std::mem::zeroed();
@@ -575,15 +581,17 @@ wrap_task! {
                                             )
                                         });
                                     if let Some((now_in_zone, work)) = zone {
-                                        if now_in_zone != in_snap_zone {
-                                            in_snap_zone = now_in_zone;
-                                            if now_in_zone {
-                                                crate::ui_tasks::snap_preview::show(
-                                                    work.0, work.1, work.2, work.3,
-                                                );
-                                            } else {
-                                                crate::ui_tasks::snap_preview::hide();
+                                        let want = if now_in_zone { Some(work) } else { None };
+                                        if want != snap_preview_rect {
+                                            match want {
+                                                Some((wx, wy, ww, wh)) => {
+                                                    crate::ui_tasks::snap_preview::show(
+                                                        wx, wy, ww, wh,
+                                                    );
+                                                }
+                                                None => crate::ui_tasks::snap_preview::hide(),
                                             }
+                                            snap_preview_rect = want;
                                         }
                                     }
                                 }
@@ -637,7 +645,7 @@ wrap_task! {
                             // must not leave a maximize offer on screen, and
                             // must not maximize on the eventual release (the
                             // commit below re-checks `cancelled` too).
-                            in_snap_zone = false;
+                            snap_preview_rect = None;
                             crate::ui_tasks::snap_preview::hide();
                             // Tear down the hover overlay immediately so the
                             // drop-target placeholder doesn't outlive the cancel.
@@ -680,7 +688,44 @@ wrap_task! {
                 // loop ended (release, Esc-then-release, WM_QUIT, stolen
                 // capture via the wake-tick safety net).
                 crate::ui_tasks::snap_preview::hide();
-                if in_snap_zone && !cancelled {
+                // Capture cursor position before ReleaseCapture — this is the
+                // actual release point in physical screen px. Included in the
+                // window_drag_ended payload so the renderer can use these
+                // coordinates directly, eliminating the ordering race between
+                // the dispatched WM_LBUTTONUP (DOM mouseup) and this event
+                // (both travel async CEF IPC, relative arrival is not guaranteed).
+                //
+                // Read BEFORE the maximize decision below, which needs it too.
+                let mut release_cursor = POINT { x: 0, y: 0 };
+                GetCursorPos(&mut release_cursor);
+
+                // Drag-to-top maximize: commit iff the drag ENDED inside the
+                // zone and wasn't cancelled.
+                //
+                // Recomputed from the release cursor rather than reusing the
+                // cached `in_snap_zone` flag. That flag only reflects the last
+                // WM_MOUSEMOVE we actually processed, and the top-of-loop
+                // GetAsyncKeyState fast-path above can break out before the
+                // final mousemove for the true release point is ever dequeued
+                // (its own comment documents that physical button state leads
+                // the message queue). Committing off the cached value would
+                // therefore maximize — or fail to — based on a stale position
+                // whenever the user crosses the zone boundary quickly right
+                // before releasing. reagentx P1, raised across four review
+                // rounds. The flag stays authoritative for the PREVIEW, which
+                // is inherently about transitions during the drag.
+                let released_in_zone = !cancelled
+                    && snap_eligible
+                    && snap_work_area_for_cursor(release_cursor.x, release_cursor.y)
+                        .map(|(_, work_top, _, _)| {
+                            crate::client::window_snap::cursor_in_top_maximize_zone(
+                                release_cursor.y,
+                                work_top,
+                                crate::client::window_snap::SNAP_THRESHOLD_PX,
+                            )
+                        })
+                        .unwrap_or(false);
+                if released_in_zone {
                     tracing::info!(
                         "[start_window_drag] released in top snap zone — maximizing hwnd={:#x}",
                         self.hwnd
@@ -690,14 +735,6 @@ wrap_task! {
                     // already maximized when the drag began.
                     crate::commands::window::maximize_hwnd(h as *mut std::ffi::c_void);
                 }
-                // Capture cursor position before ReleaseCapture — this is the
-                // actual release point in physical screen px. Included in the
-                // window_drag_ended payload so the renderer can use these
-                // coordinates directly, eliminating the ordering race between
-                // the dispatched WM_LBUTTONUP (DOM mouseup) and this event
-                // (both travel async CEF IPC, relative arrival is not guaranteed).
-                let mut release_cursor = POINT { x: 0, y: 0 };
-                GetCursorPos(&mut release_cursor);
                 ReleaseCapture();
                 // Notify the renderer that the drag is done. cursor_x/cursor_y
                 // are physical screen px; renderer divides by posScale() (DPR on

--- a/agentmux-cef/src/ui_tasks/drag.rs
+++ b/agentmux-cef/src/ui_tasks/drag.rs
@@ -324,14 +324,19 @@ unsafe fn run_macos_native_drag_loop(window: &Window, label: &str) {
 #[cfg(target_os = "windows")]
 wrap_task! {
     // `after_unmaximize` is true on the re-posted second half of a drag that
-    // had to un-maximize first — see the `unmaximize_for_drag` call site in
-    // `execute` for why that is split across two message-loop turns.
+    // had to un-maximize first; `max_*` then carry the pre-restore maximized
+    // geometry needed to place the window under the cursor. See the
+    // `begin_unmaximize_for_drag` call site in `execute` for why this is
+    // split across two tasks.
     // (Field-level doc comments don't compile inside `wrap_task!`.)
     pub struct Win32BeginMoveTask {
         hwnd: u64,
         state: Arc<AppState>,
         source_label: Option<String>,
         after_unmaximize: bool,
+        max_left: i32,
+        max_top: i32,
+        max_width: i32,
     }
 
     impl Task {
@@ -374,20 +379,23 @@ wrap_task! {
                 //      it must not run between SetCapture and the loop that
                 //      depends on that capture.
                 //
-                //      Then we RETURN and re-post ourselves, so the modal loop
-                //      below starts on the NEXT message-loop turn instead of
-                //      immediately. This is load-bearing, not tidiness: CEF
-                //      runs its own integrated message loop (`run_message_loop`
-                //      in lib.rs), and the loop below hijacks the UI thread
-                //      with a nested `GetMessageW` pump. Starting it in the
-                //      same turn as the resize starves Chromium of the
-                //      relayout/compositor work the `WM_SIZE` just queued, so
-                //      the window frame shrinks while the CONTENT keeps
-                //      painting at its old full-screen size — visibly wrong
-                //      for the whole drag, snapping right only on release when
-                //      the normal pump resumes (reported live 2026-09-05).
-                //      Yielding one turn costs well under a frame and the
-                //      button is still down, so the drag is unaffected.
+                //      Then we RETURN and re-post ourselves on a short DELAY,
+                //      so the modal loop below doesn't start until the resize
+                //      has actually settled. This is load-bearing, not
+                //      tidiness: CEF runs its own integrated message loop
+                //      (`run_message_loop` in lib.rs), and the loop below
+                //      hijacks the UI thread with a nested `GetMessageW` pump.
+                //      Chromium defers non-nestable work while a nested native
+                //      loop is running, so the relayout/compositor work queued
+                //      by the `WM_SIZE` doesn't complete — the window frame
+                //      shrinks while the CONTENT keeps painting at its old
+                //      full-screen size for the whole drag, snapping right only
+                //      on release when the normal pump resumes (reported live
+                //      2026-09-05).
+                //
+                //      An earlier attempt yielded exactly ONE message-loop turn
+                //      here; that was not enough (the pipeline spans several
+                //      frames) and the bug survived. Hence a real delay.
                 //
                 //      Floaters are excluded for the same reason they're
                 //      excluded from the snap itself (SPEC §2.4): they are
@@ -401,16 +409,38 @@ wrap_task! {
                         .as_deref()
                         .unwrap_or("main")
                         .starts_with("floating-")
-                    && unmaximize_for_drag(h)
-                {
-                    let mut task = Win32BeginMoveTask::new(
-                        self.hwnd,
-                        self.state.clone(),
-                        self.source_label.clone(),
-                        true,
+                    {
+                    if let Some((max_left, max_top, max_width)) = begin_unmaximize_for_drag(h) {
+                        let mut task = Win32BeginMoveTask::new(
+                            self.hwnd,
+                            self.state.clone(),
+                            self.source_label.clone(),
+                            true,
+                            max_left,
+                            max_top,
+                            max_width,
+                        );
+                        post_delayed_task(
+                            ThreadId::UI,
+                            Some(&mut task),
+                            UNMAXIMIZE_SETTLE_MS,
+                        );
+                        return;
+                    }
+                }
+
+                // Second half of an un-maximize drag: the restore has settled,
+                // so place the (now smaller) window under the cursor before
+                // taking capture. Positioning is a pure MOVE — no resize — so
+                // unlike the restore it needs nothing from Chromium and is safe
+                // to do immediately before the modal loop.
+                if self.after_unmaximize {
+                    place_restored_window_under_cursor(
+                        h,
+                        self.max_left,
+                        self.max_top,
+                        self.max_width,
                     );
-                    post_task(ThreadId::UI, Some(&mut task));
-                    return;
                 }
 
                 // 1. Capture the mouse to THIS (UI) thread so WM_MOUSEMOVE /
@@ -691,57 +721,97 @@ wrap_task! {
     }
 }
 
-/// If `hwnd` is maximized, restore it and reposition it under the cursor so
-/// the drag can continue naturally — see
-/// `window_snap::unmaximize_drag_origin` for the placement rules and
-/// `SPEC_WINDOW_SNAP_MAXIMIZE_2026_09_04.md` §2.6.
+/// How long to let a `SW_RESTORE` settle before starting the modal drag
+/// loop. Roughly three 60Hz frames — enough for Chromium's
+/// resize→layout→commit→present pipeline to finish while the normal message
+/// loop is still running, short enough that the window feels like it starts
+/// following the cursor immediately.
 ///
-/// No-op for a window that isn't maximized (the overwhelmingly common case),
-/// so callers can invoke it unconditionally at drag start.
-///
-/// Returns `true` only when it actually restored a maximized window — the
-/// caller uses that to decide whether it needs to yield a message-loop turn
-/// before starting the modal drag loop (see the call site).
+/// **Empirical, and deliberately the smallest knob in this design.** An
+/// earlier attempt used a single message-loop turn (effectively 0ms) and the
+/// stale-paint bug survived; if it ever resurfaces this constant is the first
+/// thing to raise. See `SPEC_WINDOW_SNAP_MAXIMIZE_2026_09_04.md` §2.6.
 #[cfg(target_os = "windows")]
-unsafe fn unmaximize_for_drag(h: windows_sys::Win32::Foundation::HWND) -> bool {
-    use windows_sys::Win32::Foundation::{POINT, RECT};
+const UNMAXIMIZE_SETTLE_MS: i64 = 48;
+
+/// Restore a maximized window at the START of a drag, returning the
+/// pre-restore maximized `(left, top, width)` the caller must hand to
+/// [`place_restored_window_under_cursor`] once the resize has settled.
+///
+/// Returns `None` — and does nothing — when the window isn't maximized (the
+/// overwhelmingly common case), so callers can invoke it unconditionally.
+///
+/// Split from the placement step on purpose: the RESTORE needs Chromium to
+/// relayout (which it can't do while a nested modal loop is running), while
+/// the placement is a pure move that needs nothing. See the call site.
+#[cfg(target_os = "windows")]
+unsafe fn begin_unmaximize_for_drag(
+    h: windows_sys::Win32::Foundation::HWND,
+) -> Option<(i32, i32, i32)> {
+    use windows_sys::Win32::Foundation::RECT;
     use windows_sys::Win32::UI::WindowsAndMessaging::{
-        GetCursorPos, GetWindowPlacement, GetWindowRect, SetWindowPos, ShowWindow, SW_MAXIMIZE,
-        SW_RESTORE, SWP_NOACTIVATE, SWP_NOSIZE, SWP_NOZORDER, WINDOWPLACEMENT,
+        GetWindowPlacement, GetWindowRect, ShowWindow, SW_MAXIMIZE, SW_RESTORE, WINDOWPLACEMENT,
     };
 
     let mut placement: WINDOWPLACEMENT = std::mem::zeroed();
     placement.length = std::mem::size_of::<WINDOWPLACEMENT>() as u32;
     if GetWindowPlacement(h, &mut placement) == 0 || placement.showCmd != SW_MAXIMIZE as u32 {
-        return false;
+        return None;
     }
 
     let mut maximized: RECT = std::mem::zeroed();
     if GetWindowRect(h, &mut maximized) == 0 {
-        return false;
+        return None;
+    }
+
+    ShowWindow(h, SW_RESTORE);
+    tracing::info!(
+        "[start_window_drag] restoring maximized window for drag hwnd={:p} — \
+         settling {}ms before the move loop",
+        h, UNMAXIMIZE_SETTLE_MS
+    );
+    Some((maximized.left, maximized.top, maximized.right - maximized.left))
+}
+
+/// Place a just-restored window under the CURRENT cursor, using the
+/// pre-restore maximized geometry to preserve the grab point — see
+/// `window_snap::unmaximize_drag_origin` for the placement rules and
+/// `SPEC_WINDOW_SNAP_MAXIMIZE_2026_09_04.md` §2.6.
+///
+/// Reads the cursor fresh (rather than reusing the mousedown position from
+/// before the settle delay) so the window lands exactly under wherever the
+/// pointer is NOW — otherwise every pixel the user moved during the settle
+/// would become a permanent grab-offset error for the rest of the drag.
+#[cfg(target_os = "windows")]
+unsafe fn place_restored_window_under_cursor(
+    h: windows_sys::Win32::Foundation::HWND,
+    max_left: i32,
+    max_top: i32,
+    max_width: i32,
+) {
+    use windows_sys::Win32::Foundation::{POINT, RECT};
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        GetCursorPos, GetWindowRect, SetWindowPos, SWP_NOACTIVATE, SWP_NOSIZE, SWP_NOZORDER,
+    };
+
+    // Read the restored size back rather than trusting
+    // `WINDOWPLACEMENT.rcNormalPosition`: that field is documented in
+    // *workspace* coordinates, which diverge from screen coordinates in
+    // exactly the multi-monitor / taskbar setups this has to work in. A
+    // post-restore GetWindowRect is unambiguously screen coords.
+    let mut restored: RECT = std::mem::zeroed();
+    if GetWindowRect(h, &mut restored) == 0 {
+        return;
     }
     let mut cursor = POINT { x: 0, y: 0 };
     GetCursorPos(&mut cursor);
 
-    ShowWindow(h, SW_RESTORE);
-
-    // Read the restored size back rather than trusting
-    // `placement.rcNormalPosition`: that field is documented in *workspace*
-    // coordinates, which diverge from screen coordinates in exactly the
-    // multi-monitor / taskbar setups this feature has to work in. The
-    // post-restore GetWindowRect is unambiguously screen coords.
-    let mut restored: RECT = std::mem::zeroed();
-    if GetWindowRect(h, &mut restored) == 0 {
-        // Already un-maximized by ShowWindow above, so the caller still needs
-        // to yield a turn for the relayout even though placement failed.
-        return true;
-    }
     let (new_x, new_y) = crate::client::window_snap::unmaximize_drag_origin(
         cursor.x,
         cursor.y,
-        maximized.left,
-        maximized.top,
-        maximized.right - maximized.left,
+        max_left,
+        max_top,
+        max_width,
         restored.right - restored.left,
     );
     SetWindowPos(
@@ -754,10 +824,9 @@ unsafe fn unmaximize_for_drag(h: windows_sys::Win32::Foundation::HWND) -> bool {
         SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
     );
     tracing::info!(
-        "[start_window_drag] un-maximized for drag hwnd={:p} -> ({},{})",
+        "[start_window_drag] placed restored window under cursor hwnd={:p} -> ({},{})",
         h, new_x, new_y
     );
-    true
 }
 
 /// Work area (PHYSICAL px, `(x, y, width, height)`) of the monitor under the
@@ -792,6 +861,6 @@ unsafe fn snap_work_area_for_cursor(x: i32, y: i32) -> Option<(i32, i32, i32, i3
 
 #[cfg(target_os = "windows")]
 pub fn post_win32_begin_move(hwnd: u64, state: Arc<AppState>, source_label: Option<String>) {
-    let mut task = Win32BeginMoveTask::new(hwnd, state, source_label, false);
+    let mut task = Win32BeginMoveTask::new(hwnd, state, source_label, false, 0, 0, 0);
     post_task(ThreadId::UI, Some(&mut task));
 }

--- a/agentmux-cef/src/ui_tasks/drag.rs
+++ b/agentmux-cef/src/ui_tasks/drag.rs
@@ -359,6 +359,31 @@ wrap_task! {
                     return;
                 }
 
+                // 0.5. Dragging a MAXIMIZED window restores it down under the
+                //      cursor first — Chrome/Windows both do this, and without
+                //      it a maximized window would either refuse to move or
+                //      slide around at full-screen size.
+                //
+                //      Done BEFORE taking capture, deliberately: ShowWindow
+                //      pumps messages and can disturb activation/capture, so
+                //      it must not run between SetCapture and the loop that
+                //      depends on that capture.
+                //
+                //      Floaters are excluded for the same reason they're
+                //      excluded from the snap itself (SPEC §2.4): they are
+                //      borderless WS_POPUPs with no native maximize placement
+                //      — `toggle_floating_maximize` manages their geometry
+                //      through the reducer instead, so SW_RESTORE here would
+                //      desync that state.
+                if !self
+                    .source_label
+                    .as_deref()
+                    .unwrap_or("main")
+                    .starts_with("floating-")
+                {
+                    unmaximize_for_drag(h);
+                }
+
                 // 1. Capture the mouse to THIS (UI) thread so WM_MOUSEMOVE /
                 //    WM_LBUTTONUP route to our GetMessage loop. ReleaseCapture
                 //    first to drop any capture Chromium set on the press.
@@ -635,6 +660,68 @@ wrap_task! {
             }
         }
     }
+}
+
+/// If `hwnd` is maximized, restore it and reposition it under the cursor so
+/// the drag can continue naturally — see
+/// `window_snap::unmaximize_drag_origin` for the placement rules and
+/// `SPEC_WINDOW_SNAP_MAXIMIZE_2026_09_04.md` §2.6.
+///
+/// No-op for a window that isn't maximized (the overwhelmingly common case),
+/// so callers can invoke it unconditionally at drag start.
+#[cfg(target_os = "windows")]
+unsafe fn unmaximize_for_drag(h: windows_sys::Win32::Foundation::HWND) {
+    use windows_sys::Win32::Foundation::{POINT, RECT};
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        GetCursorPos, GetWindowPlacement, GetWindowRect, SetWindowPos, ShowWindow, SW_MAXIMIZE,
+        SW_RESTORE, SWP_NOACTIVATE, SWP_NOSIZE, SWP_NOZORDER, WINDOWPLACEMENT,
+    };
+
+    let mut placement: WINDOWPLACEMENT = std::mem::zeroed();
+    placement.length = std::mem::size_of::<WINDOWPLACEMENT>() as u32;
+    if GetWindowPlacement(h, &mut placement) == 0 || placement.showCmd != SW_MAXIMIZE as u32 {
+        return;
+    }
+
+    let mut maximized: RECT = std::mem::zeroed();
+    if GetWindowRect(h, &mut maximized) == 0 {
+        return;
+    }
+    let mut cursor = POINT { x: 0, y: 0 };
+    GetCursorPos(&mut cursor);
+
+    ShowWindow(h, SW_RESTORE);
+
+    // Read the restored size back rather than trusting
+    // `placement.rcNormalPosition`: that field is documented in *workspace*
+    // coordinates, which diverge from screen coordinates in exactly the
+    // multi-monitor / taskbar setups this feature has to work in. The
+    // post-restore GetWindowRect is unambiguously screen coords.
+    let mut restored: RECT = std::mem::zeroed();
+    if GetWindowRect(h, &mut restored) == 0 {
+        return;
+    }
+    let (new_x, new_y) = crate::client::window_snap::unmaximize_drag_origin(
+        cursor.x,
+        cursor.y,
+        maximized.left,
+        maximized.top,
+        maximized.right - maximized.left,
+        restored.right - restored.left,
+    );
+    SetWindowPos(
+        h,
+        std::ptr::null_mut(),
+        new_x,
+        new_y,
+        0,
+        0,
+        SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
+    );
+    tracing::info!(
+        "[start_window_drag] un-maximized for drag hwnd={:p} -> ({},{})",
+        h, new_x, new_y
+    );
 }
 
 /// Work area (PHYSICAL px, `(x, y, width, height)`) of the monitor under the

--- a/agentmux-cef/src/ui_tasks/drag.rs
+++ b/agentmux-cef/src/ui_tasks/drag.rs
@@ -323,10 +323,15 @@ unsafe fn run_macos_native_drag_loop(window: &Window, label: &str) {
 // per-move IPC. Full design + risks: SPEC_WINDOW_DRAG_MANUAL_MOVE_LOOP_2026_05_29.
 #[cfg(target_os = "windows")]
 wrap_task! {
+    // `after_unmaximize` is true on the re-posted second half of a drag that
+    // had to un-maximize first — see the `unmaximize_for_drag` call site in
+    // `execute` for why that is split across two message-loop turns.
+    // (Field-level doc comments don't compile inside `wrap_task!`.)
     pub struct Win32BeginMoveTask {
         hwnd: u64,
         state: Arc<AppState>,
         source_label: Option<String>,
+        after_unmaximize: bool,
     }
 
     impl Task {
@@ -369,19 +374,43 @@ wrap_task! {
                 //      it must not run between SetCapture and the loop that
                 //      depends on that capture.
                 //
+                //      Then we RETURN and re-post ourselves, so the modal loop
+                //      below starts on the NEXT message-loop turn instead of
+                //      immediately. This is load-bearing, not tidiness: CEF
+                //      runs its own integrated message loop (`run_message_loop`
+                //      in lib.rs), and the loop below hijacks the UI thread
+                //      with a nested `GetMessageW` pump. Starting it in the
+                //      same turn as the resize starves Chromium of the
+                //      relayout/compositor work the `WM_SIZE` just queued, so
+                //      the window frame shrinks while the CONTENT keeps
+                //      painting at its old full-screen size — visibly wrong
+                //      for the whole drag, snapping right only on release when
+                //      the normal pump resumes (reported live 2026-09-05).
+                //      Yielding one turn costs well under a frame and the
+                //      button is still down, so the drag is unaffected.
+                //
                 //      Floaters are excluded for the same reason they're
                 //      excluded from the snap itself (SPEC §2.4): they are
                 //      borderless WS_POPUPs with no native maximize placement
                 //      — `toggle_floating_maximize` manages their geometry
                 //      through the reducer instead, so SW_RESTORE here would
                 //      desync that state.
-                if !self
-                    .source_label
-                    .as_deref()
-                    .unwrap_or("main")
-                    .starts_with("floating-")
+                if !self.after_unmaximize
+                    && !self
+                        .source_label
+                        .as_deref()
+                        .unwrap_or("main")
+                        .starts_with("floating-")
+                    && unmaximize_for_drag(h)
                 {
-                    unmaximize_for_drag(h);
+                    let mut task = Win32BeginMoveTask::new(
+                        self.hwnd,
+                        self.state.clone(),
+                        self.source_label.clone(),
+                        true,
+                    );
+                    post_task(ThreadId::UI, Some(&mut task));
+                    return;
                 }
 
                 // 1. Capture the mouse to THIS (UI) thread so WM_MOUSEMOVE /
@@ -669,8 +698,12 @@ wrap_task! {
 ///
 /// No-op for a window that isn't maximized (the overwhelmingly common case),
 /// so callers can invoke it unconditionally at drag start.
+///
+/// Returns `true` only when it actually restored a maximized window — the
+/// caller uses that to decide whether it needs to yield a message-loop turn
+/// before starting the modal drag loop (see the call site).
 #[cfg(target_os = "windows")]
-unsafe fn unmaximize_for_drag(h: windows_sys::Win32::Foundation::HWND) {
+unsafe fn unmaximize_for_drag(h: windows_sys::Win32::Foundation::HWND) -> bool {
     use windows_sys::Win32::Foundation::{POINT, RECT};
     use windows_sys::Win32::UI::WindowsAndMessaging::{
         GetCursorPos, GetWindowPlacement, GetWindowRect, SetWindowPos, ShowWindow, SW_MAXIMIZE,
@@ -680,12 +713,12 @@ unsafe fn unmaximize_for_drag(h: windows_sys::Win32::Foundation::HWND) {
     let mut placement: WINDOWPLACEMENT = std::mem::zeroed();
     placement.length = std::mem::size_of::<WINDOWPLACEMENT>() as u32;
     if GetWindowPlacement(h, &mut placement) == 0 || placement.showCmd != SW_MAXIMIZE as u32 {
-        return;
+        return false;
     }
 
     let mut maximized: RECT = std::mem::zeroed();
     if GetWindowRect(h, &mut maximized) == 0 {
-        return;
+        return false;
     }
     let mut cursor = POINT { x: 0, y: 0 };
     GetCursorPos(&mut cursor);
@@ -699,7 +732,9 @@ unsafe fn unmaximize_for_drag(h: windows_sys::Win32::Foundation::HWND) {
     // post-restore GetWindowRect is unambiguously screen coords.
     let mut restored: RECT = std::mem::zeroed();
     if GetWindowRect(h, &mut restored) == 0 {
-        return;
+        // Already un-maximized by ShowWindow above, so the caller still needs
+        // to yield a turn for the relayout even though placement failed.
+        return true;
     }
     let (new_x, new_y) = crate::client::window_snap::unmaximize_drag_origin(
         cursor.x,
@@ -722,6 +757,7 @@ unsafe fn unmaximize_for_drag(h: windows_sys::Win32::Foundation::HWND) {
         "[start_window_drag] un-maximized for drag hwnd={:p} -> ({},{})",
         h, new_x, new_y
     );
+    true
 }
 
 /// Work area (PHYSICAL px, `(x, y, width, height)`) of the monitor under the
@@ -756,6 +792,6 @@ unsafe fn snap_work_area_for_cursor(x: i32, y: i32) -> Option<(i32, i32, i32, i3
 
 #[cfg(target_os = "windows")]
 pub fn post_win32_begin_move(hwnd: u64, state: Arc<AppState>, source_label: Option<String>) {
-    let mut task = Win32BeginMoveTask::new(hwnd, state, source_label);
+    let mut task = Win32BeginMoveTask::new(hwnd, state, source_label, false);
     post_task(ThreadId::UI, Some(&mut task));
 }

--- a/agentmux-cef/src/ui_tasks/mod.rs
+++ b/agentmux-cef/src/ui_tasks/mod.rs
@@ -26,6 +26,8 @@ mod window;
 mod drag;
 mod pool;
 mod pane_geometry;
+#[cfg(target_os = "windows")]
+mod snap_preview;
 #[cfg(target_os = "macos")]
 pub mod pane_hole_mask;
 mod platform_macos;

--- a/agentmux-cef/src/ui_tasks/snap_preview.rs
+++ b/agentmux-cef/src/ui_tasks/snap_preview.rs
@@ -1,0 +1,150 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Translucent snap-preview overlay for the drag-to-top maximize gesture —
+//! `docs/specs/SPEC_WINDOW_SNAP_MAXIMIZE_2026_09_04.md` §2.2.
+//!
+//! A borderless, click-through, non-activating layered window that paints a
+//! single translucent rectangle over the area the dragged window would
+//! occupy if released. This is the same shape Windows' own Snap Assist
+//! preview takes, and it has to be a separate OS window rather than
+//! something the renderer draws: the preview covers the FULL work area
+//! while the dragged window itself is small and following the cursor, so
+//! there is no in-window surface that could render it.
+//!
+//! Lifecycle is owned entirely by the move loop in [`super::drag`] — show on
+//! entering the snap zone, hide on leaving it, on Esc-cancel, and
+//! unconditionally when the loop exits (belt-and-braces: an overlay that
+//! outlives its drag is a stuck always-on-top rectangle over the user's
+//! screen, so every exit path clears it).
+//!
+//! Windows-only: the gesture itself is Windows-only (see the spec's platform
+//! scope), so there is no cross-platform abstraction to justify here.
+
+#![cfg(target_os = "windows")]
+
+use std::sync::Mutex;
+
+use windows_sys::Win32::Foundation::{COLORREF, HWND};
+
+/// The one preview window, created lazily on first use and then reused for
+/// the rest of the process's life (hidden between drags rather than
+/// destroyed — creating a window inside a modal drag loop on every zone
+/// entry would be both slow and a needless failure point mid-gesture).
+static PREVIEW_HWND: Mutex<usize> = Mutex::new(0);
+
+/// Accent-ish blue at ~25% alpha. Deliberately a flat translucent fill with
+/// no border: `SetLayeredWindowAttributes` gives whole-window alpha for free
+/// via the class background brush, so this needs no `WM_PAINT` handler and
+/// no GDI resources beyond the brush.
+const PREVIEW_FILL: COLORREF = 0x00C0_7020; // BGR: a muted blue
+const PREVIEW_ALPHA: u8 = 64; // 0..255
+
+/// Show (creating if needed) the preview at the given PHYSICAL-pixel rect.
+///
+/// Best-effort: any failure to create or position the overlay is logged and
+/// swallowed. The preview is a visual affordance — losing it must never
+/// break the drag or the snap itself, both of which work fine without it.
+pub(crate) fn show(x: i32, y: i32, width: i32, height: i32) {
+    unsafe {
+        let hwnd = match ensure_window() {
+            Some(h) => h,
+            None => return,
+        };
+        use windows_sys::Win32::UI::WindowsAndMessaging::{
+            SetWindowPos, HWND_TOPMOST, SWP_NOACTIVATE, SWP_SHOWWINDOW,
+        };
+        SetWindowPos(
+            hwnd,
+            HWND_TOPMOST,
+            x,
+            y,
+            width,
+            height,
+            // NOACTIVATE is essential: activating the overlay mid-drag would
+            // steal focus from the window being dragged and can drop the
+            // capture the move loop depends on.
+            SWP_NOACTIVATE | SWP_SHOWWINDOW,
+        );
+    }
+}
+
+/// Hide the preview. Safe to call when it was never shown or never created.
+pub(crate) fn hide() {
+    unsafe {
+        let hwnd = *PREVIEW_HWND.lock().unwrap_or_else(|e| e.into_inner()) as HWND;
+        if hwnd.is_null() {
+            return;
+        }
+        use windows_sys::Win32::UI::WindowsAndMessaging::{ShowWindow, SW_HIDE};
+        ShowWindow(hwnd, SW_HIDE);
+    }
+}
+
+/// Create the overlay window on first use; return the cached HWND after.
+unsafe fn ensure_window() -> Option<HWND> {
+    use windows_sys::Win32::Graphics::Gdi::CreateSolidBrush;
+    use windows_sys::Win32::System::LibraryLoader::GetModuleHandleW;
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        CreateWindowExW, DefWindowProcW, IsWindow, RegisterClassW, SetLayeredWindowAttributes,
+        LWA_ALPHA, WNDCLASSW, WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW,
+        WS_EX_TOPMOST, WS_EX_TRANSPARENT, WS_POPUP,
+    };
+
+    let mut guard = PREVIEW_HWND.lock().unwrap_or_else(|e| e.into_inner());
+    let existing = *guard as HWND;
+    if !existing.is_null() && IsWindow(existing) != 0 {
+        return Some(existing);
+    }
+
+    // UTF-16, NUL-terminated — Win32 string convention.
+    let class_name: Vec<u16> = "AgentMuxSnapPreview\0".encode_utf16().collect();
+    let hinstance = GetModuleHandleW(std::ptr::null());
+
+    // RegisterClassW is idempotent-by-failure here: a second call with the
+    // same name fails harmlessly (ERROR_CLASS_ALREADY_EXISTS) and
+    // CreateWindowExW below still succeeds against the first registration.
+    // Only reachable a second time if the window was destroyed externally.
+    let wc = WNDCLASSW {
+        style: 0,
+        lpfnWndProc: Some(DefWindowProcW),
+        cbClsExtra: 0,
+        cbWndExtra: 0,
+        hInstance: hinstance,
+        hIcon: std::ptr::null_mut(),
+        hCursor: std::ptr::null_mut(),
+        hbrBackground: CreateSolidBrush(PREVIEW_FILL),
+        lpszMenuName: std::ptr::null(),
+        lpszClassName: class_name.as_ptr(),
+    };
+    RegisterClassW(&wc);
+
+    let hwnd = CreateWindowExW(
+        // LAYERED   — enables the whole-window alpha below.
+        // TRANSPARENT + NOACTIVATE — click-through and never takes focus, so
+        //             the overlay cannot intercept the drag's own mouse
+        //             input or steal activation mid-gesture.
+        // TOOLWINDOW — keeps it out of the taskbar and Alt-Tab.
+        // TOPMOST    — must paint above the dragged window itself.
+        WS_EX_LAYERED | WS_EX_TRANSPARENT | WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW | WS_EX_TOPMOST,
+        class_name.as_ptr(),
+        std::ptr::null(),
+        WS_POPUP,
+        0,
+        0,
+        0,
+        0,
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        hinstance,
+        std::ptr::null(),
+    );
+    if hwnd.is_null() {
+        tracing::warn!("[snap-preview] CreateWindowExW failed — snap will work without a preview");
+        return None;
+    }
+    SetLayeredWindowAttributes(hwnd, 0, PREVIEW_ALPHA, LWA_ALPHA);
+    *guard = hwnd as usize;
+    tracing::info!("[snap-preview] created overlay window {:p}", hwnd);
+    Some(hwnd)
+}

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -178,7 +178,7 @@ are doing history". Everything else is here; the completeness
 assertion in the generator fails the build rather than emit a
 partial list.
 
-### implemented (132)
+### implemented (133)
 
 | Spec | Title |
 |---|---|
@@ -307,6 +307,7 @@ partial list.
 | [`SPEC_TRANSCRIPT_NODE_HOVER_PEEK_2026_08_03`](SPEC_TRANSCRIPT_NODE_HOVER_PEEK_2026_08_03.md) | Spec: hover-to-peek on tool calls and thinking clumps |
 | [`SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25`](SPEC_TRANSCRIPT_NODE_HOVER_PEEK_ALL_KINDS_2026_08_25.md) | Spec: hover-to-peek on EVERY transcript node kind, 50ms delay |
 | [`SPEC_WINDOW_LIFECYCLE_CLOSE_RELIABILITY_2026_07_04`](SPEC_WINDOW_LIFECYCLE_CLOSE_RELIABILITY_2026_07_04.md) | SPEC: Window-close reliability — fix the `backend_window_id` race |
+| [`SPEC_WINDOW_SNAP_MAXIMIZE_2026_09_04`](SPEC_WINDOW_SNAP_MAXIMIZE_2026_09_04.md) | SPEC — Chrome-style window snap: drag-to-top maximize, border-drag vertical snap |
 | [`SPEC_WORKING_STATE_AND_SCROLL_FOLLOW_HARDENING_2026_07_27`](SPEC_WORKING_STATE_AND_SCROLL_FOLLOW_HARDENING_2026_07_27.md) | SPEC: Harden the "Working…" indicator and message-list auto-follow against four related recurring bugs |
 | [`cef-portable-build`](cef-portable-build.md) | Spec: CEF Portable Build Pipeline |
 | [`dev-build-env-isolation`](dev-build-env-isolation.md) | Dev-Build Env Isolation |

--- a/docs/specs/SPEC_WINDOW_SNAP_MAXIMIZE_2026_09_04.md
+++ b/docs/specs/SPEC_WINDOW_SNAP_MAXIMIZE_2026_09_04.md
@@ -196,6 +196,34 @@ clear any visible snap preview immediately, same as the existing
 `clear_floating_redock_hover` call in that same arm does for the floater
 case.
 
+### 2.6 The inverse gesture: dragging a maximized window restores it
+
+**Added 2026-09-05 after live testing** — drag-to-top maximize shipped
+working, but the round trip didn't: dragging the now-maximized window again
+left it maximized. Chrome/Windows both restore a maximized window down the
+moment you start dragging its title bar, and the window has to land *under
+the cursor* or the drag feels like it teleported.
+
+Implemented in `ui_tasks::drag::unmaximize_for_drag`, called at drag start:
+
+- **Before taking capture**, deliberately. `ShowWindow` pumps messages and
+  can disturb activation/capture; running it between `SetCapture` and the
+  loop that depends on that capture is exactly the kind of ordering the
+  move loop's existing `GetCapture()` sanity check exists to catch.
+- **Placement rules** (`window_snap::unmaximize_drag_origin`, unit-tested):
+  horizontally the cursor keeps its *fractional* position along the title
+  bar (absolute offset would drop the cursor past the right edge whenever
+  the restored window is much narrower); vertically it keeps its *absolute*
+  offset (title bars are a fixed height, so proportional would slide the
+  grab off the chrome on a short window).
+- **Restored size is read back via `GetWindowRect` after `SW_RESTORE`**, not
+  from `WINDOWPLACEMENT.rcNormalPosition` — that field is documented in
+  *workspace* coordinates, which diverge from screen coordinates in exactly
+  the multi-monitor/taskbar setups this has to work in.
+- Floaters excluded, same reason as §2.4: borderless `WS_POPUP`s have no
+  native maximize placement and their geometry is reducer-owned
+  (`toggle_floating_maximize`), so `SW_RESTORE` would desync that state.
+
 ## 3. Design — Feature B: border-drag vertical snap
 
 Confirmed broken (§0.2). Fix by **intercepting the native resize, not

--- a/docs/specs/SPEC_WINDOW_SNAP_MAXIMIZE_2026_09_04.md
+++ b/docs/specs/SPEC_WINDOW_SNAP_MAXIMIZE_2026_09_04.md
@@ -1,0 +1,427 @@
+# SPEC — Chrome-style window snap: drag-to-top maximize, border-drag vertical snap
+
+**Date:** 2026-09-04
+**Status:** implemented 2026-09-05 — both features built; pending live
+verification of the manual test plan in §6 (native Win32 message-loop code,
+not reachable by any test harness). See §7 for what shipped.
+**Repo:** agentmuxai/agentmux
+**Trigger:** Operator request — dragging the AgentMux window to the top of the
+screen should offer to maximize it, and dragging a window *border* to the
+top/bottom of the screen should vertically snap that edge to the screen edge
+(keep width, extend/shrink height) — "the same behavior as the Chrome
+browser." Chrome is the right reference point specifically because Chrome,
+like AgentMux, draws its own custom title bar on Windows instead of using
+the native one, so it can't just inherit this for free from `DefWindowProc`
+either — it re-implements the behavior itself.
+
+---
+
+## 0. Why this doesn't already work
+
+**Amended 2026-09-05 — operator live-tested §0.2's "likely already works"
+claim on a real build. It does not.** Border-drag vertical snap is
+confirmed broken, not just unverified. This changes the analysis below:
+the two symptoms are more likely **one root cause** wearing two faces —
+see §0.3 — not two unrelated bugs as the original pass assumed.
+
+### 0.1 Drag-to-top → maximize: genuinely missing, and the gap is on record
+
+AgentMux's title-bar drag is **not** a native OS window move. `agentmux-cef/src/ui_tasks/drag.rs:314-323` documents why: the standard trick
+(`WM_NCLBUTTONDOWN(HTCAPTION)` → `DefWindowProc` starts the OS's own modal
+move loop, which is what makes Aero Snap fire automatically) does not work
+for a CEF/Chromium window — Chromium's `HWNDMessageHandler` swallows the
+non-client message before `DefWindowProc` ever gets to start that loop
+(instrumented proof in the comment: the `SendMessageW` call returned in
+0.4ms, i.e. it never blocked on a real move loop). So `Win32BeginMoveTask`
+(`drag.rs:325-568`) runs a **fully manual** move loop instead: `SetCapture`
++ a `GetMessageW` loop + `SetWindowPos` per `WM_MOUSEMOVE`. This is
+deliberate, documented, working design (`docs/specs/SPEC_WINDOW_DRAG_MANUAL_MOVE_LOOP_2026_05_29.md`,
+which itself supersedes an earlier native-loop attempt that didn't work,
+`SPEC_WINDOW_DRAG_NATIVE_MOVE_LOOP_2026_05_29.md`) — but because it's
+manual, none of Windows' own Snap Assist/edge-detection logic ever runs
+during it. That spec says so explicitly:
+
+> Non-goals (v1): Aero Snap/snap-assist... **Lost** (v1) — can add manual
+> edge-snap later.
+
+This is that "later." The fix has to be a **manual re-implementation** of
+the top-edge-detection-and-maximize gesture, built into the same loop that
+replaced the native one — there's no way to "turn Aero Snap back on" short
+of solving the underlying CEF non-client-message problem, which the prior
+spec already tried and gave up on for good, load-bearing reasons.
+
+### 0.2 Border-drag vertical snap: CONFIRMED broken (2026-09-05 live test)
+
+Window **resizing** itself is real, unmodified native OS handling — this
+part of the original analysis holds. Top-level and floater windows are
+created with `WS_THICKFRAME` (e.g. `agentmux-cef/src/commands/floating_pane.rs:809`),
+and `WM_NCHITTEST` resolves to `HTTOP`/`HTBOTTOM`/`HTLEFT`/`HTRIGHT`/etc.
+normally (`floating_pane.rs:603-649` for the borderless floater case),
+letting Windows run its **own** resize loop. So the *mechanism* that would
+need to carry Snap Assist is genuinely native — and yet the operator's live
+test shows the snap doesn't happen. The likely explanation is §0.3, not a
+simple style-flag miss.
+
+### 0.3 Likely shared root cause: the main window is a CEF Views *frameless*
+window, and Chromium's frameless-window support doesn't carry Snap
+eligibility
+
+`agentmux-cef/src/app/mod.rs:315-317` — `AgentMuxWindowDelegate::is_frameless`
+returns `self.frameless as i32`, and for the main window this is true (it's
+what makes the custom title bar possible at all instead of a native one).
+`can_resize`/`can_maximize` (`app/mod.rs:319-325`) both report `1` at the
+CEF Views level — so CEF *itself* isn't refusing resize/maximize — but
+`is_frameless` hands control of the actual Win32 non-client-area behavior
+to Chromium's internal `views::HWNDMessageHandler`, which we do not control
+or have source for in this repo. Windows' Snap Assist (both the
+move-to-top-maximize gesture in §0.1 and the border-drag vertical-snap
+gesture here) has historically been unreliable-to-absent for Chromium/
+Electron-style frameless windows on Windows precisely because the OS's
+snap eligibility checks key off non-client-area signals (`WS_CAPTION`
+presence, standard `WM_NCCALCSIZE` non-client sizing, etc.) that a fully
+frameless window may not present in the shape Windows expects — this is a
+known category of issue for this class of app, not unique speculation about
+AgentMux specifically, but **not independently confirmed against
+Chromium's actual internal implementation** (not in this repo, can't be
+grepped) — treat as the leading hypothesis, not a certainty.
+
+**Practical consequence: don't chase a style-flag tweak on the theory that
+one bit is wrong.** Given `is_frameless` hands non-client behavior to code
+this repo doesn't own, the more tractable fix for BOTH features is the same
+shape §0.1 already committed to: **stop relying on Windows to do this and
+implement the gesture manually**, at a point AgentMux already subclasses
+the main window's WndProc. That infrastructure already exists and is
+already proven safe on this exact window — see §3.1.
+
+## 1. What already exists (do not rebuild)
+
+| Piece | Where | Reusable for this feature? |
+|---|---|---|
+| Manual move loop | `Win32BeginMoveTask` (`ui_tasks/drag.rs:325-568`) | **Yes — this is where the new detection logic goes.** Already tracks cursor position every `WM_MOUSEMOVE` in physical screen px (`GetCursorPos`, `cur`), already has a `cancelled` flag (Esc), already has an established "emit a hover-ish event mid-drag" precedent (see next row). |
+| Mid-drag hover event pattern | `update_floating_redock_hover`/`clear_floating_redock_hover`, called from inside the same `WM_MOUSEMOVE` arm at a 50ms cadence (`drag.rs:461-481`), consumed by `frontend/app/workspace/floating-pane-workspace.tsx` (redock ghost/highlight state machine, ~line 130-670) | **Model, don't reuse directly.** That mechanism is floater-redock-specific (different renderer component, different semantics). The new snap-preview affordance should follow the identical *shape* — host emits a hover-state event mid-drag, a dedicated frontend consumer renders/clears an overlay — as a sibling mechanism, not a branch inside the floater code. |
+| Drag-end/cancel events | `window_drag_ended` (`drag.rs:551-560`, carries `label`, `moved`, physical `cursor_x`/`cursor_y`) and `window_drag_cancelled` (`drag.rs:515-521`) | Reuse the same emission point (drag.rs's loop exit / Esc arm) to also clear any snap-preview state — don't invent a third exit-signaling mechanism. |
+| Monitor work-area lookup | `agentmux-cef/src/app/monitor.rs::get_monitor_work_area(px, py) -> Option<(x, y, w, h)>` (`MonitorFromPoint` + `GetMonitorInfoW`) | **Reuse the underlying Win32 calls, not the function as-is.** This helper converts physical → DIP pixels (`monitor.rs:42-50`, `scale = dpi_x / 96.0`) for CEF's `Window::set_bounds`, which expects DIP. The drag loop works entirely in **physical** px (its own comment: "no devicePixelRatio math"). Mixing the two here would reproduce exactly the physical/DIP unit-confusion bug class this codebase has already been bitten by elsewhere — call `MonitorFromPoint`/`GetMonitorInfoW` directly inside `drag.rs` and compare against `rcWork.top`/`rcWork.bottom` in physical px, don't route through `get_monitor_work_area`. |
+| Maximize toggle | `agentmux-cef/src/commands/window/chrome.rs::maximize_window(state, args)` (`GetWindowPlacement`/`ShowWindow(SW_MAXIMIZE\|SW_RESTORE)`) | The *logic* (lines 48-61) is what's needed, but it's shaped as an IPC handler taking `{label}` args and re-resolving the HWND from a label. Inside `Win32BeginMoveTask` we already hold the raw `HWND` (`self.hwnd`) on the UI thread — extract the placement-toggle body into a small `maximize_hwnd(hwnd: HWND)` helper both call sites share, rather than round-tripping through label resolution + JSON args from inside the drag loop. |
+| Frontend title-bar drag region | `frontend/app/window/window-header.tsx`, `useWindowDrag.win32.ts` (arms on mousedown, fires `start_window_drag` IPC past a 4px threshold) | Unchanged — the new behavior is entirely host-side once the drag has started. |
+| Native resize `WM_SIZING` subclass | `agentmux-cef/src/client/wndproc.rs::window_edge_resize_wndproc` (already installed on the main window via `SetWindowLongPtrW`/`GWLP_WNDPROC`) | **Yes — this is where Feature B's fix goes (§3).** Already intercepts every `WM_SIZING` tick and reads the dragged edge; currently pure-observer (forwards to the renderer, never modifies the message). Extending it to also clamp the proposed `RECT` is the whole fix — no new subclass needed. |
+
+## 2. Design — Feature A: drag-to-top → maximize
+
+### 2.1 Detection
+
+Inside `Win32BeginMoveTask`'s `WM_MOUSEMOVE` arm (`drag.rs:444-483`), after
+computing `cur` (current cursor position, physical px):
+
+1. Resolve the work area of the monitor under `cur` via `MonitorFromPoint`/
+   `GetMonitorInfoW` directly (§1 — not `get_monitor_work_area`, unit
+   mismatch).
+2. If `cur.y <= rcWork.top + SNAP_ZONE_PX` (a small threshold — Windows'
+   own Snap Assist uses a few px; start with something like 2-5px past the
+   work-area top, tune from feel, not a hard requirement here), the drag is
+   "in the top snap zone."
+3. Track this as a new `in_snap_zone: bool` local in the loop (parallel to
+   `cancelled`), transitioning it only on actual state change (entering/
+   leaving the zone) — don't re-emit every single mousemove tick.
+
+### 2.2 Visual affordance — "provide the maximize option"
+
+The trigger's phrasing ("provide the maximize option," not "just maximize
+immediately") matches Chrome/Windows' own UX: a preview appears while
+still dragging, and the user commits by releasing inside the zone (or
+backs out by dragging away). On the `in_snap_zone` transition:
+
+- **Entering the zone**: emit a new host→renderer event (same shape as
+  `update_floating_redock_hover`, different name/payload — e.g.
+  `window_snap_hover` carrying the target rect: the full work area, since
+  that's what maximizing would produce) so a new, dedicated frontend
+  listener can render a translucent preview outline. This should live
+  alongside `window-header.tsx`/the main window's own chrome, not inside
+  `floating-pane-workspace.tsx` (that component is floater-specific and
+  the main window doesn't mount it).
+- **Leaving the zone** (cursor moves back down past the threshold) or
+  **drag ends without committing**: emit a corresponding clear event —
+  reuse the existing `window_drag_ended`/`window_drag_cancelled` emission
+  points (drag.rs:515-521, 551-560) to also signal "and clear any snap
+  preview," rather than adding a fourth place that needs to remember to
+  clean this up.
+
+Exact overlay rendering (a layered Win32 window? a frontend-drawn
+absolutely-positioned div matching Chrome's own approach on custom-chrome
+Windows builds?) is an implementation-time decision, not fixed here — the
+constraint that matters is the event-driven handshake described above, so
+the overlay's lifecycle can't outlive the drag or desync from it the way
+the floater redock ghost's own bug history (see the extensive
+Windows/non-Windows race commentary already in `floating-pane-workspace.tsx`)
+shows is easy to get wrong.
+
+### 2.3 Commit — maximize on release inside the zone
+
+In the `WM_LBUTTONUP` arm (`drag.rs:484-490`) and the synthesized-up path
+in the button-already-released check (`drag.rs:411-429`): if `in_snap_zone`
+is true and the drag was not cancelled, call `maximize_hwnd(h)` (§1's
+extracted helper) **instead of** leaving the window at the dropped
+position. The existing `SetWindowPos` calls per-mousemove already moved the
+window during the drag (per §2.1, that's unavoidable — the loop can't know
+in advance the user will release inside the zone), so the maximize call
+here is a real position/size change, not a no-op; that's expected and
+matches Chrome/Windows' own feel (the window visibly snaps into place on
+release).
+
+### 2.4 Scope
+
+- **Main/`FullInstance` top-level windows**: in scope — this is what the
+  trigger describes.
+- **Floaters**: **out of scope.** They're borderless `WS_POPUP` windows
+  with their own maximize semantics already (`toggle_floating_maximize`,
+  `chrome.rs:96` — explicitly documented as NOT using
+  `ShowWindow(SW_MAXIMIZE)` because borderless popups have no usable
+  native placement) and their own drag-loop branch already does something
+  very different at the top of the screen (redock-hover / tear-off-back-in
+  detection). Adding snap-to-maximize on top of that would need its own
+  design pass against the redock interaction, not a bolt-on here.
+- **Subwindows** (`open_subwindow`, tied to a parent `FullInstance`):
+  open question — likely fine to include (same maximize semantics as main),
+  but not the trigger's stated case; confirm before extending, don't
+  assume.
+
+### 2.5 Interaction with Esc-cancel
+
+The existing Esc handler (`drag.rs:491-522`) restores the window to its
+pre-drag position and sets `cancelled = true`, but keeps looping (so the
+eventual `WM_LBUTTONUP` still balances Chromium's mousedown — a real,
+documented invariant, do not break it). The new snap logic must respect
+`cancelled`: once cancelled, stop updating `in_snap_zone` (mirroring how
+`WM_MOUSEMOVE`'s `SetWindowPos` call already gates on `!cancelled`) and
+clear any visible snap preview immediately, same as the existing
+`clear_floating_redock_hover` call in that same arm does for the floater
+case.
+
+## 3. Design — Feature B: border-drag vertical snap
+
+Confirmed broken (§0.2). Fix by **intercepting the native resize, not
+replacing it** — a much smaller change than Feature A needed, because an
+interception point already exists and is already installed on the main
+window.
+
+### 3.1 The interception point already exists
+
+`agentmux-cef/src/client/wndproc.rs:297-360ish`,
+`window_edge_resize_wndproc` — a real `SetWindowLongPtrW(hwnd, GWLP_WNDPROC,
+...)` subclass already installed on the main window (same family as
+`install_top_level_focus_restore_hook`, `wndproc.rs:33`, whose own doc
+comment records that subclassing the main CEF Views window's WndProc this
+way is "SAFE" and already proven). It already intercepts `WM_SIZING` on
+every tick of a native border-drag resize and reads the dragged edge
+(`WMSZ_TOP`/`WMSZ_BOTTOM`/etc. from `wParam`) — today purely to forward
+`windowresize:tick` events to the renderer for pane redistribution
+(`SPEC_RESIZE_DEFAULT_FLIP_AND_WINDOW_EDGE_SHIFT_2026_08_26.md` §3.4). Its
+own doc comment currently states an invariant that this change deliberately
+breaks: *"Pure observer: every message ALWAYS passes through to the
+original WndProc."*
+
+**`WM_SIZING`'s `lParam` is a pointer to the proposed `RECT`, and the OS
+contract explicitly allows the handler to modify it before returning** —
+this is standard, documented Win32 behavior (it's the whole mechanism apps
+use to enforce min/max size or aspect-ratio constraints during a native
+resize), not something being invented here. This is the same shape as
+`WM_SIZING` being the *only* per-tick point during a native resize where
+the app can influence that tick's outcome, mirroring why `WM_MOUSEMOVE`
+was the right interception point for the manual move loop in Feature A.
+
+### 3.2 The fix
+
+Extend `window_edge_resize_wndproc`'s `WM_SIZING` arm: when `edge` is
+`"top"` or `"bottom"` (or a corner combination that includes one), read the
+proposed `RECT` from `lparam`, resolve the current monitor's work area
+(`MonitorFromPoint`/`GetMonitorInfoW` — same physical-px caveat as §1's
+table entry: don't route through `get_monitor_work_area`'s DIP conversion),
+and if the proposed top/bottom is within a snap threshold of the work
+area's top/bottom, clamp that field of the RECT to the work-area edge
+exactly before returning. Write the modified RECT back through `lparam`
+and return `1` (`TRUE`) to tell Windows the app adjusted the rect, per
+`WM_SIZING`'s documented contract — do not `CallWindowProcW` first and
+modify after; the original wndproc must see (or produce) the final,
+already-clamped rect, not have its own answer overwritten after the fact.
+
+This is a **narrower, more surgical change** than Feature A's manual move
+loop: no new modal loop, no new drag-state machine — one existing
+message handler gains a conditional rect mutation on top of the
+forwarding it already does. Keep the existing `windowresize:tick` emission
+unchanged (still fires, still carries the real edge) — this fix only
+changes what final rect that tick converges to, not the pane-redistribution
+notification pipeline built on top of it.
+
+### 3.3 Scope
+
+- **Main window**: primary target, matches the trigger.
+- **Floaters**: borderless `WS_POPUP`, no native maximize placement (per
+  §2.4) — likely wants the SAME `WM_SIZING`-clamp treatment for visual
+  consistency, but floaters resize via their own `WM_NCHITTEST` zone
+  mapping (`floating_pane.rs:603-649`), a different code path than the main
+  window's `window_edge_resize_wndproc` — confirm whether that hook is also
+  installed on floater HWNDs or whether floater resize needs its own
+  parallel clamp. Don't assume parity without checking.
+- **Subwindows**: same open question as §2.4.
+
+### 3.4 What this does NOT need
+
+Unlike Feature A, this does **not** need a snap-preview overlay — a native
+resize drag already shows the window's outline moving live (that's what
+resizing *is*), so clamping the rect during `WM_SIZING` is both the
+detection and the visual feedback in one step; there's no separate
+"preview, then commit on release" phase to design the way §2.2 needed one
+for the move case.
+
+## 4. Platform scope
+
+This spec is **Windows-first**, because Aero Snap is inherently a Windows
+concept and §0's root cause (a Windows-specific CEF frameless-window
+limitation, worked around via Windows-specific WndProc subclassing) doesn't
+describe macOS or Linux:
+
+- **macOS**: `run_macos_native_drag_loop` (per the win32-move-loop's sibling
+  in `drag.rs`) — uses `NSWindow`'s own drag tracking rather than a manual
+  `SetCapture`/`GetMessage` loop, since the CEF/Chromium non-client-message
+  problem that forced the manual loop is Windows-specific. macOS has no
+  Aero-Snap-equivalent "drag to top = maximize" convention in the first
+  place (its analogue is the green traffic-light button / Option-drag for
+  fill-screen); Chrome on macOS doesn't attempt to replicate Windows' snap
+  gesture either. Out of scope for Feature A; not a gap to close.
+- **Linux**: the frontend drag hook delegates to `CefWindow::BeginWindowDrag`/
+  `xdg_toplevel.move` (a real Wayland/X11 protocol request), which most
+  compositors implement their own edge-snap/tiling behavior for at the
+  window-manager level, independent of the app. This may already provide
+  equivalent behavior for free, or may not depending on the user's WM —
+  genuinely out of AgentMux's control either way, and not this spec's
+  concern.
+- Confirm both of the above with a quick live check rather than taking this
+  section's reasoning as certain, but treat Windows as the actual scope of
+  implementation work.
+
+## 5. Non-goals
+
+- **Windows 11 Snap Layouts flyout** (hovering the maximize button shows a
+  grid of layout options). Related, visually similar, but a distinct
+  feature with its own `WM_NCHITTEST`/`ISnapLayoutSuggestions`-adjacent
+  integration surface. Not requested; would be its own spec.
+- **Left/right edge half-screen snap** (drag title bar to a side edge →
+  window fills that half of the screen). Not requested here (the trigger
+  is specifically top-drag-to-maximize and border-drag-to-vertical-snap),
+  but the mechanism in §2.1-2.3 generalizes to it almost directly (same
+  zone-detection-and-preview shape, different target rect and different
+  `SetWindowPos` on commit) — worth a one-line callout if scope grows
+  later; not building it now.
+- **Multi-monitor DPI-mismatch edge cases beyond what §2.1 already
+  handles** (dragging across monitors with different scale factors mid-drag,
+  right at a snap zone). `MonitorFromPoint` already re-resolves per current
+  cursor position each check, so ordinary cross-monitor dragging is
+  covered; exotic per-monitor-DPI edge timing is not specifically
+  hardened here.
+
+## 6. Test plan
+
+**Feature A (drag-to-top maximize) — needs a real running `task dev`
+instance, manual verification (no existing harness reaches `Win32BeginMoveTask`,
+per its own file — this is native Win32 message-loop code, not something a
+unit test can exercise):**
+
+1. Drag the title bar to the very top of the screen — a preview affordance
+   appears (exact visual TBD per §2.2's implementation-time decision).
+2. Release while still in the zone — window maximizes.
+3. Drag to the top, then drag back down before releasing — no maximize; the
+   window ends up wherever it was actually dropped, preview is gone.
+4. Esc-cancel while in the snap zone — window returns to its pre-drag
+   position (existing behavior), no maximize, preview cleared.
+5. Multi-monitor: drag to the top of a *non-primary* monitor — maximizes
+   onto that monitor's work area, not the primary's.
+6. Confirm floaters are unaffected (dragging a floater to the top still
+   does whatever the existing redock-hover/tear-off-back-in logic does
+   today, not a new maximize).
+
+**Feature B (border-drag vertical snap) — same "needs a real running `task dev`
+instance" caveat as Feature A; `window_edge_resize_wndproc` is native Win32
+message-loop code, not unit-testable:**
+
+1. Drag the top border to the screen top — height extends so the top edge
+   reaches the work area's top; width and x-position unchanged. This is
+   what distinguishes correct behavior from an accidental full maximize.
+2. Same for the bottom border, against the work area's bottom.
+3. Drag a corner (e.g. top-left) — only the axis actually being dragged
+   near an edge should clamp; confirm the OTHER axis is untouched (dragging
+   top-left near the top shouldn't also clamp the left edge to the screen's
+   left unless that edge is independently near it).
+4. Multi-monitor: perform the drag with the window straddling two monitors
+   with different work-area geometry (and, if available, different DPI) —
+   confirm it clamps against the monitor the relevant edge is actually
+   over, not a stale/wrong one.
+5. Confirm `windowresize:tick`/pane-redistribution behavior is unchanged
+   when NOT near an edge (the existing forwarding pipeline this hook
+   already drives must not regress).
+6. Floaters and subwindows — per §3.3, confirm whether they need (and
+   have, or don't have) the same treatment; don't assume from the main
+   window's result.
+
+## 7. What shipped (2026-09-05)
+
+**New — `agentmux-cef/src/client/window_snap.rs`.** All the actual decisions,
+as pure integer geometry with no Win32 types and deliberately NOT
+`#[cfg(windows)]`, so its 14 tests run on every CI target rather than only
+`windows-latest`. Both call sites below do nothing but read the answer.
+Covers: `WMSZ_*` → dragged-vertical-edge mapping (corners included, and
+pinned against `window_edge_resize_wndproc`'s own edge-string map so the two
+can't drift), the snap-fill decision, and the cursor-in-top-zone predicate.
+
+**Feature B — border-drag vertical snap** (`client/wndproc.rs`). Extended
+`window_edge_resize_wndproc`'s `WM_SIZING` arm to clamp the proposed rect,
+per §3. Notes worth carrying forward:
+
+- The clamp runs **after** the passthrough to the original (Chromium)
+  WndProc, not before. Chromium's own `WM_SIZING` handling can rewrite the
+  proposed rect (min-size / aspect-ratio constraints live there), so
+  clamping first would let it silently discard the snap. Clamping after
+  makes this the final word on the vertical axis; the clamp can only move
+  an edge by at most `SNAP_THRESHOLD_PX`, so it can't realistically push
+  the window under Chromium's minimum height.
+- The hook's doc comment previously advertised "pure observer: every message
+  ALWAYS passes through" — that invariant is now explicitly narrowed (still
+  always passes through, but `WM_SIZING`'s rect is no longer left alone) and
+  the comment was rewritten to say so rather than left stale.
+- Monitor resolution keys off the proposed rect's **center**, not a corner:
+  during a top-edge drag the top corner is exactly the point crossing the
+  screen edge, so a corner-based lookup would flip to the monitor *above*
+  at the moment the snap should engage.
+
+**Feature A — drag-to-top maximize** (`ui_tasks/drag.rs`,
+`ui_tasks/snap_preview.rs`, `commands/window/chrome.rs`).
+
+- `snap_preview.rs` (new): a borderless, click-through
+  (`WS_EX_TRANSPARENT|WS_EX_NOACTIVATE`), non-taskbar, topmost layered
+  window painting one translucent rect — same shape as Windows' own Snap
+  Assist preview. It must be a separate OS window: the preview covers the
+  full work area while the dragged window is small and following the
+  cursor, so no in-window surface could render it. Created lazily once and
+  hidden between drags (creating a window mid-modal-loop on every zone
+  entry would be slow and a needless mid-gesture failure point). Every
+  failure path is logged-and-swallowed — losing the preview must never
+  break the snap itself.
+- Zone detection keys off the **cursor**, not the window's own top edge:
+  the window follows the cursor at whatever offset the user grabbed it, so
+  its edge carries no intent. Preview is shown/hidden on zone
+  **transitions** only, not re-issued per mousemove tick.
+- Commit and preview-teardown both live at the single post-loop exit point
+  every `break` funnels through — that placement is what guarantees the
+  overlay can't outlive the drag no matter how the loop ended (release,
+  Esc-then-release, `WM_QUIT`, or the wake-tick stolen-capture safety net).
+- `chrome.rs` gained `toggle_maximize_hwnd` (extracted from
+  `maximize_window`, shared) **and a separate non-toggling `maximize_hwnd`**.
+  The gesture deliberately uses the non-toggling one: dragging an
+  already-maximized window means "maximize [again, here]", and a toggle
+  would restore-down instead — the opposite of the gesture's meaning.
+- Floaters are excluded by label prefix (`floating-`), per §2.4 — their
+  top-of-screen drag already means redock/tear-back-in.
+
+**Not done, deliberately:** §3.3's open question about whether floaters and
+subwindows want the same `WM_SIZING` clamp. `window_edge_resize_wndproc` is
+installed on "every top-level non-popup window" per its own doc comment, so
+floaters (`WS_POPUP`) do NOT currently get the clamp; whether they should is
+left to the live pass (§6 item 6) rather than guessed at.


### PR DESCRIPTION
## Summary

Operator report: dragging the window to the top of the screen doesn't offer to maximize, and dragging a window border to the screen top/bottom doesn't vertically snap — both work in Chrome. Full analysis + design: `docs/specs/SPEC_WINDOW_SNAP_MAXIMIZE_2026_09_04.md`.

**Root cause (shared by both):** Windows' own Snap Assist never fires for AgentMux's main window. It's a CEF Views *frameless* window (`AgentMuxWindowDelegate::is_frameless`), which hands Win32 non-client behavior to Chromium's internal `HWNDMessageHandler` — code this repo doesn't own. The move gesture additionally can't use the native OS move loop at all (documented at `ui_tasks/drag.rs:314-323`: Chromium swallows `WM_NCLBUTTONDOWN` before `DefWindowProc` can start it), which is why a manual move loop already exists. So both gestures are re-implemented manually rather than chased via style flags.

**Border-drag vertical snap** — extends the *existing* `WM_SIZING` subclass (`window_edge_resize_wndproc`, already installed on every top-level window) to clamp the proposed rect to the monitor work area when a top/bottom drag lands near it. Dragging either horizontal border to its screen edge fills the window vertically (both edges), matching Windows/Chrome. Notable:
- The clamp runs **after** the passthrough to Chromium's WndProc — Chromium's own `WM_SIZING` handling can rewrite the rect (min-size/aspect constraints), so clamping first would let it silently discard the snap.
- Vertical axis only; width/x untouched by construction — that's what keeps it a vertical snap rather than an accidental maximize.
- Monitor resolved from the rect's **center**, not a corner: during a top-edge drag the top corner is the point crossing the screen edge, so a corner lookup would flip to the monitor above exactly when the snap should engage.
- The hook's "pure observer, every message always passes through" doc comment was rewritten rather than left stale — it still always passes through, but `WM_SIZING`'s rect is no longer untouched.

**Drag-to-top maximize** — the manual move loop now tracks a top-of-work-area **cursor** zone (not the window's own edge; the window follows the cursor at whatever grab offset, so its edge carries no intent), shows a translucent click-through preview overlay while in the zone, and maximizes on release. Preview teardown *and* the commit both sit at the single post-loop exit point every `break` funnels through, so the overlay can't outlive the drag on any path (release, Esc-then-release, `WM_QUIT`, stolen-capture safety net). Floaters excluded — their top-of-screen drag already means redock/tear-back-in.

`chrome.rs` gained a shared `toggle_maximize_hwnd` plus a separate **non-toggling** `maximize_hwnd`; the gesture uses the latter deliberately, since toggling would restore-*down* an already-maximized window being dragged — the opposite of what the gesture means.

All the actual decisions live in a new pure `client/window_snap.rs` — plain integer geometry, no Win32 types, deliberately not `cfg(windows)`-gated — so its tests run on every CI target instead of only `windows-latest`. Both native call sites do nothing but read the answer.

## Test plan

- [x] `cargo test -p agentmux-cef` — 322 passed / 0 failed (14 new: WMSZ edge mapping incl. corners + pinned against the existing tick-event map, snap-fill decision, opposite-edge non-arming, already-filled no-op, threshold boundary, negative/non-zero work-area origins, cursor-zone predicate)
- [x] `cargo build -p agentmux-cef` — clean, no new warnings
- [ ] **Live (Windows, `task dev`)** — native message-loop code, no harness can reach it:
  - Drag title bar to screen top → preview appears; release → maximizes; drag back down before releasing → no maximize, preview gone
  - Esc mid-drag in the zone → returns to pre-drag position, no maximize, preview cleared
  - Multi-monitor: snaps to the monitor actually under the cursor
  - Drag top border to screen top → fills vertically, **width and x unchanged**; same for bottom border
  - Corner drag → only the dragged axis clamps
  - Non-edge resizes → `windowresize:tick` pane redistribution unregressed
  - Floaters unaffected (top-drag still does redock, not maximize)

Deliberately left open (§3.3): whether floaters/subwindows want the same `WM_SIZING` clamp — floaters are `WS_POPUP` and don't currently get the hook at all; left to the live pass rather than guessed.

<!-- agentmux:agent_id=loap #2 -->