### PR TITLE
Loap #2@claudius: fix(agent): hover peek panel now respects the agent pane zoom level

### DIFF
--- a/.changesets/1788683074-fix-agent-hover-peek-panel-now-respects-the-agent-pane-zoom--cp99.md
+++ b/.changesets/1788683074-fix-agent-hover-peek-panel-now-respects-the-agent-pane-zoom--cp99.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): hover peek panel now respects the agent pane zoom level

--- a/frontend/app/view/agent/components/PeekOverlay.test.tsx
+++ b/frontend/app/view/agent/components/PeekOverlay.test.tsx
@@ -233,4 +233,121 @@ describe("PeekOverlay", () => {
             vi.useRealTimers();
         }
     });
+
+    // The panel is Portal-rendered to document.body, which escapes the agent
+    // pane's `zoom` — so it used to paint at 100% while the pane around it
+    // scaled. It now reads `--agent-pane-zoom` off the anchor row (the var
+    // inherits down from the pane root) and applies it to itself.
+    describe("agent pane zoom", () => {
+        function setRect(el: Element, rect: Partial<DOMRect>) {
+            vi.spyOn(el, "getBoundingClientRect").mockReturnValue({
+                top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0, x: 0, y: 0, toJSON: () => {},
+                ...rect,
+            } as DOMRect);
+        }
+
+        /** A row inside a scroll container inside a zoomed pane root. */
+        function makeZoomedRow(paneZoom: string | null) {
+            const paneRoot = document.createElement("div");
+            if (paneZoom != null) paneRoot.style.setProperty("--agent-pane-zoom", paneZoom);
+            document.body.appendChild(paneRoot);
+            const container = document.createElement("div");
+            container.style.overflowY = "auto";
+            paneRoot.appendChild(container);
+            const row = document.createElement("div");
+            container.appendChild(row);
+            setRect(container, { top: 0, bottom: 1000, right: 400 });
+            setRect(row, { top: 100, bottom: 300, left: 100, right: 400, width: 300 });
+            return row;
+        }
+
+        function renderPeek(row: HTMLElement, align?: "end" | "stretch") {
+            render(() => (
+                <PeekOverlay show={true} rowEl={() => row} align={align}>
+                    <span>peek content</span>
+                </PeekOverlay>
+            ));
+            vi.advanceTimersByTime(50);
+            return document.querySelector(".agent-node-peek-overlay") as HTMLElement;
+        }
+
+        it("applies the pane's zoom factor to the portaled panel", () => {
+            vi.useFakeTimers();
+            try {
+                const overlay = renderPeek(makeZoomedRow("1.5"));
+                expect(overlay.style.zoom).toBe("1.5");
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        // The non-obvious half: CSS `zoom` also multiplies the element's own
+        // inset lengths, and every input here is an already-post-zoom
+        // getBoundingClientRect() value — so each must be pre-divided to land
+        // where it did before. Without this the panel would fly off-screen at
+        // high zoom instead of merely being the wrong size.
+        it("pre-divides its viewport-px geometry so the panel still lands on the row's edge", () => {
+            vi.useFakeTimers();
+            try {
+                const overlay = renderPeek(makeZoomedRow("2"));
+                // row.right is 400 real px; at zoom 2 that must be written as 200.
+                expect(parseFloat(overlay.style.left)).toBeCloseTo(200, 5);
+                // max-width tracks the row's 300px width → 150 at zoom 2.
+                expect(parseFloat(overlay.style.maxWidth)).toBeCloseTo(150, 5);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it("de-scales the stretch variant's width and left too", () => {
+            vi.useFakeTimers();
+            try {
+                const overlay = renderPeek(makeZoomedRow("2"), "stretch");
+                expect(overlay.style.zoom).toBe("2");
+                expect(parseFloat(overlay.style.left)).toBeCloseTo(50, 5);   // 100 / 2
+                expect(parseFloat(overlay.style.top)).toBeCloseTo(50, 5);    // 100 / 2
+                expect(parseFloat(overlay.style.width)).toBeCloseTo(150, 5); // 300 / 2
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        // The overwhelmingly common case must stay byte-identical to the
+        // pre-fix behavior — no `zoom` property emitted, no division.
+        it("emits no zoom and leaves geometry untouched at 100%", () => {
+            vi.useFakeTimers();
+            try {
+                const overlay = renderPeek(makeZoomedRow("1"));
+                expect(overlay.style.zoom).toBe("");
+                expect(parseFloat(overlay.style.left)).toBeCloseTo(400, 5);
+                expect(parseFloat(overlay.style.maxWidth)).toBeCloseTo(300, 5);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        // A peek rendered outside any agent pane (or in a harness with no
+        // computed custom properties) must not break.
+        it("falls back to 1 when the pane zoom variable is absent", () => {
+            vi.useFakeTimers();
+            try {
+                const overlay = renderPeek(makeZoomedRow(null));
+                expect(overlay.style.zoom).toBe("");
+                expect(parseFloat(overlay.style.left)).toBeCloseTo(400, 5);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it("ignores a malformed or non-positive zoom variable", () => {
+            vi.useFakeTimers();
+            try {
+                expect(renderPeek(makeZoomedRow("not-a-number")).style.zoom).toBe("");
+                cleanup();
+                expect(renderPeek(makeZoomedRow("0")).style.zoom).toBe("");
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+    });
 });

--- a/frontend/app/view/agent/components/PeekOverlay.tsx
+++ b/frontend/app/view/agent/components/PeekOverlay.tsx
@@ -25,10 +25,21 @@
  * above the whole transcript regardless of virtualization internals — the
  * same reason the original floating-ui `Tooltip` component never had this
  * bug. Position is `fixed` (not `absolute`) using raw
- * `getBoundingClientRect()` viewport coordinates — already zoom-safe (CSS
- * `zoom`, not `transform: scale()`, per AgentDocumentVirtualList.tsx's own
- * CDP-verified comments) — and floating-ui's `autoUpdate` keeps it synced
- * on scroll/resize without hand-rolling scroll listeners.
+ * `getBoundingClientRect()` viewport coordinates, and floating-ui's
+ * `autoUpdate` keeps it synced on scroll/resize without hand-rolling
+ * scroll listeners.
+ *
+ * **Pane zoom (2026-09-06).** Escaping the row's subtree also escapes the
+ * pane's `zoom`, which `agent-view.tsx` sets on the pane root — so this
+ * panel used to render at 100% no matter how far the agent pane was zoomed
+ * in or out, while everything around it scaled. An earlier revision of this
+ * header called the component "already zoom-safe", which was true only of
+ * its POSITION: `getBoundingClientRect()` reports post-zoom viewport pixels,
+ * so the panel always landed in the right place — at the wrong size. That
+ * half-truth is precisely why the gap survived. It now reads the pane's
+ * factor off the anchor row's inherited `--agent-pane-zoom` and applies it
+ * to itself; see `readPaneZoom` and `withPaneZoom` for the mechanism and
+ * for why every length has to be divided by the factor.
  *
  * Positioning is deliberately single-direction (top-anchored, growing
  * downward over the entry) rather than the above/below picker
@@ -91,8 +102,10 @@ interface PeekOverlayProps {
      * `translateX(-100%)` rather than a `right:` offset, deliberately —
      * `right` would need `window.innerWidth`, which is a different
      * coordinate space from the `getBoundingClientRect()` values
-     * everything else here uses, and would break the CSS-`zoom` safety
-     * this component's header documents.
+     * everything else here uses. It also keeps the pane-zoom compensation
+     * in `withPaneZoom` uniform: every length it touches is a
+     * `getBoundingClientRect()`-derived viewport pixel, divided by the same
+     * factor. A `right:` offset would need the opposite correction.
      */
     align?: "end" | "stretch";
     children?: JSX.Element;
@@ -107,6 +120,63 @@ const BOTTOM_MARGIN_PX = 4;
 // own top edge (align="end" mode only) — see the `top` computation in
 // `update()` below for why this must be strictly positive.
 const CURSOR_GAP_PX = 12;
+
+/**
+ * This overlay's owning pane's zoom factor, read off the anchor row.
+ *
+ * `agent-view.tsx` sets BOTH `zoom: <factor>` and `--agent-pane-zoom:
+ * <factor>` on the pane root. The row is inside that subtree, so the custom
+ * property inherits down to it — reading from the row means this works for
+ * whichever pane the hovered entry belongs to (and for the history view,
+ * which sets the same pair) without threading a prop through all six
+ * call sites.
+ *
+ * Returns 1 for anything unparseable, absent, or non-positive: a peek
+ * rendered outside an agent pane (or in a test harness with no computed
+ * custom properties) must keep behaving exactly as it did before.
+ */
+function readPaneZoom(row: HTMLElement | undefined): number {
+    if (!row) return 1;
+    const raw = getComputedStyle(row).getPropertyValue("--agent-pane-zoom").trim();
+    const parsed = Number.parseFloat(raw);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+}
+
+/** Style lengths that are in real viewport px and must be de-scaled. */
+const ZOOM_SCALED_LENGTHS = ["left", "top", "width", "max-width", "max-height"] as const;
+
+/**
+ * Re-express a style computed in REAL viewport pixels so it renders
+ * identically on an element that carries `zoom: paneZoom`.
+ *
+ * This is the whole fix, and the division is the non-obvious half of it.
+ * CSS `zoom` on an element multiplies the used value of that element's OWN
+ * lengths — including the inset properties of a positioned element. With
+ * `zoom: 2`, `left: 100px` paints at 200px from the viewport's left edge.
+ * Every input here comes from `getBoundingClientRect()`, which already
+ * reports post-zoom rendered pixels, so each length must be pre-divided by
+ * the factor to land where it did before.
+ *
+ * `transform: translateX(-100%)` is deliberately NOT touched: it resolves
+ * against the element's own border-box width, which scales with it, so it
+ * stays correct at any zoom.
+ *
+ * A `paneZoom` of exactly 1 returns the style untouched (no `zoom`
+ * property emitted at all) — the overwhelmingly common case stays
+ * byte-identical to the pre-fix behavior.
+ */
+function withPaneZoom(style: JSX.CSSProperties, paneZoom: number): JSX.CSSProperties {
+    if (paneZoom === 1) return style;
+    const scaled: JSX.CSSProperties = { ...style, zoom: paneZoom };
+    for (const key of ZOOM_SCALED_LENGTHS) {
+        const value = style[key];
+        if (typeof value !== "string") continue;
+        const px = Number.parseFloat(value);
+        if (!Number.isFinite(px)) continue;
+        scaled[key] = `${px / paneZoom}px`;
+    }
+    return scaled;
+}
 
 export function PeekOverlay(props: PeekOverlayProps): JSX.Element {
     const [floatingStyle, setFloatingStyle] = createSignal<JSX.CSSProperties>({
@@ -130,15 +200,21 @@ export function PeekOverlay(props: PeekOverlayProps): JSX.Element {
         if (!row) return;
         const rect = row.getBoundingClientRect();
         const container = findScrollContainerRect(row);
+        const paneZoom = readPaneZoom(row);
         if ((props.align ?? "end") === "stretch") {
             const cap = Math.max(0, container.bottom - rect.top - BOTTOM_MARGIN_PX);
-            setFloatingStyle({
-                position: "fixed",
-                left: `${rect.left}px`,
-                top: `${rect.top}px`,
-                width: `${rect.width}px`,
-                "max-height": `${cap}px`,
-            });
+            setFloatingStyle(
+                withPaneZoom(
+                    {
+                        position: "fixed",
+                        left: `${rect.left}px`,
+                        top: `${rect.top}px`,
+                        width: `${rect.width}px`,
+                        "max-height": `${cap}px`,
+                    },
+                    paneZoom,
+                ),
+            );
             return;
         }
         // Shrink-wrapped and right-anchored. No `width` is set at all, so the
@@ -201,14 +277,19 @@ export function PeekOverlay(props: PeekOverlayProps): JSX.Element {
             top = rect.top;
         }
         const cap = Math.max(0, container.bottom - top - BOTTOM_MARGIN_PX);
-        setFloatingStyle({
-            position: "fixed",
-            left: `${rect.right}px`,
-            top: `${top}px`,
-            transform: "translateX(-100%)",
-            "max-width": `${rect.width}px`,
-            "max-height": `${cap}px`,
-        });
+        setFloatingStyle(
+            withPaneZoom(
+                {
+                    position: "fixed",
+                    left: `${rect.right}px`,
+                    top: `${top}px`,
+                    transform: "translateX(-100%)",
+                    "max-width": `${rect.width}px`,
+                    "max-height": `${cap}px`,
+                },
+                paneZoom,
+            ),
+        );
     };
 
     // Track the mouse continuously while the row exists, independent of


### PR DESCRIPTION
## Summary

The hover peek panel (timestamp / token estimate / path) rendered at 100% regardless of the agent pane's zoom, while everything around it scaled.

**Cause:** the panel is `Portal`-rendered to `document.body` so it can escape the virtualized transcript rows' stacking contexts (each row carries `contain: layout` + a `transform`, so no `z-index` inside one row can out-rank a later sibling row). Escaping the subtree also escapes the pane's `zoom`, which `agent-view.tsx` sets on the pane root.

**Fix:** read the factor off the anchor row's inherited `--agent-pane-zoom` — already published by `agent-view.tsx` right next to the `zoom` it sets — and apply it to the panel. Reading from the row rather than threading a prop means no changes at any of the six call sites, and it automatically resolves to whichever pane the hovered entry belongs to (including the history view, which sets the same pair).

**The non-obvious half is the division.** CSS `zoom` also multiplies the element's *own* inset lengths, and every input here is an already-post-zoom `getBoundingClientRect()` value. So each length is pre-divided by the factor — otherwise the panel would fly off-screen at high zoom rather than merely being the wrong size. `transform: translateX(-100%)` is deliberately untouched: it resolves against the element's own border-box width, which scales with it.

A factor of exactly 1 emits no `zoom` property and performs no division, so the overwhelmingly common case is byte-identical to before.

Also corrects this file's header comment, which asserted the component was "already zoom-safe". That was true only of its **position** (`getBoundingClientRect` reports post-zoom pixels, so it always landed in the right place — at the wrong size). That half-truth is why the gap survived.

## Test plan

- [x] `npx vitest run PeekOverlay.test.tsx` — 14 passed (6 new), including the 8 pre-existing autoUpdate-lifecycle and mouse-Y-tracking tests unchanged
- [x] New coverage: zoom applied; geometry pre-divided so the panel still lands on the row's edge; the `stretch` variant de-scaled too; **no** `zoom` emitted and geometry untouched at 100%; graceful fallback when the variable is absent, malformed, or non-positive
- [x] `npx tsc --noEmit` — clean
- [ ] Live: zoom an agent pane in/out (Ctrl+wheel), hover a transcript entry — the peek panel should scale with the pane and stay pinned to the entry's right edge

Reported alongside a broader complaint that pane-level and preview-level zoom conflict; that's a separate, larger piece of work and I'm auditing it separately. This fix is self-contained.

<!-- agentmux:agent_id=loap #2 -->