### PR TITLE
feat(tray): small companion panel window opened from the tray (issue #2977 WS3)

### DIFF
--- a/.changesets/1788648231-feat-tray-small-companion-panel-window-opened-from-the-tray--uk9v.md
+++ b/.changesets/1788648231-feat-tray-small-companion-panel-window-opened-from-the-tray--uk9v.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(tray): small companion panel window opened from the tray (issue #2977 WS3)

--- a/agentmux-cef/src/commands/drag.rs
+++ b/agentmux-cef/src/commands/drag.rs
@@ -391,6 +391,7 @@ pub fn tear_off_pool_promote(
         tab_anchor_y,
         None,
         None,
+        false, // tab tear-off, not a tray panel
     ) {
         Some(label) => Ok(serde_json::json!(label)),
         None => {

--- a/agentmux-cef/src/commands/window/mod.rs
+++ b/agentmux-cef/src/commands/window/mod.rs
@@ -13,8 +13,10 @@
 // keep resolving `commands::window::<name>` unchanged.
 
 mod lifecycle;
+mod panel;
 // Cross-platform command handlers dispatched by ipc.rs.
 pub use lifecycle::{close_window, close_window_by_label, quit_app};
+pub use panel::open_panel;
 #[cfg(target_os = "windows")]
 pub use lifecycle::find_main_window;
 // Windows-only helpers other modules resolve as `commands::window::<name>`

--- a/agentmux-cef/src/commands/window/panel.rs
+++ b/agentmux-cef/src/commands/window/panel.rs
@@ -1,0 +1,193 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tray panel — issue #2977 Workstream 3,
+//! `docs/specs/SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md` §2.
+//!
+//! A small top-level window, opened from the tray, that reuses the ordinary
+//! window machinery rather than being a native OS menu or a second process.
+//! The spec rejects both alternatives explicitly: a native menu is "too
+//! limited for agent chat", and a separate process would need its own srv
+//! connection, update path, and crash supervision.
+//!
+//! ## Why this is small
+//!
+//! The panel deliberately reuses the pool promote path first, so it opens
+//! instantly (a pre-warmed window repositioned and resized) and only falls
+//! back to a cold-path window when the pool is empty. That is WS3's stated
+//! requirement — "reusing the existing pool-window hide/show/promote
+//! mechanism" — and it costs nothing extra: `promote_pool_window` already
+//! accepts explicit width/height and DPI-converts them.
+//!
+//! ## Scope, stated honestly
+//!
+//! This opens the normal UI at panel dimensions. A *visually simplified*
+//! panel view is frontend work (a new React surface) that cannot be designed
+//! or verified without a display, so it is deliberately not attempted here;
+//! the plumbing accepts an `initial_view`, so a dedicated view drops in later
+//! without touching this file.
+
+use std::sync::Arc;
+
+use crate::state::AppState;
+
+/// Panel size in logical pixels. Tall and narrow — a companion surface beside
+/// whatever the user is actually working in, not a second main window (which
+/// is what `open_new_window` is for).
+pub const PANEL_WIDTH: i32 = 420;
+pub const PANEL_HEIGHT: i32 = 640;
+
+/// Gap from the work-area edges, so the panel doesn't sit flush against the
+/// taskbar or screen edge.
+const PANEL_MARGIN: i32 = 16;
+
+/// Where to put the panel, given a monitor work area `(x, y, w, h)`.
+///
+/// Anchored to the **bottom-right** of the work area: that is where the tray
+/// lives on the default Windows layout, so the panel appears next to the
+/// thing the user just clicked rather than somewhere unrelated. The work area
+/// (not the full monitor rect) is used so the panel never lands under the
+/// taskbar.
+///
+/// Clamps rather than assuming it fits: on a small or scaled display the
+/// panel can be larger than the work area, and a negative-size or
+/// off-work-area rect would put the window somewhere the user cannot reach.
+/// Pure so all of that is testable without a display.
+pub fn panel_rect(work: (i32, i32, i32, i32)) -> (i32, i32, i32, i32) {
+    let (wx, wy, ww, wh) = work;
+
+    // Never larger than the work area minus margins; never smaller than
+    // something usable, so a pathological work area can't produce a 0-size
+    // or negative-size window.
+    let w = PANEL_WIDTH.min((ww - 2 * PANEL_MARGIN).max(1));
+    let h = PANEL_HEIGHT.min((wh - 2 * PANEL_MARGIN).max(1));
+
+    // Bottom-right, then clamp back inside the work area. `max(wx/wy)` covers
+    // the case where the panel is wider/taller than the work area itself.
+    let x = (wx + ww - w - PANEL_MARGIN).max(wx);
+    let y = (wy + wh - h - PANEL_MARGIN).max(wy);
+
+    (x, y, w, h)
+}
+
+/// Open the tray panel.
+///
+/// Pool-first (instant), cold-path fallback. Returns the window label.
+///
+/// Note this is a *normal* top-level window as far as the rest of the host is
+/// concerned — it registers, counts toward `count_live_user_windows`, and
+/// keeps the instance attended. That is deliberate: a panel the user has open
+/// is a window they are looking at, so it should suppress the "unattended"
+/// audit period and satisfy the last-window quit gate exactly like any other.
+pub fn open_panel(state: &Arc<AppState>) -> Result<serde_json::Value, String> {
+    let (x, y, w, h) = panel_rect(panel_work_area());
+
+    // Pool-first. `promote_pool_window_for_new_window` emits the
+    // `pool:new-window` promote (no workspaceId), so the frontend creates a
+    // fresh workspace — the right semantics for a panel, which is not
+    // reattaching an existing one.
+    if let Some(label) =
+        crate::commands::window_pool::promote_pool_window_for_new_window(state, x, y, w, h, None, None)
+    {
+        tracing::info!(
+            target: "tray:panel",
+            label = %label,
+            "[panel] served from the warm pool"
+        );
+        return Ok(serde_json::json!(label));
+    }
+
+    // Cold path. `explicit_rect` exists for exactly this — it skips the
+    // new-window offset/70%-of-monitor placement heuristic and uses the rect
+    // verbatim, which is what makes the panel panel-sized instead of
+    // main-window-sized.
+    tracing::info!(target: "tray:panel", "[panel] pool empty — cold-path window");
+    crate::commands::window::open_window_with_kind(
+        state,
+        crate::state::WindowKind::FullInstance,
+        None,
+        None,
+        None,
+        Some(agentmux_common::ipc::Rect {
+            left: x,
+            top: y,
+            right: x + w,
+            bottom: y + h,
+        }),
+        false,
+    )
+}
+
+/// Work area to anchor the panel in.
+///
+/// Resolved from the monitor under the *primary* origin. A more precise
+/// answer would be "the monitor containing the tray icon the user clicked",
+/// but the click arrives in the launcher and the position is not plumbed
+/// through; anchoring to the primary work area is correct on the common
+/// single-monitor case and always produces an on-screen window on the rest,
+/// which is the property that actually matters.
+fn panel_work_area() -> (i32, i32, i32, i32) {
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(wa) = crate::app::get_monitor_work_area_physical(0, 0) {
+            return wa;
+        }
+    }
+    // Conservative fallback when the OS won't say (or off-Windows): a
+    // 1280x800 area, which is smaller than essentially any real display, so
+    // the clamping above keeps the panel on screen rather than guessing big.
+    (0, 0, 1280, 800)
+}
+
+#[cfg(test)]
+mod panel_tests {
+    use super::*;
+
+    #[test]
+    fn panel_sits_inside_the_work_area_bottom_right() {
+        let (x, y, w, h) = panel_rect((0, 0, 1920, 1040));
+        assert_eq!((w, h), (PANEL_WIDTH, PANEL_HEIGHT));
+        assert_eq!(x, 1920 - PANEL_WIDTH - PANEL_MARGIN);
+        assert_eq!(y, 1040 - PANEL_HEIGHT - PANEL_MARGIN);
+    }
+
+    #[test]
+    fn panel_respects_a_work_area_that_is_not_at_the_origin() {
+        // A secondary monitor, or a primary with a top/left taskbar: the
+        // panel must anchor to the WORK AREA, not to (0,0), or it lands on
+        // the wrong screen (or under the taskbar).
+        let (x, y, w, h) = panel_rect((1920, 100, 1280, 900));
+        assert_eq!(x, 1920 + 1280 - w - PANEL_MARGIN);
+        assert_eq!(y, 100 + 900 - h - PANEL_MARGIN);
+        assert!(x >= 1920 && y >= 100);
+    }
+
+    #[test]
+    fn panel_shrinks_to_fit_a_work_area_smaller_than_itself() {
+        // Small or heavily scaled display: better a smaller panel than one
+        // whose bottom half is off-screen.
+        let (x, y, w, h) = panel_rect((0, 0, 300, 400));
+        assert!(w <= 300 && h <= 400);
+        assert!(x >= 0 && y >= 0);
+        assert!(x + w <= 300 + PANEL_MARGIN, "stays within the work area");
+    }
+
+    #[test]
+    fn panel_never_has_a_zero_or_negative_size() {
+        // Pathological work areas (a mis-reported monitor, a 1px strip)
+        // must not produce a window with no size — CEF would create
+        // something the user can neither see nor close.
+        for work in [(0, 0, 1, 1), (0, 0, 0, 0), (0, 0, 32, 32)] {
+            let (_, _, w, h) = panel_rect(work);
+            assert!(w >= 1 && h >= 1, "degenerate size for work area {:?}", work);
+        }
+    }
+
+    #[test]
+    fn panel_is_smaller_than_a_normal_window() {
+        // The whole point: a companion surface, not a second main window.
+        // POOL_WIDTH/HEIGHT (1200x800) is what an ordinary new window gets.
+        assert!(PANEL_WIDTH < 1200);
+        assert!(PANEL_HEIGHT <= 800);
+    }
+}

--- a/agentmux-cef/src/commands/window/panel.rs
+++ b/agentmux-cef/src/commands/window/panel.rs
@@ -126,6 +126,7 @@ pub fn open_panel(state: &Arc<AppState>) -> Result<serde_json::Value, String> {
         Some(y),
         None,
         None,
+        true, // this IS a panel — the liveness fallback must recover it as one
     ) {
         tracing::info!(target: "tray:panel", label = %label, "[panel] served from the warm pool");
         crate::ui_tasks::post_set_always_on_top(state, &label);

--- a/agentmux-cef/src/commands/window/panel.rs
+++ b/agentmux-cef/src/commands/window/panel.rs
@@ -41,31 +41,36 @@ pub const PANEL_HEIGHT: i32 = 640;
 /// taskbar or screen edge.
 const PANEL_MARGIN: i32 = 16;
 
-/// Where to put the panel, given a monitor work area `(x, y, w, h)`.
+/// Where to put the panel, given a monitor work area `(x, y, w, h)` and that
+/// monitor's DPI `scale`. **Everything here is PHYSICAL pixels**, including
+/// the returned size — `PANEL_WIDTH`/`PANEL_HEIGHT` are logical, so they are
+/// scaled on the way in.
 ///
 /// Anchored to the **bottom-right** of the work area: that is where the tray
-/// lives on the default Windows layout, so the panel appears next to the
-/// thing the user just clicked rather than somewhere unrelated. The work area
-/// (not the full monitor rect) is used so the panel never lands under the
-/// taskbar.
+/// lives on the default Windows layout, so the panel appears next to the thing
+/// the user just clicked. The work area (not the full monitor rect) is used so
+/// it never lands under the taskbar.
 ///
-/// Clamps rather than assuming it fits: on a small or scaled display the
-/// panel can be larger than the work area, and a negative-size or
-/// off-work-area rect would put the window somewhere the user cannot reach.
-/// Pure so all of that is testable without a display.
-pub fn panel_rect(work: (i32, i32, i32, i32)) -> (i32, i32, i32, i32) {
+/// Clamps rather than assuming it fits: on a small or heavily scaled display
+/// the panel can exceed the work area, and a negative-size or off-work-area
+/// rect would put the window somewhere unreachable.
+pub fn panel_rect(work: (i32, i32, i32, i32), scale: f32) -> (i32, i32, i32, i32) {
     let (wx, wy, ww, wh) = work;
+    let scale = if scale > 0.0 { scale } else { 1.0 };
+    let margin = (PANEL_MARGIN as f32 * scale).round() as i32;
 
-    // Never larger than the work area minus margins; never smaller than
-    // something usable, so a pathological work area can't produce a 0-size
-    // or negative-size window.
-    let w = PANEL_WIDTH.min((ww - 2 * PANEL_MARGIN).max(1));
-    let h = PANEL_HEIGHT.min((wh - 2 * PANEL_MARGIN).max(1));
+    let want_w = (PANEL_WIDTH as f32 * scale).round() as i32;
+    let want_h = (PANEL_HEIGHT as f32 * scale).round() as i32;
 
-    // Bottom-right, then clamp back inside the work area. `max(wx/wy)` covers
-    // the case where the panel is wider/taller than the work area itself.
-    let x = (wx + ww - w - PANEL_MARGIN).max(wx);
-    let y = (wy + wh - h - PANEL_MARGIN).max(wy);
+    // Never larger than the work area minus margins; never smaller than 1px,
+    // so a pathological work area cannot produce a window with no size.
+    let w = want_w.min((ww - 2 * margin).max(1));
+    let h = want_h.min((wh - 2 * margin).max(1));
+
+    // Bottom-right, clamped back inside the work area for the case where the
+    // panel is wider/taller than the work area itself.
+    let x = (wx + ww - w - margin).max(wx);
+    let y = (wy + wh - h - margin).max(wy);
 
     (x, y, w, h)
 }
@@ -74,35 +79,64 @@ pub fn panel_rect(work: (i32, i32, i32, i32)) -> (i32, i32, i32, i32) {
 ///
 /// Pool-first (instant), cold-path fallback. Returns the window label.
 ///
-/// Note this is a *normal* top-level window as far as the rest of the host is
-/// concerned — it registers, counts toward `count_live_user_windows`, and
-/// keeps the instance attended. That is deliberate: a panel the user has open
-/// is a window they are looking at, so it should suppress the "unattended"
-/// audit period and satisfy the last-window quit gate exactly like any other.
+/// The panel is a *normal* top-level window as far as the rest of the host is
+/// concerned — it registers, counts toward `count_live_user_windows`, and keeps
+/// the instance attended. Deliberate: a panel the user has open is a window
+/// they are looking at, so it should satisfy the last-window quit gate and
+/// suppress the unattended audit period exactly like any other.
 pub fn open_panel(state: &Arc<AppState>) -> Result<serde_json::Value, String> {
-    let (x, y, w, h) = panel_rect(panel_work_area());
-
-    // Pool-first. `promote_pool_window_for_new_window` emits the
-    // `pool:new-window` promote (no workspaceId), so the frontend creates a
-    // fresh workspace — the right semantics for a panel, which is not
-    // reattaching an existing one.
-    if let Some(label) =
-        crate::commands::window_pool::promote_pool_window_for_new_window(state, x, y, w, h, None, None)
-    {
-        tracing::info!(
-            target: "tray:panel",
-            label = %label,
-            "[panel] served from the warm pool"
+    // H.7 invariant. `open_new_window` checks this before ITS pool promote for
+    // a reason: creating or promoting a top-level CEF window while a pane is
+    // in `Closing` hits a Chromium deadlock that wedges the message loop. The
+    // cold path below inherits the guard from `open_window_with_kind`, but the
+    // pool promote does not — so without this a tray click arriving mid-close
+    // takes the unguarded path (Codex P1 on PR #3002).
+    if state.any_browser_pane_closing() {
+        tracing::warn!(
+            target: "wfr:gate",
+            "[wfr:gate] open_panel refused — pane is mid-close (H.7 invariant)"
         );
+        return Err("a pane is currently closing; retry shortly".to_string());
+    }
+
+    let work = panel_work_area();
+    let scale = panel_scale(work);
+    let (x, y, w, h) = panel_rect(work, scale);
+
+    // Pool-first. NOTE: `promote_pool_window_for_new_window` cannot be used
+    // here — its Windows branch deliberately DISCARDS width/height (to avoid
+    // double-DPI-converting the already-physical values its own caller passes)
+    // and falls back to POOL_WIDTH/POOL_HEIGHT, which would silently produce a
+    // normal 1200x800 window whenever the pool is warm — i.e. in the common
+    // case this feature is designed around (ReAgent + Codex P1 on PR #3002).
+    // Calling `promote_pool_window` directly lets the panel size survive: it
+    // applies `to_physical()` when width/height are `Some`, so they must be
+    // handed over as LOGICAL pixels, derived back from the clamped physical
+    // rect above.
+    let logical_w = ((w as f32) / scale).round().max(1.0) as i32;
+    let logical_h = ((h as f32) / scale).round().max(1.0) as i32;
+    if let Some(label) = crate::commands::window_pool::promote_pool_window(
+        state,
+        "", // empty workspace id => the frontend creates a fresh workspace
+        x,
+        y,
+        Some(logical_w),
+        Some(logical_h),
+        Some(x), // anchor: place the outer top-left exactly here
+        Some(y),
+        None,
+        None,
+    ) {
+        tracing::info!(target: "tray:panel", label = %label, "[panel] served from the warm pool");
+        crate::ui_tasks::post_set_always_on_top(state, &label);
         return Ok(serde_json::json!(label));
     }
 
-    // Cold path. `explicit_rect` exists for exactly this — it skips the
-    // new-window offset/70%-of-monitor placement heuristic and uses the rect
-    // verbatim, which is what makes the panel panel-sized instead of
-    // main-window-sized.
+    // Cold path. `explicit_rect` skips the new-window offset/70%-of-monitor
+    // placement heuristic and uses the rect verbatim (physical), which is what
+    // makes the panel panel-sized rather than main-window-sized.
     tracing::info!(target: "tray:panel", "[panel] pool empty — cold-path window");
-    crate::commands::window::open_window_with_kind(
+    let out = crate::commands::window::open_window_with_kind(
         state,
         crate::state::WindowKind::FullInstance,
         None,
@@ -115,17 +149,20 @@ pub fn open_panel(state: &Arc<AppState>) -> Result<serde_json::Value, String> {
             bottom: y + h,
         }),
         false,
-    )
+    )?;
+    if let Some(label) = out.as_str() {
+        crate::ui_tasks::post_set_always_on_top(state, label);
+    }
+    Ok(out)
 }
 
 /// Work area to anchor the panel in.
 ///
-/// Resolved from the monitor under the *primary* origin. A more precise
-/// answer would be "the monitor containing the tray icon the user clicked",
-/// but the click arrives in the launcher and the position is not plumbed
-/// through; anchoring to the primary work area is correct on the common
-/// single-monitor case and always produces an on-screen window on the rest,
-/// which is the property that actually matters.
+/// Resolved from the monitor under the primary origin. A more precise answer
+/// would be "the monitor containing the tray icon the user clicked", but the
+/// click arrives in the launcher and the position is not plumbed through; the
+/// primary work area is correct on the common single-monitor case and always
+/// yields an on-screen window otherwise, which is the property that matters.
 fn panel_work_area() -> (i32, i32, i32, i32) {
     #[cfg(target_os = "windows")]
     {
@@ -133,10 +170,22 @@ fn panel_work_area() -> (i32, i32, i32, i32) {
             return wa;
         }
     }
-    // Conservative fallback when the OS won't say (or off-Windows): a
-    // 1280x800 area, which is smaller than essentially any real display, so
-    // the clamping above keeps the panel on screen rather than guessing big.
+    // Conservative fallback when the OS will not say (or off-Windows):
+    // smaller than essentially any real display, so the clamping above keeps
+    // the panel on screen rather than guessing big.
     (0, 0, 1280, 800)
+}
+
+/// DPI scale for the monitor the panel will land on.
+fn panel_scale(_work: (i32, i32, i32, i32)) -> f32 {
+    #[cfg(target_os = "windows")]
+    {
+        return crate::app::dpi_scale_at(_work.0, _work.1);
+    }
+    #[allow(unreachable_code)]
+    {
+        1.0
+    }
 }
 
 #[cfg(test)]
@@ -145,7 +194,7 @@ mod panel_tests {
 
     #[test]
     fn panel_sits_inside_the_work_area_bottom_right() {
-        let (x, y, w, h) = panel_rect((0, 0, 1920, 1040));
+        let (x, y, w, h) = panel_rect((0, 0, 1920, 1040), 1.0);
         assert_eq!((w, h), (PANEL_WIDTH, PANEL_HEIGHT));
         assert_eq!(x, 1920 - PANEL_WIDTH - PANEL_MARGIN);
         assert_eq!(y, 1040 - PANEL_HEIGHT - PANEL_MARGIN);
@@ -153,20 +202,45 @@ mod panel_tests {
 
     #[test]
     fn panel_respects_a_work_area_that_is_not_at_the_origin() {
-        // A secondary monitor, or a primary with a top/left taskbar: the
-        // panel must anchor to the WORK AREA, not to (0,0), or it lands on
-        // the wrong screen (or under the taskbar).
-        let (x, y, w, h) = panel_rect((1920, 100, 1280, 900));
+        // A secondary monitor, or a primary with a top/left taskbar: anchor
+        // to the WORK AREA, not (0,0), or it lands on the wrong screen or
+        // under the taskbar.
+        let (x, y, w, h) = panel_rect((1920, 100, 1280, 900), 1.0);
         assert_eq!(x, 1920 + 1280 - w - PANEL_MARGIN);
         assert_eq!(y, 100 + 900 - h - PANEL_MARGIN);
         assert!(x >= 1920 && y >= 100);
+    }
+
+    /// The returned rect is PHYSICAL, so on a scaled display the panel must
+    /// come back proportionally larger — otherwise it renders at half size on
+    /// a 200% display.
+    #[test]
+    fn panel_size_scales_with_display_dpi() {
+        let (_, _, w1, h1) = panel_rect((0, 0, 3840, 2100), 1.0);
+        let (_, _, w2, h2) = panel_rect((0, 0, 3840, 2100), 2.0);
+        assert_eq!((w1, h1), (PANEL_WIDTH, PANEL_HEIGHT));
+        assert_eq!((w2, h2), (PANEL_WIDTH * 2, PANEL_HEIGHT * 2));
+    }
+
+    /// The logical size handed to `promote_pool_window` is derived by dividing
+    /// the clamped physical rect back by the scale — it must round-trip, or
+    /// the promoted window is the wrong size on a HiDPI display.
+    #[test]
+    fn physical_size_round_trips_back_to_the_logical_panel_size() {
+        for scale in [1.0f32, 1.25, 1.5, 2.0] {
+            let (_, _, w, h) = panel_rect((0, 0, 3840, 2160), scale);
+            let logical_w = ((w as f32) / scale).round() as i32;
+            let logical_h = ((h as f32) / scale).round() as i32;
+            assert_eq!(logical_w, PANEL_WIDTH, "width at scale {}", scale);
+            assert_eq!(logical_h, PANEL_HEIGHT, "height at scale {}", scale);
+        }
     }
 
     #[test]
     fn panel_shrinks_to_fit_a_work_area_smaller_than_itself() {
         // Small or heavily scaled display: better a smaller panel than one
         // whose bottom half is off-screen.
-        let (x, y, w, h) = panel_rect((0, 0, 300, 400));
+        let (x, y, w, h) = panel_rect((0, 0, 300, 400), 1.0);
         assert!(w <= 300 && h <= 400);
         assert!(x >= 0 && y >= 0);
         assert!(x + w <= 300 + PANEL_MARGIN, "stays within the work area");
@@ -174,19 +248,29 @@ mod panel_tests {
 
     #[test]
     fn panel_never_has_a_zero_or_negative_size() {
-        // Pathological work areas (a mis-reported monitor, a 1px strip)
-        // must not produce a window with no size — CEF would create
-        // something the user can neither see nor close.
+        // Pathological work areas (a mis-reported monitor, a 1px strip) must
+        // not produce a window with no size — CEF would create something the
+        // user can neither see nor close.
         for work in [(0, 0, 1, 1), (0, 0, 0, 0), (0, 0, 32, 32)] {
-            let (_, _, w, h) = panel_rect(work);
-            assert!(w >= 1 && h >= 1, "degenerate size for work area {:?}", work);
+            for scale in [1.0f32, 2.0] {
+                let (_, _, w, h) = panel_rect(work, scale);
+                assert!(w >= 1 && h >= 1, "degenerate size for {:?} @{}", work, scale);
+            }
         }
+    }
+
+    #[test]
+    fn a_nonsense_scale_does_not_produce_a_degenerate_panel() {
+        // GetDpiForMonitor can fail; the caller substitutes a scale that must
+        // not divide-by-zero or invert the rect.
+        let (x, y, w, h) = panel_rect((0, 0, 1920, 1040), 0.0);
+        assert!(w >= 1 && h >= 1 && x >= 0 && y >= 0);
     }
 
     #[test]
     fn panel_is_smaller_than_a_normal_window() {
         // The whole point: a companion surface, not a second main window.
-        // POOL_WIDTH/HEIGHT (1200x800) is what an ordinary new window gets.
+        // An ordinary new window gets POOL_WIDTH/HEIGHT (1200x800).
         assert!(PANEL_WIDTH < 1200);
         assert!(PANEL_HEIGHT <= 800);
     }

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -1034,6 +1034,14 @@ struct PromoteFallback {
     pos_y: i32,
     width: i32,
     height: i32,
+    /// Issue #2977 WS3 — this promote was a tray PANEL, not an ordinary
+    /// window. Without it the fallback would recover a failed panel promote
+    /// as a normal, full-size, normally-placed window with no always-on-top:
+    /// the user asks for a panel, the renderer fails to confirm, and they get
+    /// something entirely different (Codex P2 + ReAgent P2 on PR #3002).
+    /// Uses the same `pos_x/pos_y/width/height` above, which for a panel are
+    /// already the exact rect it was promoted at.
+    panel: bool,
 }
 
 /// Workstream 0 Phase 1 prerequisite #2 (issue #2977) — arm a bounded
@@ -1121,7 +1129,32 @@ fn arm_promote_liveness(state: &Arc<AppState>, label: &str, fallback: PromoteFal
              opening a fresh cold-path window instead of leaving the user with a possibly-dead one"
         );
 
-        let result = if fallback.workspace_id.is_empty() {
+        let result = if fallback.panel {
+            // Recreate a PANEL: explicit rect (so it is panel-sized and
+            // panel-placed rather than taking the new-window offset
+            // heuristic) plus always-on-top, matching what `open_panel`'s own
+            // cold path does.
+            let out = crate::commands::window::open_window_with_kind(
+                &state,
+                WindowKind::FullInstance,
+                None,
+                fallback.initial_view.as_deref(),
+                fallback.initial_meta.as_deref(),
+                Some(agentmux_common::ipc::Rect {
+                    left: fallback.pos_x,
+                    top: fallback.pos_y,
+                    right: fallback.pos_x + fallback.width,
+                    bottom: fallback.pos_y + fallback.height,
+                }),
+                false,
+            );
+            if let Ok(v) = &out {
+                if let Some(label) = v.as_str() {
+                    crate::ui_tasks::post_set_always_on_top(&state, label);
+                }
+            }
+            out
+        } else if fallback.workspace_id.is_empty() {
             // New-window promote (Cmd+N / File → New Window): no workspace to
             // reattach, the frontend creates a fresh one. Position is
             // arbitrary here, so take the cold path's normal offset placement
@@ -1204,6 +1237,11 @@ pub fn promote_pool_window(
     tab_anchor_y: Option<i32>,
     initial_view: Option<String>,
     initial_meta: Option<String>,
+    // Issue #2977 WS3 — this promote is a tray panel. Only affects the
+    // liveness FALLBACK (`PromoteFallback::panel`), so a panel whose renderer
+    // never confirms is recovered as a panel rather than as an ordinary
+    // full-size window.
+    is_panel: bool,
 ) -> Option<String> {
     // PR #5 H.4 — atomic pop+remove via reducer. The dispatch pops
     // the front of the pool queue, removes the label from
@@ -1619,6 +1657,7 @@ pub fn promote_pool_window(
             pos_y,
             width: win_w,
             height: win_h,
+            panel: is_panel,
         },
     );
 
@@ -1735,6 +1774,11 @@ pub fn promote_pool_window(
     tab_anchor_y: Option<i32>,
     initial_view: Option<String>,
     initial_meta: Option<String>,
+    // Issue #2977 WS3 — this promote is a tray panel. Only affects the
+    // liveness FALLBACK (`PromoteFallback::panel`), so a panel whose renderer
+    // never confirms is recovered as a panel rather than as an ordinary
+    // full-size window.
+    is_panel: bool,
 ) -> Option<String> {
     // Atomic pop from the pool queue via reducer. Returns None if empty
     // — caller falls back to cold path.
@@ -1789,6 +1833,7 @@ pub fn promote_pool_window(
             pos_y: y,
             width: w,
             height: h,
+            panel: is_panel,
         },
     );
 
@@ -1872,6 +1917,7 @@ pub fn promote_pool_window_for_new_window(
             Some(pos_y),  // tab_anchor_y
             initial_view,
             initial_meta,
+            false, // ordinary new window, not a panel
         );
     }
 
@@ -1919,6 +1965,7 @@ pub fn promote_pool_window_for_new_window(
                 pos_y,
                 width,
                 height,
+                panel: false,
             },
         );
 

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -224,6 +224,8 @@ async fn route_command(
         // (see `quit_app`'s doc for why the ordinary last-window path and
         // `Event::HostShouldQuit` both cannot serve here).
         "quit_app" => commands::window::quit_app(state),
+        // Issue #2977 WS3 — the tray panel: a small top-level window, pool-first.
+        "open_panel" => commands::window::open_panel(state),
         "minimize_window" => commands::window::minimize_window(state, args),
         "maximize_window" => commands::window::maximize_window(state, args),
         "toggle_floating_maximize" => commands::window::toggle_floating_maximize(state, args),

--- a/agentmux-cef/src/ui_tasks/pool.rs
+++ b/agentmux-cef/src/ui_tasks/pool.rs
@@ -495,3 +495,52 @@ pub fn post_resize_mother_window_win32(state: &Arc<AppState>, hwnd: isize, new_w
     let mut task = ResizeMotherWindowWin32Task::new(state.clone(), hwnd, new_w_dip);
     post_task(ThreadId::UI, Some(&mut task));
 }
+
+/// Issue #2977 WS3 — mark a window always-on-top.
+///
+/// The tray panel is specified as a "small, separate, **always-on-top** CEF
+/// window" (`SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md` §2). Without
+/// it the panel drops behind whatever the user was working in the moment they
+/// click back into it, which defeats a companion surface (Codex P2 on PR
+/// #3002).
+///
+/// Uses the CEF Views `Window::set_always_on_top` rather than a Win32
+/// `HWND_TOPMOST` call so it works identically on every platform and needs no
+/// HWND resolution — and so it applies equally to a pool-promoted window
+/// (HWND already exists) and a cold-path one (HWND does not exist until CEF
+/// creates it). Posted, because Views calls are UI-thread-only.
+pub fn post_set_always_on_top(state: &Arc<AppState>, label: &str) {
+    let mut task = SetAlwaysOnTopTask::new(state.clone(), label.to_string());
+    post_task(ThreadId::UI, Some(&mut task));
+}
+
+wrap_task! {
+    pub struct SetAlwaysOnTopTask {
+        state: Arc<AppState>,
+        label: String,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            // Resolve on the UI thread: for the cold path the window may not
+            // have existed when this task was posted. A miss is logged, not
+            // fatal — a panel that is merely not-topmost is still usable,
+            // whereas panicking here would take down the UI thread.
+            match super::get_window_on_ui(&self.state, &self.label) {
+                Some(window) => {
+                    window.set_always_on_top(1);
+                    tracing::info!(
+                        target: "tray:panel",
+                        label = %self.label,
+                        "[panel] set always-on-top"
+                    );
+                }
+                None => tracing::warn!(
+                    target: "tray:panel",
+                    label = %self.label,
+                    "[panel] window not resolvable yet — not set always-on-top"
+                ),
+            }
+        }
+    }
+}

--- a/agentmux-launcher/src/supervisor/windows.rs
+++ b/agentmux-launcher/src/supervisor/windows.rs
@@ -328,6 +328,8 @@ pub(crate) async fn run_windows(
                         // so srv still gets its per-window cleanup. Killing
                         // the job object here instead would leak srv rows and
                         // resurrect ghost windows on next launch.
+                        // Issue #2977 WS3 — small companion window, pool-first.
+                        tray::TrayAction::ShowPanel => "open_panel",
                         tray::TrayAction::Quit => "quit_app",
                     };
                     forward_tray_cmd(&tray_data_dir, &tray_dir_hash, cmd);

--- a/agentmux-launcher/src/tray/mod.rs
+++ b/agentmux-launcher/src/tray/mod.rs
@@ -49,6 +49,10 @@ pub enum TrayAction {
     /// second way to make a window (see §7.5.1: the reopen path already exists
     /// and is what the macOS reopen delegate uses).
     OpenWindow,
+    /// "Show Panel" — the small companion window (issue #2977 WS3). A real
+    /// CEF window reusing the pool promote path, NOT a native menu: the spec
+    /// rejects a native menu as "too limited for agent chat".
+    ShowPanel,
     /// "Quit AgentMux" — a genuine, user-intended full shutdown, distinct from
     /// closing the last window while background-service mode is on.
     Quit,
@@ -82,6 +86,10 @@ pub fn menu_model(running: bool) -> Vec<MenuItem> {
                 "Start AgentMux".to_string()
             },
             action: TrayAction::OpenWindow,
+        },
+        MenuItem {
+            label: "Show Panel".to_string(),
+            action: TrayAction::ShowPanel,
         },
         MenuItem {
             label: "Quit AgentMux".to_string(),
@@ -181,11 +189,12 @@ mod tray_model_tests {
     }
 
     #[test]
-    fn menu_offers_open_and_quit_in_that_order() {
+    fn menu_offers_open_panel_and_quit_in_that_order() {
         let m = menu_model(true);
-        assert_eq!(m.len(), 2, "menu is deliberately minimal — the panel is WS3");
+        assert_eq!(m.len(), 3, "menu is deliberately minimal");
         assert_eq!(m[0].action, TrayAction::OpenWindow);
-        assert_eq!(m[1].action, TrayAction::Quit);
+        assert_eq!(m[1].action, TrayAction::ShowPanel);
+        assert_eq!(m[2].action, TrayAction::Quit);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Issue #2977 **Workstream 3** — the tray panel. A small top-level window opened from the tray, reusing the ordinary window machinery: **pool promote first** (so it opens instantly from a pre-warmed window), cold-path fallback when the pool is empty. That is WS3's stated requirement, and the spec rejects both alternatives explicitly — a native OS menu is "too limited for agent chat", and a separate process would need its own srv connection, update path and crash supervision.

Adds `open_panel` (host IPC) and a **Show Panel** tray menu item wired to it.

## Design notes worth reviewing

- **Geometry is a pure function**, so the parts that actually break without a display are tested: anchoring to the **work area** rather than `(0,0)` — a top/left taskbar or a secondary monitor otherwise puts the panel under the taskbar or on the wrong screen — and clamping, so a small or heavily scaled display gets a shrunk panel rather than one whose bottom half is off-screen, and a mis-reported monitor cannot produce a zero-size window the user can neither see nor close.
- **The panel is a normal top-level window** to the rest of the host: it registers, counts toward `count_live_user_windows`, and keeps the instance attended. Deliberate — a panel the user has open is a window they are looking at, so it should satisfy the last-window quit gate and suppress the unattended audit period exactly like any other window.
- **Anchored bottom-right of the work area**, where the tray lives on the default Windows layout, so it appears next to the thing the user just clicked. A more precise answer would be "the monitor containing the clicked icon", but the click arrives in the launcher and the position is not plumbed through; the primary work area is correct on the common single-monitor case and always yields an on-screen window otherwise, which is the property that matters.

## Scope, stated honestly

This opens the **normal UI at panel dimensions**. A visually *simplified* panel view is frontend work (a new React surface) that cannot be designed or verified without a display, so it is deliberately not attempted here. The plumbing already accepts an `initial_view`, so a dedicated view drops in later without touching this file.

## Test plan

- [x] `cargo test -p agentmux-cef --lib --release` — **360 passed** (5 new panel-geometry tests)
- [x] `cargo test -p agentmux-launcher --release` — **231 passed** (menu-model test updated for the third entry)
- [x] Both crates build clean
- [ ] Not visually verified that the panel renders or is correctly placed — same display constraint as the rest of WS1/WS3. The geometry logic is unit-tested; the rendering is not.

<!-- agentmux:agent_id=agent5 -->