### PR TITLE
fix(host): publish ipc-port where the launcher reads it under task dev

### DIFF
--- a/.changesets/1788668658-fix-host-publish-the-ipc-port-file-where-the-launcher-reads--dtpk.md
+++ b/.changesets/1788668658-fix-host-publish-the-ipc-port-file-where-the-launcher-reads--dtpk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(host): publish the ipc-port file where the launcher reads it in dev mode

--- a/agentmux-cef/src/lib.rs
+++ b/agentmux-cef/src/lib.rs
@@ -1324,7 +1324,7 @@ pub unsafe extern "system" fn RunWinMain(
 ///
 /// This MUST agree with where the launcher reads it — `paths.data_dir`, used by
 /// `second_instance::forward_host_cmd` (single-instance window forwarding) and
-/// by `tray::windows::service_reachable` (the tray running-indicator). When the
+/// by `tray::windows::service_reachable` (the tray's running-indicator). When the
 /// two diverge the failure is silent: forwarding reports a transient read error
 /// and the tray icon simply claims the service is down forever.
 ///
@@ -1332,8 +1332,8 @@ pub unsafe extern "system" fn RunWinMain(
 /// is a dev build. `AGENTMUX_IPC_HASH` is set by the launcher and by nothing
 /// else (`supervisor/windows.rs`, `supervisor/unix.rs`), and whenever it is
 /// set, `AGENTMUX_DATA_DIR` came from that same launcher via
-/// `paths.common.to_env_vars()` — so it is that instance own data dir, not
-/// some other instance one.
+/// `paths.common.to_env_vars()` — so it is that instance's own data dir, not
+/// some other instance's.
 ///
 /// Keying on `is_dev_build_exe` instead was wrong, on a premise stated in the
 /// old comment: "in dev mode there is no launcher". `task dev` DOES run the
@@ -1357,7 +1357,7 @@ fn port_file_dir(
         // A launcher spawned us: its data dir is authoritative, dev or not.
         (true, Some(dir)) => dir,
         // No launcher (or it told us nothing): a dev build must not touch the
-        // inherited parent instance port file.
+        // inherited parent instance's port file.
         (_, inherited) => {
             if is_dev_build {
                 host_data_dir.to_path_buf()
@@ -1379,7 +1379,7 @@ mod port_file_dir_tests {
 
     /// The bug this function exists to fix. Under `task dev` a launcher IS
     /// present, so the port file must go where the launcher reads it —
-    /// otherwise the tray running-indicator is stuck false forever.
+    /// otherwise the tray's running-indicator is stuck false forever.
     #[test]
     fn a_dev_build_under_a_launcher_writes_where_the_launcher_reads() {
         assert_eq!(
@@ -1394,8 +1394,8 @@ mod port_file_dir_tests {
     }
 
     /// The hazard the old dev branch was protecting against, kept intact:
-    /// `dev:standalone` inherits the PARENT instance `AGENTMUX_DATA_DIR`, and
-    /// writing there would break that parent single-instance forwarding.
+    /// `dev:standalone` inherits the PARENT instance's `AGENTMUX_DATA_DIR`, and
+    /// writing there would break that parent's single-instance forwarding.
     #[test]
     fn a_standalone_dev_build_does_not_clobber_the_parent_instances_port_file() {
         assert_eq!(

--- a/agentmux-cef/src/lib.rs
+++ b/agentmux-cef/src/lib.rs
@@ -615,15 +615,15 @@ pub fn run(windows_sandbox_info: *mut std::ffi::c_void) -> i32 {
     // Dev builds inherit AGENTMUX_DATA_DIR from the parent pane they were
     // launched from. Writing ipc-port there would overwrite the parent
     // instance's port:token and break its single-instance forwarding.
-    // In dev mode there is no launcher so port forwarding isn't wired
-    // anyway — use the dev data dir directly.
-    let port_file_dir = if agentmux_common::is_dev_build_exe(&host_exe_dir) {
-        data_dir.clone()
-    } else {
-        std::env::var_os("AGENTMUX_DATA_DIR")
-            .map(std::path::PathBuf::from)
-            .unwrap_or_else(|| data_dir.clone())
-    };
+    // That hazard is real ONLY when no launcher spawned us; see
+    // `port_file_dir` for why the launcher's presence is the deciding
+    // factor rather than "is this a dev build".
+    let port_file_dir = port_file_dir(
+        std::env::var_os("AGENTMUX_IPC_HASH").is_some_and(|h| !h.is_empty()),
+        std::env::var_os("AGENTMUX_DATA_DIR").map(std::path::PathBuf::from),
+        agentmux_common::is_dev_build_exe(&host_exe_dir),
+        &data_dir,
+    );
     let _ = std::fs::create_dir_all(&port_file_dir);
     // Use a version-scoped filename so two concurrent release versions
     // don't overwrite each other's port file (codex P1 on #1227).
@@ -1320,3 +1320,111 @@ pub unsafe extern "system" fn RunWinMain(
     run(sandbox_info)
 }
 
+/// Which directory the host publishes its `ipc-port-<hash>` file into.
+///
+/// This MUST agree with where the launcher reads it — `paths.data_dir`, used by
+/// `second_instance::forward_host_cmd` (single-instance window forwarding) and
+/// by `tray::windows::service_reachable` (the tray running-indicator). When the
+/// two diverge the failure is silent: forwarding reports a transient read error
+/// and the tray icon simply claims the service is down forever.
+///
+/// The deciding factor is **whether a launcher spawned us**, not whether this
+/// is a dev build. `AGENTMUX_IPC_HASH` is set by the launcher and by nothing
+/// else (`supervisor/windows.rs`, `supervisor/unix.rs`), and whenever it is
+/// set, `AGENTMUX_DATA_DIR` came from that same launcher via
+/// `paths.common.to_env_vars()` — so it is that instance own data dir, not
+/// some other instance one.
+///
+/// Keying on `is_dev_build_exe` instead was wrong, on a premise stated in the
+/// old comment: "in dev mode there is no launcher". `task dev` DOES run the
+/// launcher — only `task dev:standalone` bypasses it. So a dev build under a
+/// launcher wrote the port file to its host-local data dir while the launcher
+/// looked in the instance data dir, and the tray indicator was stuck at "not
+/// running" for the whole session. Verified live, not theorised: the file
+/// landed in `<instance>/cef-cache/` while the tray probed `<instance>/data/`.
+///
+/// The parent-pane hazard the old branch guarded against is still guarded:
+/// with no launcher there is no `AGENTMUX_IPC_HASH`, so a dev build falls
+/// through to its own data dir and cannot clobber the port file of the parent
+/// AgentMux instance whose env it inherited.
+fn port_file_dir(
+    launcher_managed: bool,
+    env_data_dir: Option<std::path::PathBuf>,
+    is_dev_build: bool,
+    host_data_dir: &std::path::Path,
+) -> std::path::PathBuf {
+    match (launcher_managed, env_data_dir) {
+        // A launcher spawned us: its data dir is authoritative, dev or not.
+        (true, Some(dir)) => dir,
+        // No launcher (or it told us nothing): a dev build must not touch the
+        // inherited parent instance port file.
+        (_, inherited) => {
+            if is_dev_build {
+                host_data_dir.to_path_buf()
+            } else {
+                inherited.unwrap_or_else(|| host_data_dir.to_path_buf())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod port_file_dir_tests {
+    use super::port_file_dir;
+    use std::path::{Path, PathBuf};
+
+    fn p(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+
+    /// The bug this function exists to fix. Under `task dev` a launcher IS
+    /// present, so the port file must go where the launcher reads it —
+    /// otherwise the tray running-indicator is stuck false forever.
+    #[test]
+    fn a_dev_build_under_a_launcher_writes_where_the_launcher_reads() {
+        assert_eq!(
+            port_file_dir(
+                true,
+                Some(p("/instance/data")),
+                true,
+                Path::new("/instance/cef-cache")
+            ),
+            p("/instance/data")
+        );
+    }
+
+    /// The hazard the old dev branch was protecting against, kept intact:
+    /// `dev:standalone` inherits the PARENT instance `AGENTMUX_DATA_DIR`, and
+    /// writing there would break that parent single-instance forwarding.
+    #[test]
+    fn a_standalone_dev_build_does_not_clobber_the_parent_instances_port_file() {
+        assert_eq!(
+            port_file_dir(false, Some(p("/parent/data")), true, Path::new("/dev/cef-cache")),
+            p("/dev/cef-cache")
+        );
+    }
+
+    #[test]
+    fn a_release_build_uses_the_launcher_supplied_data_dir() {
+        assert_eq!(
+            port_file_dir(true, Some(p("/prod/data")), false, Path::new("/prod/cef-cache")),
+            p("/prod/data")
+        );
+    }
+
+    /// An absent/empty `AGENTMUX_IPC_HASH` means no launcher, so a release
+    /// build still honours an inherited data dir rather than losing it.
+    #[test]
+    fn a_release_build_without_a_launcher_still_honours_the_env_data_dir() {
+        assert_eq!(
+            port_file_dir(false, Some(p("/prod/data")), false, Path::new("/prod/cef-cache")),
+            p("/prod/data")
+        );
+    }
+
+    #[test]
+    fn nothing_configured_falls_back_to_the_host_data_dir() {
+        assert_eq!(port_file_dir(true, None, false, Path::new("/fallback")), p("/fallback"));
+        assert_eq!(port_file_dir(false, None, true, Path::new("/fallback")), p("/fallback"));
+    }
+}


### PR DESCRIPTION
## Summary

Found while running `task dev` to visually verify the tray from #2996 (issue #2977 WS1). The icon rendered fine, but its running-indicator was stuck at "not running" for the entire session — even though `srv` came up one second later.

The host picked the port-file directory by asking *"am I a dev build"*, on a premise stated in the comment itself:

> In dev mode there is no launcher so port forwarding isn't wired anyway

That premise is false. **`task dev` does run the launcher** — only `task dev:standalone` bypasses it. So under `task dev` the host wrote `<instance>/cef-cache/ipc-port-<hash>` while the launcher read `<instance>/data/ipc-port-<hash>`.

Both consumers of that file failed silently:
- `tray::windows::service_reachable` → the icon claims the service is down, forever. Which is a bad failure for this particular icon: WS4's whole justification for it is that it must be a *reliable* "is it actually running" indicator, and it was reliably wrong.
- `second_instance::forward_host_cmd` → the tray's **Open Window** / **Show Panel** actions cannot reach the host.

## The fix

The deciding factor is whether a **launcher** spawned us, not whether this is a dev build. `AGENTMUX_IPC_HASH` is set by the launcher and by nothing else (`supervisor/windows.rs`, `supervisor/unix.rs`), and whenever it is set, `AGENTMUX_DATA_DIR` came from that same launcher via `paths.common.to_env_vars()` — so it is that instance's own data dir, not another instance's.

**The hazard the old branch guarded against is preserved**, and covered by its own test: a dev build with *no* launcher still writes to its host-local dir, so it cannot clobber the port file of the parent AgentMux instance whose env it inherited (`dev:standalone`).

Extracted as a pure function so all five cases are covered without mutating process env in tests.

## Verification

Falsified rather than assumed — restoring the `is_dev_build`-only logic fails exactly one test:

```
a_dev_build_under_a_launcher_writes_where_the_launcher_reads
  left: "/instance/cef-cache"
 right: "/instance/data"
```

Those are the same two paths I observed on disk. The parent-clobber test still passes under the broken version, which confirms the two concerns are independently covered rather than one test doing both jobs.

**Also verified live, which is how it was found in the first place.** Before:

```
tray: icon created (service_reachable=false); entering message pump
   (…nothing further, for the whole session)
```

After:

```
tray: icon created (service_reachable=false); entering message pump
tray: service_reachable -> true
```

— one `STATUS_POLL` interval later, and the port file now lands in `<instance>/data/`.

`cef 384 passed`, `launcher 231 passed`.

## Note for #2977

This is a prerequisite for anyone verifying WS1's remaining (visual) acceptance criteria, since `task dev` is the natural way to do it and the indicator was misleading there. Separately, that same run produced the first runtime confirmation that the tray works at all on Windows: `tray: icon created (…); entering message pump` — the launcher has no Win32 message pump of its own, so this was the one genuinely unverified architectural assumption in the design.

<!-- agentmux:agent_id=agent5 -->
