### PR TITLE
fix(providers): bump pinned CLI versions per overnight drift report

### DIFF
--- a/.changesets/1788709326-fix-providers-bump-pinned-cli-versions-per-overnight-drift-r-giib.md
+++ b/.changesets/1788709326-fix-providers-bump-pinned-cli-versions-per-overnight-drift-r-giib.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(providers): bump pinned CLI versions per overnight drift report

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -13,7 +13,7 @@ on:
         # frontend/app/view/agent/providers/pin-consistency.test.ts.
         description: 'Claude Code version to pin (empty = latest)'
         required: false
-        default: '2.1.247'
+        default: '2.1.263'
 
 env:
   REGISTRY: ghcr.io

--- a/agentmux-cef/src/commands/providers.rs
+++ b/agentmux-cef/src/commands/providers.rs
@@ -201,9 +201,9 @@ fn detect_cli(name: &str) -> CliDetectionResult {
 // frontend/app/view/agent/providers/index.ts `pinnedVersion`, and
 // .github/workflows/container-image.yml `claude_version` default — enforced by
 // frontend/app/view/agent/providers/pin-consistency.test.ts.
-const CLAUDE_VERSION: &str = "2.1.247";
-const CODEX_VERSION: &str = "0.116.0";
-const GEMINI_VERSION: &str = "0.32.1";
+const CLAUDE_VERSION: &str = "2.1.263";
+const CODEX_VERSION: &str = "0.153.4";
+const GEMINI_VERSION: &str = "0.58.0";
 
 fn get_provider_install_dir(data_dir: &str, provider: &str) -> Result<std::path::PathBuf, String> {
     Ok(std::path::PathBuf::from(data_dir)

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -212,7 +212,7 @@ static CLAUDE: ProviderConfig = ProviderConfig {
     // agentmux-cef/src/commands/providers.rs `CLAUDE_VERSION`, and
     // .github/workflows/container-image.yml `claude_version` default — enforced by
     // frontend/app/view/agent/providers/pin-consistency.test.ts.
-    pinned_version: "2.1.247",
+    pinned_version: "2.1.263",
     // Documented Claude Code behavior: redirects the CLI at a non-Anthropic
     // (or proxied) backend — Bedrock, Vertex, OpenRouter, a custom proxy.
     base_url_env_var: Some("ANTHROPIC_BASE_URL"),
@@ -243,7 +243,7 @@ static CODEX: ProviderConfig = ProviderConfig {
     auth_extra_env: &[],
     unset_env: &[],
     npm_package: "@openai/codex",
-    pinned_version: "0.116.0",
+    pinned_version: "0.153.4",
     base_url_env_var: None,
     supported_vendors: &["openai"],
     // Confirmed: SPEC_CODEX_PROVIDER_INTEGRATION_2026_08_08.md §10.2 —
@@ -269,7 +269,7 @@ static GEMINI: ProviderConfig = ProviderConfig {
     auth_extra_env: &[("GEMINI_FORCE_FILE_STORAGE", "true")],
     unset_env: &[],
     npm_package: "@google/gemini-cli",
-    pinned_version: "0.32.1",
+    pinned_version: "0.58.0",
     base_url_env_var: None,
     supported_vendors: &["google"],
     // Confirmed: Gemini CLI docs — context files default to GEMINI.md;
@@ -308,7 +308,7 @@ static QWEN: ProviderConfig = ProviderConfig {
     auth_extra_env: &[],
     unset_env: &[],
     npm_package: "@qwen-code/qwen-code",
-    pinned_version: "0.19.2",
+    pinned_version: "0.23.0",
     // Note: qwen's default backend already routes through an OpenAI-compatible
     // endpoint (see comment above) as a fixed part of its auth setup — but
     // that's baked-in default routing, not a confirmed user-configurable
@@ -394,7 +394,7 @@ static OPENCLAW: ProviderConfig = ProviderConfig {
     auth_extra_env: &[],
     unset_env: &[],
     npm_package: "openclaw",
-    pinned_version: "2026.6.10",
+    pinned_version: "2026.9.2",
     base_url_env_var: None,
     supported_vendors: &["openai", "anthropic", "google"],
     // Confirmed convention, UNCONFIRMED path: docs.openclaw.ai/reference/AGENTS.default
@@ -495,7 +495,7 @@ static COPILOT: ProviderConfig = ProviderConfig {
     auth_extra_env: &[],
     unset_env: &[],
     npm_package: "@github/copilot",
-    pinned_version: "1.0.65",
+    pinned_version: "1.0.83",
     base_url_env_var: None,
     supported_vendors: &["github"],
     // Confirmed: GitHub Copilot CLI custom-instructions docs — supports

--- a/docker/Dockerfile.agent-agentmux
+++ b/docker/Dockerfile.agent-agentmux
@@ -33,7 +33,7 @@ RUN usermod -l agent -d /home/agent -m node \
 
 # Claude Code — version pinned at build time for reproducible images.
 # Managed by rebuilding with a new CLAUDE_VERSION arg, not npm update.
-ARG CLAUDE_VERSION=2.1.247
+ARG CLAUDE_VERSION=2.1.263
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_VERSION}
 
 # Prevent in-container auto-updates — version is managed at the image level.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -337,7 +337,7 @@ partial list.
 | [`SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29`](SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29.md) | Spec: multi-tier discovery + remote API invocation over muxbus |
 | [`SPEC_WINDOW_NAME_API_HARDENING_2026_08_08`](SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md) | SPEC: Window-name App API hardening (phantom-id success + status codes) |
 
-### proposed (96)
+### proposed (97)
 
 | Spec | Title |
 |---|---|
@@ -403,6 +403,7 @@ partial list.
 | [`SPEC_PERFORMANCE_INSTRUMENTATION_AND_OPTIMIZATION`](SPEC_PERFORMANCE_INSTRUMENTATION_AND_OPTIMIZATION.md) | Performance instrumentation + optimization strategy |
 | [`SPEC_PER_NODE_TOKEN_ACCOUNTING_2026_08_03`](SPEC_PER_NODE_TOKEN_ACCOUNTING_2026_08_03.md) | Spec: true per-node token accounting |
 | [`SPEC_PROVIDER_AWARE_STARTUP_INSTRUCTIONS_2026_08_24`](SPEC_PROVIDER_AWARE_STARTUP_INSTRUCTIONS_2026_08_24.md) | SPEC: Provider-aware startup instructions filename + visibility in Global Memory |
+| [`SPEC_PROVIDER_CLI_VERSION_UPGRADE_2026_09_06`](SPEC_PROVIDER_CLI_VERSION_UPGRADE_2026_09_06.md) | Provider CLI version upgrade (2026-09-06 drift report) |
 | [`SPEC_RESPONSIVE_TAB_BAR_TOP_POSITION_2026_08_24`](SPEC_RESPONSIVE_TAB_BAR_TOP_POSITION_2026_08_24.md) | SPEC: Move the narrow-width responsive tab bar to the top (from the bottom) |
 | [`SPEC_SESSION_RESTORE_AND_SAVED_LAYOUTS_2026_08_13`](SPEC_SESSION_RESTORE_AND_SAVED_LAYOUTS_2026_08_13.md) | Spec: Restore-on-relaunch + named, reloadable "Layouts" |
 | [`SPEC_SHUTDOWN_COUNTDOWN_MODAL_2026_09_04`](SPEC_SHUTDOWN_COUNTDOWN_MODAL_2026_09_04.md) | A formal shutdown sequence: countdown-confirm modal + splash-style progress |

--- a/docs/specs/SPEC_PROVIDER_CLI_VERSION_UPGRADE_2026_09_06.md
+++ b/docs/specs/SPEC_PROVIDER_CLI_VERSION_UPGRADE_2026_09_06.md
@@ -1,0 +1,89 @@
+# Provider CLI version upgrade (2026-09-06 drift report)
+
+**Status:** proposed → implementing
+
+## 1. Source
+
+`a5af/shared-infrastructure`'s new `provider-reporter` Lambda (PR #458,
+`shared-infrastructure/provider-reporter/`) ran its scheduled drift check
+overnight and archived the result at
+`s3://infrastructure-provider-reporter-reports/reports/agentmux/2026-09-06.json`
+(`generated_at: 2026-09-06T13:15:32Z`). It compares each provider's
+`pinnedVersion` in AgentMux's `catalog.ts` against the latest version
+published on npm.
+
+## 2. Findings
+
+| Provider | Package | Pinned | Latest | Action |
+|---|---|---|---|---|
+| claude | `@anthropic-ai/claude-code` | 2.1.247 | 2.1.263 | **Bump** |
+| codex | `@openai/codex` | 0.116.0 | 0.153.4 | **Bump** |
+| gemini | `@google/gemini-cli` | 0.32.1 | 0.58.0 | **Bump** |
+| qwen | `@qwen-code/qwen-code` | 0.19.2 | 0.23.0 | **Bump** |
+| openclaw | `openclaw` | 2026.6.10 | 2026.9.2 | **Bump** |
+| copilot | `@github/copilot` | 1.0.65 | 1.0.83 | **Bump** |
+| pi | `@mariozechner/pi-coding-agent` | 0.73.1 | 0.73.1 | none — current |
+| kimi | (none, pip-based) | — | — | none — intentionally unmonitored |
+| muxcode | `@agentmuxai/muxcode` | 0.1.0 | lookup-failed | **not a real drift** — see §3 |
+| antigravity | `@google/antigravity-cli` | 1.0.0 | lookup-failed | **not a real drift** — see §3 |
+
+Model catalog section of the report: all four curated Claude rows
+(`opus`/`sonnet`/`haiku`/`claude-fable-5-1`) are `current` against the
+Anthropic-authoritative source. No model catalog changes needed.
+
+## 3. `lookup-failed` is expected here, not a defect
+
+Verified directly against the npm registry: both
+`https://registry.npmjs.org/@agentmuxai/muxcode` and
+`https://registry.npmjs.org/@google/antigravity-cli` return **404** — the
+packages are genuinely unpublished (muxcode is AgentMux's own first-party
+CLI, not yet released to npm; antigravity is Google's harness, not yet
+public on npm either). The reporter's `lookup-failed` severity (`warn`)
+already exists precisely to distinguish this from a registry error rather
+than silently reporting "no drift" (see `provider-reporter/README.md`
+"Known limitations"). There is nothing to bump for either provider — their
+`pinnedVersion` stays as-is until the package actually publishes.
+
+## 4. Fix — bump six pins across all locations the pin-consistency test enforces
+
+Per `frontend/app/view/agent/providers/pin-consistency.test.ts`'s header
+comment, the **claude** pin is duplicated across five locations that must
+agree; **codex** and **gemini** across three (no container/Dockerfile
+copy — those are Claude-specific because the container image is a Claude
+agent image); **qwen**, **openclaw**, and **copilot** are not covered by
+that test at all today (the cef host installer's `get_pinned_version` only
+handles claude/codex/gemini) — their pin lives in exactly two places
+(`catalog.ts` + `agentmux-srv/providers.rs`), both updated here for
+consistency even though nothing currently machine-checks them.
+
+| Location | claude | codex | gemini | qwen | openclaw | copilot |
+|---|---|---|---|---|---|---|
+| `frontend/app/view/agent/providers/catalog.ts` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `agentmux-srv/src/backend/providers.rs` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `agentmux-cef/src/commands/providers.rs` | ✅ | ✅ | ✅ | — | — | — |
+| `.github/workflows/container-image.yml` (`claude_version` default) | ✅ | — | — | — | — | — |
+| `docker/Dockerfile.agent-agentmux` (`ARG CLAUDE_VERSION`) | ✅ | — | — | — | — | — |
+
+New pins: claude `2.1.263`, codex `0.153.4`, gemini `0.58.0`, qwen `0.23.0`,
+openclaw `2026.9.2`, copilot `1.0.83`.
+
+## 5. Non-goals
+
+- No change to `muxcode`/`antigravity`/`kimi`/`pi` pins (§3, and pi/kimi
+  need no change per §2).
+- No model catalog changes (all current per §2).
+- Not fixing `provider-reporter`'s own known limitation that `catalog.ts`
+  is scraped rather than consumed as a generated contract — tracked
+  separately in `shared-infrastructure/specs/SPEC_REPORTER_PLATFORM_CONSOLIDATION_2026_09_05.md`,
+  out of scope for this repo.
+
+## 6. Testing
+
+- `npx vitest run frontend/app/view/agent/providers/pin-consistency.test.ts` —
+  the existing drift guard must pass with the new claude/codex/gemini pins.
+- `npx tsc --noEmit -p .`
+- `cargo check -p agentmux-srv -p agentmux-cef` (or `task build:backend`) to
+  confirm the Rust pin literals compile.
+- Manual: none required — pin bumps don't change install/launch behavior
+  beyond which concrete version string is passed to `npm install -g
+  <pkg>@<version>`.

--- a/docs/specs/SPEC_PROVIDER_CLI_VERSION_UPGRADE_2026_09_06.md
+++ b/docs/specs/SPEC_PROVIDER_CLI_VERSION_UPGRADE_2026_09_06.md
@@ -67,6 +67,23 @@ consistency even though nothing currently machine-checks them.
 New pins: claude `2.1.263`, codex `0.153.4`, gemini `0.58.0`, qwen `0.23.0`,
 openclaw `2026.9.2`, copilot `1.0.83`.
 
+## 4.1. Codex default-model re-verification (ReAgent finding on this PR)
+
+`frontend/app/view/agent/buildRuntimeArgs.ts`'s `CODEX_DEFAULT_MODEL`
+comment explicitly instructs: "re-verify ChatGPT-account availability when
+bumping the codex CLI pin" — codex 0.116.0's own baked default
+(`gpt-5.3-codex`) was rejected for ChatGPT-account auth, which is why
+AgentMux overrides it to `gpt-5.5` in the first place. The initial version
+of this spec (and PR) missed this check entirely. Re-verified 2026-09-06
+against OpenAI's own Codex model documentation: `gpt-5.5` **remains fully
+supported for ChatGPT sign-in auth** under the new pin (0.153.4) — it's
+now described as the "previous-generation flagship" (superseded at the top
+by `gpt-6-astra`, launched 2026-09-03, but that rollout is staged to a
+limited set of organizations as of this check, not yet broadly available),
+not retired or rejected. **No `CODEX_DEFAULT_MODEL` change is needed.**
+See the updated comment at `buildRuntimeArgs.ts:34-42` for the same note
+inline.
+
 ## 5. Non-goals
 
 - No change to `muxcode`/`antigravity`/`kimi`/`pi` pins (§3, and pi/kimi
@@ -84,6 +101,7 @@ openclaw `2026.9.2`, copilot `1.0.83`.
 - `npx tsc --noEmit -p .`
 - `cargo check -p agentmux-srv -p agentmux-cef` (or `task build:backend`) to
   confirm the Rust pin literals compile.
-- Manual: none required — pin bumps don't change install/launch behavior
-  beyond which concrete version string is passed to `npm install -g
-  <pkg>@<version>`.
+- Manual: pin bumps mostly only change which concrete version string is
+  passed to `npm install -g <pkg>@<version>` — but see §4.1 for the one
+  exception found on review (codex's hardcoded default model), which was
+  checked and confirmed safe, not just assumed.

--- a/frontend/app/view/agent/buildRuntimeArgs.ts
+++ b/frontend/app/view/agent/buildRuntimeArgs.ts
@@ -32,9 +32,13 @@ const PERMISSION_STRIP = new Set([
 ]);
 
 // Default codex model. The Claude-named `ModelChoice` (opus/sonnet/haiku) does
-// not apply to codex, and codex 0.116.0's baked default (gpt-5.3-codex) is
-// rejected for ChatGPT-account auth. gpt-5.5 is the current ChatGPT-supported
-// codex frontier (more intelligent + more token-efficient than gpt-5.4).
+// not apply to codex, and codex 0.116.0's baked default (gpt-5.3-codex) was
+// rejected for ChatGPT-account auth. gpt-5.5 remains valid — re-verified
+// 2026-09-06 against OpenAI's own Codex model docs when the CLI pin bumped to
+// 0.153.4 (SPEC_PROVIDER_CLI_VERSION_UPGRADE_2026_09_06.md): gpt-5.5 is
+// explicitly still supported for ChatGPT sign-in auth, described there as the
+// "previous-generation flagship" (gpt-6-astra is newer but in a staged,
+// limited-org rollout as of that date, so gpt-5.5 stays the safer default).
 // Per-provider model selection is a follow-up — see
 // docs/specs/SPEC_PROVIDER_MODELS_EFFORT_GENERALIZATION_2026-06-14.md
 // (re-verify ChatGPT-account availability when bumping the codex CLI pin).

--- a/frontend/app/view/agent/providers/catalog.ts
+++ b/frontend/app/view/agent/providers/catalog.ts
@@ -119,7 +119,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         // agentmux-cef/src/commands/providers.rs `CLAUDE_VERSION`, and
         // .github/workflows/container-image.yml `claude_version` default — enforced by
         // ./pin-consistency.test.ts.
-        pinnedVersion: "2.1.247",
+        pinnedVersion: "2.1.263",
         docsUrl: "https://docs.anthropic.com/claude-code",
         windowsInstallCommand: "irm https://claude.ai/install.ps1 | iex",
         unixInstallCommand: "curl -fsSL https://claude.ai/install.sh | bash",
@@ -196,7 +196,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         authCheckCommand: ["login", "status"],
         authLoginCommand: ["login"],
         npmPackage: "@openai/codex",
-        pinnedVersion: "0.116.0",
+        pinnedVersion: "0.153.4",
         docsUrl: "https://platform.openai.com/docs/codex",
         windowsInstallCommand: "npm install -g @openai/codex",
         unixInstallCommand: "npm install -g @openai/codex",
@@ -272,7 +272,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         authCheckCommand: ["auth", "status"],
         authLoginCommand: ["auth", "login"],
         npmPackage: "@google/gemini-cli",
-        pinnedVersion: "0.32.1",
+        pinnedVersion: "0.58.0",
         docsUrl: "https://ai.google.dev/gemini-cli",
         windowsInstallCommand: "npm install -g @google/gemini-cli",
         unixInstallCommand: "npm install -g @google/gemini-cli",
@@ -314,7 +314,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         authCheckCommand: ["auth", "status"],
         authLoginCommand: ["auth"],
         npmPackage: "@qwen-code/qwen-code",
-        pinnedVersion: "0.19.2",
+        pinnedVersion: "0.23.0",
         docsUrl: "https://qwenlm.github.io/qwen-code-docs",
         windowsInstallCommand: "npm install -g @qwen-code/qwen-code",
         unixInstallCommand: "npm install -g @qwen-code/qwen-code",
@@ -370,7 +370,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         // only the args here. Kimi's `["login"]` is the convention.
         authLoginCommand: ["models", "auth", "login", "--provider", "openai-codex"],
         npmPackage: "openclaw",
-        pinnedVersion: "2026.6.10",
+        pinnedVersion: "2026.9.2",
         docsUrl: "https://docs.openclaw.ai",
         windowsInstallCommand: "npm install -g openclaw",
         unixInstallCommand: "npm install -g openclaw",
@@ -438,7 +438,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         authCheckCommand: ["auth", "status"],
         authLoginCommand: ["auth", "login"],
         npmPackage: "@github/copilot",
-        pinnedVersion: "1.0.65",
+        pinnedVersion: "1.0.83",
         docsUrl: "https://docs.github.com/copilot/concepts/agents/about-copilot-cli",
         windowsInstallCommand: "npm install -g @github/copilot",
         unixInstallCommand: "npm install -g @github/copilot",


### PR DESCRIPTION
## Summary
- shared-infrastructure's new `provider-reporter` Lambda (PR #458) ran its first scheduled drift check overnight and archived a report showing six AgentMux-pinned provider CLIs behind upstream npm: `claude` (2.1.247→2.1.263), `codex` (0.116.0→0.153.4), `gemini` (0.32.1→0.58.0), `qwen` (0.19.2→0.23.0), `openclaw` (2026.6.10→2026.9.2), `copilot` (1.0.65→1.0.83).
- Bumps each pin across every location `pin-consistency.test.ts` requires to agree (`catalog.ts` + `agentmux-srv/providers.rs` for all six; `agentmux-cef/providers.rs` + `container-image.yml` + `Dockerfile.agent-agentmux` additionally for claude/codex/gemini).
- `muxcode` and `antigravity`'s "lookup-failed" rows in the report are **not** real drift — verified directly against the npm registry, both packages genuinely 404 (not yet published). Left untouched.
- Model catalog section of the report showed no drift (all curated Claude rows current) — no model changes.

Spec: `docs/specs/SPEC_PROVIDER_CLI_VERSION_UPGRADE_2026_09_06.md`

## Test plan
- [x] `npx vitest run frontend/app/view/agent/providers/pin-consistency.test.ts frontend/app/view/agent/providers/index.test.ts` — 33/33 pass
- [x] `npx tsc --noEmit -p .` — clean
- [x] `cargo check -p agentmux-srv -p agentmux-cef` — compiles clean (pre-existing unrelated dead-code warnings only)
- [x] `check-doc-status.sh`, `check-spec-citations.sh`, `gen-docs-index.sh --check`, `check-menu-positioning.sh`, `check-scrollbar-cursor.sh`, `check-input-handler-layout-reads.sh` — all clean

<!-- agentmux:agent_id=agent3 -->