### PR TITLE
Loap #2@claudius: fix(agent): previews zoom with the pane instead of their own broken font-scale

### DIFF
--- a/.changesets/1788686287-fix-agent-previews-now-zoom-with-the-pane-instead-of-their-o-apy2.md
+++ b/.changesets/1788686287-fix-agent-previews-now-zoom-with-the-pane-instead-of-their-o-apy2.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): previews now zoom with the pane instead of their own broken font-scale

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -42,7 +42,7 @@ import { useTick } from "@/app/hook/useTick";
 import { estimateTokenCount, formatCompactNumber } from "@/util/format-count";
 import { formatExactTime, formatTimeAgo } from "@/util/format-time";
 import clsx from "clsx";
-import { Show, createEffect, createMemo, createSignal, onCleanup, onMount, type JSX } from "solid-js";
+import { Show, createEffect, createMemo, createSignal, type JSX } from "solid-js";
 import { extractToolDetail } from "../stream-parser";
 import { useNodePeek } from "../hooks/useNodePeek";
 import type { AgentDispatch } from "../../swarm/swarm-model";
@@ -128,9 +128,30 @@ const STATUS_ICON: Record<ToolNode["status"], string> = {
     canceled: "⏹",
 };
 
-const PREVIEW_ZOOM_STEP = 0.05;
-const PREVIEW_ZOOM_MIN = 0.7;
-const PREVIEW_ZOOM_MAX = 2.0;
+// The tool preview used to carry its OWN Ctrl+wheel zoom here — a local
+// `previewFontScale` signal applied as `font-size: N%` on the overlay-log
+// wrapper. Removed 2026-09-06; see
+// docs/reports/REPORT_ZOOM_BINDINGS_AUDIT_2026_09_06.md for the full audit.
+//
+// Short version: it could not work, and deleting it makes previews zoom
+// MORE, not less. Pane zoom is CSS `zoom` on the pane root, which scales the
+// whole box tree; the preview's font-size percentage only reached
+// descendants authored in `em`/`%`, and `_document-nodes.scss` is 66
+// hardcoded-px font-size rules against 8 relative ones. So it moved ~11% of
+// the type in the panel, and whether it appeared to do anything at all
+// depended on which renderer you happened to be looking at (DiffViewer,
+// BashOutputViewer, HighlightedCode and CompactResult never referenced the
+// scale). That is the "sometimes it doesn't even work" this removes.
+//
+// It also fought the pane: the same Ctrl+wheel did different things a few
+// pixels apart (an `overPreviewBody` hit-test with no visual cue), the two
+// scales composed multiplicatively under different clamps (0.5–2.0 vs
+// 0.7–2.0), and the scale lived in a component-local signal inside a
+// VIRTUALIZED list — so it silently reset on scroll, and `<Index>` slot
+// reuse could land a stale scale on an unrelated tool block.
+//
+// Ctrl+wheel over a preview now simply zooms the pane, which already
+// scales previews correctly, hardcoded pixels included.
 
 export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     // Drives the peek tooltip's live "time ago" text (§2.3 of
@@ -139,35 +160,6 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     // the tooltip is actually open, since Tooltip doesn't expose that state
     // to its caller.
     const peekTick = useTick(1000);
-
-    // Independent font-scale for the tool preview panel. Ctrl+Scroll inside the
-    // panel zooms only the preview; the pane-level zoom (block.meta["term:zoom"])
-    // is unaffected. Ephemeral — not persisted to block meta.
-    const [previewFontScale, setPreviewFontScale] = createSignal(1.0);
-    let panelRef: HTMLDivElement | undefined;
-    onMount(() => {
-        if (!panelRef) return;
-        const onWheel = (e: WheelEvent) => {
-            if (!e.ctrlKey) return;
-            // Only zoom the PREVIEW when the pointer is over the preview body.
-            // Over the file-path header (or anywhere else in the panel), let
-            // Ctrl+wheel bubble through to the pane zoom (term:zoom) — the header
-            // belongs to the pane, not the preview. Without this gate, Ctrl+wheel
-            // over the filename zoomed the preview, and there was no way to zoom
-            // the whole pane while hovering the tool block.
-            const t = e.target as HTMLElement | null;
-            const overPreviewBody =
-                !!t?.closest(".agent-tool-overlay-log") &&
-                !t.closest(".agent-tool-file-path, .agent-tool-file-path-row");
-            if (!overPreviewBody) return; // fall through → pane zoom
-            e.preventDefault();
-            e.stopPropagation();
-            const delta = e.deltaY < 0 ? PREVIEW_ZOOM_STEP : -PREVIEW_ZOOM_STEP;
-            setPreviewFontScale((prev) => Math.min(PREVIEW_ZOOM_MAX, Math.max(PREVIEW_ZOOM_MIN, prev + delta)));
-        };
-        panelRef.addEventListener("wheel", onWheel, { passive: false });
-        onCleanup(() => panelRef?.removeEventListener("wheel", onWheel));
-    });
 
     // A tool stays expanded after completing live until its row scrolls off the
     // top — the "post-completion hold" now lives in `documentState.expandedTools`
@@ -521,7 +513,6 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                  * remove it from the focus/a11y tree when hidden.
                  */}
                 <div
-                    ref={panelRef}
                     class={clsx("agent-tool-panel", {
                         "agent-tool-panel--hidden": panelMode() === "hidden",
                         "agent-tool-panel--flow": panelMode() === "flow",
@@ -537,7 +528,7 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                     aria-hidden={!expanded()}
                     onClick={(e) => e.stopPropagation()}
                 >
-                    <ToolBlockOverlay node={props.node} previewFontScale={previewFontScale} dispatchMatch={props.dispatchMatch} />
+                    <ToolBlockOverlay node={props.node} dispatchMatch={props.dispatchMatch} />
                 </div>
             </div>
         </Show>

--- a/frontend/app/view/agent/components/ToolBlockOverlay.tsx
+++ b/frontend/app/view/agent/components/ToolBlockOverlay.tsx
@@ -33,7 +33,6 @@ import { ToolOverlayLog } from "./ToolOverlayLog";
 
 export interface ToolBlockOverlayProps {
     node: ToolNode;
-    previewFontScale?: () => number;
     /** Ordinal-matched live dispatch for an Agent/Task/Workflow tool call —
      *  see `activity/dispatch-correlation.ts`. */
     dispatchMatch?: AgentDispatch;
@@ -64,7 +63,7 @@ export const ToolBlockOverlay = (props: ToolBlockOverlayProps): JSX.Element => (
                 {STATUS_LABEL[props.node.status]}
             </span>
         </div>
-        <ToolOverlayLog node={props.node} fontScale={props.previewFontScale} dispatchMatch={props.dispatchMatch} />
+        <ToolOverlayLog node={props.node} dispatchMatch={props.dispatchMatch} />
     </div>
 );
 

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -44,7 +44,6 @@ import "./tool-renderers/DispatchCard";
 
 interface ToolOverlayLogProps {
     node: ToolNode;
-    fontScale?: () => number;
     /** Ordinal-matched live dispatch for an Agent/Task/Workflow tool call —
      *  see `activity/dispatch-correlation.ts`. Undefined when no confident
      *  match was found, or for any other tool kind. */
@@ -160,8 +159,13 @@ export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
         const el = scrollRef;
         if (!el) return;
         const onWheel = (e: WheelEvent) => {
-            // Ctrl+wheel is the preview font-zoom gesture (ToolBlock.tsx) —
-            // leave it alone.
+            // Ctrl+wheel is a ZOOM gesture, not a scroll — never scroll-chain
+            // it. It used to belong to the preview's own font-zoom
+            // (ToolBlock.tsx); that was removed 2026-09-06 and it now falls
+            // through to the pane zoom in app.tsx. The guard is still
+            // required either way: without it, a Ctrl+wheel at this box's
+            // scroll boundary would zoom the pane AND scroll it at the same
+            // time.
             if (e.ctrlKey) return;
             const atTop = el.scrollTop <= 0;
             const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1;
@@ -341,7 +345,6 @@ export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
             class="agent-tool-overlay-log"
             ref={scrollRef}
             onScroll={onScroll}
-            style={props.fontScale ? { "font-size": `${props.fontScale() * 100}%` } : undefined}
         >
             <Switch>
                 <Match when={isStreaming() && hasChunks()}>


### PR DESCRIPTION
## Summary

Deletes the tool preview's separate Ctrl+wheel zoom. Ctrl+wheel over a preview now zooms the pane, like everywhere else.

Implements §3 of the audit in #3010.

**This makes previews zoom *more*, not less** — which is the counterintuitive part worth reading before reviewing. The two systems used different CSS mechanisms:

| | Mechanism | Scales hardcoded `px`? |
|---|---|---|
| Pane zoom | CSS `zoom` on the pane root | **Yes** — scales the whole box tree |
| Preview zoom (deleted) | `font-size: N%` on one wrapper | **No** — only `em`/`%` descendants |

`_document-nodes.scss` carries **66 hardcoded `font-size: …px` rules against 8 relative ones**, so the preview gesture could only ever move ~11% of the type in the panel — and `DiffViewer`, `BashOutputViewer`, `HighlightedCode` and `CompactResult` never referenced the scale at all. That's the reported *"sometimes it doesn't even work"*: whether it did anything depended on which renderer you happened to be looking at.

It also fought the pane three ways:
1. The same Ctrl+wheel did different things a few pixels apart (an `overPreviewBody` hit-test, no visual cue where the boundary was).
2. The two scales composed multiplicatively under different clamps (0.5–2.0 vs 0.7–2.0).
3. The scale lived in a component-local signal inside a **virtualized** list — so it silently reset on scroll, and per `ToolBlock`'s own comments `<Index>` recycles instances across nodes, so a stale scale could land on an unrelated tool block.

## Deliberately kept

`ToolOverlayLog`'s `if (e.ctrlKey) return` scroll-chain guard. Its old rationale ("leave the preview zoom alone") is gone, but the guard is still load-bearing: without it, a Ctrl+wheel at that box's scroll boundary would now zoom the pane **and** scroll it at the same time. Comment rewritten rather than deleted.

## What is genuinely lost

Enlarging a dense diff without enlarging the surrounding transcript. Worth naming plainly rather than pretending the feature was pure cost — though in practice it worked on ~11% of the panel's text and reset on scroll. If it's wanted back, the correct build is CSS `zoom` on the preview container plus block-meta persistence, mirroring the pane system.

**Behavior change to expect:** previews will *start* obeying pane zoom in places they previously didn't. That's the fix, but it's visible on first launch — flagged here and in the changeset so it doesn't read as a regression.

## Test plan

- [x] `npx vitest run frontend/app/view/agent/` — 1787 passed / 132 files, 0 failures
- [x] `ToolBlock.test.tsx` + `ToolOverlayLog.test.tsx` specifically — 44 passed
- [x] `npx tsc --noEmit` — clean (also removed `onMount`/`onCleanup` from `ToolBlock`'s imports, now unused)
- [x] No `previewFontScale` / `PREVIEW_ZOOM_*` / `fontScale` references remain anywhere in `frontend/`
- [ ] Live: Ctrl+wheel over a tool preview body, over its filename header, and over plain transcript text — all three should now zoom the pane identically, and the preview content should scale along with it

<!-- agentmux:agent_id=loap #2 -->