### PR TITLE
fix(agent): swap remaining tail glyphs from weak-coverage arrow

### DIFF
--- a/.changesets/1788664032-fix-agent-swap-the-remaining-tail-glyphs-from-the-weak-cover-bt9e.md
+++ b/.changesets/1788664032-fix-agent-swap-the-remaining-tail-glyphs-from-the-weak-cover-bt9e.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): swap the remaining tail glyphs from the weak-coverage arrow

--- a/frontend/app/view/agent/components/PaneRow.test.tsx
+++ b/frontend/app/view/agent/components/PaneRow.test.tsx
@@ -23,7 +23,7 @@ describe("PaneRow", () => {
         expect(screen.getByText("⑂")).toBeInTheDocument();
         expect(screen.getByText("pr-422-review")).toBeInTheDocument();
         expect(screen.getByText("[0:42]")).toBeInTheDocument();
-        // Tail is prefixed with the ↳ glyph in the same element.
+        // Tail is prefixed with the → glyph in the same element.
         expect(screen.getByText(/ready on :5173/)).toBeInTheDocument();
     });
 

--- a/frontend/app/view/agent/components/PaneRow.tsx
+++ b/frontend/app/view/agent/components/PaneRow.tsx
@@ -94,7 +94,9 @@ export const PaneRow = (props: PaneRowProps): JSX.Element => {
                     <span class="pane-row-meta">{props.meta}</span>
                 </Show>
                 <Show when={props.tail}>
-                    <span class="pane-row-tail">↳ {props.tail}</span>
+                    {/* U+2192 (→), not U+21B3 (↳) — see
+                        SPEC_ACTIVITY_DOCK_TITLE_WIDTH_AND_TAIL_GLYPH_2026_09_05.md §3.1. */}
+                    <span class="pane-row-tail">→ {props.tail}</span>
                 </Show>
                 <For each={props.actions ?? []}>
                     {(action) => (

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -471,7 +471,9 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                                         class="agent-tool-live-tail"
                                         title={`latest stream output (${chunks.length} chunks)`}
                                     >
-                                        ↳ {lastOutput.content}
+                                        {/* U+2192 (→), not U+21B3 (↳) — see
+                                            SPEC_ACTIVITY_DOCK_TITLE_WIDTH_AND_TAIL_GLYPH_2026_09_05.md §3.1. */}
+                                        → {lastOutput.content}
                                     </span>
                                 );
                             }


### PR DESCRIPTION
## Summary
Follow-up to #2995 (`SPEC_ACTIVITY_DOCK_TITLE_WIDTH_AND_TAIL_GLYPH_2026_09_05.md` §3.1's flagged-but-untouched cases): the same `↳` (U+21B3) glyph, with the same weak font-coverage risk, also appeared in:
- `ToolBlock.tsx`'s tool-call live-tail
- `PaneRow.tsx`'s tail

Swapped both for `→` (U+2192), matching the dock/shell-block fix already shipped in #2995.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — PaneRow/ToolBlock suites (40 tests) pass unchanged (no test asserted the glyph itself; only a stale comment needed updating)
- [ ] Manual verification — not yet confirmed by a human

<!-- agentmux:agent_id=agent3 -->