### PR TITLE
Camper@claudius: fix(agent): bump stale fable pin, stop the picker advertising a model it doesn't select

### DIFF
--- a/.changesets/1788632478-fix-agent-bump-the-stale-fable-model-pin-and-stop-the-picker-q5f6.md
+++ b/.changesets/1788632478-fix-agent-bump-the-stale-fable-model-pin-and-stop-the-picker-q5f6.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): bump the stale fable model pin and stop the picker advertising a model it doesn't select

--- a/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
+++ b/frontend/app/view/agent/components/AgentCreateFromTemplateModal.tsx
@@ -22,14 +22,14 @@
  * universal modal system per `feedback_use_universal_modal_system`.
  */
 
-import { createEffect, createMemo, createResource, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { createEffect, createMemo, createResource, createSignal, For, onCleanup, onMount, Show, untrack, type JSX } from "solid-js";
 
 import { Button } from "@/element/button";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
 import { PROVIDERS } from "../providers/catalog";
-import { getProvider } from "../providers";
+import { familyKey, getProvider } from "../providers";
 import { resolveEffectiveLaunchProvider } from "../agent-launch-env";
 import { providerSupportsModelFlag } from "../buildRuntimeArgs";
 import { isAvailable, watchCapability } from "@/app/store/toolchain-capabilities";
@@ -144,8 +144,24 @@ export const AgentCreateFromTemplateModalPanel = (
     // (modelTouched), mirroring runtimeTouched below.
     let modelTouched = false;
     createEffect(() => {
-        if (modelTouched) return;
-        setModel(modelOptions().find((m) => m.default)?.value ?? modelOptions()[0]?.value ?? "");
+        const opts = modelOptions();
+        if (!modelTouched) {
+            setModel(opts.find((m) => m.default)?.value ?? opts[0]?.value ?? "");
+            return;
+        }
+        // The user has chosen, so we normally leave their pick alone — but a
+        // CONCRETE (version-pinned) option value can be *replaced* underneath
+        // them: `setProviderModels` refreshes those values when the live
+        // catalog resolves, which can land after a selection is made. Without
+        // this, the list would show the refreshed row while `model()` still
+        // held the old id, and submit sends `model()` — creating the exact
+        // advertise-one/select-another gap this PR set out to close.
+        // Alias rows are unaffected (their values never change). Codex P2,
+        // PR #2990.
+        const current = untrack(model);
+        if (!current || opts.some((m) => m.value === current)) return;
+        const replacement = opts.find((m) => familyKey(m.value) === familyKey(current));
+        if (replacement) setModel(replacement.value);
     });
     const pickModel = (v: string) => {
         modelTouched = true;

--- a/frontend/app/view/agent/components/AgentRuntimeDropup.test.tsx
+++ b/frontend/app/view/agent/components/AgentRuntimeDropup.test.tsx
@@ -137,3 +137,66 @@ describe("AgentRuntimeDropup — click outside", () => {
         expect(screen.getByRole("listbox")).toBeInTheDocument();
     });
 });
+
+describe("AgentRuntimeDropup — superseded persisted model migration", () => {
+    // The live-catalog overlay refreshes CONCRETE option values, so an agent
+    // configured before such a bump holds an id no longer in modelOptions().
+    // Without migration `modelLabel()` renders the raw id and no row is marked
+    // current — the dropdown silently loses its selection display.
+    // reagent P1, PR #2990.
+    // getRuntimeConfig reads a nested object under "agent:runtime", not
+    // dotted keys — see buildRuntimeArgs.ts:153.
+    const metaWith = (model: string) => ({
+        "agent:runtime": { model, permissionMode: "default", effort: "high" },
+    });
+
+    it("migrates a superseded concrete id to its current family member", async () => {
+        const { applyRuntimeChange } = await import("../runtime-apply");
+        vi.mocked(applyRuntimeChange).mockClear();
+
+        render(() => (
+            <AgentRuntimeDropup
+                blockId="block-1"
+                blockAtom={() => ({ meta: metaWith("claude-fable-5") }) as any}
+                providerId="claude"
+            />
+        ));
+
+        await vi.waitFor(() => expect(applyRuntimeChange).toHaveBeenCalled());
+        const cfg = vi.mocked(applyRuntimeChange).mock.calls[0][2] as { model: string };
+        expect(cfg.model).toMatch(/^claude-fable-5-1$/);
+    });
+
+    it("leaves an alias selection untouched", async () => {
+        const { applyRuntimeChange } = await import("../runtime-apply");
+        vi.mocked(applyRuntimeChange).mockClear();
+
+        render(() => (
+            <AgentRuntimeDropup
+                blockId="block-1"
+                blockAtom={() => ({ meta: metaWith("sonnet") }) as any}
+                providerId="claude"
+            />
+        ));
+
+        // Aliases are never superseded, so nothing should be rewritten.
+        await new Promise((r) => setTimeout(r, 20));
+        expect(applyRuntimeChange).not.toHaveBeenCalled();
+    });
+
+    it("leaves an unrecognised id alone rather than guessing a family", async () => {
+        const { applyRuntimeChange } = await import("../runtime-apply");
+        vi.mocked(applyRuntimeChange).mockClear();
+
+        render(() => (
+            <AgentRuntimeDropup
+                blockId="block-1"
+                blockAtom={() => ({ meta: metaWith("some-other-vendor-model-9") }) as any}
+                providerId="claude"
+            />
+        ));
+
+        await new Promise((r) => setTimeout(r, 20));
+        expect(applyRuntimeChange).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/app/view/agent/components/AgentRuntimeDropup.tsx
+++ b/frontend/app/view/agent/components/AgentRuntimeDropup.tsx
@@ -31,7 +31,7 @@ import { autoUpdate } from "@floating-ui/dom";
 import { createEffect, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
 import { getRuntimeConfig } from "../buildRuntimeArgs";
-import { getProvider, type ProviderModel } from "../providers";
+import { familyKey, getProvider, type ProviderModel } from "../providers";
 import { applyRuntimeChange } from "../runtime-apply";
 import type { AgentRuntimeConfig, EffortLevel, PermissionMode } from "../types";
 
@@ -119,6 +119,30 @@ export const AgentRuntimeDropup = (props: AgentRuntimeDropupProps): JSX.Element 
     };
 
     const modelOptions = (): ProviderModel[] => getProvider(props.providerId)?.models ?? FALLBACK_MODEL_OPTIONS;
+
+    // Migrate a persisted model id the live-catalog overlay has superseded.
+    //
+    // `setProviderModels` refreshes CONCRETE (version-pinned) option values
+    // when the authoritative catalog resolves, so an agent configured before
+    // such a bump holds an id that is no longer present in `modelOptions()`.
+    // Left alone, `modelLabel()` falls back to rendering the raw id and
+    // `build()` marks no row `current` — the dropdown silently loses its
+    // selection display for that agent.
+    //
+    // This migrates the PERSISTED value rather than making the lookups
+    // family-tolerant. A display-only fix would show the new row as selected
+    // while block meta still held the old id — reintroducing exactly the
+    // advertise-one/select-another mismatch this PR exists to remove, one
+    // layer further down. Alias values ("opus"/"sonnet") are never superseded,
+    // so they never enter this path. reagent P1, PR #2990.
+    createEffect(() => {
+        const opts = modelOptions();
+        const current = runtime().model;
+        if (!current || opts.length === 0) return;
+        if (opts.some((o) => o.value === current)) return;
+        const replacement = opts.find((o) => familyKey(o.value) === familyKey(current));
+        if (replacement) void updateRuntime({ model: replacement.value });
+    });
 
     const modelLabel = (value: string): string => modelOptions().find((o) => o.value === value)?.label ?? value;
     const effortLabel = (value: string): string => EFFORT_OPTIONS.find((o) => o.value === value)?.label ?? value;

--- a/frontend/app/view/agent/providers/catalog.ts
+++ b/frontend/app/view/agent/providers/catalog.ts
@@ -164,16 +164,23 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         // which is `sonnet` (faster default for routine turns). A mismatch here
         // desyncs the strip's Model dropdown from the actual default and is a
         // trap for any `models.find(m => m.default)` reader.
+        // Descriptions are deliberately VERSION-FREE. The label carries the
+        // version and is refreshed from the live catalog by `setProviderModels`;
+        // a description that also named one could contradict it, which is
+        // exactly what users saw — a row reading "Fable 5.1" above the text
+        // "Claude Fable 5". Keep version numbers in `label` only.
         models: [
-            { value: "opus", label: "Opus 5", description: "Claude Opus 5 — highest quality", aliases: ["claude-opus"] },
-            { value: "sonnet", label: "Sonnet 5", default: true, description: "Claude Sonnet 5 — balanced", aliases: ["claude-sonnet"] },
-            { value: "haiku", label: "Haiku 4.5", description: "Claude Haiku 4.5 — fastest", aliases: ["claude-haiku"] },
-            // No confirmed generic "fable" alias (unlike opus/sonnet/haiku above), so this
-            // pins the concrete model id directly — same id already relied on by
-            // context-window.ts's 1M-context-window band. Kept current here so the
-            // offline/API-failure fallback still shows it (see setProviderModels below
-            // for how this stays in sync with the live catalog once reachable).
-            { value: "claude-fable-5", label: "Fable 5", description: "Claude Fable 5" },
+            { value: "opus", label: "Opus 5", description: "Highest quality", aliases: ["claude-opus"] },
+            { value: "sonnet", label: "Sonnet 5", default: true, description: "Balanced speed and quality", aliases: ["claude-sonnet"] },
+            { value: "haiku", label: "Haiku 4.5", description: "Fastest", aliases: ["claude-haiku"] },
+            // No confirmed generic "fable" alias (unlike opus/sonnet/haiku above) —
+            // `claude --help` documents `--model` as taking "an alias for the latest
+            // model (e.g. 'sonnet' or 'opus') or a model's full name", and lists no
+            // fable shorthand — so this pins the concrete model id directly. Same id
+            // family already relied on by context-window.ts's 1M band. Unlike the
+            // alias rows above, a concrete id does NOT self-resolve, so
+            // `setProviderModels` refreshes this row's `value` as well as its label.
+            { value: "claude-fable-5-1", label: "Fable 5.1", description: "Most capable for long-horizon work" },
         ],
     },
     codex: {

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -11,4 +11,4 @@ export type { ProviderModel, ProviderDefinition } from "./types";
 
 export { GIT_PREREQ, PROVIDERS, PROVIDER_ALIASES, resolveProviderAlias } from "./catalog";
 
-export { setProviderModels, getProvider, getProviderList } from "./model-overlay";
+export { setProviderModels, getProvider, getProviderList, familyKey } from "./model-overlay";

--- a/frontend/app/view/agent/providers/model-overlay.test.ts
+++ b/frontend/app/view/agent/providers/model-overlay.test.ts
@@ -17,7 +17,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { getProvider, setProviderModels } from "./model-overlay";
+import { familyKey, getProvider, setProviderModels } from "./model-overlay";
 
 /** Shape the backend's `providers.models` RPC delivers. */
 const apiModels = (...ids: Array<[string, string]>) =>
@@ -102,5 +102,15 @@ describe("curated catalog", () => {
         // full model name for `--model` to resolve.
         const fable = claudeModels().find((m) => m.label.startsWith("Fable"));
         expect(fable!.value).toMatch(/^claude-fable-/);
+    });
+});
+
+describe("familyKey (exported for selection migration)", () => {
+    it("groups versions of the same family so a stale selection can be migrated", () => {
+        // AgentCreateFromTemplateModal uses this to move a user's touched
+        // selection when the overlay replaces a concrete value underneath it.
+        expect(familyKey("claude-fable-5")).toBe(familyKey("claude-fable-5-1"));
+        expect(familyKey("claude-fable-5")).not.toBe(familyKey("claude-opus-5"));
+        expect(familyKey("opus")).toBe("opus");
     });
 });

--- a/frontend/app/view/agent/providers/model-overlay.test.ts
+++ b/frontend/app/view/agent/providers/model-overlay.test.ts
@@ -13,22 +13,33 @@
  * row produces a picker entry that displays "Fable 5.1" while still passing
  * `claude-fable-5` to `--model` — advertising one model and selecting an older
  * one, with nothing in the UI indicating the mismatch.
+ *
+ * `setProviderModels` writes to a module-level signal, so every test re-imports
+ * the module through `vi.resetModules()` to get a clean catalog. Without that,
+ * the "curated catalog" assertions below would run against state left by
+ * earlier tests rather than the curated defaults they mean to check — passing
+ * or failing depending on execution order. reagent P2, PR #2990.
  */
 
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { familyKey, getProvider, setProviderModels } from "./model-overlay";
+type Overlay = typeof import("./model-overlay");
+let overlay: Overlay;
+
+beforeEach(async () => {
+    vi.resetModules();
+    overlay = await import("./model-overlay");
+});
 
 /** Shape the backend's `providers.models` RPC delivers. */
 const apiModels = (...ids: Array<[string, string]>) =>
     ids.map(([value, label]) => ({ value, label }));
 
-const claudeModels = () => getProvider("claude")!.models;
-const row = (value: string) => claudeModels().find((m) => m.value === value);
+const claudeModels = () => overlay.getProvider("claude")!.models;
 
 describe("setProviderModels", () => {
     it("refreshes an alias row's label without touching its value", () => {
-        setProviderModels("claude", apiModels(["claude-opus-6", "Claude Opus 6"]));
+        overlay.setProviderModels("claude", apiModels(["claude-opus-6", "Claude Opus 6"]));
         const opus = claudeModels().find((m) => m.label === "Opus 6");
         expect(opus).toBeDefined();
         // The alias must survive — the CLI resolves it to whatever is current.
@@ -36,7 +47,7 @@ describe("setProviderModels", () => {
     });
 
     it("refreshes a concrete row's value as well as its label", () => {
-        setProviderModels("claude", apiModels(["claude-fable-6", "Claude Fable 6"]));
+        overlay.setProviderModels("claude", apiModels(["claude-fable-6", "Claude Fable 6"]));
         const fable = claudeModels().find((m) => m.label === "Fable 6");
         expect(fable).toBeDefined();
         // Value moved with the label — no advertise-one/select-another gap.
@@ -44,7 +55,7 @@ describe("setProviderModels", () => {
     });
 
     it("picks the newest family member regardless of API ordering", () => {
-        setProviderModels(
+        overlay.setProviderModels(
             "claude",
             apiModels(
                 ["claude-fable-5-1", "Claude Fable 5.1"],
@@ -57,7 +68,7 @@ describe("setProviderModels", () => {
     });
 
     it("does not emit a duplicate row for a family it already covers", () => {
-        setProviderModels(
+        overlay.setProviderModels(
             "claude",
             apiModels(
                 ["claude-fable-5", "Claude Fable 5"],
@@ -69,7 +80,7 @@ describe("setProviderModels", () => {
     });
 
     it("appends an unseen family rather than dropping it", () => {
-        setProviderModels("claude", apiModels(["claude-mythos-5-1", "Claude Mythos 5.1"]));
+        overlay.setProviderModels("claude", apiModels(["claude-mythos-5-1", "Claude Mythos 5.1"]));
         const mythos = claudeModels().find((m) => m.value === "claude-mythos-5-1");
         expect(mythos).toBeDefined();
         expect(mythos!.label).toBe("Mythos 5.1");
@@ -77,18 +88,19 @@ describe("setProviderModels", () => {
 
     it("leaves the static catalog untouched when the API returns nothing", () => {
         const before = claudeModels().map((m) => m.value);
-        setProviderModels("claude", []);
+        overlay.setProviderModels("claude", []);
         expect(claudeModels().map((m) => m.value)).toEqual(before);
     });
 
     it("preserves the default marker through a refresh", () => {
-        setProviderModels("claude", apiModels(["claude-sonnet-6", "Claude Sonnet 6"]));
+        overlay.setProviderModels("claude", apiModels(["claude-sonnet-6", "Claude Sonnet 6"]));
         const dflt = claudeModels().find((m) => m.default);
         expect(dflt?.value).toBe("sonnet");
     });
 });
 
 describe("curated catalog", () => {
+    // These read the UNOVERLAID catalog — hence the per-test module reset.
     it("keeps version numbers out of descriptions so they cannot contradict labels", () => {
         // A description naming a version goes stale the moment the label is
         // refreshed — the "Fable 5.1 over Claude Fable 5" report.
@@ -103,14 +115,19 @@ describe("curated catalog", () => {
         const fable = claudeModels().find((m) => m.label.startsWith("Fable"));
         expect(fable!.value).toMatch(/^claude-fable-/);
     });
+
+    it("ships the current fable id, not the superseded one", () => {
+        const fable = claudeModels().find((m) => m.label.startsWith("Fable"));
+        expect(fable!.value).toBe("claude-fable-5-1");
+    });
 });
 
 describe("familyKey (exported for selection migration)", () => {
     it("groups versions of the same family so a stale selection can be migrated", () => {
-        // AgentCreateFromTemplateModal uses this to move a user's touched
-        // selection when the overlay replaces a concrete value underneath it.
-        expect(familyKey("claude-fable-5")).toBe(familyKey("claude-fable-5-1"));
-        expect(familyKey("claude-fable-5")).not.toBe(familyKey("claude-opus-5"));
-        expect(familyKey("opus")).toBe("opus");
+        // AgentCreateFromTemplateModal and AgentRuntimeDropup both use this to
+        // move a selection when the overlay replaces a concrete value.
+        expect(overlay.familyKey("claude-fable-5")).toBe(overlay.familyKey("claude-fable-5-1"));
+        expect(overlay.familyKey("claude-fable-5")).not.toBe(overlay.familyKey("claude-opus-5"));
+        expect(overlay.familyKey("opus")).toBe("opus");
     });
 });

--- a/frontend/app/view/agent/providers/model-overlay.test.ts
+++ b/frontend/app/view/agent/providers/model-overlay.test.ts
@@ -1,0 +1,106 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The live-catalog overlay's contract.
+ *
+ * The distinction under test: an ALIAS row ("opus") is resolved by the CLI at
+ * call time, so the overlay must refresh only its label and never its value —
+ * self-resolution is the point. A CONCRETE row ("claude-fable-5-1") does not
+ * self-resolve, so its value must be refreshed alongside its label.
+ *
+ * Getting this wrong is not cosmetic: refreshing only the label on a concrete
+ * row produces a picker entry that displays "Fable 5.1" while still passing
+ * `claude-fable-5` to `--model` — advertising one model and selecting an older
+ * one, with nothing in the UI indicating the mismatch.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { getProvider, setProviderModels } from "./model-overlay";
+
+/** Shape the backend's `providers.models` RPC delivers. */
+const apiModels = (...ids: Array<[string, string]>) =>
+    ids.map(([value, label]) => ({ value, label }));
+
+const claudeModels = () => getProvider("claude")!.models;
+const row = (value: string) => claudeModels().find((m) => m.value === value);
+
+describe("setProviderModels", () => {
+    it("refreshes an alias row's label without touching its value", () => {
+        setProviderModels("claude", apiModels(["claude-opus-6", "Claude Opus 6"]));
+        const opus = claudeModels().find((m) => m.label === "Opus 6");
+        expect(opus).toBeDefined();
+        // The alias must survive — the CLI resolves it to whatever is current.
+        expect(opus!.value).toBe("opus");
+    });
+
+    it("refreshes a concrete row's value as well as its label", () => {
+        setProviderModels("claude", apiModels(["claude-fable-6", "Claude Fable 6"]));
+        const fable = claudeModels().find((m) => m.label === "Fable 6");
+        expect(fable).toBeDefined();
+        // Value moved with the label — no advertise-one/select-another gap.
+        expect(fable!.value).toBe("claude-fable-6");
+    });
+
+    it("picks the newest family member regardless of API ordering", () => {
+        setProviderModels(
+            "claude",
+            apiModels(
+                ["claude-fable-5-1", "Claude Fable 5.1"],
+                ["claude-fable-5", "Claude Fable 5"],
+            ),
+        );
+        const fable = claudeModels().find((m) => m.label.startsWith("Fable"));
+        expect(fable!.value).toBe("claude-fable-5-1");
+        expect(fable!.label).toBe("Fable 5.1");
+    });
+
+    it("does not emit a duplicate row for a family it already covers", () => {
+        setProviderModels(
+            "claude",
+            apiModels(
+                ["claude-fable-5", "Claude Fable 5"],
+                ["claude-fable-5-1", "Claude Fable 5.1"],
+            ),
+        );
+        const fableRows = claudeModels().filter((m) => m.label.startsWith("Fable"));
+        expect(fableRows).toHaveLength(1);
+    });
+
+    it("appends an unseen family rather than dropping it", () => {
+        setProviderModels("claude", apiModels(["claude-mythos-5-1", "Claude Mythos 5.1"]));
+        const mythos = claudeModels().find((m) => m.value === "claude-mythos-5-1");
+        expect(mythos).toBeDefined();
+        expect(mythos!.label).toBe("Mythos 5.1");
+    });
+
+    it("leaves the static catalog untouched when the API returns nothing", () => {
+        const before = claudeModels().map((m) => m.value);
+        setProviderModels("claude", []);
+        expect(claudeModels().map((m) => m.value)).toEqual(before);
+    });
+
+    it("preserves the default marker through a refresh", () => {
+        setProviderModels("claude", apiModels(["claude-sonnet-6", "Claude Sonnet 6"]));
+        const dflt = claudeModels().find((m) => m.default);
+        expect(dflt?.value).toBe("sonnet");
+    });
+});
+
+describe("curated catalog", () => {
+    it("keeps version numbers out of descriptions so they cannot contradict labels", () => {
+        // A description naming a version goes stale the moment the label is
+        // refreshed — the "Fable 5.1 over Claude Fable 5" report.
+        for (const m of claudeModels()) {
+            expect(m.description ?? "").not.toMatch(/\d/);
+        }
+    });
+
+    it("pins the fable row to a concrete id, not a bare family name", () => {
+        // There is no documented `fable` CLI alias, so the row must carry a
+        // full model name for `--model` to resolve.
+        const fable = claudeModels().find((m) => m.label.startsWith("Fable"));
+        expect(fable!.value).toMatch(/^claude-fable-/);
+    });
+});

--- a/frontend/app/view/agent/providers/model-overlay.ts
+++ b/frontend/app/view/agent/providers/model-overlay.ts
@@ -42,7 +42,7 @@ function pickNewest(models: ProviderModel[]): ProviderModel {
 /** Family key for an id the curated list doesn't cover — its alphabetic tokens
  *  minus the "claude" prefix, e.g. "claude-fable-5" → "fable". Groups versions
  *  of a genuinely new family so we surface one (newest) entry for it. */
-function familyKey(id: string): string {
+export function familyKey(id: string): string {
     const alpha = id.split("-").filter((t) => /^[a-z]+$/i.test(t) && t.toLowerCase() !== "claude");
     return alpha.join("-").toLowerCase() || id.toLowerCase();
 }

--- a/frontend/app/view/agent/providers/model-overlay.ts
+++ b/frontend/app/view/agent/providers/model-overlay.ts
@@ -53,6 +53,17 @@ function cleanLabel(label: string): string {
     return label.replace(/^claude\s+/i, "").trim();
 }
 
+/** Whether a curated `value` is a family ALIAS rather than a concrete model id.
+ *
+ *  An alias carries no version digits ("opus", "sonnet", "haiku") and is
+ *  resolved by the CLI at call time, so it must keep its curated value — that
+ *  self-resolution is the entire point. A concrete id ("claude-fable-5-1") does
+ *  NOT self-resolve, so its value has to be refreshed alongside its label or the
+ *  row ends up advertising a model it doesn't actually select. */
+function isAliasValue(value: string): boolean {
+    return !/\d/.test(value);
+}
+
 /**
  * Fold the authoritative catalog into a provider's model list. Behavior-
  * preserving by design:
@@ -83,13 +94,20 @@ export function setProviderModels(id: string, apiModels: ProviderModel[]): void 
 
     const consumed = new Set<string>();
 
-    // 1. Refresh curated family labels from the newest API model in that family.
+    // 1. Refresh curated family entries from the newest API model in that family.
     const curated = base.models.map((m) => {
         const family = familyKey(m.value);
         const matches = apiModels.filter((a) => familyKey(a.value) === family);
         if (matches.length === 0) return m;
         matches.forEach((a) => consumed.add(a.value)); // don't re-surface as an "extra"
-        return { ...m, label: cleanLabel(pickNewest(matches).label) };
+        const newest = pickNewest(matches);
+        const label = cleanLabel(newest.label);
+        // Alias rows keep their curated value (the CLI resolves it); concrete
+        // version-pinned rows must have their value refreshed too. Refreshing
+        // only the label there produced a row that displayed "Fable 5.1" while
+        // still passing `claude-fable-5` to `--model` — advertising one model
+        // and selecting an older one.
+        return isAliasValue(m.value) ? { ...m, label } : { ...m, value: newest.value, label };
     });
 
     // 2. Surface families the curated list misses (grouped, newest per family).


### PR DESCRIPTION
## Summary

Reported as **"why does the panel say Fable 5.1 and Fable 5?"** — the runtime dropup was rendering two different versions in a single row. Three distinct causes, all fixed.

### 1. The fable pin was stale (the real defect)

The curated row pinned `claude-fable-5`, which is now a **legacy** model — `claude-fable-5-1` is current.

This matters more for fable than it would for the others, because of a distinction that wasn't previously explicit anywhere:

| Row | Value | Behaviour |
|---|---|---|
| `opus` / `sonnet` / `haiku` | family **alias** | CLI resolves it at call time → always current, only the label can drift |
| `claude-fable-5` | **concrete id** | Does **not** self-resolve → a stale value actually selects the older model |

### 2. The overlay refreshed `label` but never `value`

`setProviderModels` folded the live catalog in by updating only the label. That's correct for alias rows — self-resolution is the whole point — but wrong for concrete ones: the row displayed **"Fable 5.1"** while still passing **`claude-fable-5`** to `--model`. Advertising one model, selecting another, with nothing in the UI showing the mismatch.

The overlay now refreshes `value` alongside `label` for concrete rows and leaves alias values untouched, so this **cannot silently recur** when the next version ships.

### 3. The visible contradiction: version numbers in `description`

The static `description` also named a version ("Claude Fable 5") and was never refreshed, so it disagreed with the refreshed label — that's literally the "5.1 over 5" that was reported. Descriptions are now **version-free**; the label is the single source of version truth. That removes the whole class rather than patching this instance.

## On the concrete id

`claude --help` documents `--model` as taking *"an alias for the latest model (e.g. 'sonnet' or 'opus') or a model's full name"* and lists no `fable` shorthand — so a full model name is the correct form here, not an invented alias.

## Tests

Adds `model-overlay.test.ts` (9 tests). The overlay had **no direct coverage**, which is why the alias/concrete distinction was never pinned down — the tests now assert both halves explicitly, plus newest-wins ordering, no-duplicate-family, unseen-family passthrough, empty-API no-op, `default` marker survival, and a guard that descriptions never contain digits.

## Test plan

- [x] `npx vitest run frontend` — **3658 tests, 247 files, all passing**
- [x] `npx tsc --noEmit` — clean
- [ ] Visual confirmation in the running app (not done by the agent)

## Related

Found during the audit that also produced `a5af/shared-infrastructure#458` (provider-reporter), whose drift engine independently flagged this same row as `pinned-stale` at `error` severity while correctly leaving the three alias rows alone.

<!-- agentmux:agent_id=camper -->