### PR TITLE
fix(pool): fall back to a fresh window when a promoted pool window never proves its renderer is alive

### DIFF
--- a/.changesets/1788623755-fix-pool-fall-back-to-a-fresh-window-when-a-promoted-pool-wi-t25k.md
+++ b/.changesets/1788623755-fix-pool-fall-back-to-a-fresh-window-when-a-promoted-pool-wi-t25k.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(pool): fall back to a fresh window when a promoted pool window never proves its renderer is alive

--- a/agentmux-cef/src/commands/window/meta.rs
+++ b/agentmux-cef/src/commands/window/meta.rs
@@ -239,6 +239,22 @@ pub fn register_backend_window(state: &Arc<AppState>, args: &serde_json::Value) 
             });
         }
 
+        // Workstream 0 Phase 1 prerequisite #2 (issue #2977) — the SAME
+        // registration is also the liveness proof a promoted pool window is
+        // waiting for. Reuses this signal for exactly the reason the block
+        // above does: it proves the renderer loaded, ran JS, and
+        // round-tripped IPC. `confirm` is false for every ordinary
+        // (non-promoted) registration, which is the common case. See
+        // `state::promote_liveness` for why `IsWindow()` alone can't
+        // establish this and why `on_load_end` can't be used here.
+        if state.promote_liveness.lock().confirm(label) {
+            tracing::info!(
+                target: "dnd:tearoff:pool",
+                label = %label,
+                "[pool] promoted window confirmed live (renderer registered its backend window)"
+            );
+        }
+
         // SPEC_PILLAR1_STEP3 Phase 2 — write-through this window's kind +
         // parent linkage to srv now that its concrete window_id is known.
         // This is the first point in the window's life where the host has

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -530,6 +530,22 @@ pub fn on_pool_window_destroyed(state: &Arc<AppState>, label: &str) {
     if !label.starts_with("window-pool-") {
         return;
     }
+    // Workstream 0 Phase 1 prereq #2 (ReAgent P1 on PR #2987) — this path
+    // also runs for POST-promote closes (see the `take_pool_window_view`
+    // comment below, and `pool_destroyed_was_unpromoted` further down, which
+    // exist precisely to tell the two cases apart). A promoted window that
+    // the user closes inside `PROMOTE_LIVENESS_TIMEOUT` must not leave an
+    // armed watch behind that then pops a replacement window at them.
+    // Eager cancellation; `should_open_fallback`'s own registered-check is
+    // the level-triggered backstop that makes correctness independent of
+    // having instrumented every close path.
+    if state.promote_liveness.lock().cancel(label) {
+        tracing::info!(
+            target: "dnd:tearoff:pool",
+            label = %label,
+            "[pool] promoted window closed before confirming — cancelling its liveness watch"
+        );
+    }
     // Drop the cached HWND so the map can't grow unbounded across the
     // process lifetime. Idempotent — fine if the entry isn't present
     // (e.g. a window destroyed before register_pool_window populated
@@ -998,9 +1014,40 @@ pub fn init_pool(state: &Arc<AppState>) {
     spawn_pool_window(state);
 }
 
+/// What the promote-liveness fallback needs in order to recreate what this
+/// promote was supposed to deliver. Grouped into a struct rather than passed
+/// as loose parameters because the tear-off case has to carry enough to
+/// rebuild a real tear-off (`workspace_id` above all — see the fallback's own
+/// comment on why losing it is data-loss-shaped).
+struct PromoteFallback {
+    /// The srv workspace the promoted window was meant to attach. Empty for
+    /// the new-window (Cmd+N) promote, non-empty for a tab tear-off — which
+    /// is exactly the discriminator the fallback branches on.
+    workspace_id: String,
+    initial_view: Option<String>,
+    initial_meta: Option<String>,
+    /// Where the promoted window was placed. Used only by the tear-off
+    /// branch, in the same units that platform's promote used (physical px
+    /// on Windows, DIP elsewhere) — matching what `post_create_window`
+    /// expects on each.
+    pos_x: i32,
+    pos_y: i32,
+    width: i32,
+    height: i32,
+}
+
 /// Workstream 0 Phase 1 prerequisite #2 (issue #2977) — arm a bounded
 /// liveness watch on a just-promoted pool window, and fall back to a fresh
 /// cold-path window if the promote never proves itself alive.
+///
+/// MUST be called BEFORE the promote event is emitted/posted. The renderer's
+/// `register_backend_window` is handled concurrently on another thread, so
+/// arming after the emit leaves a window in which a confirmation can arrive
+/// with no watch to consume it — that confirmation is silently dropped and
+/// the later-armed watch then opens a duplicate window despite a perfectly
+/// healthy promote (Codex P2 on PR #2987). Arming first is free: the epoch
+/// guard still handles a superseding promote, and the only cost is that the
+/// 10s budget starts microseconds earlier.
 ///
 /// WHY this exists at all:
 /// `docs/retro/retro-fresh-vm-suspend-orphaned-frontend-2026-09-03.md`
@@ -1031,12 +1078,7 @@ pub fn init_pool(state: &Arc<AppState>) {
 /// offset placement instead of landing exactly on top of the suspect one —
 /// the retro describes stacked, indistinguishable windows as its own
 /// usability failure.
-fn arm_promote_liveness(
-    state: &Arc<AppState>,
-    label: &str,
-    initial_view: Option<String>,
-    initial_meta: Option<String>,
-) {
+fn arm_promote_liveness(state: &Arc<AppState>, label: &str, fallback: PromoteFallback) {
     let epoch = state.promote_liveness.lock().arm(label.to_string());
     let state = Arc::clone(state);
     let label = label.to_string();
@@ -1053,13 +1095,19 @@ fn arm_promote_liveness(
             return; // confirmed live, or superseded by a newer promote
         }
 
-        // Drain interlock — see `promote_liveness::should_open_fallback`.
+        // Drain + still-exists interlocks — see
+        // `promote_liveness::should_open_fallback` for why the "is it still
+        // registered" check lives here (level-triggered) rather than only in
+        // the close paths.
         let quit_state = state.host_state.lock().quit_state.clone();
-        if !crate::state::should_open_fallback(unconfirmed, &quit_state) {
+        let browser_still_registered = state.get_browser(&label).is_some();
+        if !crate::state::should_open_fallback(unconfirmed, &quit_state, browser_still_registered) {
             tracing::warn!(
                 target: "dnd:tearoff:pool",
                 label = %label,
-                "[pool] promote unconfirmed but the instance is draining — skipping fallback"
+                still_registered = browser_still_registered,
+                "[pool] promote unconfirmed, but the window is already gone or the \
+                 instance is draining — skipping fallback (nothing to replace)"
             );
             return;
         }
@@ -1068,19 +1116,58 @@ fn arm_promote_liveness(
             target: "dnd:tearoff:pool",
             label = %label,
             timeout_ms = crate::state::PROMOTE_LIVENESS_TIMEOUT.as_millis(),
+            workspace_id = %fallback.workspace_id,
             "[pool] promoted window never confirmed its renderer is alive — \
              opening a fresh cold-path window instead of leaving the user with a possibly-dead one"
         );
 
-        match crate::commands::window::open_window_with_kind(
-            &state,
-            WindowKind::FullInstance,
-            None,
-            initial_view.as_deref(),
-            initial_meta.as_deref(),
-            None, // normal offset placement — don't stack on the suspect window
-            false,
-        ) {
+        let result = if fallback.workspace_id.is_empty() {
+            // New-window promote (Cmd+N / File → New Window): no workspace to
+            // reattach, the frontend creates a fresh one. Position is
+            // arbitrary here, so take the cold path's normal offset placement
+            // rather than stacking exactly on the suspect window — the retro
+            // calls out indistinguishable stacked windows as its own failure.
+            crate::commands::window::open_window_with_kind(
+                &state,
+                WindowKind::FullInstance,
+                None,
+                fallback.initial_view.as_deref(),
+                fallback.initial_meta.as_deref(),
+                None,
+                false,
+            )
+        } else {
+            // Tear-off promote: the tab has ALREADY been moved into
+            // `workspace_id` by the frontend before this promote ran (see
+            // `tear_off_sc_move_handshake`'s doc comment). `open_window_with_kind`
+            // has no workspace parameter and its URL therefore creates a
+            // FRESH workspace — using it here would strand the torn-off tab
+            // in a workspace no window displays and hand the user an
+            // unrelated empty window, turning a recoverable failure into
+            // apparent data loss (Codex P1 on PR #2987). Reuse the real
+            // tear-off cold path, which appends `&workspaceId=`.
+            //
+            // Position IS meaningful for a tear-off (the user dropped the tab
+            // somewhere specific), so unlike the new-window branch above this
+            // honors the drop point via the tab anchor, accepting overlap with
+            // the suspect window — the fresh window is created on top, and a
+            // window that appears where the user dropped is worth more than
+            // avoiding an overlap with a corpse they are about to close.
+            crate::commands::drag::open_window_at_position(
+                &state,
+                &serde_json::json!({
+                    "workspaceId": fallback.workspace_id,
+                    "screenX": fallback.pos_x,
+                    "screenY": fallback.pos_y,
+                    "tabAnchorX": fallback.pos_x,
+                    "tabAnchorY": fallback.pos_y,
+                    "width": fallback.width,
+                    "height": fallback.height,
+                }),
+            )
+        };
+
+        match result {
             Ok(_) => tracing::warn!(
                 target: "dnd:tearoff:pool",
                 label = %label,
@@ -1517,6 +1604,24 @@ pub fn promote_pool_window(
     // Phase B.7.3.3 — the launcher's typed events drive the
     // InstancePanel atoms via the CEF JS bridge. No sync emit here.
 
+    // Workstream 0 Phase 1 prerequisite #2 — everything above proved the
+    // HWND exists, not that the renderer we are about to hand the workspace
+    // to is alive to receive it. Armed BEFORE the emit so a fast
+    // confirmation can't race past an unarmed watch (see the fn's doc).
+    arm_promote_liveness(
+        state,
+        &label,
+        PromoteFallback {
+            workspace_id: workspace_id.to_string(),
+            initial_view: initial_view.clone(),
+            initial_meta: initial_meta.clone(),
+            pos_x,
+            pos_y,
+            width: win_w,
+            height: win_h,
+        },
+    );
+
     // Now tell the pool window's renderer to bootstrap the workspace.
     crate::events::emit_event_to_window(
         state,
@@ -1528,12 +1633,6 @@ pub fn promote_pool_window(
             "initialMeta": initial_meta,
         }),
     );
-
-    // Workstream 0 Phase 1 prerequisite #2 — everything above proved the
-    // HWND exists, not that the renderer we just handed the workspace to is
-    // alive to receive it. Arm the bounded liveness watch now that the
-    // promote event is actually out.
-    arm_promote_liveness(state, &label, initial_view, initial_meta);
 
     // Refill the pool in the background.
     spawn_pool_window(state);
@@ -1673,15 +1772,28 @@ pub fn promote_pool_window(
     let w = width.unwrap_or(POOL_WIDTH);
     let h = height.unwrap_or(POOL_HEIGHT);
 
+    // Workstream 0 Phase 1 prerequisite #2 — same rationale as the Windows
+    // variant, and armed before the post for the same reason. The retro
+    // documented this against the Windows `IsWindow()` path, but the gap is
+    // platform-neutral: "CEF state presence" (this variant's check, above)
+    // is an even weaker liveness signal than `IsWindow()`, and says nothing
+    // about the renderer either.
+    arm_promote_liveness(
+        state,
+        &label,
+        PromoteFallback {
+            workspace_id: workspace_id.to_string(),
+            initial_view,
+            initial_meta,
+            pos_x: x,
+            pos_y: y,
+            width: w,
+            height: h,
+        },
+    );
+
     // Reposition + emit pool:promote on the CEF UI thread.
     crate::ui_tasks::post_promote_pool_window(state, &label, workspace_id, x, y, w, h);
-
-    // Workstream 0 Phase 1 prerequisite #2 — same rationale as the Windows
-    // variant. The retro documented this against the Windows `IsWindow()`
-    // path, but the gap is platform-neutral: "CEF state presence" (this
-    // variant's check, above) is an even weaker liveness signal than
-    // `IsWindow()`, and says nothing about the renderer either.
-    arm_promote_liveness(state, &label, initial_view, initial_meta);
 
     // Refill the pool asynchronously.
     spawn_pool_window(state);
@@ -1790,15 +1902,29 @@ pub fn promote_pool_window_for_new_window(
             return None;
         }
 
-        crate::ui_tasks::post_promote_pool_window_for_new_window(
-            state, &label, pos_x, pos_y, width, height,
-            initial_view.clone(), initial_meta.clone(),
-        );
         // Workstream 0 Phase 1 prerequisite #2 — the `pool:new-window`
         // promote reaches the same renderer-side path (`awaitPoolPromote`
         // → `initHostNewWindow` → `registerBackendWindow`), so it needs the
-        // same liveness confirmation as `pool:promote`.
-        arm_promote_liveness(state, &label, initial_view, initial_meta);
+        // same liveness confirmation as `pool:promote`. Empty workspace_id:
+        // this path deliberately creates a fresh workspace, so the fallback
+        // takes its new-window branch.
+        arm_promote_liveness(
+            state,
+            &label,
+            PromoteFallback {
+                workspace_id: String::new(),
+                initial_view: initial_view.clone(),
+                initial_meta: initial_meta.clone(),
+                pos_x,
+                pos_y,
+                width,
+                height,
+            },
+        );
+
+        crate::ui_tasks::post_promote_pool_window_for_new_window(
+            state, &label, pos_x, pos_y, width, height, initial_view, initial_meta,
+        );
         spawn_pool_window(state);
 
         Some(label)

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -998,6 +998,105 @@ pub fn init_pool(state: &Arc<AppState>) {
     spawn_pool_window(state);
 }
 
+/// Workstream 0 Phase 1 prerequisite #2 (issue #2977) — arm a bounded
+/// liveness watch on a just-promoted pool window, and fall back to a fresh
+/// cold-path window if the promote never proves itself alive.
+///
+/// WHY this exists at all:
+/// `docs/retro/retro-fresh-vm-suspend-orphaned-frontend-2026-09-03.md`
+/// documents that neither HWND-resolution branch above proves the RENDERER
+/// is alive — `IsWindow()` (and CEF's own `window_handle()`) survive a
+/// suspend/resume that left the page dead, so a promote can hand the user a
+/// corpse while every check logs success. The only trustworthy signal is one
+/// the renderer itself produces after the promote; see
+/// `state::promote_liveness` for why `register_backend_window` is that
+/// signal and why `on_load_end` is not.
+///
+/// THREADING: runs on the caller's thread (the IPC thread for the promote
+/// paths — NOT the CEF UI thread; see the Views-show call site's own comment
+/// in the Windows variant). Only touches a `parking_lot::Mutex` and spawns a
+/// plain timer thread. The fallback calls `open_window_with_kind`, which is
+/// safe off the UI thread by construction — it does reducer bookkeeping then
+/// posts `CreateWindowTask` to the UI thread itself, and is already invoked
+/// from a non-UI tokio task by the reproject driver
+/// (`launcher_ipc`'s `reproject_from_snapshot_and_stage_closures` call).
+/// Deliberately NOT a `wrap_task!`/`post_task` UI hop: nothing here needs the
+/// UI thread, and a posted task can be silently dropped during teardown.
+///
+/// The fallback does NOT close the unconfirmed window. That window may be
+/// merely slow rather than dead, and destroying a live-but-late window would
+/// lose user state; an extra window is the honest, recoverable cost the
+/// retro's own recommendation #2 accepts. It also deliberately passes
+/// `explicit_rect: None` so the fresh window takes the cold path's normal
+/// offset placement instead of landing exactly on top of the suspect one —
+/// the retro describes stacked, indistinguishable windows as its own
+/// usability failure.
+fn arm_promote_liveness(
+    state: &Arc<AppState>,
+    label: &str,
+    initial_view: Option<String>,
+    initial_meta: Option<String>,
+) {
+    let epoch = state.promote_liveness.lock().arm(label.to_string());
+    let state = Arc::clone(state);
+    let label = label.to_string();
+    std::thread::spawn(move || {
+        std::thread::sleep(crate::state::PROMOTE_LIVENESS_TIMEOUT);
+
+        // Snapshot-and-drop: never hold the watches lock across the
+        // fallback's own state work.
+        let unconfirmed = {
+            let mut watches = state.promote_liveness.lock();
+            watches.take_if_unconfirmed(&label, epoch)
+        };
+        if !unconfirmed {
+            return; // confirmed live, or superseded by a newer promote
+        }
+
+        // Drain interlock — see `promote_liveness::should_open_fallback`.
+        let quit_state = state.host_state.lock().quit_state.clone();
+        if !crate::state::should_open_fallback(unconfirmed, &quit_state) {
+            tracing::warn!(
+                target: "dnd:tearoff:pool",
+                label = %label,
+                "[pool] promote unconfirmed but the instance is draining — skipping fallback"
+            );
+            return;
+        }
+
+        tracing::error!(
+            target: "dnd:tearoff:pool",
+            label = %label,
+            timeout_ms = crate::state::PROMOTE_LIVENESS_TIMEOUT.as_millis(),
+            "[pool] promoted window never confirmed its renderer is alive — \
+             opening a fresh cold-path window instead of leaving the user with a possibly-dead one"
+        );
+
+        match crate::commands::window::open_window_with_kind(
+            &state,
+            WindowKind::FullInstance,
+            None,
+            initial_view.as_deref(),
+            initial_meta.as_deref(),
+            None, // normal offset placement — don't stack on the suspect window
+            false,
+        ) {
+            Ok(_) => tracing::warn!(
+                target: "dnd:tearoff:pool",
+                label = %label,
+                "[pool] cold-path fallback window requested after unconfirmed promote"
+            ),
+            Err(e) => tracing::error!(
+                target: "dnd:tearoff:pool",
+                label = %label,
+                error = %e,
+                "[pool] cold-path fallback after unconfirmed promote FAILED — \
+                 user may be left with no working window"
+            ),
+        }
+    });
+}
+
 /// Promote a pool window for tear-off. Pops a label, sends a
 /// move-and-show task to the CEF UI thread, and emits
 /// `pool:promote` to the renderer with the workspace ID. Returns
@@ -1430,6 +1529,12 @@ pub fn promote_pool_window(
         }),
     );
 
+    // Workstream 0 Phase 1 prerequisite #2 — everything above proved the
+    // HWND exists, not that the renderer we just handed the workspace to is
+    // alive to receive it. Arm the bounded liveness watch now that the
+    // promote event is actually out.
+    arm_promote_liveness(state, &label, initial_view, initial_meta);
+
     // Refill the pool in the background.
     spawn_pool_window(state);
 
@@ -1529,8 +1634,8 @@ pub fn promote_pool_window(
     height: Option<i32>,
     tab_anchor_x: Option<i32>,
     tab_anchor_y: Option<i32>,
-    _initial_view: Option<String>,
-    _initial_meta: Option<String>,
+    initial_view: Option<String>,
+    initial_meta: Option<String>,
 ) -> Option<String> {
     // Atomic pop from the pool queue via reducer. Returns None if empty
     // — caller falls back to cold path.
@@ -1570,6 +1675,13 @@ pub fn promote_pool_window(
 
     // Reposition + emit pool:promote on the CEF UI thread.
     crate::ui_tasks::post_promote_pool_window(state, &label, workspace_id, x, y, w, h);
+
+    // Workstream 0 Phase 1 prerequisite #2 — same rationale as the Windows
+    // variant. The retro documented this against the Windows `IsWindow()`
+    // path, but the gap is platform-neutral: "CEF state presence" (this
+    // variant's check, above) is an even weaker liveness signal than
+    // `IsWindow()`, and says nothing about the renderer either.
+    arm_promote_liveness(state, &label, initial_view, initial_meta);
 
     // Refill the pool asynchronously.
     spawn_pool_window(state);
@@ -1679,8 +1791,14 @@ pub fn promote_pool_window_for_new_window(
         }
 
         crate::ui_tasks::post_promote_pool_window_for_new_window(
-            state, &label, pos_x, pos_y, width, height, initial_view, initial_meta,
+            state, &label, pos_x, pos_y, width, height,
+            initial_view.clone(), initial_meta.clone(),
         );
+        // Workstream 0 Phase 1 prerequisite #2 — the `pool:new-window`
+        // promote reaches the same renderer-side path (`awaitPoolPromote`
+        // → `initHostNewWindow` → `registerBackendWindow`), so it needs the
+        // same liveness confirmation as `pool:promote`.
+        arm_promote_liveness(state, &label, initial_view, initial_meta);
         spawn_pool_window(state);
 
         Some(label)

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -146,7 +146,7 @@ const TITLE_BAR_OFFSET_PX: i32 = 16;
 /// off-screen (the 2026-06-21 "blank new window" bug: a window parked at the
 /// DPI-scaled `POOL_OFFSCREEN`, e.g. `-25600 = -32000 × 0.8` at 125%). Pure — the
 /// work-area rect is passed in — so the placement logic is unit-tested without
-/// Win32. See docs/specs/PLAN_POOL_NEW_WINDOW_DPI_POSITIONING_2026_06_21.md.
+/// Win32. See docs/specs/archive/PLAN_POOL_NEW_WINDOW_DPI_POSITIONING_2026_06_21.md.
 pub(crate) fn clamp_rect_within(
     x: i32,
     y: i32,

--- a/agentmux-cef/src/state/mod.rs
+++ b/agentmux-cef/src/state/mod.rs
@@ -16,6 +16,7 @@ mod pool;
 mod quit;
 mod top_level_creation;
 mod pending_reproject;
+mod promote_liveness;
 mod ui_thread_gate;
 
 pub use drag::{DragType, DragPayload, DragSession};
@@ -32,6 +33,9 @@ pub use top_level_creation::{
     PendingBrowserPaneCreate, FloatingRedockGhostState,
 };
 pub use pending_reproject::PendingReprojectClosures;
+pub use promote_liveness::{
+    PromoteLivenessWatches, should_open_fallback, PROMOTE_LIVENESS_TIMEOUT,
+};
 pub use ui_thread_gate::{UiThreadGate, MainReadyAction, SnapshotAction};
 
 // Phase B.5e — `WindowInstanceRegistry` struct deleted. Sequential
@@ -655,6 +659,16 @@ pub struct AppState {
     /// (safe, if imperfect) fallback behavior as before this whole cleanup
     /// existed: the old data lingers, but is never lost.
     pub pending_reproject_closures: Mutex<PendingReprojectClosures>,
+
+    /// Workstream 0 Phase 1 prerequisite #2 (issue #2977) — armed
+    /// post-promote liveness watches, keyed by window label. A promoted pool
+    /// window that never reaches `register_backend_window` within
+    /// `PROMOTE_LIVENESS_TIMEOUT` is treated as having handed back a corpse
+    /// (`IsWindow()` can't tell a live renderer from a suspended-then-dead
+    /// one — see the module's own docs), and the promote falls back to a
+    /// fresh cold-path window. Shares the confirmation signal, and the
+    /// stage/confirm shape, with `pending_reproject_closures` directly above.
+    pub promote_liveness: Mutex<PromoteLivenessWatches>,
 }
 
 impl Default for AppState {
@@ -742,6 +756,7 @@ impl Default for AppState {
             window_transparent: std::sync::atomic::AtomicBool::new(false),
             ui_thread_gate: Mutex::new(UiThreadGate::default()),
             pending_reproject_closures: Mutex::new(PendingReprojectClosures::default()),
+            promote_liveness: Mutex::new(PromoteLivenessWatches::default()),
         }
     }
 }

--- a/agentmux-cef/src/state/promote_liveness.rs
+++ b/agentmux-cef/src/state/promote_liveness.rs
@@ -102,6 +102,18 @@ impl PromoteLivenessWatches {
         self.armed.remove(label).is_some()
     }
 
+    /// The watched window went away (closed by the user, or destroyed) before
+    /// it ever confirmed. Returns true iff a watch was actually cancelled.
+    ///
+    /// Distinct from `confirm` only in intent and logging: confirm means
+    /// "proved alive", cancel means "no longer exists, so there is nothing
+    /// to replace". Both must stop the timer from opening a window — a
+    /// deliberate close within the timeout is not the corpse scenario this
+    /// feature targets (ReAgent P1 on PR #2987).
+    pub fn cancel(&mut self, label: &str) -> bool {
+        self.armed.remove(label).is_some()
+    }
+
     /// Timer expiry. Returns true iff a watch for `label` at exactly
     /// `epoch` is still armed — meaning the promote was never confirmed and
     /// the caller should fall back. Removes it, so the fallback fires at
@@ -127,14 +139,40 @@ impl PromoteLivenessWatches {
 /// Pure decision: given an expired, unconfirmed watch, should the fallback
 /// actually open a replacement window?
 ///
-/// Split out of the timer thread so the drain interlock is testable without
-/// a live instance. `quit_state != Running` means a drain/quit began inside
-/// the timeout window — opening a window then would both surprise the user
-/// mid-shutdown and race teardown with a cold-path spawn (the pool is
-/// already draining, so it would take the slow path). The instance is going
-/// away regardless; an unconfirmed promote no longer needs replacing.
-pub fn should_open_fallback(unconfirmed: bool, quit_state: &super::QuitState) -> bool {
-    unconfirmed && matches!(quit_state, super::QuitState::Running)
+/// Split out of the timer thread so all three interlocks are testable
+/// without a live instance.
+///
+/// - `unconfirmed` — the watch survived to expiry (see `take_if_unconfirmed`).
+/// - `quit_state != Running` — a drain/quit began inside the timeout window.
+///   Opening a window then would both surprise the user mid-shutdown and
+///   race teardown with a cold-path spawn. The instance is going away
+///   regardless; an unconfirmed promote no longer needs replacing.
+/// - `browser_still_registered` — the promoted window still exists in the
+///   host's browser registry. This is the LEVEL-TRIGGERED guard for
+///   "the user closed (or crashed) the torn-off window inside the timeout"
+///   (ReAgent P1 on PR #2987): a deliberate close is not the corpse scenario,
+///   and replacing a window the user just dismissed is exactly the spurious
+///   extra window this feature must not cause.
+///
+///   Checked here at the decision point rather than relying solely on
+///   cancelling from each close path, deliberately: this codebase already
+///   learned that lesson once, when an EDGE-triggered quit gate missed close
+///   paths and orphaned the process tree — `reducer/quit.rs`'s header
+///   documents the level-triggered `reconcile_quit` rewrite that replaced it.
+///   A promoted window can leave through several paths (`on_before_close`,
+///   Windows parking close, WRR crash-destroy, orphan cleanup), and this
+///   check cannot miss one, now or after a future refactor.
+///   `on_pool_window_destroyed` *also* cancels eagerly (cheap, and it closes
+///   the narrow window where a close lands between expiry and this read),
+///   but correctness does not depend on having found every such site.
+pub fn should_open_fallback(
+    unconfirmed: bool,
+    quit_state: &super::QuitState,
+    browser_still_registered: bool,
+) -> bool {
+    unconfirmed
+        && browser_still_registered
+        && matches!(quit_state, super::QuitState::Running)
 }
 
 #[cfg(test)]
@@ -233,10 +271,10 @@ mod promote_liveness_tests {
     #[test]
     fn fallback_opens_only_for_an_unconfirmed_watch_on_a_running_instance() {
         use crate::state::QuitState;
-        assert!(should_open_fallback(true, &QuitState::Running));
+        assert!(should_open_fallback(true, &QuitState::Running, true));
         // A confirmed promote never opens a replacement, whatever the
         // instance is doing.
-        assert!(!should_open_fallback(false, &QuitState::Running));
+        assert!(!should_open_fallback(false, &QuitState::Running, true));
     }
 
     #[test]
@@ -246,12 +284,46 @@ mod promote_liveness_tests {
         // window must not get a surprise window racing teardown.
         assert!(!should_open_fallback(
             true,
-            &QuitState::Draining { reason: QuitReason::LastWindowClosed }
+            &QuitState::Draining { reason: QuitReason::LastWindowClosed },
+            true,
         ));
         assert!(!should_open_fallback(
             true,
-            &QuitState::Draining { reason: QuitReason::LauncherRequested }
+            &QuitState::Draining { reason: QuitReason::LauncherRequested },
+            true,
         ));
-        assert!(!should_open_fallback(true, &QuitState::Quit));
+        assert!(!should_open_fallback(true, &QuitState::Quit, true));
+    }
+
+    /// ReAgent P1 on PR #2987: tear off a window, then close it (or it
+    /// crashes) inside the 10s timeout, before it ever registered. That
+    /// close is intentional, not the suspend/corpse scenario — replacing it
+    /// would pop an unwanted window on a user who just dismissed one.
+    #[test]
+    fn fallback_never_replaces_a_window_the_user_already_closed() {
+        use crate::state::QuitState;
+        assert!(
+            !should_open_fallback(true, &QuitState::Running, false),
+            "a promoted window that is no longer registered must not be replaced"
+        );
+    }
+
+    #[test]
+    fn cancel_stops_the_timer_from_opening_a_window() {
+        let mut w = PromoteLivenessWatches::default();
+        let epoch = w.arm("window-pool-abc".to_string());
+        assert!(w.cancel("window-pool-abc"), "cancel reports it was armed");
+        assert!(
+            !w.take_if_unconfirmed("window-pool-abc", epoch),
+            "a cancelled watch must not fall back when its timer fires"
+        );
+    }
+
+    #[test]
+    fn cancel_is_false_for_a_window_that_was_never_promoted() {
+        // on_pool_window_destroyed runs for PRE-promote pool deaths too —
+        // those never armed a watch and must be a silent no-op.
+        let mut w = PromoteLivenessWatches::default();
+        assert!(!w.cancel("window-pool-never-promoted"));
     }
 }

--- a/agentmux-cef/src/state/promote_liveness.rs
+++ b/agentmux-cef/src/state/promote_liveness.rs
@@ -1,0 +1,257 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Workstream 0 Phase 1 prerequisite #2 (issue #2977,
+//! `SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md` §7) — bounded
+//! liveness confirmation for a PROMOTED pool window.
+//!
+//! ## The gap this closes
+//!
+//! `docs/retro/retro-fresh-vm-suspend-orphaned-frontend-2026-09-03.md`
+//! documents that `promote_pool_window`'s Windows liveness check
+//! (`IsWindow()` against a cached HWND) proves only that the OS hasn't
+//! destroyed or recycled the window handle. It cannot prove the renderer
+//! behind that handle is responsive or that its page's connection survived
+//! — and critically, a suspend/resume cycle does not destroy window handles,
+//! so `IsWindow()` returns true for a corpse. That retro's own correction
+//! notes this is a real, code-level gap independent of what caused the
+//! incident it was originally written about.
+//!
+//! Note this is NOT specific to the cached-HWND fallback branch: CEF's own
+//! `window_handle()` is equally intact across a suspend, so a fix scoped to
+//! only the "weaker evidence" branch would miss the actual failure mode.
+//! The check here is therefore applied to every promote, after the fact,
+//! regardless of which branch resolved the HWND.
+//!
+//! ## The signal
+//!
+//! `register_backend_window` is already established in this codebase as the
+//! canonical proof that a window's frontend "actually loaded and
+//! round-tripped IPC, not just that a CreateWindowTask was posted" — see
+//! `commands/window/meta.rs`'s `pending_reproject_closures.confirm(label)`
+//! call site (SPEC_PILLAR1_STEP4 Phase 3 addendum, reagent P1 PR #2032).
+//! This module reuses that exact signal, and deliberately mirrors
+//! `PendingReprojectClosures`' stage/confirm shape.
+//!
+//! A promoted pool window reaches it end-to-end: `?pool=1` short-circuits
+//! the renderer's init until `pool:promote` arrives
+//! (`frontend/app/init/pool.ts`), then `initHostNewWindow()` runs and calls
+//! `registerBackendWindow` (`frontend/app-init.ts`). So a confirmation
+//! proves the renderer is alive, executing JS, and able to reach both srv
+//! and the host — the three things `IsWindow()` cannot establish. Because
+//! pool mode short-circuits BEFORE that call, a pool window cannot confirm
+//! at spawn time; the only possible confirmation is post-promote.
+//!
+//! Deliberately NOT used: `on_load_end`. The promote path never navigates —
+//! `pool.ts` applies the workspace id with `history.replaceState`, so no
+//! load event fires and a load-based gate would time out on every healthy
+//! promote.
+//!
+//! ## Epoch guard
+//!
+//! Watches are keyed by label but carry a monotonic epoch, so a timer that
+//! fires late cannot consume a watch armed by a *later* promote of the same
+//! label. Same discipline as the browser-pane load watchdog's epoch
+//! (`browser_pane::callbacks`).
+
+use std::collections::HashMap;
+
+/// How long a promoted pool window has to prove its renderer is alive
+/// before the promote is treated as having handed back a corpse.
+///
+/// Chosen to be generous rather than tight: the cost of a FALSE POSITIVE is
+/// a redundant extra window (annoying, recoverable — and the honest cost the
+/// retro's recommendation #2 explicitly accepts), while the cost of being
+/// too tight is duplicating windows for merely-slow-but-healthy promotes on
+/// a loaded machine. For calibration: the cold path's own window creation is
+/// documented at ~2.5-3.5s, and a promoted window still has to run
+/// `initHostNewWindow` (a full srv round trip) before it can register.
+pub const PROMOTE_LIVENESS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Armed post-promote liveness watches, keyed by window label.
+///
+/// Mirrors `PendingReprojectClosures`' shape (a thin named wrapper over a
+/// map, so the logic is unit-testable without a live instance) with one
+/// addition: a monotonic epoch per watch, so a late timer can't consume a
+/// newer watch for the same label.
+#[derive(Debug, Default)]
+pub struct PromoteLivenessWatches {
+    /// label → epoch of the currently-armed watch for that label.
+    armed: HashMap<String, u64>,
+    next_epoch: u64,
+}
+
+impl PromoteLivenessWatches {
+    /// Arm a watch for `label`. Returns the epoch the caller must pass back
+    /// to `take_if_unconfirmed` when its timer fires. Re-arming a label that
+    /// already has a watch replaces it (and the older epoch is thereby
+    /// invalidated — its timer becomes a no-op).
+    pub fn arm(&mut self, label: String) -> u64 {
+        self.next_epoch += 1;
+        let epoch = self.next_epoch;
+        self.armed.insert(label, epoch);
+        epoch
+    }
+
+    /// Called from `register_backend_window` for EVERY registering label.
+    /// Returns true iff this label had an armed watch — i.e. this
+    /// registration is the liveness proof a promote was waiting for.
+    /// `false` for every ordinary (non-promoted) window registration, which
+    /// is the overwhelmingly common case.
+    pub fn confirm(&mut self, label: &str) -> bool {
+        self.armed.remove(label).is_some()
+    }
+
+    /// Timer expiry. Returns true iff a watch for `label` at exactly
+    /// `epoch` is still armed — meaning the promote was never confirmed and
+    /// the caller should fall back. Removes it, so the fallback fires at
+    /// most once. Returns false (without disturbing anything) when the
+    /// watch was already confirmed, or when a newer promote for the same
+    /// label has superseded this epoch.
+    pub fn take_if_unconfirmed(&mut self, label: &str, epoch: u64) -> bool {
+        match self.armed.get(label) {
+            Some(&current) if current == epoch => {
+                self.armed.remove(label);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.armed.len()
+    }
+}
+
+/// Pure decision: given an expired, unconfirmed watch, should the fallback
+/// actually open a replacement window?
+///
+/// Split out of the timer thread so the drain interlock is testable without
+/// a live instance. `quit_state != Running` means a drain/quit began inside
+/// the timeout window — opening a window then would both surprise the user
+/// mid-shutdown and race teardown with a cold-path spawn (the pool is
+/// already draining, so it would take the slow path). The instance is going
+/// away regardless; an unconfirmed promote no longer needs replacing.
+pub fn should_open_fallback(unconfirmed: bool, quit_state: &super::QuitState) -> bool {
+    unconfirmed && matches!(quit_state, super::QuitState::Running)
+}
+
+#[cfg(test)]
+mod promote_liveness_tests {
+    use super::*;
+
+    #[test]
+    fn unconfirmed_watch_reports_for_fallback_on_expiry() {
+        let mut w = PromoteLivenessWatches::default();
+        let epoch = w.arm("window-pool-abc".to_string());
+        assert!(
+            w.take_if_unconfirmed("window-pool-abc", epoch),
+            "a promote that never registered must report unconfirmed"
+        );
+    }
+
+    #[test]
+    fn confirmed_watch_does_not_fall_back() {
+        let mut w = PromoteLivenessWatches::default();
+        let epoch = w.arm("window-pool-abc".to_string());
+        assert!(w.confirm("window-pool-abc"), "confirm reports it was armed");
+        assert!(
+            !w.take_if_unconfirmed("window-pool-abc", epoch),
+            "a confirmed promote must never fall back when its timer fires"
+        );
+    }
+
+    #[test]
+    fn fallback_fires_at_most_once() {
+        let mut w = PromoteLivenessWatches::default();
+        let epoch = w.arm("window-pool-abc".to_string());
+        assert!(w.take_if_unconfirmed("window-pool-abc", epoch));
+        assert!(
+            !w.take_if_unconfirmed("window-pool-abc", epoch),
+            "a second expiry for the same watch must not spawn a second window"
+        );
+    }
+
+    #[test]
+    fn confirm_is_false_for_ordinary_window_registrations() {
+        // main, cold-path windows, and never-promoted labels all flow
+        // through register_backend_window — none of them may be mistaken
+        // for a promote confirmation.
+        let mut w = PromoteLivenessWatches::default();
+        w.arm("window-pool-real".to_string());
+        assert!(!w.confirm("main"));
+        assert!(!w.confirm("window-cold-path"));
+        assert_eq!(w.len(), 1, "unrelated registrations leave the real watch alone");
+        assert!(w.confirm("window-pool-real"));
+    }
+
+    #[test]
+    fn a_stale_timer_cannot_consume_a_newer_watch_for_the_same_label() {
+        // The epoch guard: promote #1's timer fires AFTER promote #2 armed
+        // a fresh watch for the same label. It must not consume #2's watch
+        // (which would both skip #2's real protection and spawn a spurious
+        // fallback window).
+        let mut w = PromoteLivenessWatches::default();
+        let stale = w.arm("window-pool-abc".to_string());
+        let current = w.arm("window-pool-abc".to_string());
+        assert_ne!(stale, current, "re-arming must allocate a fresh epoch");
+        assert!(
+            !w.take_if_unconfirmed("window-pool-abc", stale),
+            "the stale timer must be a no-op"
+        );
+        assert!(
+            w.take_if_unconfirmed("window-pool-abc", current),
+            "the current watch must still be armed and able to fall back"
+        );
+    }
+
+    #[test]
+    fn watches_are_independent_per_label() {
+        let mut w = PromoteLivenessWatches::default();
+        let a = w.arm("window-pool-a".to_string());
+        let b = w.arm("window-pool-b".to_string());
+        assert_eq!(w.len(), 2);
+        assert!(w.confirm("window-pool-a"));
+        assert_eq!(w.len(), 1);
+        assert!(
+            !w.take_if_unconfirmed("window-pool-a", a),
+            "confirmed label must not fall back"
+        );
+        assert!(
+            w.take_if_unconfirmed("window-pool-b", b),
+            "the other label's watch is unaffected by its sibling"
+        );
+    }
+
+    #[test]
+    fn expiry_for_a_never_armed_label_is_a_noop() {
+        let mut w = PromoteLivenessWatches::default();
+        assert!(!w.take_if_unconfirmed("window-pool-never", 1));
+    }
+
+    #[test]
+    fn fallback_opens_only_for_an_unconfirmed_watch_on_a_running_instance() {
+        use crate::state::QuitState;
+        assert!(should_open_fallback(true, &QuitState::Running));
+        // A confirmed promote never opens a replacement, whatever the
+        // instance is doing.
+        assert!(!should_open_fallback(false, &QuitState::Running));
+    }
+
+    #[test]
+    fn fallback_never_opens_a_window_while_the_instance_is_shutting_down() {
+        use crate::state::{QuitReason, QuitState};
+        // The drain interlock: a quit that began inside the 10s timeout
+        // window must not get a surprise window racing teardown.
+        assert!(!should_open_fallback(
+            true,
+            &QuitState::Draining { reason: QuitReason::LastWindowClosed }
+        ));
+        assert!(!should_open_fallback(
+            true,
+            &QuitState::Draining { reason: QuitReason::LauncherRequested }
+        ));
+        assert!(!should_open_fallback(true, &QuitState::Quit));
+    }
+}


### PR DESCRIPTION
## Summary

Workstream 0 / Phase 1, prerequisite **#2** of #2977 — the second and last item in that workstream (prereq #1 shipped in #2983).

`docs/retro/retro-fresh-vm-suspend-orphaned-frontend-2026-09-03.md` documents that `promote_pool_window`'s liveness check proves only that the OS still has the window handle. A suspend/resume cycle leaves window handles **fully intact** while the renderer behind them is dead — so every check on the promote path logs success and the user is handed a corpse, with no mechanism anywhere that notices.

This adds a bounded post-promote liveness watch (`agentmux-cef/src/state/promote_liveness.rs`): arm on promote → confirm on that label's own `register_backend_window` → on a 10s timeout with no confirmation, open a fresh cold-path window rather than leaving the user with a possibly-dead one.

## Two things I got wrong on the first pass, corrected by reading the code

Recording these because the issue's own framing (and my earlier note on it) pointed the wrong way:

1. **`on_load_end` cannot be the signal.** The obvious reading of the retro's recommendation ("a fresh first-paint/WebSocket-connected event *after* the promote") suggests hooking the load handler. But `frontend/app/init/pool.ts` applies the workspace id with `window.history.replaceState` — the promote path **never navigates**, so no load event fires. A load-based gate would have timed out on *every healthy promote* and duplicated every window.
2. **The gap is not in the cached-HWND fallback branch.** The retro's excerpt centres on the `IsWindow()`-against-cache branch (the "weaker evidence" one), which invites a fix scoped there. But CEF's own `window_handle()` is equally intact across a suspend — a fix scoped to one branch would miss the actual failure mode. The watch is therefore armed after the fact, for every promote, regardless of which branch resolved the HWND.

## Why `register_backend_window` is the right signal

It is already this codebase's canonical proof that a window's frontend "actually loaded and round-tripped IPC, not just that a CreateWindowTask was posted" — that is the literal justification for the `pending_reproject_closures.confirm(label)` call sitting a few lines above the new one (SPEC_PILLAR1_STEP4 Phase 3 addendum, reagent P1 PR #2032). This module deliberately mirrors `PendingReprojectClosures`' stage/confirm shape, and hangs off the same call site.

A promoted pool window reaches it end-to-end: `?pool=1` defers init until `pool:promote` arrives (`pool.ts`), then `initHostNewWindow()` runs and calls `registerBackendWindow` (`app-init.ts:477`). Because pool mode short-circuits **before** that call, a pool window cannot confirm at spawn time — the only possible confirmation is post-promote, so it is unambiguous. Confirming proves the renderer is alive, executing JS, and able to reach both srv and the host: exactly the three things `IsWindow()` cannot establish.

## Scope

Wired into all **three** promote sites, not just the Windows one the retro named — the gap is platform-neutral, and the non-Windows variant's check ("is the browser still in CEF state") is a weaker signal than `IsWindow()`, not a stronger one.

Design choices worth reviewing:

- **The fallback does not close the unconfirmed window.** It may be merely slow rather than dead, and destroying a live-but-late window loses user state. An extra window is the honest, recoverable cost the retro's recommendation #2 explicitly accepts.
- **`explicit_rect: None`** so the fresh window takes normal offset placement instead of stacking exactly on the suspect one — the retro calls out indistinguishable stacked windows as its own usability failure.
- **10s timeout**, deliberately generous: a false positive costs one redundant window, while too-tight costs duplicated windows for merely-slow-but-healthy promotes. Cold-path creation alone is documented at ~2.5-3.5s and a promoted window still has a full srv round trip to make.
- **No UI-thread hop.** Nothing in the timer needs the UI thread; `open_window_with_kind` is safe off it by construction (it does reducer bookkeeping then posts `CreateWindowTask` itself) and is already called from a non-UI tokio task by the reproject driver. A `post_task` would additionally risk being silently dropped during teardown.
- **Drain interlock** so a quit that begins inside the timeout window does not get a surprise window racing teardown.

## Test plan

- [x] `cargo test -p agentmux-cef --lib --release` — **325/325** (316 pre-existing + 9 new), zero regressions
- [x] Falsified all three gates individually, confirming the specific test fails each time, then restored: the **epoch guard** (a late timer must not consume a newer promote's watch — 1 test fails), **confirm** (a confirmed promote must never be duplicated — 3 tests fail), and the **drain interlock** (1 test fails)
- [x] `cargo clippy -p agentmux-cef --lib --release --tests` — no warnings on any new line (one it did catch, an unused test import, is fixed)
- [ ] **Not covered:** the issue's literal acceptance wording ("a *synthetic* stale-but-not-destroyed pool window reproducibly falls back") — that needs a real suspended/hung renderer, which I cannot stage without live GUI interaction on the shared multi-agent desktop this repo's agents run on. The decision logic is fully unit-tested; the timer-to-fallback wiring itself is covered by review, not by an executed end-to-end repro. Flagging honestly rather than claiming the criterion is met.

<!-- agentmux:agent_id=agent5 -->
