### PR TITLE
Posa@Area54: chore: release v0.55.36

### DIFF
--- a/.changesets/1788496373-fix-agent-provider-flags-were-dropped-from-cmd-args-on-every-zk5t.md
+++ b/.changesets/1788496373-fix-agent-provider-flags-were-dropped-from-cmd-args-on-every-zk5t.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): provider_flags were dropped from cmd:args on every send

--- a/.changesets/1788592044-fix-host-gate-last-window-quit-behind-background-service-mod-e3iy.md
+++ b/.changesets/1788592044-fix-host-gate-last-window-quit-behind-background-service-mod-e3iy.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(host): gate last-window quit behind background-service mode (tray Workstream 0 prereq #1)

--- a/.changesets/1788623152-fix-agent-pane-hide-the-tab-strip-entirely-on-a-fresh-pane-s-cu3l.md
+++ b/.changesets/1788623152-fix-agent-pane-hide-the-tab-strip-entirely-on-a-fresh-pane-s-cu3l.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): hide the tab strip entirely on a fresh pane, so the picker isn't overlaid by a lone +

--- a/.changesets/1788623510-feat-window-chrome-style-drag-to-top-maximize-and-border-dra-r417.md
+++ b/.changesets/1788623510-feat-window-chrome-style-drag-to-top-maximize-and-border-dra-r417.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(window): Chrome-style drag-to-top maximize and border-drag vertical snap

--- a/.changesets/1788623755-fix-pool-fall-back-to-a-fresh-window-when-a-promoted-pool-wi-t25k.md
+++ b/.changesets/1788623755-fix-pool-fall-back-to-a-fresh-window-when-a-promoted-pool-wi-t25k.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(pool): fall back to a fresh window when a promoted pool window never proves its renderer is alive

--- a/.changesets/1788624586-feat-layout-drop-armory-from-the-default-startup-panes-cpu-n-iktr.md
+++ b/.changesets/1788624586-feat-layout-drop-armory-from-the-default-startup-panes-cpu-n-iktr.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(layout): drop Armory from the default startup panes; CPU now sits above Swarm

--- a/.changesets/1788624955-fix-tabs-tab-bar-highlights-the-clicked-tab-immediately-inst-3twe.md
+++ b/.changesets/1788624955-fix-tabs-tab-bar-highlights-the-clicked-tab-immediately-inst-3twe.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tabs): tab bar highlights the clicked tab immediately instead of waiting on the destination pane's reveal

--- a/.changesets/1788629419-feat-armory-memory-file-picker-is-a-tile-grid-not-a-dropdown-36bh.md
+++ b/.changesets/1788629419-feat-armory-memory-file-picker-is-a-tile-grid-not-a-dropdown-36bh.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(armory): memory file picker is a tile grid, not a dropdown

--- a/.changesets/1788632465-docs-tray-answer-the-launcher-event-loop-assumption-from-cod-ykzq.md
+++ b/.changesets/1788632465-docs-tray-answer-the-launcher-event-loop-assumption-from-cod-ykzq.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(tray): answer the launcher event-loop assumption from code — no Win32 pump exists

--- a/.changesets/1788632478-fix-agent-bump-the-stale-fable-model-pin-and-stop-the-picker-q5f6.md
+++ b/.changesets/1788632478-fix-agent-bump-the-stale-fable-model-pin-and-stop-the-picker-q5f6.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): bump the stale fable model pin and stop the picker advertising a model it doesn't select

--- a/.changesets/1788633257-docs-tray-document-the-tray-less-reopen-path-for-background--58nb.md
+++ b/.changesets/1788633257-docs-tray-document-the-tray-less-reopen-path-for-background--58nb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(tray): document the tray-less reopen path for background-service mode

--- a/.changesets/1788644383-fix-agent-activity-dock-title-no-longer-over-truncates-fix-g-bud3.md
+++ b/.changesets/1788644383-fix-agent-activity-dock-title-no-longer-over-truncates-fix-g-bud3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): activity dock title no longer over-truncates; fix garbled tail glyph

--- a/.changesets/1788644530-feat-tray-optional-windows-tray-icon-with-graceful-quit-issu-9pkv.md
+++ b/.changesets/1788644530-feat-tray-optional-windows-tray-icon-with-graceful-quit-issu-9pkv.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(tray): optional Windows tray icon with graceful quit (issue #2977 WS1)

--- a/.changesets/1788645667-feat-autostart-opt-in-auto-start-registration-for-windows-ma-7esy.md
+++ b/.changesets/1788645667-feat-autostart-opt-in-auto-start-registration-for-windows-ma-7esy.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(autostart): opt-in auto-start registration for Windows, macOS and Linux (issue #2977 WS2)

--- a/.changesets/1788647738-feat-audit-record-and-surface-what-the-background-service-di-hqom.md
+++ b/.changesets/1788647738-feat-audit-record-and-surface-what-the-background-service-di-hqom.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(audit): record and surface what the background service did while unattended (issue #2977 WS4)

--- a/.changesets/1788648231-feat-tray-small-companion-panel-window-opened-from-the-tray--uk9v.md
+++ b/.changesets/1788648231-feat-tray-small-companion-panel-window-opened-from-the-tray--uk9v.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(tray): small companion panel window opened from the tray (issue #2977 WS3)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.35"
+version = "0.55.36"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.35"
+version = "0.55.36"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.35"
+version = "0.55.36"
 dependencies = [
  "base64",
  "dirs 5.0.1",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.35"
+version = "0.55.36"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.35"
+version = "0.55.36"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.35"
+version = "0.55.36"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.35"
+version = "0.55.36"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,24 @@
 # AgentMux Version History
 
+## 0.55.36 — 2026-09-05
+
+- fix(agent): provider_flags were dropped from cmd:args on every send
+- fix(host): gate last-window quit behind background-service mode (tray Workstream 0 prereq #1)
+- fix(agent-pane): hide the tab strip entirely on a fresh pane, so the picker isn't overlaid by a lone +
+- feat(window): Chrome-style drag-to-top maximize and border-drag vertical snap
+- fix(pool): fall back to a fresh window when a promoted pool window never proves its renderer is alive
+- feat(layout): drop Armory from the default startup panes; CPU now sits above Swarm
+- fix(tabs): tab bar highlights the clicked tab immediately instead of waiting on the destination pane's reveal
+- feat(armory): memory file picker is a tile grid, not a dropdown
+- docs(tray): answer the launcher event-loop assumption from code — no Win32 pump exists
+- fix(agent): bump the stale fable model pin and stop the picker advertising a model it doesn't select
+- docs(tray): document the tray-less reopen path for background-service mode
+- fix(agent): activity dock title no longer over-truncates; fix garbled tail glyph
+- feat(tray): optional Windows tray icon with graceful quit (issue #2977 WS1)
+- feat(autostart): opt-in auto-start registration for Windows, macOS and Linux (issue #2977 WS2)
+- feat(audit): record and surface what the background service did while unattended (issue #2977 WS4)
+- feat(tray): small companion panel window opened from the tray (issue #2977 WS3)
+
 ## 0.55.35 — 2026-09-04
 
 - fix(toolchain): persist system-tool install success across stale-PATH refresh, show live version and collapsible install details

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.35",
+  "version": "0.55.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.35",
+      "version": "0.55.36",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.35",
+  "version": "0.55.36",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Release **v0.55.36**, consuming 16 pending changesets.

## Patch forced over a computed minor — worth a look before merging

Run as `task release -- --as patch`. The computed bump was **minor**; **six** `feat` entries requested it:

- `feat(window)`: Chrome-style drag-to-top maximize and border-drag vertical snap
- `feat(layout)`: drop Armory from the default startup panes; CPU now sits above Swarm
- `feat(armory)`: memory file picker is a tile grid, not a dropdown
- `feat(tray)`: optional Windows tray icon with graceful quit (issue #2977 **WS1**)
- `feat(autostart)`: opt-in auto-start registration for Windows, macOS and Linux (issue #2977 **WS2**)
- `feat(audit)`: record and surface what the background service did while unattended (issue #2977 **WS4**)
- `feat(tray)`: small companion panel window opened from the tray (issue #2977 **WS3**)

**All still ship in this release and are changelogged** — they just ship under a patch version rather than `0.56.0`. The release script printed its intended loud `WARNING` for forcing a bump lower than the changesets request.

Flagging this more prominently than the previous two overrides because of what's in it: this is a larger and more user-visible batch than the earlier forced patches — **most of the #2977 tray workstream (WS1–WS4)**, plus default-startup-pane and window-chrome changes. If any of that is meant to land as `0.56.0` instead, say so and I will redo the bump without `--as`; nothing here is hard to reverse before merge.

## Version consistency

`0.55.35 → 0.55.36`. All five locations verified independently after the script's own post-bump check:

| Location | Value |
|---|---|
| `package.json` | 0.55.36 |
| `package-lock.json` (root) | 0.55.36 |
| `Cargo.toml` `[workspace.package]` | 0.55.36 |
| `Cargo.lock` (`agentmux-cef`) | 0.55.36 |
| `VERSION_HISTORY.md` head | `## 0.55.36 — 2026-09-05` |

## Contents

```
fix(agent): provider_flags were dropped from cmd:args on every send
fix(host): gate last-window quit behind background-service mode (tray Workstream 0 prereq #1)
fix(agent-pane): hide the tab strip entirely on a fresh pane, so the picker isn't overlaid by a lone +
feat(window): Chrome-style drag-to-top maximize and border-drag vertical snap
fix(pool): fall back to a fresh window when a promoted pool window never proves its renderer is alive
feat(layout): drop Armory from the default startup panes; CPU now sits above Swarm
fix(tabs): tab bar highlights the clicked tab immediately instead of waiting on the destination pane's reveal
feat(armory): memory file picker is a tile grid, not a dropdown
docs(tray): answer the launcher event-loop assumption from code — no Win32 pump exists
fix(agent): bump the stale fable model pin and stop the picker advertising a model it doesn't select
docs(tray): document the tray-less reopen path for background-service mode
fix(agent): activity dock title no longer over-truncates; fix garbled tail glyph
feat(tray): optional Windows tray icon with graceful quit (issue #2977 WS1)
feat(autostart): opt-in auto-start registration for Windows, macOS and Linux (issue #2977 WS2)
feat(audit): record and surface what the background service did while unattended (issue #2977 WS4)
feat(tray): small companion panel window opened from the tray (issue #2977 WS3)
```

## Notes for review

- No code changes — version files, `VERSION_HISTORY.md`, and the consumed changeset deletions only.
- Branched from `6c3e09400` (current `main`).

<!-- agentmux:agent_id=posa -->
