### PR TITLE
fix(settings): seed settings.json at startup, not only when the Settings pane opens

### DIFF
--- a/.changesets/1788690515-fix-settings-seed-settings-json-at-startup-instead-of-only-w-egie.md
+++ b/.changesets/1788690515-fix-settings-seed-settings-json-at-startup-instead-of-only-w-egie.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(settings): seed settings.json at startup instead of only when the Settings pane opens

--- a/agentmux-cef/src/sidecar.rs
+++ b/agentmux-cef/src/sidecar.rs
@@ -9,6 +9,44 @@ use std::sync::Arc;
 
 use crate::state::AppState;
 
+/// Seed `settings.json` from the template as soon as the config dir is known.
+///
+/// Until this existed, `ensure_settings_file` was only ever reached from the
+/// Settings pane and the "open settings file" command — i.e. **a fresh
+/// instance had no `settings.json` at all until a human happened to open
+/// Settings**. Every setting silently ran on its code default, and because
+/// settings are per-channel/per-instance isolated
+/// (`SPEC_SETTINGS_ISOLATED_BY_CHANNEL_2026_08_19.md`), a value set in one
+/// instance did not apply to another — so the file's absence was invisible
+/// AND the defaults were not what the operator believed they had configured.
+/// Found via a `network:lan_discovery` toggle that appeared set but wasn't,
+/// on an instance whose data dir had no config file at all.
+///
+/// Called from BOTH backend-init paths (launcher-provided endpoints and
+/// host-spawned) through this one helper deliberately: two independently
+/// maintained provisioning paths is exactly how the auth-dir seeding gap
+/// happened (see `prepare_provider_auth_dir`'s call sites).
+///
+/// Non-fatal by design — a failure here must never block startup. The app is
+/// fully usable on defaults; it just won't have a browsable/editable file
+/// until the next attempt.
+fn seed_settings_file(state: &Arc<AppState>) {
+    match crate::commands::platform::ensure_settings_file(state) {
+        Ok(path) => {
+            tracing::info!(
+                path = %path.as_str().unwrap_or_default(),
+                "settings.json ensured at startup"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "could not ensure settings.json at startup — continuing on defaults"
+            );
+        }
+    }
+}
+
 /// State returned after successfully spawning the backend.
 #[derive(Clone, Debug)]
 pub struct BackendSpawnResult {
@@ -101,6 +139,9 @@ pub fn use_launcher_endpoints(
         *state.version_data_dir.lock() = Some(data_dir);
         *state.version_config_dir.lock() = Some(config_dir);
         *state.user_home_dir.lock() = Some(user_home_dir);
+        // Config dir is now known — materialize settings.json (see the
+        // helper's doc comment for why this can't wait for the Settings pane).
+        seed_settings_file(state);
 
         let version = env!("CARGO_PKG_VERSION").to_string();
         Ok(BackendSpawnResult {
@@ -191,6 +232,9 @@ pub async fn spawn_backend(state: &Arc<AppState>) -> Result<BackendSpawnResult, 
     // so the value must be the account-wide root, not a per-version
     // subdir.
     *state.user_home_dir.lock() = Some(paths.home_dir.to_string_lossy().to_string());
+    // Config dir is now known — materialize settings.json (see the helper's
+    // doc comment for why this can't wait for the Settings pane).
+    seed_settings_file(state);
 
     // 3. Resolve the backend binary path
     let backend_name = "agentmux-srv";


### PR DESCRIPTION
## The bug

`ensure_settings_file()` had exactly **three callers, all user-initiated UI** — `settings-view.tsx` (×2) and a command-registry action. **Nothing called it at startup.**

So a fresh instance has **no `settings.json` at all** until a human happens to open the Settings pane.

Two things make that worse than it sounds:

- Settings are per-channel/per-instance isolated (`SPEC_SETTINGS_ISOLATED_BY_CHANNEL_2026_08_19`), so a value set in one instance doesn't apply to another. The missing file is invisible **and** the effective values are code defaults rather than what the operator believes they configured.
- Nothing signals the file is absent. The app just quietly runs on defaults.

## How it was found

Debugging why LAN discovery was off on a peer machine despite the operator having enabled it. `network:lan_discovery` read `false` because that instance's data dir had **no `config/settings.json`** — while the toggle they'd set lived in a *different* instance's file. The same confusion is possible for every other setting; LAN discovery just happened to be the one with a visible symptom.

Confirmed on the peer: live instance dir has no `config/settings.json`, zero `LAN discovery started` lines in its srv log, and `dns-sd -B _agentmux._tcp` returns nothing — it never advertises.

## The fix

Seed from the template as soon as `version_config_dir` is known.

Routed through **one shared helper** called from both backend-init paths (launcher-provided endpoints and host-spawned) rather than duplicating the call at each — two independently-maintained provisioning paths is precisely how the provider auth-dir seeding gap happened, and that lesson is cited in the helper's doc comment.

**Non-fatal by design:** failure logs a warning and startup continues. The app is fully usable on defaults; it just won't have a browsable file until the next attempt. Blocking boot on settings materialization would be a worse failure than the one being fixed.

## Scope / limits

- Only affects instances started **after** this change. An already-running instance with no `settings.json` still needs a restart.
- **Not unit-tested:** the seam is CEF-host startup wiring, which has no existing test harness. `ensure_settings_file`'s own merge behaviour is already covered (`wconfig::tests::test_merge_into_template_*`). Flagging rather than papering over it — if reviewers want coverage here, it needs a new harness, which is a bigger change than the fix.

## Verification

- `cargo check -p agentmux-cef --lib` → clean (exit 0; remaining warnings pre-existing and unrelated).

<!-- agentmux:agent_id=agent2 -->