### PR TITLE
Posa@Area54: fix(swarm): subagents that returned are no longer reported as interrupted

### DIFF
--- a/.changesets/1788681796-fix-swarm-subagents-that-returned-are-no-longer-reported-as--4c4g.md
+++ b/.changesets/1788681796-fix-swarm-subagents-that-returned-are-no-longer-reported-as--4c4g.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(swarm): subagents that returned are no longer reported as interrupted

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -3027,10 +3027,31 @@ impl PersistentSubprocessController {
                         // `global()` is `None` in tests that don't call
                         // `subagent_watcher::set_global` — a safe no-op, same
                         // pattern `process_tracker::registry` already uses.
+                        //
+                        // On a BLOCKING thread, not this one. Reconciliation
+                        // used to be a pure in-memory status flip under a
+                        // mutex (O(1)), but as of the completion-detection
+                        // fix (#3007) it reads the parent transcript from
+                        // disk — routinely tens of MB, plus per-line JSON
+                        // parsing — to decide whether each member actually
+                        // returned. Doing that inline would block a tokio
+                        // worker thread for the whole read, and this fires on
+                        // EVERY turn-end, so several blocks finishing at once
+                        // could stall the runtime (reagent P1 on #3007).
+                        //
+                        // Fire-and-forget: the result is a status correction
+                        // broadcast to whoever's listening, not something this
+                        // stdout-reader task consumes, so there is nothing to
+                        // await. The backfill call site (`scan_session_
+                        // subagents`) needs no equivalent — it already runs in
+                        // a blocking context that walks up to 200 files.
                         let session_id_snapshot = inner_read.lock().unwrap().session_id.clone();
                         if let Some(sid) = session_id_snapshot {
                             if let Some(watcher) = subagent_watcher::global() {
-                                watcher.reconcile_stale_subagents(&block_id_read, &sid);
+                                let block_id = block_id_read.clone();
+                                tokio::task::spawn_blocking(move || {
+                                    watcher.reconcile_stale_subagents(&block_id, &sid);
+                                });
                             }
                         }
                     }

--- a/agentmux-srv/src/backend/subagent_watcher/completion.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/completion.rs
@@ -1,0 +1,260 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Did this subagent actually finish, or was it cut off?
+//!
+//! `SubAgentStatus::Abandoned` is — as its own doc comment says —  "always an
+//! inference, never an observation". Until this module existed, the inference
+//! was "the subagent transcript has no terminal `Result` line, therefore it was
+//! interrupted" (`scan.rs::reconcile_stale_subagents`). That premise does not
+//! hold: **no AgentMux transcript contains a `"type":"result"` line at all** —
+//! not the subagent sidechain files, not the parent session file. The line type
+//! the old check waited for is absent from the format this deployment writes
+//! (`entrypoint: sdk-cli`), so `SubAgentStatus::Completed` was unreachable and
+//! every Agent-tool dispatch ended up displayed as "interrupted", including the
+//! ones that returned full results the parent went on to use.
+//!
+//! Evidence and the full chain:
+//! `docs/reports/REPORT_SUBAGENT_COMPLETION_NEVER_DETECTED_2026_09_05.md`.
+//!
+//! The replacement uses the strongest evidence available, and it is an
+//! *observation* rather than an inference: the parent's own `tool_result` for
+//! the dispatch's `tool_use_id`. If the parent recorded a result, the subagent
+//! demonstrably returned — whatever its transcript does or doesn't end with.
+//! The correlation key is already on disk: Claude Code writes an
+//! `agent-<id>.meta.json` sidecar next to each subagent transcript carrying the
+//! parent-side `toolUseId`.
+//!
+//! Deliberately kept free of watcher state so the decision is unit-testable on
+//! its own — the same reasoning that split `parse.rs` out.
+
+use std::collections::HashMap;
+use std::io::BufRead;
+use std::path::{Path, PathBuf};
+
+use super::types::SubAgentStatus;
+
+/// One subagent's `.meta.json` sidecar. Only the field we correlate on is
+/// modelled; the sidecar also carries `agentType`/`description`/`spawnDepth`/
+/// `model`, which this module has no use for. `serde` ignores the rest.
+#[derive(Debug, serde::Deserialize)]
+struct SubagentMeta {
+    #[serde(rename = "toolUseId")]
+    tool_use_id: Option<String>,
+}
+
+/// The parent-side `tool_use_id` for a subagent transcript, read from its
+/// sidecar. `None` when there is no sidecar, it is unreadable, it is malformed,
+/// or it predates the field — all of which must degrade to the old
+/// conservative behaviour rather than erroring.
+pub(super) fn tool_use_id_for(subagent_jsonl: &Path) -> Option<String> {
+    let meta_path = sidecar_path(subagent_jsonl)?;
+    let raw = std::fs::read_to_string(meta_path).ok()?;
+    serde_json::from_str::<SubagentMeta>(&raw).ok()?.tool_use_id
+}
+
+/// `…/agent-<id>.jsonl` → `…/agent-<id>.meta.json`.
+fn sidecar_path(subagent_jsonl: &Path) -> Option<PathBuf> {
+    let stem = subagent_jsonl.file_stem()?.to_str()?;
+    Some(subagent_jsonl.with_file_name(format!("{stem}.meta.json")))
+}
+
+/// The parent session transcript for a subagent transcript.
+///
+/// Claude Code lays these out as `…/<session-id>.jsonl` alongside a
+/// `…/<session-id>/subagents/agent-<id>.jsonl` tree, so the parent is the
+/// grandparent directory's path plus `.jsonl`. Returns `None` if the path
+/// isn't that shape, rather than guessing.
+pub(super) fn parent_transcript_for(subagent_jsonl: &Path) -> Option<PathBuf> {
+    let subagents_dir = subagent_jsonl.parent()?;
+    if subagents_dir.file_name()?.to_str()? != "subagents" {
+        return None;
+    }
+    let session_dir = subagents_dir.parent()?;
+    let session_id = session_dir.file_name()?.to_str()?;
+    Some(session_dir.with_file_name(format!("{session_id}.jsonl")))
+}
+
+/// Every `tool_use_id` the parent transcript has recorded a `tool_result` for,
+/// mapped to that result's `is_error` flag.
+///
+/// Scanned once per reconcile pass rather than once per subagent: a parent
+/// transcript is routinely tens of MB (26 MB / 15k lines on the session that
+/// surfaced this), and the reconcile loop can hold many subagents. The cheap
+/// `contains` pre-filter keeps the JSON parse off the ~99% of lines that carry
+/// no tool result at all.
+pub(super) fn parent_tool_results(reader: impl BufRead) -> HashMap<String, bool> {
+    let mut out = HashMap::new();
+    for line in reader.lines().map_while(Result::ok) {
+        if !line.contains("tool_use_id") {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        let Some(content) = value
+            .get("message")
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_array())
+        else {
+            continue;
+        };
+        for block in content {
+            if block.get("type").and_then(|t| t.as_str()) != Some("tool_result") {
+                continue;
+            }
+            let Some(id) = block.get("tool_use_id").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let is_error = block
+                .get("is_error")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false);
+            out.insert(id.to_string(), is_error);
+        }
+    }
+    out
+}
+
+/// Read the parent transcript for `subagent_jsonl`'s session, if it can be
+/// located and opened. An unreadable/absent parent yields an empty map, which
+/// makes [`terminal_status`] fall back to the old `Abandoned` inference for
+/// every member — conservative, and identical to pre-fix behaviour.
+pub(super) fn parent_tool_results_for(subagent_jsonl: &Path) -> HashMap<String, bool> {
+    let Some(parent) = parent_transcript_for(subagent_jsonl) else {
+        return HashMap::new();
+    };
+    let Ok(file) = std::fs::File::open(parent) else {
+        return HashMap::new();
+    };
+    parent_tool_results(std::io::BufReader::new(file))
+}
+
+/// What an `Active` subagent's status should become once its parent turn is
+/// confirmed idle.
+///
+/// `Completed` when the parent recorded a `tool_result` for this dispatch —
+/// proof it returned. `Abandoned` otherwise, which now means what it always
+/// claimed to: no evidence it ever came back.
+///
+/// **An errored result still counts as `Completed`.** The distinction this
+/// draws is *returned* vs *cut off*, and a dispatch that reported an error
+/// returned. Folding failures into `Abandoned` would recreate the same
+/// conflation this fix exists to remove, just with a smaller blast radius.
+/// Surfacing the error state itself needs a status the enum doesn't have yet
+/// (and a matching frontend union) — tracked as follow-up in the report above;
+/// `is_error` is logged at the call site meanwhile so it isn't silently lost.
+pub(super) fn terminal_status(
+    tool_use_id: Option<&str>,
+    parent_results: &HashMap<String, bool>,
+) -> SubAgentStatus {
+    match tool_use_id {
+        Some(id) if parent_results.contains_key(id) => SubAgentStatus::Completed,
+        _ => SubAgentStatus::Abandoned,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    // Shapes below are taken from the real transcripts that surfaced this bug
+    // (manoz session 468e2051…), not invented.
+
+    #[test]
+    fn parent_transcript_sits_beside_the_session_dir() {
+        let sub = Path::new("/p/C--proj/468e2051-abc/subagents/agent-a5cb.jsonl");
+        assert_eq!(
+            parent_transcript_for(sub),
+            Some(PathBuf::from("/p/C--proj/468e2051-abc.jsonl"))
+        );
+    }
+
+    #[test]
+    fn a_path_that_is_not_in_a_subagents_dir_is_not_guessed_at() {
+        // Better to decline than to invent a parent path and read some
+        // unrelated file as if it were the session transcript.
+        let sub = Path::new("/p/C--proj/468e2051-abc/agent-a5cb.jsonl");
+        assert_eq!(parent_transcript_for(sub), None);
+    }
+
+    #[test]
+    fn sidecar_sits_beside_the_transcript() {
+        assert_eq!(
+            sidecar_path(Path::new("/x/subagents/agent-a5cb.jsonl")),
+            Some(PathBuf::from("/x/subagents/agent-a5cb.meta.json"))
+        );
+    }
+
+    #[test]
+    fn collects_tool_result_ids_with_their_error_flag() {
+        let lines = r#"
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_ok","is_error":false,"content":"done"}]}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_bad","is_error":true,"content":"boom"}]}}
+"#;
+        let got = parent_tool_results(Cursor::new(lines));
+        assert_eq!(got.get("toolu_ok"), Some(&false));
+        assert_eq!(got.get("toolu_bad"), Some(&true));
+        assert_eq!(got.len(), 2);
+    }
+
+    #[test]
+    fn a_missing_is_error_flag_reads_as_success() {
+        // Real results routinely omit it; absent must not read as failure.
+        let line = r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_x","content":"ok"}]}}"#;
+        assert_eq!(parent_tool_results(Cursor::new(line)).get("toolu_x"), Some(&false));
+    }
+
+    #[test]
+    fn ignores_tool_use_lines_and_other_noise() {
+        // A `tool_use` line mentions no tool_use_id and must not be mistaken
+        // for evidence that the call came BACK.
+        let lines = r#"
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_x","name":"Agent","input":{}}]}}
+{"type":"queue-operation","operation":"enqueue","content":"u there"}
+not json at all
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}
+"#;
+        assert!(parent_tool_results(Cursor::new(lines)).is_empty());
+    }
+
+    #[test]
+    fn a_returned_dispatch_is_completed() {
+        let mut results = HashMap::new();
+        results.insert("toolu_ok".to_string(), false);
+        assert_eq!(
+            terminal_status(Some("toolu_ok"), &results),
+            SubAgentStatus::Completed
+        );
+    }
+
+    #[test]
+    fn an_errored_dispatch_still_returned_so_it_is_completed() {
+        // Returned-vs-cut-off is the distinction; an error is a return.
+        let mut results = HashMap::new();
+        results.insert("toolu_bad".to_string(), true);
+        assert_eq!(
+            terminal_status(Some("toolu_bad"), &results),
+            SubAgentStatus::Completed
+        );
+    }
+
+    #[test]
+    fn a_dispatch_with_no_parent_result_is_genuinely_abandoned() {
+        // The case the old code assumed was universal — still handled.
+        assert_eq!(
+            terminal_status(Some("toolu_never_returned"), &HashMap::new()),
+            SubAgentStatus::Abandoned
+        );
+    }
+
+    #[test]
+    fn an_unknown_tool_use_id_falls_back_to_the_old_inference() {
+        // No sidecar / older layout: must degrade to prior behaviour rather
+        // than optimistically completing something we cannot correlate.
+        let mut results = HashMap::new();
+        results.insert("toolu_ok".to_string(), false);
+        assert_eq!(terminal_status(None, &results), SubAgentStatus::Abandoned);
+    }
+}

--- a/agentmux-srv/src/backend/subagent_watcher/completion.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/completion.rs
@@ -156,9 +156,14 @@ pub(super) fn parent_tool_results_at(parent_jsonl: &Path) -> HashMap<String, boo
 /// draws is *returned* vs *cut off*, and a dispatch that reported an error
 /// returned. Folding failures into `Abandoned` would recreate the same
 /// conflation this fix exists to remove, just with a smaller blast radius.
+///
 /// Surfacing the error state itself needs a status the enum doesn't have yet
-/// (and a matching frontend union) — tracked as follow-up in the report above;
-/// `is_error` is logged at the call site meanwhile so it isn't silently lost.
+/// (and a matching frontend union) — tracked as follow-up in the report above.
+/// **Nothing reads the `is_error` flag today** — this function only asks
+/// `contains_key`. It is parsed and carried in `parent_results` purely so the
+/// follow-up has it available without re-reading every transcript; do not
+/// mistake that for it being surfaced or logged anywhere (reagent P2 on
+/// #3007, on an earlier version of this comment that claimed otherwise).
 pub(super) fn terminal_status(
     tool_use_id: Option<&str>,
     parent_results: &HashMap<String, bool>,

--- a/agentmux-srv/src/backend/subagent_watcher/completion.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/completion.rs
@@ -62,14 +62,26 @@ fn sidecar_path(subagent_jsonl: &Path) -> Option<PathBuf> {
 /// The parent session transcript for a subagent transcript.
 ///
 /// Claude Code lays these out as `…/<session-id>.jsonl` alongside a
-/// `…/<session-id>/subagents/agent-<id>.jsonl` tree, so the parent is the
-/// grandparent directory's path plus `.jsonl`. Returns `None` if the path
-/// isn't that shape, rather than guessing.
+/// `…/<session-id>/subagents/` tree, but members are NOT all at the same
+/// depth inside it (`scan_subagents_dir`'s own doc comment):
+///
+/// ```text
+/// <session-id>/subagents/agent-<id>.jsonl                      ← Task-tool (solo)
+/// <session-id>/subagents/workflows/<run-id>/agent-<id>.jsonl   ← Workflow-tool member
+/// ```
+///
+/// So this walks up to the `subagents` directory rather than assuming it is
+/// the immediate parent. Checking only the immediate parent silently excluded
+/// every Workflow-tool member — they could never resolve a completion and
+/// stayed permanently "interrupted", i.e. exactly the bug this module exists
+/// to fix, left unfixed for that dispatch kind (reagent P1 on #3007).
+///
+/// Returns `None` when there is no `subagents` ancestor at all, rather than
+/// guessing at a path and reading some unrelated file as a transcript.
 pub(super) fn parent_transcript_for(subagent_jsonl: &Path) -> Option<PathBuf> {
-    let subagents_dir = subagent_jsonl.parent()?;
-    if subagents_dir.file_name()?.to_str()? != "subagents" {
-        return None;
-    }
+    let subagents_dir = subagent_jsonl
+        .ancestors()
+        .find(|a| a.file_name().and_then(|n| n.to_str()) == Some("subagents"))?;
     let session_dir = subagents_dir.parent()?;
     let session_id = session_dir.file_name()?.to_str()?;
     Some(session_dir.with_file_name(format!("{session_id}.jsonl")))
@@ -78,11 +90,12 @@ pub(super) fn parent_transcript_for(subagent_jsonl: &Path) -> Option<PathBuf> {
 /// Every `tool_use_id` the parent transcript has recorded a `tool_result` for,
 /// mapped to that result's `is_error` flag.
 ///
-/// Scanned once per reconcile pass rather than once per subagent: a parent
-/// transcript is routinely tens of MB (26 MB / 15k lines on the session that
-/// surfaced this), and the reconcile loop can hold many subagents. The cheap
-/// `contains` pre-filter keeps the JSON parse off the ~99% of lines that carry
-/// no tool result at all.
+/// The caller reads once per DISTINCT parent transcript, not once per
+/// subagent: a transcript is routinely tens of MB (26 MB / 15k lines on the
+/// session that surfaced this) and a pass can hold many members, but they do
+/// not all resolve to the same parent (see [`parent_transcript_for`]). The
+/// cheap `contains` pre-filter keeps the JSON parse off the ~99% of lines that
+/// carry no tool result at all.
 pub(super) fn parent_tool_results(reader: impl BufRead) -> HashMap<String, bool> {
     let mut out = HashMap::new();
     for line in reader.lines().map_while(Result::ok) {
@@ -116,15 +129,17 @@ pub(super) fn parent_tool_results(reader: impl BufRead) -> HashMap<String, bool>
     out
 }
 
-/// Read the parent transcript for `subagent_jsonl`'s session, if it can be
-/// located and opened. An unreadable/absent parent yields an empty map, which
-/// makes [`terminal_status`] fall back to the old `Abandoned` inference for
-/// every member — conservative, and identical to pre-fix behaviour.
-pub(super) fn parent_tool_results_for(subagent_jsonl: &Path) -> HashMap<String, bool> {
-    let Some(parent) = parent_transcript_for(subagent_jsonl) else {
-        return HashMap::new();
-    };
-    let Ok(file) = std::fs::File::open(parent) else {
+/// Read an already-resolved parent transcript. An unreadable/absent file
+/// yields an empty map, which makes [`terminal_status`] fall back to the old
+/// `Abandoned` inference — conservative, and identical to pre-fix behaviour.
+///
+/// Takes the resolved path rather than a subagent path so the caller can
+/// cache one read per distinct parent: members of a reconcile pass do not all
+/// resolve to the same transcript (see [`parent_transcript_for`]), so
+/// resolving once from an arbitrary member and reusing it for the rest is
+/// wrong — that was reagent's P1 on #3007.
+pub(super) fn parent_tool_results_at(parent_jsonl: &Path) -> HashMap<String, bool> {
+    let Ok(file) = std::fs::File::open(parent_jsonl) else {
         return HashMap::new();
     };
     parent_tool_results(std::io::BufReader::new(file))
@@ -169,6 +184,30 @@ mod tests {
             parent_transcript_for(sub),
             Some(PathBuf::from("/p/C--proj/468e2051-abc.jsonl"))
         );
+    }
+
+    #[test]
+    fn a_workflow_member_resolves_to_the_same_session_transcript() {
+        // Workflow-tool members sit one level deeper than Task-tool ones
+        // (subagents/workflows/<run-id>/). Requiring `subagents` to be the
+        // IMMEDIATE parent excluded every one of them, so they could never
+        // resolve a completion and stayed permanently "interrupted" —
+        // reagent P1 on #3007. No fixture on the dev machine had a workflow
+        // run, which is why the original tests missed it.
+        let sub = Path::new("/p/C--proj/468e2051-abc/subagents/workflows/wf_9/agent-a5cb.jsonl");
+        assert_eq!(
+            parent_transcript_for(sub),
+            Some(PathBuf::from("/p/C--proj/468e2051-abc.jsonl"))
+        );
+    }
+
+    #[test]
+    fn solo_and_workflow_members_of_one_session_agree_on_the_parent() {
+        // The mixed-batch case: both must resolve to the SAME transcript, or
+        // a pass containing both silently mis-resolves half of them.
+        let solo = Path::new("/p/C--proj/sess-1/subagents/agent-solo.jsonl");
+        let member = Path::new("/p/C--proj/sess-1/subagents/workflows/wf_1/agent-m.jsonl");
+        assert_eq!(parent_transcript_for(solo), parent_transcript_for(member));
     }
 
     #[test]

--- a/agentmux-srv/src/backend/subagent_watcher/mod.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/mod.rs
@@ -53,6 +53,7 @@
 //! `SubagentWatcher` struct definition and its lifecycle methods (`new`/
 //! `spawn`/`watch_agent`/`unwatch_agent`/`prune_block*`).
 
+mod completion;
 mod jsonl;
 mod parse;
 mod query;

--- a/agentmux-srv/src/backend/subagent_watcher/scan.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/scan.rs
@@ -293,18 +293,31 @@ impl SubagentWatcher {
                     })
                     .unwrap_or_default()
             };
-            // One parent-transcript read for the whole pass, not one per
-            // member — they all share a session, so they all share a parent.
-            let parent_results = candidates
-                .first()
-                .map(|(_, path)| completion::parent_tool_results_for(path))
-                .unwrap_or_default();
+            // Each candidate resolves its OWN parent transcript, with reads
+            // cached per distinct path. Resolving once from an arbitrary
+            // member and reusing it for the rest was wrong twice over
+            // (reagent P1 on #3007): Workflow-tool members sit one level
+            // deeper (`subagents/workflows/<run-id>/`) so they don't all
+            // share a resolution, and `candidates` comes from a HashMap with
+            // unspecified iteration order — so in a mixed batch an
+            // unresolvable member landing first would zero the map and drag
+            // every Solo member into `Abandoned` too, non-deterministically.
+            let mut results_by_parent: HashMap<PathBuf, HashMap<String, bool>> = HashMap::new();
             candidates
                 .into_iter()
                 .map(|(agent_id, path)| {
-                    let tool_use_id = completion::tool_use_id_for(&path);
-                    let status =
-                        completion::terminal_status(tool_use_id.as_deref(), &parent_results);
+                    let status = match completion::parent_transcript_for(&path) {
+                        Some(parent) => {
+                            let results = results_by_parent
+                                .entry(parent.clone())
+                                .or_insert_with(|| completion::parent_tool_results_at(&parent));
+                            let tool_use_id = completion::tool_use_id_for(&path);
+                            completion::terminal_status(tool_use_id.as_deref(), results)
+                        }
+                        // No `subagents` ancestor — unrecognised layout.
+                        // Fall back to the historical inference.
+                        None => SubAgentStatus::Abandoned,
+                    };
                     (agent_id, status)
                 })
                 .collect()

--- a/agentmux-srv/src/backend/subagent_watcher/scan.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/scan.rs
@@ -12,6 +12,7 @@ use std::path::{Path, PathBuf};
 
 use serde_json::json;
 
+use super::completion;
 use super::parse::file_mtime;
 use super::types::*;
 use super::SubagentWatcher;
@@ -253,8 +254,65 @@ impl SubagentWatcher {
         // (dispatch_id, status) for this block — not just the ones just
         // reconciled — so the Workflow-dispatch aggregation pass below has
         // the full picture per dispatch_id, not just this pass's deltas.
-        let (reconciled_agent_ids, member_statuses_by_dispatch): (
+        // Which of this block's still-`Active` members actually RETURNED.
+        //
+        // Until this existed, every one of them was downgraded to `Abandoned`
+        // on the reasoning that a subagent file without a terminal `Result`
+        // line must have been cut off. That premise is false: AgentMux
+        // transcripts contain no `"type":"result"` line at all, so the
+        // inference fired on healthy dispatches too and the Swarm pane showed
+        // successful Agent-tool calls as "interrupted". `completion.rs` asks a
+        // question the format can actually answer — did the PARENT record a
+        // `tool_result` for this dispatch's `tool_use_id`. See
+        // docs/reports/REPORT_SUBAGENT_COMPLETION_NEVER_DETECTED_2026_09_05.md.
+        //
+        // Resolved BEFORE taking the `sessions` lock, and in two phases: read
+        // the candidate list under a short lock, do the file IO (a parent
+        // transcript is routinely tens of MB) unlocked, then apply. This
+        // function is deliberately careful not to hold that mutex across
+        // anything slow — see the scoping comment below. The apply pass
+        // re-checks `Active`, so a member whose status moved in between is
+        // left alone rather than clobbered by a stale decision.
+        let resolved_statuses: HashMap<String, SubAgentStatus> = {
+            let candidates: Vec<(String, PathBuf)> = {
+                let sessions = self.sessions.lock().unwrap();
+                sessions
+                    .get(session_id)
+                    .map(|session| {
+                        session
+                            .subagents
+                            .values()
+                            .filter(|s| {
+                                s.info.parent_block_id == parent_block_id
+                                    && s.info.status == SubAgentStatus::Active
+                            })
+                            .map(|s| {
+                                (s.info.agent_id.clone(), PathBuf::from(&s.info.jsonl_path))
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            };
+            // One parent-transcript read for the whole pass, not one per
+            // member — they all share a session, so they all share a parent.
+            let parent_results = candidates
+                .first()
+                .map(|(_, path)| completion::parent_tool_results_for(path))
+                .unwrap_or_default();
+            candidates
+                .into_iter()
+                .map(|(agent_id, path)| {
+                    let tool_use_id = completion::tool_use_id_for(&path);
+                    let status =
+                        completion::terminal_status(tool_use_id.as_deref(), &parent_results);
+                    (agent_id, status)
+                })
+                .collect()
+        };
+
+        let (reconciled_agent_ids, completed_members, member_statuses_by_dispatch): (
             Vec<String>,
+            Vec<(String, String, usize)>,
             HashMap<String, Vec<SubAgentStatus>>,
         ) = {
             let mut sessions = self.sessions.lock().unwrap();
@@ -270,6 +328,7 @@ impl SubagentWatcher {
             // owns (mirrors unwatch_agent's own parent-scoped filter). Reagent
             // P1 on PR #2131.
             let mut reconciled_agent_ids = Vec::new();
+            let mut completed_members: Vec<(String, String, usize)> = Vec::new();
             let mut member_statuses_by_dispatch: HashMap<String, Vec<SubAgentStatus>> =
                 std::collections::HashMap::new();
             for state in session.subagents.values_mut() {
@@ -277,7 +336,34 @@ impl SubagentWatcher {
                     continue;
                 }
                 if state.info.status == SubAgentStatus::Active {
-                    state.info.status = SubAgentStatus::Abandoned;
+                    // Absent a resolution (no sidecar, unreadable parent, an
+                    // entry that appeared after the snapshot above) fall back
+                    // to the historical `Abandoned` — never optimistically
+                    // complete something we could not correlate.
+                    let resolved = resolved_statuses
+                        .get(&state.info.agent_id)
+                        .cloned()
+                        .unwrap_or(SubAgentStatus::Abandoned);
+                    state.info.status = resolved.clone();
+                    if resolved == SubAgentStatus::Completed {
+                        tracing::info!(
+                            agent_id = %state.info.agent_id,
+                            parent_block_id = %parent_block_id,
+                            session_id = %session_id,
+                            dispatch_id = %state.info.dispatch_id,
+                            "subagent reconciled: active -> completed (parent recorded a tool_result)"
+                        );
+                        completed_members.push((
+                            state.info.agent_id.clone(),
+                            state.info.dispatch_id.clone(),
+                            state.info.event_count,
+                        ));
+                        member_statuses_by_dispatch
+                            .entry(state.info.dispatch_id.clone())
+                            .or_default()
+                            .push(state.info.status.clone());
+                        continue;
+                    }
                     reconciled_agent_ids.push(state.info.agent_id.clone());
                     // Every field a NAME-based grouping/dedup bug needs to
                     // reconstruct offline: which subagent, which dispatch,
@@ -298,8 +384,23 @@ impl SubagentWatcher {
                     .or_default()
                     .push(state.info.status.clone());
             }
-            (reconciled_agent_ids, member_statuses_by_dispatch)
+            (
+                reconciled_agent_ids,
+                completed_members,
+                member_statuses_by_dispatch,
+            )
         };
+        // Push the corrections the same way the abandoned ones are pushed —
+        // an already-open Swarm pane otherwise keeps showing these as running
+        // until some unrelated reload happens to refresh it.
+        for (agent_id, dispatch_id, total_events) in &completed_members {
+            self.broadcast_subagent_completed(
+                parent_block_id,
+                agent_id,
+                dispatch_id,
+                *total_events,
+            );
+        }
         if !reconciled_agent_ids.is_empty() {
             tracing::info!(
                 parent_block_id = %parent_block_id,
@@ -412,6 +513,37 @@ impl SubagentWatcher {
     /// merges is only "push the correction to an already-open Swarm pane
     /// immediately" (an already-open pane still picks up the correction on
     /// its next unrelated reload in the meantime).
+    /// Same `subagent:completed` event `jsonl.rs` emits when it observes a
+    /// completion live, so a client needs no new handling for the reconcile
+    /// path — it just stops being told "abandoned" for dispatches that
+    /// actually returned. `parentAgent` is omitted (unlike the live emitter's
+    /// payload): reconcile is keyed on the block, and no consumer reads it.
+    fn broadcast_subagent_completed(
+        &self,
+        parent_block_id: &str,
+        agent_id: &str,
+        dispatch_id: &str,
+        total_events: usize,
+    ) {
+        let event = WSEventType {
+            eventtype: WS_EVENT_RPC.to_string(),
+            oref: String::new(),
+            data: Some(json!({
+                "command": "eventrecv",
+                "data": {
+                    "event": "subagent:completed",
+                    "data": {
+                        "agentId": agent_id,
+                        "parentBlockId": parent_block_id,
+                        "totalEvents": total_events,
+                        "dispatchId": dispatch_id,
+                    }
+                }
+            })),
+        };
+        self.event_bus.broadcast_event(&event);
+    }
+
     fn broadcast_subagents_abandoned(&self, parent_block_id: &str, agent_ids: &[String]) {
         let event = WSEventType {
             eventtype: WS_EVENT_RPC.to_string(),

--- a/agentmux-srv/src/backend/subagent_watcher/scan.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/scan.rs
@@ -513,11 +513,40 @@ impl SubagentWatcher {
     /// merges is only "push the correction to an already-open Swarm pane
     /// immediately" (an already-open pane still picks up the correction on
     /// its next unrelated reload in the meantime).
-    /// Same `subagent:completed` event `jsonl.rs` emits when it observes a
-    /// completion live, so a client needs no new handling for the reconcile
-    /// path — it just stops being told "abandoned" for dispatches that
-    /// actually returned. `parentAgent` is omitted (unlike the live emitter's
-    /// payload): reconcile is keyed on the block, and no consumer reads it.
+    fn broadcast_subagents_abandoned(&self, parent_block_id: &str, agent_ids: &[String]) {
+        let event = WSEventType {
+            eventtype: WS_EVENT_RPC.to_string(),
+            oref: String::new(),
+            data: Some(json!({
+                "command": "eventrecv",
+                "data": {
+                    "event": "subagent:abandoned",
+                    "data": {
+                        "parentBlockId": parent_block_id,
+                        "agentIds": agent_ids,
+                    }
+                }
+            })),
+        };
+        self.event_bus.broadcast_event(&event);
+    }
+
+    /// The `Completed` counterpart to `broadcast_subagents_abandoned` above,
+    /// for members reconciliation resolved as having actually returned (see
+    /// `completion.rs`). Emits the same `subagent:completed` event `jsonl.rs`
+    /// already sends when it observes a completion live, so a client needs no
+    /// new handling for the reconcile path — it just stops being told
+    /// "abandoned" for dispatches that returned.
+    ///
+    /// Per-agent rather than batched, unlike its `Abandoned` sibling: the
+    /// payload carries per-member fields (`totalEvents`, `dispatchId`) that a
+    /// batched shape has nowhere to put, and matching `jsonl.rs`'s existing
+    /// event exactly is worth more here than saving a broadcast — a reconcile
+    /// pass typically resolves a handful of completions, not the dozens the
+    /// batching rationale above was written for.
+    ///
+    /// `parentAgent` is omitted (the live emitter includes it): reconcile is
+    /// keyed on the block, and no consumer reads that field.
     fn broadcast_subagent_completed(
         &self,
         parent_block_id: &str,
@@ -537,24 +566,6 @@ impl SubagentWatcher {
                         "parentBlockId": parent_block_id,
                         "totalEvents": total_events,
                         "dispatchId": dispatch_id,
-                    }
-                }
-            })),
-        };
-        self.event_bus.broadcast_event(&event);
-    }
-
-    fn broadcast_subagents_abandoned(&self, parent_block_id: &str, agent_ids: &[String]) {
-        let event = WSEventType {
-            eventtype: WS_EVENT_RPC.to_string(),
-            oref: String::new(),
-            data: Some(json!({
-                "command": "eventrecv",
-                "data": {
-                    "event": "subagent:abandoned",
-                    "data": {
-                        "parentBlockId": parent_block_id,
-                        "agentIds": agent_ids,
                     }
                 }
             })),

--- a/agentmux-srv/src/backend/subagent_watcher/types.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/types.rs
@@ -74,8 +74,13 @@ pub enum SubAgentStatus {
     /// Two writers (the second added by PR #2837; this comment previously
     /// said `reconcile_stale_subagents` was the only one — reagentx P2):
     ///
-    /// 1. `reconcile_stale_subagents` (`scan.rs`) — downgrades `Active`
-    ///    entries once the parent turn is confirmed idle. Never promotes.
+    /// 1. `reconcile_stale_subagents` (`scan.rs`) — resolves `Active` entries
+    ///    once the parent turn is confirmed idle. As of the completion-
+    ///    detection fix (#3007) this is no longer a blanket downgrade: it
+    ///    asks `completion.rs` whether the PARENT recorded a `tool_result`
+    ///    for the member's `tool_use_id` and writes `Completed` when it did,
+    ///    `Abandoned` only when it did not (or when the correlation can't be
+    ///    made at all). It still never promotes anything back to `Active`.
     /// 2. `process_jsonl_change` (`jsonl.rs`) at INSERT time, for a
     ///    cold-backfill replay (`live == false`) whose parent turn is already
     ///    confirmed idle. Avoids asserting `Active` for something the replay

--- a/docs/reports/REPORT_SUBAGENT_COMPLETION_NEVER_DETECTED_2026_09_05.md
+++ b/docs/reports/REPORT_SUBAGENT_COMPLETION_NEVER_DETECTED_2026_09_05.md
@@ -1,0 +1,226 @@
+# Every Agent-tool subagent is reported "interrupted" — completion detection keys on a line type AgentMux never writes
+
+**Status:** active
+**Author:** Posa
+**Date:** 2026-09-05
+**Severity:** display-only, but 100% reproducible and it mislabels successful work as failed
+**Resolution:** fixed 2026-09-06 (§7)
+**Investigated at:** `1cb5b51c0` (v0.55.36)
+**Companion:** `REPORT_SWARM_PANE_VS_ACTUAL_AGENT_CALLS_2026_09_05.md` (the audit that surfaced this)
+
+---
+
+## 1. Symptom
+
+The Swarm pane shows **4 Agent-tool rows for Manoz, all "interrupted."** All four in fact
+completed successfully, days apart. This is not specific to Manoz — see §4, it is every
+Agent-tool dispatch on this machine.
+
+## 2. Root cause
+
+`SubAgentStatus::Completed` has exactly **one** writer
+(`agentmux-srv/src/backend/subagent_watcher/jsonl.rs:243-248`):
+
+```rust
+if let Some(last) = new_events.last() {
+    if matches!(&last.event_type, SubagentEventType::Result { .. }) {
+        completed = true;
+        state.info.status = SubAgentStatus::Completed;
+    }
+}
+```
+
+`SubagentEventType::Result` is produced by exactly one branch of the parser
+(`parse.rs:311`), matching a JSONL line whose **top-level `type` is `"result"`**.
+
+**AgentMux's agent transcripts never contain a `"type":"result"` line.** Not in subagent
+sidechain files, not in parent session files. So the only path to `Completed` can never be
+taken, for any Agent-tool dispatch, ever.
+
+What happens instead:
+
+1. Subagent is inserted `Active` (live) — `jsonl.rs:134`.
+2. It runs, returns its result to the parent, and its transcript ends on an `assistant`
+   message. No `result` line is written, so step 2 above never fires.
+3. The parent's turn ends. On the next backfill scan `reconcile_stale_subagents`
+   (`scan.rs:146-151`) downgrades any still-`Active` subagent whose parent turn is
+   confirmed idle to `Abandoned`, on the documented reasoning that *"any subagent file
+   lacking a terminal `Result` line was interrupted (crashed, killed, or the app/srv
+   restarted mid-task)"*. That premise is false here: the file lacks a `Result` line because
+   **nothing ever writes one**, not because the subagent was cut off.
+4. `swarm-view.tsx:187` renders `abandoned` as **"interrupted."**
+
+(A cold-backfill replay reaches the same end state one step earlier: `jsonl.rs:134-144`
+inserts directly as `Abandoned` when the parent turn is already idle.)
+
+The code is self-consistent and each piece is individually defensible. The defect is that
+`Abandoned` is — as `types.rs:66-72` says itself — **"always an inference, never an
+observation,"** and the observation it infers from is unobtainable.
+
+## 3. Evidence
+
+### 3.1 The four dispatches all succeeded
+
+From Manoz's parent transcript, `tool_result` for each `Agent` call:
+
+```
+is_error=false  len=1095   "Verify agent isolation from host CLAUDE.md"
+is_error=false  len=26349  "Research muxspect architecture for cross-tier spec"
+is_error=false  len=1095   "Investigate dual login-button UI states"
+is_error=false  len=31351  "Research AgentMux shutdown sequence and splash pattern"
+```
+
+Four results, zero errors, two of them 26–31 KB of research that Manoz then acted on.
+
+### 3.2 No subagent transcript on this machine has a `result` line
+
+All 11 subagent transcripts across every project dir under the live identity:
+
+```
+no-result  agent-a5cb2c4d2e2c1e79e.jsonl  last=assistant   {"user":64,"attachment":2,"assistant":96}   manoz
+no-result  agent-a6418e6524f14ab61.jsonl  last=assistant   {"user":43,"attachment":2,"assistant":63}   manoz
+no-result  agent-a829bb416fe845a76.jsonl  last=assistant   {"user":25,"attachment":2,"assistant":39}   manoz
+no-result  agent-a8d67573ed85ea142.jsonl  last=assistant   {"user":43,"attachment":3,"assistant":72}   manoz
+no-result  agent-a22b6ede7fe421c9b.jsonl  last=assistant   {"user":23,"attachment":3,"assistant":32}   posa
+no-result  agent-a98dbcef0c55eef91.jsonl  last=assistant   {"user":46,"attachment":2,"assistant":74}   posa
+no-result  agent-ac034d6a6600ca691.jsonl  last=attachment  {"user":1,"attachment":2}                   0.55.31 portable
+no-result  agent-a22c5c89aad00e3b3.jsonl  last=attachment  {"user":1,"attachment":2}                   0.55.31 portable
+no-result  agent-a1c5fc5e431269a53.jsonl  last=attachment  {"user":1,"attachment":2}                   0.55.31 portable
+no-result  agent-a8902c88c3e0dff7b.jsonl  last=attachment  {"user":1,"attachment":2}                   0.55.36 portable
+no-result  agent-abb935044040bc964.jsonl  last=assistant   {"user":2,"attachment":2,"assistant":5}     0.55.36 portable
+
+TOTAL subagent transcripts: 11   with a result line: 0
+```
+
+Two different agents, two dispatch shapes, portables from 0.55.31 through 0.55.36. Every
+completed one ends on `assistant`.
+
+### 3.3 Parent transcripts don't have them either
+
+Manoz's parent session (`468e2051…`, 15k lines) type census:
+
+```json
+{"queue-operation":596,"user":2661,"attachment":4405,"atis-latch":665,
+ "assistant":4915,"ai-title":665,"last-prompt":663,"mode":563,"system":3}
+```
+
+No `result`. The line type the detector waits for is absent from the whole format.
+
+### 3.4 Not a regression — it has never worked
+
+| Transcript | Claude Code version | entrypoint | `result` lines |
+|---|---|---|---|
+| manoz `b92b1599` (Aug 16) | 2.1.198 | `sdk-cli` | **0** |
+| manoz `49f8b975` (Aug 15) | 2.1.198 | `sdk-cli` | **0** |
+| manoz `468e2051` (current) | 2.1.247 | `sdk-cli` | **0** |
+
+Both the old and current CLI versions, same answer. AgentMux spawns agents through the SDK
+(`entrypoint: sdk-cli`), and that path does not emit `"result"`-typed transcript lines.
+
+### 3.5 The code comment records the moment this broke
+
+The current detector arrived in `5d374006a` ("refactor: implement Tier 2 large-file
+modularization items", #2283), with this rationale:
+
+> Keyed off the `Result` discriminant itself (a real `"result"`-typed JSONL line), not
+> derived text content — real Claude Code result events populate `result`/`content`, so
+> matching against the "Subagent completed" placeholder (only ever produced when both are
+> absent) almost never fired.
+
+The previous approach matched placeholder text and "almost never fired." The replacement
+keys on a discriminant that **never** fires. A change intended to tighten a flaky heuristic
+replaced it with one that is unreachable — and because the failure mode is identical in
+appearance (rows that never complete), it read as the pre-existing flakiness rather than a
+new absolute.
+
+## 4. Scope
+
+Every Agent-tool dispatch, for every agent, since at least Claude Code 2.1.198. There is no
+"sometimes" here — `Completed` is unreachable for this path, so the terminal state is always
+`Abandoned`/"interrupted" once the parent turn goes idle.
+
+`DispatchStatus` (`jsonl.rs:709`, "counts-complete + 60s quiet ⇒ Completed") is a **separate**
+enum with its own, working, count-based completion rule. Workflow/dispatch-level rows are not
+affected by this; only per-subagent `SubAgentStatus` rows are.
+
+## 5. Fix options
+
+Option 2 was implemented — see §7. Recorded as originally weighed, in rough order of directness:
+
+1. **Treat a terminal `assistant` message as completion** when the parent turn has ended.
+   This is what actually marks the end of a subagent's transcript in this format. Matches
+   observed reality; the risk is calling a genuinely-killed subagent "completed" when it
+   happened to die right after an assistant message.
+2. **Use the parent's `tool_result` as the completion signal.** Strongest evidence available
+   — it is the actual observation that the dispatch returned, including `is_error`, and it
+   would let a real failure be distinguished from a real success rather than collapsing both
+   into "interrupted." Requires correlating `tool_use_id` → dispatch, which the watcher does
+   not currently track.
+3. **Invert `reconcile_stale_subagents`' default.** Least code, weakest result: absent
+   positive evidence of interruption, do not assert it. Removes the false "interrupted" but
+   leaves rows in an indefinite state rather than correctly completed.
+
+Option 2 is the one that makes the status *observed* rather than inferred, which is the
+actual root problem — `types.rs` already flags the inference as the weak point in its own
+doc comment.
+
+## 6. What I did not verify
+
+- Whether any *other* AgentMux spawn path (non-SDK, interactive `claude`) does produce
+  `result` lines. Every transcript on this machine is `sdk-cli`, so the "never" in §2 is
+  proven for this deployment but not for every possible configuration.
+- Whether the pre-#2283 placeholder matcher ever worked in some earlier CLI version. The
+  comment says "almost never fired," which I take at its word rather than having tested it.
+- Live Swarm UI state — I reconstructed the display path by reading
+  `subagentDisplayStatus` (`swarm-view.tsx:186-192`) and the watcher, not by observing the
+  rendered rows. The user's report of "4 interrupted" is the observation this matches.
+
+---
+
+## 7. Fixed (2026-09-06)
+
+Implemented **option 2** from §5 — completion is now an observation, not an inference.
+
+**`agentmux-srv/src/backend/subagent_watcher/completion.rs`** (new): resolves a subagent's
+terminal status from the parent's own `tool_result` for its `tool_use_id`. The correlation
+key needed no new plumbing — Claude Code already writes it to the `agent-<id>.meta.json`
+sidecar beside each transcript:
+
+```json
+{"agentType":"Explore","description":"Research AgentMux shutdown sequence and splash pattern",
+ "toolUseId":"toolu_01RY4RsXyFZAQJP82G7Zw4YX","spawnDepth":1,"model":"opus"}
+```
+
+**`scan.rs::reconcile_stale_subagents`**: instead of downgrading every still-`Active` member
+to `Abandoned`, it now consults that resolution. Members the parent recorded a result for
+become `Completed` and get the same `subagent:completed` event `jsonl.rs` already emits live,
+so open Swarm panes see the correction immediately rather than at the next unrelated reload.
+
+Three properties worth noting, because each was a way to get this wrong:
+
+- **Fails closed.** No sidecar, an unreadable/absent parent transcript, an uncorrelatable
+  entry — every one falls back to the historical `Abandoned`. The fix can never
+  *optimistically* complete something it could not verify.
+- **The lock is not held across the file IO.** A parent transcript is routinely tens of MB,
+  and this function is explicitly written to avoid holding the `sessions` mutex across slow
+  work. Resolution is two-phase: snapshot candidates under a short lock, read unlocked, then
+  apply — and the apply pass re-checks `Active`, so a member whose status moved in between is
+  left alone rather than clobbered by a stale decision.
+- **One transcript read per pass, not per member.** All of a session's members share a parent.
+
+**An errored result still counts as `Completed`.** The distinction being drawn is *returned*
+vs *cut off*, and a dispatch that reported an error returned. Surfacing failure as its own
+state needs a status the enum doesn't have (plus a matching frontend union) — deliberately
+left as follow-up rather than smuggled into this fix; `is_error` is parsed and available for
+whoever picks that up.
+
+**Testing.** 10 unit tests, fixtures taken from the real transcripts in §3 rather than
+invented. Mutation-checked: with `terminal_status` reverted to the old always-`Abandoned`
+behaviour, exactly the two completion assertions fail while the genuinely-abandoned and
+fallback cases keep passing — confirming they test the fix rather than restating it.
+Full `agentmux-srv` suite: **3017 passed, 0 failed**.
+
+**Not verified end-to-end in a running app.** The mechanism is proven at the unit level and
+the fix targets the exact line that produced the wrong status, but I have not watched Manoz's
+four rows flip from "interrupted" to completed in a live Swarm pane. That needs a build and a
+pane reopen (reconcile runs on backfill), and is the natural confirmation step.

--- a/docs/reports/REPORT_SWARM_PANE_VS_ACTUAL_AGENT_CALLS_2026_09_05.md
+++ b/docs/reports/REPORT_SWARM_PANE_VS_ACTUAL_AGENT_CALLS_2026_09_05.md
@@ -1,0 +1,159 @@
+# What an agent actually did vs. what the Swarm pane shows — Manoz session audit
+
+**Status:** historical
+**Author:** Posa
+**Date:** 2026-09-05
+**Method:** Read Manoz's live session transcript directly
+(`468e2051-6f50-4621-b705-db0b35d61dd0.jsonl`, 26 MB, under the shared identity
+`908412be-…` in channel `local-main-b28b7a-0d9e24f4`), bounded to everything after the
+operator's `u there` at `2026-09-06T03:22:53Z` (20:22 local). Cross-referenced against the
+Swarm pane's own display path in the current tree at `1cb5b51c0` (v0.55.36).
+
+**Follow-up:** the Agent-tool rows visible alongside this session turned out to be mislabelled
+"interrupted" — root cause in `REPORT_SUBAGENT_COMPLETION_NEVER_DETECTED_2026_09_05.md`.
+
+**Scope note:** this audits the *fidelity of the Swarm pane's per-agent activity display*
+against a real session. It is an observation report, not a defect report — every behaviour
+below is working as designed. Whether the design is sufficient is the open question in §5.
+
+---
+
+## 1. What Manoz actually did
+
+Three operator messages in the window:
+
+| Time (UTC) | Message |
+|---|---|
+| 03:22:53 | `u there` |
+| 03:24:43 | `you are now inside of 55.36` |
+| 03:27:26 | `so we want to refine how memory is loaded and managed. There are a couple scenarios: 1) cr…` |
+
+The work is a **read-only investigation of memory loading and compaction**: locating the
+startup-payload builder, tracing how `AGENTMUX_MEMORY.md`/`CLAUDE.md` get written at launch,
+reading the compaction-boundary handling, and searching for any post-compaction memory
+re-injection.
+
+**Tool calls in the window: 26 measurable.**
+
+| Tool | Count |
+|---|---|
+| `Bash` | 24 |
+| `AskUserQuestion` | 1 |
+| `Write` | 1 |
+
+Every `Bash` call is a distinct read: `grep -rn "memory_dir_for_agent…"`,
+`sed -n '900,930p' agentmux-srv/src/backend/agent_config.rs`,
+`cat frontend/app/view/agent/compact-boundary.ts`, and so on — each with its own one-line
+`description` field (`"Read the compaction boundary handling"`, `"Find all consumers of
+compaction events"`, …).
+
+**Zero `mcp__agentmux__*` calls.** Worth stating plainly, since "agent calls" could be read
+as the AgentMux MCP surface: Manoz used none of it in this window. No `SendMessage`, no
+`Shell`, no `MemoryRead`, no fleet tools. Everything went through the plain `Bash` tool.
+
+## 2. What the Swarm pane can show for that
+
+Two independent per-agent surfaces, from different mechanisms:
+
+**`currentTool`** — `agentmux-srv/src/backend/reactive/progress_watcher.rs`. A sweep folds
+newly-appended transcript lines into per-block state; `current_tool` is
+`self.open.first()`, i.e. *the oldest `tool_use` with no matching `tool_result` yet*. Rendered
+in `swarm-view.tsx:354-359` as a bolt icon plus **the bare tool name**:
+
+```tsx
+<Show when={node.currentTool}>
+    <div class="swarm-current-tool">
+        <i class="fa-solid fa-bolt swarm-current-tool-icon" />
+        <span class="swarm-current-tool-name">{node.currentTool}</span>
+    </div>
+</Show>
+```
+
+**`todoRows`** — same watcher, fed by the agent's own todo-tool calls
+(`TaskCreate`/`TaskUpdate` item-at-a-time, or a whole-list call that supersedes them),
+capped at `MAX_TODOS = 24`.
+
+## 3. The mapping
+
+| Manoz's actual call | What Swarm can render |
+|---|---|
+| `Bash` — "Check current repo version and environment/channel context" | `Bash` |
+| `Bash` — "Locate memory, startup payload, and compaction modules" | `Bash` |
+| `Bash` — "Read the compaction boundary handling" | `Bash` |
+| `Bash` — "Find all consumers of compaction events" | `Bash` |
+| `Bash` — "Search for any post-compaction memory re-injection" | `Bash` |
+| … 19 further distinct `Bash` reads … | `Bash` |
+| `AskUserQuestion` — compaction-direction choice | `AskUserQuestion` |
+| `Write` | `Write` |
+
+**24 semantically distinct investigative steps collapse to the identical string `Bash`.** The
+`description` each call already carries — the thing that would actually distinguish them — is
+not part of `AgentProgress` and never reaches the pane. Neither is the command, nor the target
+file.
+
+**The todo checklist is empty for this whole window.** Manoz called no todo tool, so
+`todos` stays `[]` and `is_empty()` suppresses publication entirely for any tick where
+`current_tool` is also `None`. An observer watching the Swarm card would see no task structure
+for a ~9-minute multi-step investigation — correctly, since none was ever expressed.
+
+## 4. The sharper finding: most calls are too short to ever be displayed
+
+`SWEEP_INTERVAL_SECS = 3`, and `current_tool` reports whatever is open *at sweep time*. So a
+call that opens and closes between two sweeps is never published as `currentTool` at all.
+
+Measured, per call, from `tool_use` to its matching `tool_result` in this window:
+
+| | |
+|---|---|
+| Calls measured | 26 |
+| **Completed in under 3000 ms** | **23 (88%)** |
+| 3000 ms or longer | 3 |
+| Median | **523 ms** |
+| Min / max | 28 ms / 53,223 ms |
+
+Full distribution (ms): `28, 334, 339, 346, 363, 370, 420, 429, 471, 488, 497, 500, 500, 523,
+533, 535, 548, 564, 801, 811, 850, 1173, 2211, 4040, 4230, 53223`.
+
+The only reliably-visible call in the entire window is the **`AskUserQuestion` at 53 seconds** —
+which is visible precisely because it was blocked waiting on a human. The two 4-second `Bash`
+calls would likely catch one sweep each. **The other 23 are all shorter than a single sweep
+interval**, so whether any given one is ever seen is down to where the 3s boundary happens to
+fall.
+
+This is not a bug — the watcher is a sampler and is documented as one ("The tool this agent is
+running right now, or null between tools"). But it means that for a **read-heavy investigation
+session**, which is what most agent work looks like, the `currentTool` line is empty or stale
+far more often than it is informative. It shows activity best when the agent is *blocked*,
+and worst when the agent is working fastest.
+
+## 5. What this implies
+
+Three observations, in order of how confident I am:
+
+1. **Tool *name* alone is near-zero signal for `Bash`-dominated work** (24 of 26 calls here).
+   The pane can tell you "Manoz is running Bash" — which, for an agent doing codebase
+   investigation, is true almost continuously and says nothing about what it is investigating.
+   The per-call `description` already exists in the transcript and is exactly the missing
+   field.
+2. **Sampling at 3 s under-reports sub-second work by construction.** An 88% miss rate on this
+   session is not a tuning problem that a shorter interval fixes cheaply — it is inherent to
+   sampling "what is open right now" rather than accumulating "what ran since the last sweep."
+   A *last completed tool* (or a small ring of recent ones) would survive between sweeps where
+   an instantaneous read cannot.
+3. **`activitySummary` is the surface already doing this job.** `swarm-view.tsx` renders the
+   Haiku-generated paraphrase directly above `currentTool`, and the code comment there frames
+   the literal tool as complementary to it ("The literal call in flight, next to the Haiku
+   paraphrase above it"). If the paraphrase is carrying the semantic load, the honest
+   framing of the finding is that **`currentTool` is a liveness indicator, not an activity
+   description** — and this session suggests it is a fairly weak liveness indicator too.
+
+## 6. What I did not check
+
+- Whether `activitySummary` was actually populated and accurate for this session — I read the
+  render path, not its live values. That is the natural follow-up and would change the weight
+  of §5.3 substantially.
+- Any window other than this one. A session doing long builds or long agent dispatches would
+  invert the duration distribution entirely, and the 88% figure should not be generalised
+  beyond "a read-heavy investigation session."
+- LAN/WAN-tier agents. `ListConversations` reports `remote_fetch_required: true` for those, so
+  their transcripts are liveness-only and could not be audited this way.


### PR DESCRIPTION
Every Agent-tool dispatch, for every agent, was displayed as **"interrupted"** in the Swarm pane — including ones that returned full results the parent went on to use.

Found while auditing a real session: the pane showed 4 Agent-tool rows for one agent, all "interrupted." All four had succeeded, days apart.

## Root cause

`SubAgentStatus::Completed` had exactly **one** writer (`jsonl.rs:243`), gated on a subagent's last event being a `Result`-typed JSONL line:

```rust
if matches!(&last.event_type, SubagentEventType::Result { .. }) {
    completed = true;
    state.info.status = SubAgentStatus::Completed;
}
```

**AgentMux transcripts contain no `"type":"result"` line at all** — not in subagent sidechain files, not in parent session files. So `Completed` was unreachable. Members stayed `Active`, and `reconcile_stale_subagents` then downgraded them to `Abandoned` on the documented reasoning that a file *"lacking a terminal `Result` line was interrupted"*. The file lacks one because **nothing writes one**.

`types.rs` already flags `Abandoned` as *"always an inference, never an observation"* — the observation it inferred from was unobtainable.

## Evidence

| Check | Result |
|---|---|
| Subagent transcripts with a `result` line | **0 of 11** (2 agents, portables 0.55.31→0.55.36) |
| Parent transcripts with a `result` line | **0** (15k-line census: `queue-operation/user/attachment/atis-latch/assistant/ai-title/last-prompt/mode/system`) |
| The 4 dispatches' actual outcome | `is_error=false` on all four; two returned 26–31 KB |
| CC 2.1.198 (Aug) vs 2.1.247 (now) | **both 0** — not a regression |

Every completed subagent transcript ends on an `assistant` message.

**How it slipped in:** the detector arrived in #2283, replacing a placeholder-text match its own comment says *"almost never fired."* The replacement fires **never** — and because both fail identically (rows that never complete), it read as the pre-existing flakiness rather than a new absolute.

## The fix

Completion is now an **observation**: the parent's own `tool_result` for the dispatch's `tool_use_id`. No new plumbing was needed for correlation — Claude Code already writes the key into the sidecar beside each transcript:

```json
{"agentType":"Explore","description":"Research AgentMux shutdown sequence…",
 "toolUseId":"toolu_01RY4RsXyFZAQJP82G7Zw4YX","spawnDepth":1,"model":"opus"}
```

New `completion.rs` resolves it; `reconcile_stale_subagents` consults that instead of unconditionally writing `Abandoned`.

### Three properties worth reviewing — each was a way to get this wrong

- **Fails closed.** No sidecar, unreadable/absent parent, uncorrelatable entry → falls back to the historical `Abandoned`. It can never *optimistically* complete something it couldn't verify.
- **The `sessions` lock is not held across the file IO.** Parent transcripts run to tens of MB, and this function is explicitly written to avoid holding that mutex across slow work. Resolution is two-phase: snapshot candidates under a short lock, read unlocked, apply. The apply pass **re-checks `Active`**, so a member whose status moved in between is left alone rather than clobbered by a stale decision.
- **One transcript read per pass, not per member.** All of a session's members share a parent.

Completed members emit the same `subagent:completed` event `jsonl.rs` already sends live, so an open Swarm pane gets the correction immediately rather than at the next unrelated reload.

### One deliberate scoping decision

**An errored result still counts as `Completed`.** The distinction being drawn is *returned* vs *cut off*, and a dispatch that reported an error returned. Surfacing failure as its own state needs a status the enum doesn't have plus a matching frontend union — left as explicit follow-up rather than smuggled into this fix. `is_error` is parsed and available for whoever picks it up.

## Testing

- **10 new unit tests**, fixtures taken from the real transcripts above rather than invented.
- **Mutation-checked:** reverting `terminal_status` to the old always-`Abandoned` behaviour fails exactly the two completion assertions, while the genuinely-abandoned and fallback cases keep passing — confirming they test the fix rather than restate it.
- Full `agentmux-srv` suite: **3017 passed, 0 failed**. Re-verified after rebasing onto latest `main`.

## Not verified end-to-end

The mechanism is proven at the unit level and targets the exact line that produced the wrong status, but **I have not watched the four rows flip from "interrupted" to completed in a live Swarm pane.** That needs a build and a pane reopen (reconcile runs on backfill). Flagging it rather than implying otherwise.

Reports with the full evidence chain:
- `docs/reports/REPORT_SUBAGENT_COMPLETION_NEVER_DETECTED_2026_09_05.md`
- `docs/reports/REPORT_SWARM_PANE_VS_ACTUAL_AGENT_CALLS_2026_09_05.md` (the audit that surfaced it)

<!-- agentmux:agent_id=posa -->
