### PR TITLE
fix(tray): rename Open AgentMux to New Window, drop the panel entry

### DIFF
--- a/.changesets/1788686547-fix-tray-rename-open-agentmux-to-new-window-and-drop-the-pan-wien.md
+++ b/.changesets/1788686547-fix-tray-rename-open-agentmux-to-new-window-and-drop-the-pan-wien.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(tray): rename Open AgentMux to New Window and drop the panel entry

--- a/agentmux-launcher/src/supervisor/windows.rs
+++ b/agentmux-launcher/src/supervisor/windows.rs
@@ -328,8 +328,6 @@ pub(crate) async fn run_windows(
                         // so srv still gets its per-window cleanup. Killing
                         // the job object here instead would leak srv rows and
                         // resurrect ghost windows on next launch.
-                        // Issue #2977 WS3 — small companion window, pool-first.
-                        tray::TrayAction::ShowPanel => "open_panel",
                         tray::TrayAction::Quit => "quit_app",
                     };
                     forward_tray_cmd(&tray_data_dir, &tray_dir_hash, cmd);

--- a/agentmux-launcher/src/tray/mod.rs
+++ b/agentmux-launcher/src/tray/mod.rs
@@ -44,15 +44,12 @@ mod windows;
 /// platform-neutral, so the handling logic is written and tested once.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrayAction {
-    /// "Open AgentMux" — or a left-click / double-click on the icon itself.
+    /// "New Window" (or "Start AgentMux" when the service is down) — also a
+    /// left-click / double-click on the icon itself.
     /// Reuses the existing `open_new_window` forward rather than introducing a
     /// second way to make a window (see §7.5.1: the reopen path already exists
     /// and is what the macOS reopen delegate uses).
     OpenWindow,
-    /// "Show Panel" — the small companion window (issue #2977 WS3). A real
-    /// CEF window reusing the pool promote path, NOT a native menu: the spec
-    /// rejects a native menu as "too limited for agent chat".
-    ShowPanel,
     /// "Quit AgentMux" — a genuine, user-intended full shutdown, distinct from
     /// closing the last window while background-service mode is on.
     Quit,
@@ -80,16 +77,17 @@ pub struct MenuItem {
 pub fn menu_model(running: bool) -> Vec<MenuItem> {
     vec![
         MenuItem {
+            // "New Window" rather than "Open AgentMux": the icon's presence
+            // already says AgentMux is up, so "Open" read as a no-op for a
+            // state the user can see is true. When the service is NOT
+            // reachable the wording still has to change — "New Window" would
+            // promise something that cannot happen — hence "Start AgentMux".
             label: if running {
-                "Open AgentMux".to_string()
+                "New Window".to_string()
             } else {
                 "Start AgentMux".to_string()
             },
             action: TrayAction::OpenWindow,
-        },
-        MenuItem {
-            label: "Show Panel".to_string(),
-            action: TrayAction::ShowPanel,
         },
         MenuItem {
             label: "Quit AgentMux".to_string(),
@@ -189,19 +187,21 @@ mod tray_model_tests {
     }
 
     #[test]
-    fn menu_offers_open_panel_and_quit_in_that_order() {
+    fn menu_offers_new_window_and_quit_in_that_order() {
+        // Two items, deliberately. The panel entry was removed: `open_panel`
+        // still exists as a host IPC command (issue #2977 WS3, PR #3002), it
+        // is simply not reachable from the tray for now.
         let m = menu_model(true);
-        assert_eq!(m.len(), 3, "menu is deliberately minimal");
+        assert_eq!(m.len(), 2, "menu is deliberately minimal");
         assert_eq!(m[0].action, TrayAction::OpenWindow);
-        assert_eq!(m[1].action, TrayAction::ShowPanel);
-        assert_eq!(m[2].action, TrayAction::Quit);
+        assert_eq!(m[1].action, TrayAction::Quit);
     }
 
     #[test]
     fn menu_and_tooltip_report_running_state_honestly() {
         // WS4: the icon must be a reliable "is it actually running"
         // indicator, so both surfaces have to change with the state.
-        assert_eq!(menu_model(true)[0].label, "Open AgentMux");
+        assert_eq!(menu_model(true)[0].label, "New Window");
         assert_eq!(menu_model(false)[0].label, "Start AgentMux");
         assert!(tooltip(true).contains("running in the background"));
         assert!(tooltip(false).contains("not running"));


### PR DESCRIPTION
## Summary

Repo owner's call after using the tray for real.

**"Open AgentMux" → "New Window".** The label was wrong precisely in the state where you read it: the icon is only in the tray when AgentMux is *up*, so the menu was offering to open something you can plainly see is already open. It reads as a no-op. What the item actually does is make a new window, so it now says that.

**"Show Panel" removed.** Not reachable from the tray for now.

**"Quit AgentMux" unchanged.**

## Details worth flagging

**The not-running label still differs.** `OpenWindow`'s label is state-dependent, and "New Window" would promise something that cannot happen when the service is unreachable — so that case keeps **"Start AgentMux"**. The menu still changes with running state, which is the WS4 requirement that the icon *and* its menu be honest about whether the service is up. Only the running-state wording changed.

**Nothing is deleted from the panel feature.** `open_panel` remains a host IPC command with its geometry tests (issue #2977 WS3, #3002) — it is simply not wired to a tray entry. I removed the `TrayAction::ShowPanel` variant and its dispatch arm along with the menu item rather than leaving them behind: unused, they would draw a dead-code warning and, worse, read to the next person as a live path that just doesn't work. Restoring the entry is a three-line change against this diff.

## Tests

Updated, not deleted:
- the ordering test now asserts **two** items, so an accidentally reintroduced entry still fails rather than silently passing a `len()`-free check
- the label test pins the new wording

`launcher 232 passed`.

<!-- agentmux:agent_id=agent5 -->
