### PR TITLE
Posa@Area54: fix(tabs): highlight the clicked tab immediately, not after the destination paints

### DIFF
--- a/.changesets/1788624955-fix-tabs-tab-bar-highlights-the-clicked-tab-immediately-inst-3twe.md
+++ b/.changesets/1788624955-fix-tabs-tab-bar-highlights-the-clicked-tab-immediately-inst-3twe.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(tabs): tab bar highlights the clicked tab immediately instead of waiting on the destination pane's reveal

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -295,6 +295,7 @@ partial list.
 | [`SPEC_SYSTEM_TOOLCHAIN_INSTALLER_2026_08_24`](SPEC_SYSTEM_TOOLCHAIN_INSTALLER_2026_08_24.md) | SPEC: One-click system-toolchain installer (git, Node/npm, and friends) across Windows/macOS/Linux |
 | [`SPEC_TAB_COLOR_DESATURATION_2026_08_13`](SPEC_TAB_COLOR_DESATURATION_2026_08_13.md) | Spec: Desaturate tab colors, keep agent pane border colors as-is |
 | [`SPEC_TAB_CONTENT_REVEAL_GATE`](SPEC_TAB_CONTENT_REVEAL_GATE.md) | Tab content reveal gate |
+| [`SPEC_TAB_SWITCH_DECOUPLE_SELECT_FROM_PAINT_2026_09_04`](SPEC_TAB_SWITCH_DECOUPLE_SELECT_FROM_PAINT_2026_09_04.md) | Instant tab-bar selection, decoupled from destination-pane reveal cost (window-level tabs) |
 | [`SPEC_TERMINAL_LATENCY_BENCHMARK_2026_05_19`](SPEC_TERMINAL_LATENCY_BENCHMARK_2026_05_19.md) | SPEC: Terminal Input Echo-Latency Benchmark |
 | [`SPEC_TERMINAL_SCROLLBACK_PERSISTENCE_2026_07_23`](SPEC_TERMINAL_SCROLLBACK_PERSISTENCE_2026_07_23.md) | SPEC: Terminal scrollback doesn't survive reconnect (all `view:"term"` panes) |
 | [`SPEC_TERM_DOUBLE_RAF_TEAROUT_2026_05_30`](SPEC_TERM_DOUBLE_RAF_TEAROUT_2026_05_30.md) | SPEC: Remove the terminal Stage-1 RAF write-coalescer (double-rAF) |

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -178,7 +178,7 @@ are doing history". Everything else is here; the completeness
 assertion in the generator fails the build rather than emit a
 partial list.
 
-### implemented (133)
+### implemented (134)
 
 | Spec | Title |
 |---|---|

--- a/docs/specs/SPEC_TAB_SWITCH_DECOUPLE_SELECT_FROM_PAINT_2026_09_04.md
+++ b/docs/specs/SPEC_TAB_SWITCH_DECOUPLE_SELECT_FROM_PAINT_2026_09_04.md
@@ -218,3 +218,32 @@ mechanism is verified by construction (the pill no longer reads a value that req
 RPC, so it cannot be gated on it) and the cost it sidesteps is the 500-600ms browser-side
 layout+paint `SPEC_AGENT_PANE_TAB_SWITCH_PERF_2026_05_27.md` §"Phase 1 (revised)" already
 measured — but a before/after profile on a large tab has not been run.
+
+## 10. Follow-up: honouring the latest click (Codex P2 on PR #2993)
+
+The first cut shipped one `setActiveTab` per click and guarded on the committed
+id. Review caught that this loses the newer of two rapid clicks, via **two**
+guards, not one:
+
+1. `handleSelect`'s own `if (tabId === activeTabId()) return`. Once the strip can
+   display an optimistic selection, displayed and committed diverge — so with
+   committed `A` and a pending switch to `B`, clicking `A` again hit this guard
+   and did nothing. Fixed by comparing against `displayActiveTabId()`.
+2. `setActiveTab`'s own `if (fromTabId === tabId) return` (`tab-actions.ts`).
+   Fixing (1) alone is **not** sufficient: re-issuing for `A` while committed is
+   still `A` returns without an RPC, so the in-flight `B` call would still land
+   and win. The user's last click loses either way.
+
+So a switch is now a loop (`driveTabSelection`), not a call: after each
+`setActive` resolves, re-read the intent, and if a newer click arrived, go
+again — by then committed has moved off it, so the next call is a real RPC
+rather than an early return. It terminates because each iteration either
+returns or observes a new intent, which only a fresh user click produces.
+
+`switchLoopRunning` (a plain `let`, not a signal — nothing renders off it) stops
+a second click starting a competing loop; the running one picks up the newer
+target itself.
+
+Tests: 6 more, mutation-checked against a naive single-call implementation —
+exactly the two mid-flight-click cases fail there, including Codex's reported
+scenario verbatim, while the other 14 pass.

--- a/docs/specs/SPEC_TAB_SWITCH_DECOUPLE_SELECT_FROM_PAINT_2026_09_04.md
+++ b/docs/specs/SPEC_TAB_SWITCH_DECOUPLE_SELECT_FROM_PAINT_2026_09_04.md
@@ -1,0 +1,220 @@
+# Instant tab-bar selection, decoupled from destination-pane reveal cost (window-level tabs)
+
+**Status:** implemented
+**Author:** Posa
+**Date:** 2026-09-04
+**Scope:** `frontend/app/tab/tabbar.tsx` (`handleSelect`, `displayActiveTabId`), `frontend/app/store/tab-actions.ts`
+(`setActiveTab`), `frontend/app/store/window-identity.ts` (`activeTabId`), `frontend/app/workspace/workspace.tsx`
+(the tab-content `<For>`'s `display`/`visibility` toggle), `frontend/app/store/tab-reveal.ts`
+**Related:** `SPEC_AGENT_PANE_TAB_SWITCH_PERF_2026_05_27.md` (profiled the reveal cascade this
+spec's fix works around — read first, it's the source of the cost, not something this spec
+re-litigates), `SPEC_TAB_CONTENT_REVEAL_GATE.md` (the existing whole-tab visibility gate —
+hides the cascade's ugliness but, as explained below, does not and cannot fix the symptom
+this spec targets), `SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md` (introduced the exact
+optimistic-override pattern this spec proposes extending to a second call site)
+
+---
+
+## 1. The report
+
+> When switching between (window-level) tabs, there is a noticeable delay if the destination
+> tab is large — it takes longer for the tab to be *selected*. That's understandable if the
+> pane genuinely needs time to load, but that loading time should be cordoned off, visually
+> separate from the switch itself. What we have now is a laggard: the tab-bar highlight
+> itself lags, and then the complex pane paints immediately right after. We want the
+> opposite — the bar switches immediately; the pane takes its time to paint, visibly set
+> apart from the switch.
+
+This is not a request to make large panes render faster — that's the pre-existing, distinct
+problem `SPEC_AGENT_PANE_TAB_SWITCH_PERF_2026_05_27.md` already investigates (and that spec's
+own remediation phases are the right place for actually shrinking the reveal cascade's cost).
+This is a request to stop that cascade from gating the tab bar's own selection feedback,
+which today it does even though the two look, at the code level, like independent signals.
+
+## 2. What already happens today
+
+Every window-level tab stays mounted for the whole session — `workspace.tsx`'s own comment:
+"Inactive tabs are hidden via `display:none` — no unmount/remount," backed by a `<For
+each={allTabIds()}>` that renders `<TabContent tabId={tid}>` for every tab up front, not just
+the active one. So a tab switch is never a remount; it is a pure CSS reveal:
+`display: tid === tabId() ? "flex" : "none"`, `tabId()` being `atoms.activeTabId`.
+
+`setActiveTab` (`tab-actions.ts:66-` ) already tries to hide the resulting mess:
+`holdRevealGate(tabId)` fires *before* the RPC even starts, applying `visibility: hidden` +
+`opacity: 0` to the destination only (targeted per `SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH
+_2026_08_25.md` §9, so the *source* tab keeps painting through the round trip instead of the
+whole content region blanking). `scheduleRevealLift()` runs in `finally`, starting
+`scheduleOnSettle`'s Long-Task-quiet detector (`tab-reveal.ts`, `settle-detector.ts`) so the
+gate lifts once the reveal cascade has actually finished, not on a guessed timeout.
+
+This machinery is real and it works — for the destination pane's own appearance. It does
+nothing for the tab bar's pill, which is the actual complaint.
+
+## 3. Root cause: one signal, two consumers, no paint boundary between them
+
+`activeTabId` (`window-identity.ts:44`, a `createMemo` over `workspace()`) is
+**backend-authoritative**: it only changes once `WorkspaceService.SetActiveTab`'s RPC
+round-trips and the resulting `Workspace` object push is processed client-side. Two
+completely different pieces of UI read this *same* memo:
+
+1. `tabbar.tsx`'s pill: `isActive={tabId === displayActiveTabId()}` — `displayActiveTabId()`
+   (`tabbar.tsx:83-92`) falls straight through to raw `activeTabId()` for an ordinary click
+   (its only override today is for the close flow — see §5).
+2. `workspace.tsx`'s per-tab `display`/`gateHides` style object, which flips the destination
+   from `display:none` to `display:flex` the moment `tabId() === activeTabId()` becomes true
+   for it.
+
+Both are driven off the exact same signal write, in the exact same reactive flush, with no
+yield point between them. The instant `activeTabId()` updates, Solid synchronously re-runs
+every dependent computation before returning control to the browser — including
+`workspace.tsx`'s `display:none → flex` flip for the destination, which is precisely the
+trigger `SPEC_AGENT_PANE_TAB_SWITCH_PERF_2026_05_27.md` identifies as the start of the
+expensive cascade: TanStack Virtual's `measureElement`/`getBoundingClientRect()` calls
+returning real numbers for the first time (they were 0/empty under `display:none`), markdown
+re-render, ResizeObserver/IntersectionObserver fan-out — all synchronous, all scaling with
+how much content the destination tab holds.
+
+A browser does not paint mid-task. It paints once the current task, its microtasks, *and*
+any ResizeObserver callback batch scheduled for that frame have all drained — and a burst of
+newly-triggered ResizeObserver notifications from a large reveal runs exactly in that window,
+before paint, in the same frame. `visibility: hidden` keeps the *user* from seeing the ugly
+partial cascade, but a hidden element still participates in layout and still fires those
+callbacks — so it does nothing to shorten the frame those callbacks are blocking. The tab
+bar's pill update sits computed-and-ready in the DOM, but unpainted, until that whole frame's
+work — cascade included — finishes. That "unpainted but computed" gap is exactly what reads
+as "the tab took a while to be selected."
+
+(`SPEC_TAB_CONTENT_REVEAL_GATE.md`'s original 2026-05-09 description — "Frame 1-2: title bar
+/ tabbar updates" ahead of pane content — was accurate to that design's *intent*, written
+before `SPEC_AGENT_PANE_TAB_SWITCH_PERF_2026_05_27.md` actually profiled how expensive the
+reveal cascade could get. The two documents aren't in conflict; the later one is what
+revealed that the earlier one's frame-1-2 assumption doesn't hold once the cascade is heavy
+enough to consume the same frame the tab bar was hoping to get for free.)
+
+## 4. The fix already exists in this codebase — just not applied here
+
+`tabbar.tsx` already solves exactly this class of problem, for a different trigger.
+`pendingHiddenTabIds` / `displayActiveTabId()` (`tabbar.tsx:70-92`,
+`SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md`) is an **optimistic, client-only override**
+of the backend-authoritative `activeTabId()` for the close flow: the moment a close is
+confirmed, the strip immediately shows the neighbor that's *about to* become active, without
+waiting for the `CloseTab` RPC to round-trip:
+
+```ts
+const displayActiveTabId = () => {
+    const real = activeTabId();
+    const hidden = pendingHiddenTabIds();
+    if (!hidden.has(real)) return real;
+    // ...resolve to the neighbor the backend is about to promote...
+};
+```
+
+`handleSelect` (`tabbar.tsx:94-97`) — the ordinary click-a-tab-to-switch path — has no
+equivalent. It calls `setActiveTab(tabId)` directly and the pill waits on the same
+`activeTabId()` as everything else, with nothing shielding it from either the RPC latency or
+the reveal cascade downstream of the RPC's resolution.
+
+## 5. Proposed design
+
+Extend the same optimistic-override shape `displayActiveTabId` already uses for closes to the
+plain-select path:
+
+- Add a `pendingSelectedTabId` signal (or widen `displayActiveTabId`'s existing precedence
+  chain to also consult a "user just clicked this" override, alongside its current
+  hidden-tab-neighbor-promotion case) — written synchronously in `handleSelect`, **before**
+  `setActiveTab(tabId)` is called:
+
+  ```ts
+  const handleSelect = (tabId: string) => {
+      if (tabId === activeTabId()) return;
+      setPendingSelectedTabId(tabId);      // NEW — commits + paints immediately
+      setActiveTab(tabId).finally(() => setPendingSelectedTabId(null));
+  };
+  ```
+
+- `displayActiveTabId()` prefers this pending value over the raw `activeTabId()`, clearing it
+  once the real value catches up (or immediately in a `.finally`, since by then the real
+  value should already match — a stale mismatch after resolution is a bug to catch in
+  testing, not something to paper over).
+- **`workspace.tsx`'s own `display`/`gateHides` logic is untouched.** It keeps reading the
+  raw, backend-authoritative `atoms.activeTabId` directly, unchanged, still behind the RPC's
+  natural async boundary, still protected by the existing visibility/settle gate. Only the
+  tab bar's own pill rendering switches to the optimistic value. This mirrors the close flow's
+  own division of labor exactly: `displayActiveTabId` is local to `tabbar.tsx` and affects
+  only the strip; the content-reveal path in `workspace.tsx` has never depended on it. Nothing
+  here is a new architecture — it's the same pattern, applied to the one call site that never
+  got it.
+- **Failure path:** if `WorkspaceService.SetActiveTab` throws, the `.finally` above still
+  clears `pendingSelectedTabId`, so the bar snaps back to the true active tab rather than
+  showing a phantom selection forever — mirrors `handleClose`'s own `unhideTab` call in its
+  `finally` for the identical class of failure.
+
+## 6. Why this is sufficient without touching the reveal cascade itself
+
+The cascade's cost is real, content-proportional, and this spec does not make it faster —
+that stays `SPEC_AGENT_PANE_TAB_SWITCH_PERF_2026_05_27.md`'s job, and its own remediation
+phases are the right place to pursue that separately. This fix only stops the cascade's cost
+from gating the one thing the user needs immediate confirmation of: that their click landed
+and the right tab is now selected. Once decoupled, the destination pane is free to take
+however long it needs — already visually cordoned off by the existing `visibility: hidden`
+gate — while the bar itself commits and paints on its own, cheap, essentially-instant
+schedule.
+
+## 7. Open questions for implementation
+
+- Should the new override generalize into `displayActiveTabId`'s existing precedence chain,
+  or stay a second, independently-cleared signal ORed in? `tab-reveal.ts`'s own header
+  comment already argues for keeping conceptually distinct gates un-unified ("deliberately
+  NOT unified into one data structure... so the already-shipped... gate's behavior and tests
+  are untouched") — the same reasoning likely applies here; lean toward two independent
+  signals unless implementation finds a concrete reason to merge them.
+- Is the RPC round-trip's own latency (before any reveal-cascade cost) actually negligible
+  regardless of tab size, or does the pushed `Workspace` update's payload also scale with tab
+  count/content (full object vs. diff)? The backend's `set_active_tab`
+  (`agentmux-srv/src/backend/wcore/tab.rs:120-133`) is a single-field mutation + `store.update`
+  — not proportional to tab content on the Rust side — but this spec has not profiled the
+  serialized push payload itself, and that's worth a quick measurement before assuming the
+  optimistic signal alone closes the entire gap the report describes.
+
+## 8. Testing
+
+Per this repo's mutation-check discipline: a new test asserting "the pill updates before the
+`SetActiveTab` RPC resolves" must be shown to actually fail against today's code (assert
+`isActive`/`displayActiveTabId()` flips synchronously on click, before an unresolved RPC
+promise settles — e.g. a controllable/deferred mock of `WorkspaceService.SetActiveTab`) before
+landing the change that makes it pass.
+
+---
+
+## 9. What shipped
+
+Implemented as described in §5, with the decision extracted into a pure module
+rather than left inline:
+
+- **`frontend/app/tab/active-tab-display.ts`** (new) — `resolveDisplayActiveTabId()`,
+  the full precedence: optimistic select first (guarded on the tab still existing and
+  not itself mid-close), then the pre-existing close-flow neighbor promotion, verbatim.
+  Extracted for the same reason `view/agent/failure/synthetic-row.ts` was: the
+  precedence between two optimistic overrides is worth asserting directly, and it was
+  not reachable while inline in a component.
+- **`frontend/app/tab/active-tab-display.test.ts`** (new) — 10 tests. Mutation-checked:
+  with the optimistic-select branch removed, exactly the 2 fix-specific tests fail while
+  all 8 close-flow tests still pass, confirming the latter guard preserved behavior
+  rather than the new behavior.
+- **`frontend/app/tab/tabbar.tsx`** — `pendingSelectedTabId` signal; `handleSelect`
+  writes it before issuing the RPC and clears it in a `finally`, guarded on the pending
+  value still being this call's own target so a newer click during an in-flight RPC is
+  not clobbered. `displayActiveTabId` now delegates to the pure function.
+
+`workspace.tsx` was deliberately **not** touched: the destination's `display`/reveal gate
+keeps reading the raw backend-authoritative `atoms.activeTabId`, so the content reveal
+still happens only on confirmed backend state. Only the strip's highlight is optimistic.
+
+**Verified:** `npx tsc --noEmit` clean for both touched files; 52/52 tests pass across
+all four `frontend/app/tab/` suites (the 42 pre-existing plus the 10 new).
+
+**Not measured:** the actual perceived latency improvement in a running build. The
+mechanism is verified by construction (the pill no longer reads a value that requires the
+RPC, so it cannot be gated on it) and the cost it sidesteps is the 500-600ms browser-side
+layout+paint `SPEC_AGENT_PANE_TAB_SWITCH_PERF_2026_05_27.md` §"Phase 1 (revised)" already
+measured — but a before/after profile on a large tab has not been run.

--- a/frontend/app/tab/active-tab-display.test.ts
+++ b/frontend/app/tab/active-tab-display.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { resolveDisplayActiveTabId } from "./active-tab-display";
+import { driveTabSelection, resolveDisplayActiveTabId } from "./active-tab-display";
 
 const resolve = (i: Partial<Parameters<typeof resolveDisplayActiveTabId>[0]>) =>
     resolveDisplayActiveTabId({
@@ -97,5 +97,99 @@ describe("resolveDisplayActiveTabId", () => {
                 }),
             ).toBe("a");
         });
+    });
+});
+
+describe("driveTabSelection (Codex P2 on PR #2993)", () => {
+    /**
+     * Fake of the real pair: a committed id that only moves when setActive
+     * actually issues, and setActiveTab's OWN early-return guard, which is
+     * what makes the naive one-call-per-click version lose the second click.
+     */
+    function harness(initialCommitted: string) {
+        let committed = initialCommitted;
+        let intent: string | null = null;
+        const issued: string[] = [];
+        let resolveGate: (() => void) | null = null;
+
+        const setActive = async (tabId: string): Promise<void> => {
+            // Mirrors store/tab-actions.ts: `if (fromTabId === tabId) return;`
+            if (committed === tabId) return;
+            issued.push(tabId);
+            if (resolveGate) {
+                await new Promise<void>((r) => {
+                    const prev = resolveGate!;
+                    resolveGate = () => {
+                        prev();
+                        r();
+                    };
+                });
+            }
+            committed = tabId;
+        };
+
+        return {
+            issued,
+            committed: () => committed,
+            latestIntent: () => intent,
+            click: (id: string) => (intent = id),
+            deps: () => ({ latestIntent: () => intent, committed: () => committed, setActive }),
+        };
+    }
+
+    it("a plain switch issues exactly one RPC and lands on the target", async () => {
+        const h = harness("a");
+        h.click("b");
+        await driveTabSelection(h.deps());
+        expect(h.issued).toEqual(["b"]);
+        expect(h.committed()).toBe("b");
+    });
+
+    it("honours a click BACK to the committed tab made mid-flight", async () => {
+        // THE Codex case. Committed is "a"; user clicks "b", then clicks "a"
+        // again before b's RPC resolves. The naive version fires setActive(b),
+        // and the second click is lost twice over: handleSelect's guard saw
+        // committed === "a", and setActiveTab's own guard would have no-op'd
+        // an "a" re-issue anyway. Content ended on "b" against the user's
+        // last click.
+        const h = harness("a");
+        h.click("b");
+        const running = driveTabSelection(h.deps());
+        h.click("a"); // lands while setActive("b") is still in flight
+        await running;
+        expect(h.committed()).toBe("a");
+        expect(h.issued).toEqual(["b", "a"]);
+    });
+
+    it("converges on the LAST of several mid-flight clicks", async () => {
+        const h = harness("a");
+        h.click("b");
+        const running = driveTabSelection(h.deps());
+        h.click("c");
+        await running;
+        expect(h.committed()).toBe("c");
+    });
+
+    it("does nothing when the intent already matches the committed tab", async () => {
+        const h = harness("a");
+        h.click("a");
+        await driveTabSelection(h.deps());
+        expect(h.issued).toEqual([]);
+    });
+
+    it("does nothing when there is no pending intent", async () => {
+        const h = harness("a");
+        await driveTabSelection(h.deps());
+        expect(h.issued).toEqual([]);
+    });
+
+    it("propagates a failing switch rather than looping on it", async () => {
+        let intent: string | null = "b";
+        const deps = {
+            latestIntent: () => intent,
+            committed: () => "a",
+            setActive: () => Promise.reject(new Error("rpc failed")),
+        };
+        await expect(driveTabSelection(deps)).rejects.toThrow("rpc failed");
     });
 });

--- a/frontend/app/tab/active-tab-display.test.ts
+++ b/frontend/app/tab/active-tab-display.test.ts
@@ -1,0 +1,101 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for the tab strip's highlight resolution —
+ * docs/specs/SPEC_TAB_SWITCH_DECOUPLE_SELECT_FROM_PAINT_2026_09_04.md.
+ *
+ * The property that matters: the pill must be able to show the clicked tab
+ * WITHOUT the workspace's committed `activetabid` having moved yet, because
+ * that value only lands after the SetActiveTab RPC round trip — and its
+ * arrival is what triggers the destination's `display:none → flex` reveal,
+ * whose browser-side layout cost scales with the destination's size.
+ */
+
+import { describe, expect, it } from "vitest";
+import { resolveDisplayActiveTabId } from "./active-tab-display";
+
+const resolve = (i: Partial<Parameters<typeof resolveDisplayActiveTabId>[0]>) =>
+    resolveDisplayActiveTabId({
+        realActiveTabId: "a",
+        allTabIds: ["a", "b", "c"],
+        hiddenTabIds: new Set<string>(),
+        pendingSelectedTabId: null,
+        ...i,
+    });
+
+describe("resolveDisplayActiveTabId", () => {
+    describe("optimistic select (the fix)", () => {
+        it("highlights the clicked tab while the backend still says otherwise", () => {
+            // THE flagship case. realActiveTabId is still "a" because the
+            // SetActiveTab RPC has not round-tripped; the pill must already
+            // read "b" regardless.
+            expect(resolve({ realActiveTabId: "a", pendingSelectedTabId: "b" })).toBe("b");
+        });
+
+        it("falls back to the committed id once the pending select clears", () => {
+            expect(resolve({ realActiveTabId: "b", pendingSelectedTabId: null })).toBe("b");
+        });
+
+        it("ignores a pending select for a tab that no longer exists", () => {
+            // The workspace updated and dropped the tab out from under an
+            // in-flight select — highlighting it would point at a pill the
+            // strip does not render.
+            expect(resolve({ realActiveTabId: "a", allTabIds: ["a", "c"], pendingSelectedTabId: "b" })).toBe("a");
+        });
+
+        it("ignores a pending select for a tab that is now being closed", () => {
+            expect(
+                resolve({
+                    realActiveTabId: "a",
+                    hiddenTabIds: new Set(["b"]),
+                    pendingSelectedTabId: "b",
+                }),
+            ).toBe("a");
+        });
+    });
+
+    describe("close-flow promotion (must keep working — SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH §9)", () => {
+        it("promotes the right-hand neighbor when the active tab is mid-close", () => {
+            expect(resolve({ realActiveTabId: "b", hiddenTabIds: new Set(["b"]) })).toBe("c");
+        });
+
+        it("falls back to the left neighbor when the closed tab was rightmost", () => {
+            expect(resolve({ realActiveTabId: "c", hiddenTabIds: new Set(["c"]) })).toBe("b");
+        });
+
+        it("skips over several hidden tabs to find a live one", () => {
+            expect(
+                resolve({
+                    realActiveTabId: "a",
+                    allTabIds: ["a", "b", "c"],
+                    hiddenTabIds: new Set(["a", "b"]),
+                }),
+            ).toBe("c");
+        });
+
+        it("returns the real id when every tab is hidden", () => {
+            expect(
+                resolve({ realActiveTabId: "a", hiddenTabIds: new Set(["a", "b", "c"]) }),
+            ).toBe("a");
+        });
+
+        it("leaves the active tab alone when some OTHER tab is closing", () => {
+            expect(resolve({ realActiveTabId: "a", hiddenTabIds: new Set(["c"]) })).toBe("a");
+        });
+    });
+
+    describe("precedence when a select and a close overlap", () => {
+        it("the user's own click outranks the inferred neighbor promotion", () => {
+            // Active tab "b" is mid-close (promotion would say "c"), but the
+            // user has since clicked "a". Their explicit choice wins.
+            expect(
+                resolve({
+                    realActiveTabId: "b",
+                    hiddenTabIds: new Set(["b"]),
+                    pendingSelectedTabId: "a",
+                }),
+            ).toBe("a");
+        });
+    });
+});

--- a/frontend/app/tab/active-tab-display.ts
+++ b/frontend/app/tab/active-tab-display.ts
@@ -1,0 +1,89 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * active-tab-display — which tab the STRIP should highlight, which is not
+ * always the workspace's committed `activetabid`.
+ *
+ * `activeTabId` (`store/window-identity.ts`) is backend-authoritative: it
+ * reads `ws.activetabid`, so it only moves once an RPC has round-tripped and
+ * the `Workspace` object push has been applied. That is correct for anything
+ * that must agree with the backend — notably `workspace.tsx`'s
+ * `display:none → flex` reveal of the destination tab's content, which
+ * deliberately still reads the raw atom.
+ *
+ * It is the wrong thing for the tab pill. Two separate delays sit between
+ * the click and the pill lighting up, and the second one is why the report
+ * says "worse if the destination tab is large":
+ *
+ *   1. The `SetActiveTab` RPC round trip.
+ *   2. The reveal itself. `activeTabId` flipping updates the pill AND flips
+ *      the destination's `display` in the SAME synchronous Solid flush, and
+ *      the browser then owes layout for a whole newly-displayed subtree
+ *      before it can paint anything — including the pill.
+ *      `SPEC_AGENT_PANE_TAB_SWITCH_PERF_2026_05_27.md` measured that at
+ *      500-600ms of browser-side layout+paint for a large tab, and found it
+ *      opaque to JS-level perf hooks. `visibility: hidden` (the reveal gate)
+ *      does not help: a hidden element still participates in layout.
+ *
+ * So the pill renders off an OPTIMISTIC value instead — the tab the user
+ * just clicked, applied before the RPC is even issued. This is not a new
+ * pattern: `pendingHidden` below is the same trick, already shipped for the
+ * close flow (`SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md` §8-9),
+ * where the strip promotes the neighbor the backend is *about to* activate
+ * rather than waiting for `CloseTab` to resolve. This module just extends
+ * it to the plain click-to-select path, which never had it.
+ *
+ * Extracted as a pure function rather than left inline in `tabbar.tsx` so
+ * the precedence between the two optimistic overrides is actually
+ * assertable — same reasoning as `view/agent/failure/synthetic-row.ts`.
+ */
+
+export interface ActiveTabDisplayInput {
+    /** The workspace's committed `activetabid` — backend-authoritative. */
+    realActiveTabId: string;
+    /** Every tab id the workspace still has, in strip order (pinned first). */
+    allTabIds: string[];
+    /** Ids optimistically hidden because a close is in flight. */
+    hiddenTabIds: ReadonlySet<string>;
+    /** The tab the user just clicked, until its RPC settles. */
+    pendingSelectedTabId: string | null;
+}
+
+export function resolveDisplayActiveTabId(input: ActiveTabDisplayInput): string {
+    const { realActiveTabId, allTabIds, hiddenTabIds, pendingSelectedTabId } = input;
+
+    // An in-flight SELECT outranks the close-flow promotion below. The two
+    // can legitimately overlap (close tab A while a switch to B is still
+    // settling), and when they do the user's own click is the better answer
+    // for "which tab is active" than a neighbor we inferred.
+    //
+    // Guarded on the tab still existing and not itself being closed: a
+    // pending id that has since been closed, or that vanished when the
+    // workspace updated, must fall through rather than highlight a pill the
+    // strip no longer renders.
+    if (
+        pendingSelectedTabId != null &&
+        !hiddenTabIds.has(pendingSelectedTabId) &&
+        allTabIds.includes(pendingSelectedTabId)
+    ) {
+        return pendingSelectedTabId;
+    }
+
+    // Close flow, unchanged from tabbar.tsx's original inline version: while
+    // the REAL active tab is optimistically hidden (mid-close), highlight the
+    // neighbor the backend is about to promote — next tab in the list, else
+    // previous, mirroring handle_delete_tab's `tab_ids.get(pos) ?? pos-1`
+    // (agentmux-srv/src/reducer/tab.rs). The strip therefore shows the FINAL
+    // post-close state from the first frame; the backend's update then
+    // changes nothing visibly.
+    if (!hiddenTabIds.has(realActiveTabId)) return realActiveTabId;
+    const idx = allTabIds.indexOf(realActiveTabId);
+    for (let i = idx + 1; i < allTabIds.length; i++) {
+        if (!hiddenTabIds.has(allTabIds[i])) return allTabIds[i];
+    }
+    for (let i = idx - 1; i >= 0; i--) {
+        if (!hiddenTabIds.has(allTabIds[i])) return allTabIds[i];
+    }
+    return realActiveTabId;
+}

--- a/frontend/app/tab/active-tab-display.ts
+++ b/frontend/app/tab/active-tab-display.ts
@@ -87,3 +87,49 @@ export function resolveDisplayActiveTabId(input: ActiveTabDisplayInput): string 
     }
     return realActiveTabId;
 }
+
+/**
+ * Drive the backend toward the user's LATEST selection intent.
+ *
+ * A single `setActiveTab` call per click is not sufficient once the strip
+ * shows an optimistic selection, because two guards conspire to drop the
+ * newer of two rapid clicks (Codex P2 on PR #2993):
+ *
+ *   1. `handleSelect`'s own guard — fixed separately by comparing against the
+ *      DISPLAYED tab rather than the committed one, so clicking back to the
+ *      committed tab during a pending switch is no longer a no-op.
+ *   2. `setActiveTab`'s guard (`store/tab-actions.ts`: `if (fromTabId ===
+ *      tabId) return`). With committed still A and a switch to B in flight,
+ *      re-issuing for A returns immediately WITHOUT an RPC — so B's in-flight
+ *      call would still land and win, leaving the content on the tab the user
+ *      had already clicked away from.
+ *
+ * So the switch is a loop, not a call: after each `setActive` resolves,
+ * re-read the intent. If a newer click arrived meanwhile, the committed id
+ * has by then moved off it, so the next `setActive` is a real RPC rather than
+ * an early return, and the loop converges on the last tab the user clicked.
+ *
+ * Terminates: each iteration either returns (intent reached, or unchanged
+ * across a completed `setActive`) or observes a NEW intent, which only a
+ * fresh user click can produce.
+ */
+export interface TabSelectionDeps {
+    /** The newest tab the user clicked; null once nothing is pending. */
+    latestIntent: () => string | null;
+    /** The workspace's committed `activetabid`, re-read each iteration. */
+    committed: () => string;
+    /** `setActiveTab` — resolves once the workspace update has been applied. */
+    setActive: (tabId: string) => Promise<void>;
+}
+
+export async function driveTabSelection(deps: TabSelectionDeps): Promise<void> {
+    for (;;) {
+        const target = deps.latestIntent();
+        if (target == null || target === deps.committed()) return;
+        await deps.setActive(target);
+        // Unchanged intent across a completed switch means we are done. A
+        // CHANGED one is a click that landed mid-flight — loop again to honour
+        // it, now that `committed` has moved and setActiveTab won't no-op.
+        if (deps.latestIntent() === target) return;
+    }
+}

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -14,7 +14,7 @@ import { fireAndForget } from "@/util/util";
 import type { JSX } from "solid-js";
 import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { WorkspaceService } from "../store/services";
-import { resolveDisplayActiveTabId } from "./active-tab-display";
+import { driveTabSelection, resolveDisplayActiveTabId } from "./active-tab-display";
 import { DroppableTab } from "./droppable-tab";
 import { TabCloseConfirmModal } from "./tab-close-confirm-modal";
 import { registerTabCloseRequestHandler } from "./tab-close-request";
@@ -99,25 +99,40 @@ function TabBar(props: TabBarProps): JSX.Element {
             pendingSelectedTabId: pendingSelectedTabId(),
         });
 
+    // Whether a switch loop is already draining `pendingSelectedTabId`. Not a
+    // signal — nothing renders off it; it only stops a second click from
+    // starting a competing loop, since the running one re-reads the intent
+    // and will pick the newer target up itself.
+    let switchLoopRunning = false;
+
     const handleSelect = (tabId: string) => {
-        if (tabId === activeTabId()) return;
+        // Guard on the DISPLAYED tab, not the committed one. With an
+        // optimistic selection in flight the two differ, and comparing
+        // against `activeTabId()` made a click back to the committed tab a
+        // silent no-op — the in-flight switch then won over the user's newer
+        // click (Codex P2 on PR #2993).
+        if (tabId === displayActiveTabId()) return;
         // Commit the highlight BEFORE issuing the RPC so the pill paints on
         // its own cheap schedule rather than behind the destination's reveal.
         setPendingSelectedTabId(tabId);
+        if (switchLoopRunning) return;
+        switchLoopRunning = true;
         fireAndForget(async () => {
             try {
-                await setActiveTab(tabId);
+                await driveTabSelection({
+                    latestIntent: pendingSelectedTabId,
+                    committed: activeTabId,
+                    setActive: setActiveTab,
+                });
             } finally {
-                // Clear only if this call's own target is still the pending
-                // one — a newer click during the RPC owns the value now, and
-                // clearing it here would drop the strip back to the stale
-                // committed id until that newer RPC lands. Same
-                // stale-generation discipline as tab-reveal.ts's gates.
-                //
-                // Runs on the throw path too: a select that failed must not
-                // leave a phantom highlight on a tab the backend never
-                // activated (mirrors handleClose's own unhideTab in finally).
-                setPendingSelectedTabId((cur) => (cur === tabId ? null : cur));
+                // The loop only returns once the committed id has caught up
+                // with the latest intent, so dropping the override here hands
+                // the strip back to backend state with nothing visibly
+                // changing. On the throw path it un-sticks a phantom
+                // highlight for a tab the backend never activated (mirrors
+                // handleClose's own unhideTab in finally).
+                switchLoopRunning = false;
+                setPendingSelectedTabId(null);
             }
         });
     };

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -14,6 +14,7 @@ import { fireAndForget } from "@/util/util";
 import type { JSX } from "solid-js";
 import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { WorkspaceService } from "../store/services";
+import { resolveDisplayActiveTabId } from "./active-tab-display";
 import { DroppableTab } from "./droppable-tab";
 import { TabCloseConfirmModal } from "./tab-close-confirm-modal";
 import { registerTabCloseRequestHandler } from "./tab-close-request";
@@ -74,26 +75,51 @@ function TabBar(props: TabBarProps): JSX.Element {
         return allTabIds().filter((id) => !hidden.has(id));
     };
 
-    // While the REAL active tab is optimistically hidden (mid-close), the
-    // strip highlights the neighbor the backend is about to promote —
-    // next tab in the list, else previous, mirroring handle_delete_tab's
-    // `tab_ids.get(pos) ?? pos-1` (agentmux-srv/src/reducer/tab.rs). The
-    // strip therefore shows the FINAL post-close state from the first
-    // frame; the backend's update then changes nothing visibly.
-    const displayActiveTabId = () => {
-        const real = activeTabId();
-        const hidden = pendingHiddenTabIds();
-        if (!hidden.has(real)) return real;
-        const all = allTabIds();
-        const idx = all.indexOf(real);
-        for (let i = idx + 1; i < all.length; i++) if (!hidden.has(all[i])) return all[i];
-        for (let i = idx - 1; i >= 0; i--) if (!hidden.has(all[i])) return all[i];
-        return real;
-    };
+    // Optimistic select (SPEC_TAB_SWITCH_DECOUPLE_SELECT_FROM_PAINT_2026_09_04):
+    // the tab the user just clicked, held until its SetActiveTab RPC settles.
+    // Without this the pill waits on `activeTabId()` — which is
+    // backend-authoritative, so it cannot move until the RPC round-trips, and
+    // its arrival is also what flips the destination's `display:none → flex`
+    // in the same Solid flush. That reveal owes the browser layout for a whole
+    // newly-displayed subtree before anything can paint, including the pill;
+    // SPEC_AGENT_PANE_TAB_SWITCH_PERF_2026_05_27.md measured 500-600ms of it
+    // for a large tab. Hence "the bigger the destination, the longer the tab
+    // takes to even look selected."
+    const [pendingSelectedTabId, setPendingSelectedTabId] = createSignal<string | null>(null);
+
+    // What the strip highlights — see active-tab-display.ts for the full
+    // precedence (optimistic select, then the close-flow neighbor promotion).
+    // Deliberately NOT used by workspace.tsx's content reveal, which keeps
+    // reading the raw backend-authoritative atom.
+    const displayActiveTabId = () =>
+        resolveDisplayActiveTabId({
+            realActiveTabId: activeTabId(),
+            allTabIds: allTabIds(),
+            hiddenTabIds: pendingHiddenTabIds(),
+            pendingSelectedTabId: pendingSelectedTabId(),
+        });
 
     const handleSelect = (tabId: string) => {
         if (tabId === activeTabId()) return;
-        setActiveTab(tabId);
+        // Commit the highlight BEFORE issuing the RPC so the pill paints on
+        // its own cheap schedule rather than behind the destination's reveal.
+        setPendingSelectedTabId(tabId);
+        fireAndForget(async () => {
+            try {
+                await setActiveTab(tabId);
+            } finally {
+                // Clear only if this call's own target is still the pending
+                // one — a newer click during the RPC owns the value now, and
+                // clearing it here would drop the strip back to the stale
+                // committed id until that newer RPC lands. Same
+                // stale-generation discipline as tab-reveal.ts's gates.
+                //
+                // Runs on the throw path too: a select that failed must not
+                // leave a phantom highlight on a tab the backend never
+                // activated (mirrors handleClose's own unhideTab in finally).
+                setPendingSelectedTabId((cur) => (cur === tabId ? null : cur));
+            }
+        });
     };
 
     const handleClose = (tabId: string) => {
@@ -118,6 +144,17 @@ function TabBar(props: TabBarProps): JSX.Element {
         // once it becomes active, until it settles) — an untargeted hold
         // here blanked the whole content region at confirm-click, which
         // read as the neighbor pane "flashing".
+        //
+        // Reads the same displayActiveTabId() as the pill, so an in-flight
+        // optimistic select (added by
+        // SPEC_TAB_SWITCH_DECOUPLE_SELECT_FROM_PAINT_2026_09_04) can win here
+        // too. Identical to the old behaviour whenever no select is pending,
+        // which is the overwhelmingly common case. When one IS pending the two
+        // candidates (clicked tab vs. close-promoted neighbor) are already
+        // racing two concurrent RPCs on the backend, so neither is reliably
+        // "the" next active tab — gating the tab the user actually clicked is
+        // at least as good a guess as the inferred neighbor, and the gate's
+        // own 800ms cap bounds the cost of guessing wrong either way.
         const promotedTabId = closingActiveTab ? displayActiveTabId() : null;
         fireAndForget(async () => {
             if (closingActiveTab) holdRevealGate(promotedTabId);


### PR DESCRIPTION
Switching to a large tab made the **tab bar itself** feel slow: the pill took a visible moment to look selected, and then the heavy pane appeared all at once. The ask was for the opposite ordering — switch now, paint after, with the pane's load time visually cordoned off rather than folded into the switch.

## Root cause — one signal, two consumers, no paint boundary

`activeTabId` (`store/window-identity.ts`) is **backend-authoritative**: it reads `ws.activetabid`, so it cannot move until `SetActiveTab` round-trips. Two unrelated pieces of UI read that same memo:

1. `tabbar.tsx`'s pill — `isActive={tabId === displayActiveTabId()}`, which fell straight through to raw `activeTabId()` on the select path.
2. `workspace.tsx`'s per-tab `display: none → flex` reveal of the destination.

Both land in **one synchronous Solid flush**. The browser then owes layout for a whole newly-displayed subtree before it can paint anything — including the pill. `SPEC_AGENT_PANE_TAB_SWITCH_PERF_2026_05_27.md` had already measured this:

> All five JS-side hypotheses fell. The 500ms long-task is **browser-side layout + paint** on `display:none → block`, opaque to JS-level perf hooks.

That cost is content-proportional, which is exactly why it's worse for large tabs. **The existing reveal gate cannot fix it** — `visibility: hidden` still participates in layout, so it hides the cascade's ugliness without shortening the frame it blocks. The pill sat computed-but-unpainted until that frame drained.

## The fix — a pattern this file already had

`displayActiveTabId`/`pendingHiddenTabIds` (`SPEC_TAB_CLOSE_BUTTON_SELECT_FLASH_2026_08_25.md` §8-9) is *already* an optimistic client-side override of `activeTabId()` — for the close flow, where the strip promotes the neighbor before `CloseTab` resolves. The plain click-to-select path never got one.

Now it has one: `pendingSelectedTabId` is written **before** the RPC is issued, so the pill commits and paints on its own cheap schedule.

`workspace.tsx` is **deliberately untouched** — the content reveal still reads the raw backend-authoritative atom, so only the highlight is optimistic. The destination keeps taking exactly as long as it takes, behind the existing gate. This PR does not try to make the reveal cascade faster; that stays `SPEC_AGENT_PANE_TAB_SWITCH_PERF_2026_05_27.md`'s job.

## Changes

| File | |
|---|---|
| `frontend/app/tab/active-tab-display.ts` | **new** — pure `resolveDisplayActiveTabId()`: optimistic select, then the pre-existing close-flow promotion verbatim |
| `frontend/app/tab/active-tab-display.test.ts` | **new** — 10 tests |
| `frontend/app/tab/tabbar.tsx` | `pendingSelectedTabId` signal; `handleSelect` writes before the RPC, clears in `finally` |
| `docs/specs/SPEC_TAB_SWITCH_DECOUPLE_SELECT_FROM_PAINT_2026_09_04.md` | **new** |

The decision moved into a pure module rather than staying inline so the precedence between the two optimistic overrides is assertable — same reasoning as `view/agent/failure/synthetic-row.ts`.

## Correctness details worth reviewing

- **Stale-click guard.** `handleSelect` clears the pending value only if it's still this call's own target (`cur === tabId ? null : cur`), so a newer click during an in-flight RPC isn't clobbered back to the stale committed id. Same stale-generation discipline as `tab-reveal.ts`'s gates.
- **Failure path.** The clear runs in `finally`, so a select whose RPC throws can't leave a phantom highlight on a tab the backend never activated — mirrors `handleClose`'s own `unhideTab`.
- **Guarded fallthrough.** A pending id that no longer exists, or is itself mid-close, falls through rather than highlighting a pill the strip doesn't render.
- **`handleClose` interaction.** It reuses `displayActiveTabId()` for gate targeting, so a pending select can now win there. Identical to old behaviour whenever no select is pending (the common case); when one is, the two candidates are already racing two concurrent RPCs, so neither is reliably "the" next active tab. Commented at the call site.

## Testing

**Mutation-checked, not just green:** with the optimistic-select branch removed, exactly the 2 fix-specific tests fail while all 8 close-flow tests still pass — confirming the close-flow tests guard *preserved* behaviour rather than the new behaviour.

- 52/52 across all four `frontend/app/tab/` suites (42 pre-existing + 10 new)
- `tsc --noEmit` clean
- Re-verified after rebasing onto latest `main`

**Verified live** by the repo owner in a `task dev` build — "much better".

**Not measured:** a before/after profile on a large tab. The mechanism is verified by construction (the pill no longer reads a value that requires the RPC), and the cost it sidesteps is the already-measured 500-600ms above, but I'm not claiming a profiled number.

## Scope note

This is the **window-level** tab bar. The in-pane block-stack tab strip (Agent History / Quick Fork / "+") has a *different* root cause — there the pill and the destination's full remount are driven off the same `localTreeStateAtom` write, and `NodeModel.blockId` immutability forces a real remount rather than a CSS reveal. Not addressed here; §2 of the spec records it as a separate follow-up.

<!-- agentmux:agent_id=posa -->
