### PR TITLE
Manoz@Area54: feat(layout): drop Armory from the default startup panes, put CPU above Swarm

### DIFF
--- a/.changesets/1788624586-feat-layout-drop-armory-from-the-default-startup-panes-cpu-n-iktr.md
+++ b/.changesets/1788624586-feat-layout-drop-armory-from-the-default-startup-panes-cpu-n-iktr.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(layout): drop Armory from the default startup panes; CPU now sits above Swarm

--- a/agentmux-srv/src/backend/obj.rs
+++ b/agentmux-srv/src/backend/obj.rs
@@ -650,8 +650,8 @@ mod tests {
     /// the frontend produces today MUST yield the typed LayoutNode, and
     /// reserializing MUST produce equivalent JSON. The shapes here cover:
     ///   1. Single-leaf root (dnd / tear-off shape)
-    ///   2. The first-launch four-pane shape (deep nesting + mixed
-    ///      group/leaf nodes)
+    ///   2. A multi-pane shape (deep nesting + mixed group/leaf nodes) —
+    ///      the former first-launch four-pane layout, see below
     ///   3. Edge: missing `children` array for leaves
     #[test]
     fn test_layout_node_serde_compat_with_frontend_shapes() {

--- a/agentmux-srv/src/backend/obj.rs
+++ b/agentmux-srv/src/backend/obj.rs
@@ -673,8 +673,11 @@ mod tests {
         let reparsed: LayoutNode = serde_json::from_value(reserialized).unwrap();
         assert_eq!(leaf, reparsed);
 
-        // Shape 2 — first-launch four-pane (matches wcore::mod.rs —
-        // SPEC_DEFAULT_WIDGETS_REORDER_2026_08_25.md).
+        // Shape 2 — a nested row/column tree with a multi-child right
+        // column. This was the first-launch four-pane layout when written;
+        // the default is now three panes (wcore::default_three_pane_tree),
+        // but the fixture is kept as-is: what it exercises is serde
+        // round-tripping of a nested LayoutNode, not the current default.
         let four_pane_json = serde_json::json!({
             "id": "root-id",
             "flexDirection": "row",

--- a/agentmux-srv/src/backend/wcore/mod.rs
+++ b/agentmux-srv/src/backend/wcore/mod.rs
@@ -111,27 +111,33 @@ pub fn ensure_initial_data(store: &Store) -> Result<bool, StoreError> {
     // Create initial tab in workspace (pinned, matching Go's isInitialLaunch=true)
     let tab = create_tab_with_opts(store, &ws.oid, "", true)?;
 
-    // Seed the default 4-pane launch layout (agent + swarm + armory +
-    // sysinfo). Shared with the new-window path so "Open another window"
+    // Seed the default 3-pane launch layout (agent + sysinfo + swarm).
+    // Shared with the new-window path so "Open another window"
     // matches first launch.
     seed_default_layout(store, &tab.oid)?;
 
     Ok(first_launch)
 }
 
-/// Seed a tab with the default 4-pane launch layout (agent + swarm + armory
-/// + sysinfo — SPEC_DEFAULT_WIDGETS_REORDER_2026_08_25.md):
+/// Seed a tab with the default 3-pane launch layout (agent + sysinfo + swarm):
 ///
 /// ```text
 ///   ┌────────────────┬──────────────┐
-///   │                │    swarm     │  size 4 of 10 ≈ 40%
-///   │     agent      ├──────────────┤
-///   │    (tall)      │   armory     │  size 4 of 10 ≈ 40%
-///   │                ├──────────────┤
 ///   │                │   sysinfo    │  size 2 of 10 ≈ 20%
+///   │     agent      ├──────────────┤
+///   │    (tall)      │              │
+///   │                │    swarm     │  size 8 of 10 ≈ 80%
+///   │                │              │
 ///   └────────────────┴──────────────┘
 ///        50% width         50% width
 /// ```
+///
+/// Armory was dropped from the starter set (it's still one click away in the
+/// widget bar) and sysinfo moved above swarm, keeping its previous 20% share
+/// of the right column. Supersedes the 4-pane arrangement from
+/// SPEC_DEFAULT_WIDGETS_REORDER_2026_08_25.md. Only affects tabs seeded from
+/// here — first launch and newly-created windows; an existing persisted
+/// layout is untouched.
 ///
 /// Shared by first-launch bootstrap (`ensure_initial_data`) and the new-window
 /// path (`server::service`'s `CreateWindow` with an empty workspace) so "Open
@@ -155,27 +161,16 @@ pub(crate) fn seed_default_layout(store: &Store, tab_id: &str) -> Result<(), Sto
     swarm_meta.insert("view".to_string(), serde_json::json!("swarm"));
     let swarm_block = create_block(store, &tab.oid, swarm_meta)?;
 
-    let mut armory_meta = MetaMapType::new();
-    armory_meta.insert("view".to_string(), serde_json::json!("armory"));
-    let armory_block = create_block(store, &tab.oid, armory_meta)?;
-
     let mut sysinfo_meta = MetaMapType::new();
     sysinfo_meta.insert("view".to_string(), serde_json::json!("sysinfo"));
     let sysinfo_block = create_block(store, &tab.oid, sysinfo_meta)?;
 
-    write_default_four_pane_layout(
-        store,
-        tab_id,
-        &agent_block.oid,
-        &swarm_block.oid,
-        &armory_block.oid,
-        &sysinfo_block.oid,
-    )
+    write_default_three_pane_layout(store, tab_id, &agent_block.oid, &swarm_block.oid, &sysinfo_block.oid)
 }
 
-/// Write the default 4-pane launch layout (`agent | [swarm / armory /
-/// sysinfo]`) into `tab_id`'s `LayoutState`, wrapping four block IDs that
-/// the caller has ALREADY created.
+/// Write the default 3-pane launch layout (`agent | [sysinfo / swarm]`) into
+/// `tab_id`'s `LayoutState`, wrapping three block IDs that the caller has
+/// ALREADY created.
 ///
 /// Split out of `seed_default_layout` for the 2nd-window-tear-off desync fix
 /// (#1681). `seed_default_layout` creates its blocks store-only via
@@ -187,17 +182,16 @@ pub(crate) fn seed_default_layout(store: &Store, tab_id: &str) -> Result<(), Sto
 /// them, and `TearOffBlock` rejects them as "block not found" (the reducer never
 /// saw them). Both callers share this one function for the tree shape so the
 /// layout can never drift between the two paths.
-pub(crate) fn write_default_four_pane_layout(
+pub(crate) fn write_default_three_pane_layout(
     store: &Store,
     tab_id: &str,
     agent_block_id: &str,
     swarm_block_id: &str,
-    armory_block_id: &str,
     sysinfo_block_id: &str,
 ) -> Result<(), StoreError> {
     let tab = store.must_get::<Tab>(tab_id)?;
     let (rootnode, focused_node_id, leaforder) =
-        default_four_pane_tree(agent_block_id, swarm_block_id, armory_block_id, sysinfo_block_id);
+        default_three_pane_tree(agent_block_id, swarm_block_id, sysinfo_block_id);
     let mut layout = store.must_get::<LayoutState>(&tab.layoutstate)?;
     layout.rootnode = Some(rootnode);
     layout.focusednodeid = focused_node_id;
@@ -207,23 +201,26 @@ pub(crate) fn write_default_four_pane_layout(
     Ok(())
 }
 
-/// Pure builder for the default 4-pane tree (`agent | [swarm / armory /
-/// sysinfo]`). Returns `(rootnode, focused_node_id, leaforder)`. Shared by
+/// Pure builder for the default 3-pane tree (`agent | [sysinfo / swarm]`).
+/// Returns `(rootnode, focused_node_id, leaforder)`. Shared by
 /// the pre-bootstrap store-direct writer above (first launch — reducer not
 /// hydrated yet) and the post-bootstrap reducer-routed CreateWindow seed
 /// (SPEC_864 Phase 3, `seed_layout_via_reducer`), so the layout shape can
 /// never drift between the two paths.
-pub(crate) fn default_four_pane_tree(
+///
+/// Parameter order is semantic (agent/swarm/sysinfo), NOT top-to-bottom
+/// display order — sysinfo renders above swarm in the right column. Callers
+/// that build their block list positionally must keep passing them by
+/// meaning, not by visual position.
+pub(crate) fn default_three_pane_tree(
     agent_block_id: &str,
     swarm_block_id: &str,
-    armory_block_id: &str,
     sysinfo_block_id: &str,
 ) -> (LayoutNode, String, Vec<LeafOrderEntry>) {
     // Node IDs for each tree position. Leaves get their own node IDs distinct
     // from the block IDs they wrap.
     let agent_node_id = Uuid::new_v4().to_string();
     let swarm_node_id = Uuid::new_v4().to_string();
-    let armory_node_id = Uuid::new_v4().to_string();
     let sysinfo_node_id = Uuid::new_v4().to_string();
     let right_col_id = Uuid::new_v4().to_string();
     let root_id = Uuid::new_v4().to_string();
@@ -251,28 +248,8 @@ pub(crate) fn default_four_pane_tree(
                 flex_direction: FlexDirection::Column,
                 size: 5.0,
                 children: vec![
-                    LayoutNode {
-                        id: swarm_node_id.clone(),
-                        flex_direction: FlexDirection::Row,
-                        size: 4.0,
-                        children: Vec::new(),
-                        data: Some(LayoutNodeData {
-                            block_id: swarm_block_id.to_string(),
-                            ..Default::default()
-                        }),
-                        ..Default::default()
-                    },
-                    LayoutNode {
-                        id: armory_node_id.clone(),
-                        flex_direction: FlexDirection::Row,
-                        size: 4.0,
-                        children: Vec::new(),
-                        data: Some(LayoutNodeData {
-                            block_id: armory_block_id.to_string(),
-                            ..Default::default()
-                        }),
-                        ..Default::default()
-                    },
+                    // sysinfo (CPU) sits ABOVE swarm, keeping the same 20%
+                    // share of the right column it had in the 4-pane layout.
                     LayoutNode {
                         id: sysinfo_node_id.clone(),
                         flex_direction: FlexDirection::Row,
@@ -280,6 +257,17 @@ pub(crate) fn default_four_pane_tree(
                         children: Vec::new(),
                         data: Some(LayoutNodeData {
                             block_id: sysinfo_block_id.to_string(),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                    LayoutNode {
+                        id: swarm_node_id.clone(),
+                        flex_direction: FlexDirection::Row,
+                        size: 8.0,
+                        children: Vec::new(),
+                        data: Some(LayoutNodeData {
+                            block_id: swarm_block_id.to_string(),
                             ..Default::default()
                         }),
                         ..Default::default()
@@ -292,11 +280,11 @@ pub(crate) fn default_four_pane_tree(
         ..Default::default()
     };
 
+    // Display order (agent, then the right column top-to-bottom).
     let leaforder = vec![
         LeafOrderEntry { nodeid: agent_node_id.clone(), blockid: agent_block_id.to_string() },
-        LeafOrderEntry { nodeid: swarm_node_id, blockid: swarm_block_id.to_string() },
-        LeafOrderEntry { nodeid: armory_node_id, blockid: armory_block_id.to_string() },
         LeafOrderEntry { nodeid: sysinfo_node_id, blockid: sysinfo_block_id.to_string() },
+        LeafOrderEntry { nodeid: swarm_node_id, blockid: swarm_block_id.to_string() },
     ];
     (rootnode, agent_node_id, leaforder)
 }
@@ -447,7 +435,7 @@ mod tests {
     }
 
     #[test]
-    fn seed_default_layout_creates_four_pane_layout() {
+    fn seed_default_layout_creates_three_pane_layout() {
         // Regression: "Open another window" opened blank because new windows
         // never received the default layout (only first launch did). This is
         // the shared primitive both paths now use.
@@ -461,9 +449,10 @@ mod tests {
 
         seed_default_layout(&store, &tab.oid).unwrap();
 
-        // 4 blocks: agent + swarm + armory + sysinfo (SPEC_DEFAULT_WIDGETS_REORDER_2026_08_25.md).
+        // 3 blocks: agent + swarm + sysinfo. Armory is deliberately NOT
+        // seeded any more — it stays reachable from the widget bar.
         let tab = store.must_get::<Tab>(&tab.oid).unwrap();
-        assert_eq!(tab.blockids.len(), 4, "agent + swarm + armory + sysinfo");
+        assert_eq!(tab.blockids.len(), 3, "agent + swarm + sysinfo");
         let views: Vec<String> = tab
             .blockids
             .iter()
@@ -480,13 +469,38 @@ mod tests {
             .collect();
         assert!(views.contains(&"agent".to_string()));
         assert!(views.contains(&"swarm".to_string()));
-        assert!(views.contains(&"armory".to_string()));
         assert!(views.contains(&"sysinfo".to_string()));
+        assert!(!views.contains(&"armory".to_string()), "armory must not be seeded");
 
         // Layout populated (the regression was new windows getting rootnode=None).
         let layout = store.must_get::<LayoutState>(&tab.layoutstate).unwrap();
         assert!(layout.rootnode.is_some(), "rootnode must be populated, not blank");
-        assert_eq!(layout.leaforder.as_ref().unwrap().len(), 4);
+        assert_eq!(layout.leaforder.as_ref().unwrap().len(), 3);
+    }
+
+    /// The right column is `[sysinfo, swarm]` top-to-bottom — CPU above
+    /// swarm, not below it — and sysinfo keeps the 20% share it had in the
+    /// old 4-pane layout. Asserted on the tree directly, since `leaforder`
+    /// alone wouldn't catch the two being swapped in `children`.
+    #[test]
+    fn default_three_pane_tree_puts_sysinfo_above_swarm() {
+        let (root, focused, leaforder) = default_three_pane_tree("b-agent", "b-swarm", "b-sysinfo");
+
+        assert_eq!(root.children.len(), 2, "agent | right-column");
+        let agent = &root.children[0];
+        assert_eq!(agent.data.as_ref().unwrap().block_id, "b-agent");
+        assert_eq!(focused, agent.id, "agent pane starts focused");
+
+        let right = &root.children[1];
+        assert_eq!(right.flex_direction, FlexDirection::Column);
+        assert_eq!(right.children.len(), 2, "sysinfo + swarm only — no armory");
+        assert_eq!(right.children[0].data.as_ref().unwrap().block_id, "b-sysinfo", "sysinfo on top");
+        assert_eq!(right.children[1].data.as_ref().unwrap().block_id, "b-swarm", "swarm below");
+        assert_eq!(right.children[0].size, 2.0);
+        assert_eq!(right.children[1].size, 8.0);
+
+        let order: Vec<&str> = leaforder.iter().map(|e| e.blockid.as_str()).collect();
+        assert_eq!(order, vec!["b-agent", "b-sysinfo", "b-swarm"]);
     }
 
     #[test]

--- a/agentmux-srv/src/server/service/reducer_helpers.rs
+++ b/agentmux-srv/src/server/service/reducer_helpers.rs
@@ -64,7 +64,7 @@ pub(crate) async fn compensate_via_reducer(
 /// it inside ONE hold of the reducer mutex, so persist order equals
 /// dispatch order — the same contract as `UpdateObject`'s Phase-2 route in
 /// `object.rs`. Replaces the wcore-direct seeders
-/// (`write_default_four_pane_layout` post-bootstrap caller,
+/// (`write_default_three_pane_layout` post-bootstrap caller,
 /// `setup_torn_off_block_layout`): the reducer's `TabRecord.rootnode` is
 /// authoritative, and the persist subscriber is the sole `db_layout`
 /// writer on this path.

--- a/agentmux-srv/src/server/service/session_restore.rs
+++ b/agentmux-srv/src/server/service/session_restore.rs
@@ -8,7 +8,7 @@
 //! workspace/tabs/blocks (`e3a6f85c2`, wired to the last-window "main" case
 //! by `4cbf856b7` — see `docs/retro/retro-pane-layout-restore-was-a-leak-not-a-feature-2026-08-13.md`),
 //! so the next cold launch always finds `Client.windowids` empty and reseeds
-//! the hardcoded default 4-pane layout (`window_create::default_four_pane_tree`).
+//! the hardcoded default 3-pane layout (`window_create::default_three_pane_tree`).
 //!
 //! This module adds an independent, durable "what was open last" record —
 //! written just before that destroy cascade runs (`window_close::handle_close_window`)

--- a/agentmux-srv/src/server/service/window_create.rs
+++ b/agentmux-srv/src/server/service/window_create.rs
@@ -149,9 +149,9 @@ pub(crate) async fn handle_create_window(state: &AppState, call: &WebCallType) -
                     ));
                 }
             }
-            // Seed the default 4-pane launch layout (agent + swarm +
-            // armory + sysinfo) into the fresh tab so "Open another
-            // window" matches first launch instead of opening blank. Only this
+            // Seed the default 3-pane launch layout (agent | sysinfo /
+            // swarm) into the fresh tab so "Open another window" matches
+            // first launch instead of opening blank. Only this
             // fresh-workspace branch seeds; tear-off (existing workspace,
             // the `else` arm) reattaches its populated workspace as-is.
             // Non-fatal: a seed failure leaves an empty tab (the prior

--- a/agentmux-srv/src/server/service/window_create.rs
+++ b/agentmux-srv/src/server/service/window_create.rs
@@ -178,10 +178,12 @@ pub(crate) async fn handle_create_window(state: &AppState, call: &WebCallType) -
                 }
                 _ => None,
             }) {
-                // Dispatch the four seed blocks through the reducer, in the
-                // target display order (SPEC_DEFAULT_WIDGETS_REORDER_2026_08_25.md).
+                // Dispatch the three seed blocks through the reducer. This
+                // order is the one `default_three_pane_tree` expects
+                // positionally (agent, swarm, sysinfo) — NOT top-to-bottom
+                // display order, since sysinfo renders above swarm.
                 let mut seeded_ids: Vec<String> = Vec::new();
-                for view in ["agent", "swarm", "armory", "sysinfo"] {
+                for view in ["agent", "swarm", "sysinfo"] {
                     let evs = dispatch_to_reducer(
                         state,
                         agentmux_common::ipc::Command::CreateBlock {
@@ -226,18 +228,17 @@ pub(crate) async fn handle_create_window(state: &AppState, call: &WebCallType) -
                     block_seed_events.extend(evs);
                 }
 
-                if seeded_ids.len() == 4 {
+                if seeded_ids.len() == 3 {
                     // SPEC_864 Phase 3 — post-bootstrap seed routes
                     // through the reducer (single writer of
                     // db_layout); the tree shape is shared with the
                     // pre-bootstrap store-direct first-launch seed
-                    // via `default_four_pane_tree`.
+                    // via `default_three_pane_tree`.
                     let (tree, focused, leaforder) =
-                        crate::backend::wcore::default_four_pane_tree(
+                        crate::backend::wcore::default_three_pane_tree(
                             &seeded_ids[0],
                             &seeded_ids[1],
                             &seeded_ids[2],
-                            &seeded_ids[3],
                         );
                     if let Err(e) = super::reducer_helpers::seed_layout_via_reducer(
                         state,

--- a/agentmux-srv/src/server/service/window_create.rs
+++ b/agentmux-srv/src/server/service/window_create.rs
@@ -421,7 +421,7 @@ mod create_window_seed_tests {
 
     /// Regression for the 2nd-window-tear-off desync (#1681).
     ///
-    /// "Open another window" used to seed its four default blocks straight
+    /// "Open another window" used to seed its default blocks straight
     /// into SQLite (`seed_default_layout` → `create_block`), bypassing the
     /// reducer. The handler runs after bootstrap, so those blocks never
     /// reached the in-memory `srv_state`. The frontend rendered them (it reads
@@ -444,14 +444,14 @@ mod create_window_seed_tests {
             .expect("window has a workspaceid")
             .to_string();
 
-        // The fix: the four seed blocks are present in the in-memory reducer
+        // The fix: the seed blocks are present in the in-memory reducer
         // state, attached to the new window's tab.
         let (tab_id, block_id) = {
             let s = state.srv_state.lock().await;
             assert_eq!(
                 s.blocks.len(),
-                blocks_before + 4,
-                "the 4 seed blocks must be tracked in srv_state, not only SQLite"
+                blocks_before + 3,
+                "the 3 seed blocks must be tracked in srv_state, not only SQLite"
             );
             let ws = s
                 .workspaces
@@ -461,8 +461,8 @@ mod create_window_seed_tests {
             let tab = s.tabs.get(&tab_id).expect("new tab is in the reducer");
             assert_eq!(
                 tab.block_ids.len(),
-                4,
-                "the new window's tab must hold its 4 seed blocks in the reducer"
+                3,
+                "the new window's tab must hold its 3 seed blocks in the reducer"
             );
             (tab_id, tab.block_ids[0].clone())
         };

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -1774,7 +1774,7 @@ async fn layout_seeders_route_through_reducer_coherently() {
         })
         .unwrap();
 
-    // ── four-pane seed (the CreateWindow post-bootstrap path) ──
+    // ── three-pane seed (the CreateWindow post-bootstrap path) ──
     let tab_evs = dispatch_apply(
         &state,
         Command::CreateTab {
@@ -1796,30 +1796,30 @@ async fn layout_seeders_route_through_reducer_coherently() {
     // reducer-routed seeders — see
     // docs/investigations/INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08.md)
     // now prunes any seeded leaf whose block_id isn't live.
-    for bid in ["b-agent", "b-swarm", "b-armory", "b-sysinfo"] {
+    for bid in ["b-agent", "b-swarm", "b-sysinfo"] {
         srv_state.lock().await.blocks.insert(
             bid.to_string(),
             crate::state::BlockRecord { block_id: bid.to_string(), tab_id: tab1.clone() },
         );
     }
     let (tree, focused, leaforder) =
-        crate::backend::wcore::default_four_pane_tree("b-agent", "b-swarm", "b-armory", "b-sysinfo");
+        crate::backend::wcore::default_three_pane_tree("b-agent", "b-swarm", "b-sysinfo");
     crate::server::service::seed_layout_via_reducer(
         &state, &tab1, tree, focused, leaforder, String::new(),
     )
     .await
-    .expect("four-pane seed via reducer");
+    .expect("three-pane seed via reducer");
 
     let layout_oid = wstore.get::<Tab>(&tab1).unwrap().unwrap().layoutstate;
     let row = wstore.get::<LayoutState>(&layout_oid).unwrap().unwrap();
-    assert_eq!(row.leaforder.as_ref().unwrap().len(), 4);
+    assert_eq!(row.leaforder.as_ref().unwrap().len(), 3);
     assert!(!row.focusednodeid.is_empty(), "focus persisted");
     {
         let s = srv_state.lock().await;
         let rec = s.tabs.get(&tab1).expect("reducer knows tab1");
         assert_eq!(
             rec.rootnode, row.rootnode,
-            "TabRecord == db_layout after four-pane seed"
+            "TabRecord == db_layout after three-pane seed"
         );
         assert_eq!(rec.focused_node_id, row.focusednodeid);
     }
@@ -1870,7 +1870,7 @@ async fn layout_seeders_route_through_reducer_coherently() {
 async fn layout_seed_unknown_tab_errors() {
     let state = test_state();
     let (tree, focused, leaforder) =
-        crate::backend::wcore::default_four_pane_tree("a", "b", "c", "d");
+        crate::backend::wcore::default_three_pane_tree("a", "b", "c");
     let err = crate::server::service::seed_layout_via_reducer(
         &state, "ghost-tab", tree, focused, leaforder, String::new(),
     )

--- a/agentmux-srv/tests/integration_test.rs
+++ b/agentmux-srv/tests/integration_test.rs
@@ -427,11 +427,11 @@ fn restore_last_session_survives_a_real_process_restart() {
         .iter()
         .map(|v| v.as_str().unwrap().to_string())
         .collect();
-    // The default seed is 4 blocks (agent/swarm/armory/sysinfo,
-    // SPEC_DEFAULT_WIDGETS_REORDER_2026_08_25.md); our marker block was the
-    // 5th added before close, so a correct restore must bring all 5 back,
-    // not silently drop the one added after the initial seed.
-    assert_eq!(restored_block_ids.len(), 5, "expected all 5 original blocks to be restored");
+    // The default seed is 3 blocks (agent/sysinfo/swarm — see
+    // wcore::default_three_pane_tree); our marker block was the 4th added
+    // before close, so a correct restore must bring all 4 back, not
+    // silently drop the one added after the initial seed.
+    assert_eq!(restored_block_ids.len(), 4, "expected all 4 original blocks to be restored");
 
     let mut found_marker = false;
     for block_id in &restored_block_ids {

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -343,7 +343,7 @@ async function initHostWave(): Promise<void> {
         // graceful quit (the destroy-on-close cascade always empties it) or
         // on a truly first-ever launch. Pass `restoreIfAvailable: true` so
         // srv replays the last-session snapshot if one was saved on close,
-        // instead of always seeding the hardcoded default 4-pane layout.
+        // instead of always seeding the hardcoded default 3-pane layout.
         if (!windowId) {
             t = performance.now();
             const newWindow = await withTimeout(WindowService.CreateWindow(null, "", currentWindowLabel(), true), RPC_TIMEOUT, "CreateWindow");

--- a/frontend/app/store/services.ts
+++ b/frontend/app/store/services.ts
@@ -114,7 +114,7 @@ class WindowServiceType {
     // 2026_08_13 Feature 1): only the true cold-start call site in
     // app-init.ts sets this — it tells srv to replay the last-session
     // snapshot (if one exists) instead of seeding the hardcoded default
-    // 4-pane layout. Every other caller (tear-off, "Open New Window") omits
+    // 3-pane layout. Every other caller (tear-off, "Open New Window") omits
     // it and keeps today's always-blank-workspace behavior.
     CreateWindow(winSize: WinSize, workspaceId: string, hostLabel?: string, restoreIfAvailable?: boolean): Promise<WaveWindow> {
         return WOS.callBackendService("window", "CreateWindow", Array.from(arguments))

--- a/frontend/app/tab/tab-presets.test.ts
+++ b/frontend/app/tab/tab-presets.test.ts
@@ -9,6 +9,13 @@
  * only surfaced once DEFAULT_TAB_PRESET grew a 3-child vertical split
  * (swarm/armory/sysinfo, SPEC_DEFAULT_WIDGETS_REORDER_2026_08_25.md) — a
  * 2-child split can't distinguish "first child" from "previous child".
+ *
+ * DEFAULT_TAB_PRESET is back down to a 2-child right column (sysinfo above
+ * swarm; armory dropped from the starter set), so the shipped default no
+ * longer exercises this path. The fixtures below are deliberately local
+ * and stay 3-child: the applier still supports N children, and this is the
+ * only thing guarding that ordering — don't retire it just because the
+ * current default happens not to hit it.
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/frontend/app/tab/tab-presets.ts
+++ b/frontend/app/tab/tab-presets.ts
@@ -39,11 +39,18 @@ export type PresetNode = LeafNode | SplitNode;
 
 // ─── The default new-tab preset ──────────────────────────────────────────────
 //
-// agent on the left half; swarm / armory / sysinfo stacked top-to-bottom on
-// the right half (SPEC_DEFAULT_WIDGETS_REORDER_2026_08_25.md — matches the
-// window-bootstrap default in agentmux-srv/src/backend/wcore/mod.rs's
-// default_four_pane_tree, a separate mechanism kept in sync by convention,
-// not shared code).
+// agent on the left half; sysinfo (CPU) above swarm on the right half.
+// Matches the window-bootstrap default in
+// agentmux-srv/src/backend/wcore/mod.rs's `default_three_pane_tree` — a
+// SEPARATE mechanism kept in sync by convention, not shared code, so a
+// change to either one has to be mirrored here by hand. Armory was dropped
+// from the starter set (still one click away in the widget bar),
+// superseding SPEC_DEFAULT_WIDGETS_REORDER_2026_08_25.md's arrangement.
+//
+// Note this preset can't express the backend's 20/80 size split — the
+// applier only emits even splits — so the right column starts 50/50 here
+// and the backend seed is the one that carries the sizing.
+//
 // To change the defaults, edit *only* this constant — the applier and
 // every consumer of `createTab()` pick it up automatically.
 
@@ -53,11 +60,7 @@ export const DEFAULT_TAB_PRESET: PresetNode = {
         { widget: "defwidget@agent" },
         {
             split: "vertical",
-            children: [
-                { widget: "defwidget@swarm" },
-                { widget: "defwidget@armory" },
-                { widget: "defwidget@sysinfo" },
-            ],
+            children: [{ widget: "defwidget@sysinfo" }, { widget: "defwidget@swarm" }],
         },
     ],
 };


### PR DESCRIPTION
## Summary

The starter layout seeded on first launch (and for each new window) was four panes: agent on the left, then swarm / armory / sysinfo stacked down the right. It's now three — Armory is gone, and sysinfo (CPU) moved to the **top** of the right column:

```
┌────────────────┬──────────────┐
│                │   sysinfo    │  2 of 10 ≈ 20%
│     agent      ├──────────────┤
│    (tall)      │              │
│                │    swarm     │  8 of 10 ≈ 80%
└────────────────┴──────────────┘
     50% width        50% width
```

sysinfo keeps the same 20% share of the right column it already had, so swarm simply absorbs Armory's space. **Armory itself is unchanged** and still one click away in the widget bar — only the *starter* set changed.

## Notes for review

- **No migration needed.** This only affects newly-seeded tabs (first launch + newly-created windows). An existing persisted layout is untouched.
- **Both seeding paths were updated**, and they share the same tree builder so they can't drift: the pre-bootstrap store-direct first-launch seed (`wcore::seed_default_layout`) and the post-bootstrap reducer-routed `CreateWindow` seed (`window_create.rs`, which also had its `seeded_ids.len() == 4` guard updated — that would have silently skipped seeding otherwise).
- **Renamed** `*_four_pane_*` → `*_three_pane_*` across the three functions rather than leaving the arity wrong in the name.
- **One sharp edge, now documented in both places:** `default_three_pane_tree`'s parameter order is semantic (agent, swarm, sysinfo), *not* top-to-bottom display order, since sysinfo renders above swarm. `window_create` builds its block list positionally against that order.
- `obj.rs`'s `four_pane_json` serde fixture is deliberately left as-is — it exercises round-tripping a nested `LayoutNode`, not the current default; its comment now says so instead of claiming it mirrors wcore.

## Verification

- `cargo build -p agentmux-srv` — clean (only pre-existing warnings)
- `cargo test -p agentmux-srv --bins -- pane layout` — 205 passed, 0 failed
- Updated `seed_default_layout_creates_three_pane_layout` to assert 3 blocks and explicitly that armory is **not** seeded
- Added `default_three_pane_tree_puts_sysinfo_above_swarm`, asserting on the tree itself (child order + 2.0/8.0 sizes) — `leaforder` alone wouldn't catch the two being swapped in `children`
- Fixed `layout_seeders_route_through_reducer_coherently`, which had been registering a stale `b-armory` block and asserting 4 leaves

<!-- agentmux:agent_id=manoz -->