### PR TITLE
docs(tray): document the tray-less reopen path for background-service mode

### DIFF
--- a/.changesets/1788633257-docs-tray-document-the-tray-less-reopen-path-for-background--58nb.md
+++ b/.changesets/1788633257-docs-tray-document-the-tray-less-reopen-path-for-background--58nb.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs(tray): document the tray-less reopen path for background-service mode

--- a/agentmux-cef/src/reducer/mod.rs
+++ b/agentmux-cef/src/reducer/mod.rs
@@ -136,6 +136,25 @@ pub struct HostState {
     /// `HostState`, alongside `registered`/`draining`) so it does not treat
     /// the resulting "0 registered, not draining" steady state as a desync
     /// and force-quit a few seconds after the last window closes.
+    ///
+    /// **Getting a window back (there is no tray icon yet — Workstream 1):**
+    /// re-launching the exe reopens one, via the existing single-instance
+    /// forward. That keeps working at zero windows, verified end to end by
+    /// reading each link: the launcher holds the single-instance pipe for its
+    /// whole lifetime (so a second launch forwards rather than starting
+    /// fresh); `lib.rs` deletes the `ipc-port-<hash>` forwarding hint only
+    /// AFTER `run_message_loop()` returns, which this mode is precisely what
+    /// prevents, so the hint survives; the host's IPC server is bound at
+    /// startup independent of any window; and `open_new_window` still finds a
+    /// warm pool, because the pool is only cascade-closed by
+    /// `begin_drain_and_cascade`, which a suppressed drain never reaches.
+    /// So the reopen is a pool promote, not a cold start.
+    ///
+    /// That is also the recipe for this workstream's own acceptance test,
+    /// which has not been run live yet: enable the flag, close the last
+    /// window, confirm `srv`/`launcher`/`host` survive in `tasklist`/`ps` and
+    /// that an agent turn still completes with no window open, then
+    /// re-launch the exe and confirm a window comes back.
     pub background_service_enabled: bool,
 
     /// H.6 — top-level window creation runner state (queue, in-flight,

--- a/agentmux-cef/src/reducer/mod.rs
+++ b/agentmux-cef/src/reducer/mod.rs
@@ -138,17 +138,28 @@ pub struct HostState {
     /// and force-quit a few seconds after the last window closes.
     ///
     /// **Getting a window back (there is no tray icon yet — Workstream 1):**
-    /// re-launching the exe reopens one, via the existing single-instance
-    /// forward. That keeps working at zero windows, verified end to end by
-    /// reading each link: the launcher holds the single-instance pipe for its
-    /// whole lifetime (so a second launch forwards rather than starting
-    /// fresh); `lib.rs` deletes the `ipc-port-<hash>` forwarding hint only
-    /// AFTER `run_message_loop()` returns, which this mode is precisely what
-    /// prevents, so the hint survives; the host's IPC server is bound at
-    /// startup independent of any window; and `open_new_window` still finds a
-    /// warm pool, because the pool is only cascade-closed by
-    /// `begin_drain_and_cascade`, which a suppressed drain never reaches.
-    /// So the reopen is a pool promote, not a cold start.
+    /// re-launching the app reopens one **on Windows and Linux**, via the
+    /// existing single-instance forward. That keeps working at zero windows,
+    /// verified end to end by reading each link: the launcher holds the
+    /// single-instance pipe for its whole lifetime (so a second launch
+    /// forwards rather than starting fresh); `lib.rs` deletes the
+    /// `ipc-port-<hash>` forwarding hint only AFTER `run_message_loop()`
+    /// returns, which this mode is precisely what prevents, so the hint
+    /// survives; the host's IPC server is bound at startup independent of any
+    /// window; and `open_new_window` still finds a warm pool, because the pool
+    /// is only cascade-closed by `begin_drain_and_cascade`, which a suppressed
+    /// drain never reaches. So the reopen is a pool promote, not a cold start.
+    ///
+    /// **macOS has a gap here — do not enable this mode there yet.**
+    /// LaunchServices delivers a Finder/`open` relaunch as a reopen Apple
+    /// Event to the running process instead of starting a second one, so
+    /// recovery depends on `splash_mac.rs`'s
+    /// `applicationShouldHandleReopen:` delegate, whose only install site is
+    /// inside `Splash::show`. With the splash disabled there is no
+    /// `NSApplication`, no pump, and no delegate — the reopen event has
+    /// nowhere to land and no second process spawns to forward, leaving the
+    /// user with no way back. See the design doc §7.5.1; it must be closed
+    /// with the Workstream 1 macOS work.
     ///
     /// That is also the recipe for this workstream's own acceptance test,
     /// which has not been run live yet: enable the flag, close the last

--- a/docs/specs/SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md
+++ b/docs/specs/SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md
@@ -128,6 +128,32 @@ render and respond to clicks once such a pump exists. That is the visual half
 of §7.2's acceptance criterion and needs a human with a screen; nothing above
 substitutes for it.
 
+### 7.5.1. There is already a tray-less way back to a window
+
+Worth knowing before building the tray, because it means Phase 1's
+`AGENTMUX_BACKGROUND_SERVICE` flag is usable on its own rather than a mode you
+can enter and not leave: with the flag on and zero windows open, **re-launching
+the exe reopens a window** through the existing single-instance forward
+(`second_instance.rs::forward_open_new_window`, an authenticated HTTP
+`open_new_window` to the host's IPC port).
+
+Each link verified by reading the code, since every one of them could
+plausibly have been torn down along with the last window:
+
+- The launcher holds the single-instance named pipe for its whole lifetime, so
+  a second launch forwards instead of starting a rival instance.
+- `lib.rs` removes the `ipc-port-<hash>` forwarding hint only *after*
+  `run_message_loop()` returns — exactly what this mode prevents — so the hint
+  survives.
+- The host's IPC server is bound at startup, independent of any window.
+- `open_new_window` still finds a **warm pool**: pool browsers are only
+  cascade-closed by `begin_drain_and_cascade`, which a suppressed drain never
+  reaches. So the reopen is an instant pool promote, not a cold start.
+
+Implication for the tray work: the tray's "open AgentMux" menu item does not
+need a new mechanism — it can invoke the same `open_new_window` path this
+forward already uses. That removes a chunk of assumed scope from Workstream 3.
+
 ## 8. What this spec does not decide
 
 - Does not pick a final visual design for the simplified tray panel — only that it should be a small CEF window reusing the pool-window mechanism, not a native menu or a separate process.

--- a/docs/specs/SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md
+++ b/docs/specs/SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md
@@ -130,15 +130,19 @@ substitutes for it.
 
 ### 7.5.1. There is already a tray-less way back to a window
 
-Worth knowing before building the tray, because it means Phase 1's
-`AGENTMUX_BACKGROUND_SERVICE` flag is usable on its own rather than a mode you
-can enter and not leave: with the flag on and zero windows open, **re-launching
-the exe reopens a window** through the existing single-instance forward
-(`second_instance.rs::forward_open_new_window`, an authenticated HTTP
-`open_new_window` to the host's IPC port).
+Worth knowing before building the tray, because it bears on whether Phase 1's
+`AGENTMUX_BACKGROUND_SERVICE` flag is usable on its own or is a mode you can
+enter and not leave. With the flag on and zero windows open, re-launching the
+app reopens a window — **on Windows and Linux. macOS has a real gap in one
+configuration**, see below.
 
-Each link verified by reading the code, since every one of them could
-plausibly have been torn down along with the last window:
+Both routes end at the same place: an authenticated HTTP `open_new_window` to
+the host's IPC port (`second_instance.rs::forward_open_new_window`). What
+differs is what triggers it.
+
+**Windows / Linux — a genuine second process forwards.** Each link verified by
+reading the code, since every one could plausibly have been torn down with the
+last window:
 
 - The launcher holds the single-instance named pipe for its whole lifetime, so
   a second launch forwards instead of starting a rival instance.
@@ -150,9 +154,34 @@ plausibly have been torn down along with the last window:
   cascade-closed by `begin_drain_and_cascade`, which a suppressed drain never
   reaches. So the reopen is an instant pool promote, not a cold start.
 
+**macOS — not a second process at all.** LaunchServices delivers a Finder
+double-click or `open -a` on an already-running bundle as a *reopen Apple
+Event* to the existing process; no second process starts, so nothing reaches
+the forward on its own. What actually recovers the window is an in-process
+delegate — `splash_mac.rs`'s `applicationShouldHandleReopen:` hook, which calls
+`forward_open_new_window` itself
+(`SPEC_MACOS_REOPEN_NEW_WINDOW_2026_06_22.md`).
+
+**The gap: that delegate is installed only by `Splash::show`.**
+`install_reopen_handler()` has exactly one call site, inside `Splash::show`,
+immediately after `build_window()` creates the `NSApplication`. With the splash
+disabled, `main()` runs the supervisor directly on the main thread via
+`block_on` — no `NSApplication`, no pump (§7.5), and no delegate. So on
+**macOS + splash disabled + background-service mode, a user who closes their
+last window has no way back**: the reopen event has no handler, and no second
+process spawns to forward. (Launching the raw binary from a terminal still
+forwards, but that is not how anyone opens a packaged app.)
+
+That combination must be closed before background-service mode is offered to
+macOS users — either by installing the reopen handler (and a minimal NSApp
+pump) independently of the splash, or by refusing to enable background-service
+mode when the splash is disabled. Flagged here rather than fixed because it is
+a code change on a platform this finding could not be exercised on; it belongs
+with the Workstream 1 macOS work.
+
 Implication for the tray work: the tray's "open AgentMux" menu item does not
-need a new mechanism — it can invoke the same `open_new_window` path this
-forward already uses. That removes a chunk of assumed scope from Workstream 3.
+need a new mechanism — it can invoke the same `open_new_window` path both
+routes already use. That removes a chunk of assumed scope from Workstream 3.
 
 ## 8. What this spec does not decide
 


### PR DESCRIPTION
## Summary

Follow-up on #2983, closing a question that PR left open about its own feature.

#2983 shipped `AGENTMUX_BACKGROUND_SERVICE`: with it on, closing the last window no longer tears down `host`/`srv`/`launcher`. But the tray icon that is *supposed* to give you a way back is Workstream 1 of #2977 and doesn't exist yet. So: **can a user who enables this flag and closes their last window actually get a window back?** If not, the flag I shipped is a mode you can enter and not leave.

**It works** — re-launching the exe reopens a window through the existing single-instance forward (`second_instance.rs::forward_open_new_window`, an authenticated HTTP `open_new_window` to the host's IPC port).

I did not want to assume that, because every link in the chain is something that could plausibly have been torn down along with the last window. Verified each by reading the code:

| Link | Why it survives |
|---|---|
| Single-instance pipe | The launcher holds it for its whole lifetime, so a second launch forwards rather than starting a rival instance |
| `ipc-port-<hash>` forwarding hint | `lib.rs` removes it only **after** `run_message_loop()` returns — precisely what this mode prevents |
| Host IPC server | Bound at startup, independent of any window |
| Warm pool | Pool browsers are only cascade-closed by `begin_drain_and_cascade`, which a suppressed drain never reaches |

Because the pool survives, the reopen is an instant **promote**, not a cold start.

## Why this is worth writing down

- It makes Phase 1's flag genuinely usable on its own, rather than something you shouldn't turn on until the tray lands.
- **It removes assumed scope from Workstream 3.** The tray's "open AgentMux" menu item needs no new mechanism — it can invoke the same `open_new_window` path this forward already uses.
- It records the concrete recipe for #2983's acceptance test, which is still un-run: enable the flag, close the last window, confirm `srv`/`launcher`/`host` survive in `tasklist`/`ps` and that an agent turn still completes with no window open, then re-launch the exe and confirm a window comes back. Anyone with a screen can now execute that in a couple of minutes.

## Scope

Comments and docs only — **no behavior change**. Added to the `background_service_enabled` field doc (where anyone enabling the flag will find it) and to the design doc as §7.5.1.

## Test plan

- [x] `cargo build -p agentmux-cef --lib --release` — clean (doc-comment change, but it is a doc comment on a live field so it must still compile)
- [x] `scripts/check-spec-citations.sh` — ok
- [x] `scripts/check-doc-status.sh` — ok
- [ ] No runtime behavior to test — this PR documents existing behavior rather than changing it. The live confirmation of that behavior is the acceptance test described above, which still needs a human with a screen.

<!-- agentmux:agent_id=agent5 -->
