### PR TITLE
perf(lan): query LAN peers concurrently instead of sequentially

### DIFF
--- a/.changesets/1788712277-perf-lan-query-lan-peers-concurrently-instead-of-sequentiall-a696.md
+++ b/.changesets/1788712277-perf-lan-query-lan-peers-concurrently-instead-of-sequentiall-a696.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+perf(lan): query LAN peers concurrently instead of sequentially

--- a/agentmux-srv/src/backend/lan_discovery.rs
+++ b/agentmux-srv/src/backend/lan_discovery.rs
@@ -147,6 +147,56 @@ struct LanCacheEntry {
     expires: std::time::Instant,
 }
 
+/// One in-flight `GET /agentmux/reactive/agent?id=…` against a single peer.
+type PeerQueryOutcome = (String, String, Result<reqwest::Response, reqwest::Error>);
+
+/// Query EVERY eligible LAN peer concurrently for `agent_id`, yielding results
+/// as they arrive.
+///
+/// Replaces the sequential `for peer in &peers { … .await }` both lookups used
+/// to run. That loop cost up to `LAN_PEER_QUERY_TIMEOUT_SECS × peer_count`
+/// before a message could be delivered — 10s across five peers — and the
+/// pathological ordering (a dead or slow peer ahead of the right one) is the
+/// common case on a laptop network where stale peers linger until their mDNS
+/// TTL expires. Fanning out makes the worst case ~one timeout regardless of
+/// peer count.
+///
+/// Returns a stream so each caller keeps its OWN acceptance rule: `find_agent`
+/// accepts any 2xx, while `find_agent_lan_pubkey` must keep trying after a 2xx
+/// whose body carries no `lan_public_key` (that peer hosts the agent but hasn't
+/// minted a key). A shared "first success wins" helper could not express both.
+///
+/// **Dropping the returned stream cancels every still-in-flight request** —
+/// so a caller that `break`s on the first acceptable answer stops paying for
+/// the rest, rather than merely ignoring them.
+fn query_peers_concurrently<'a>(
+    peers: &'a [LanInstance],
+    agent_id: &'a str,
+    http: &'a reqwest::Client,
+) -> futures_util::stream::FuturesUnordered<impl std::future::Future<Output = PeerQueryOutcome> + 'a> {
+    let futures = futures_util::stream::FuturesUnordered::new();
+    for peer in peers {
+        // Same eligibility rule the sequential loops used: a peer with no
+        // address or no scoped lan_key can't be queried at all.
+        if peer.address.is_empty() || peer.auth_key.is_empty() {
+            continue;
+        }
+        let peer_url = format!("http://{}:{}", peer.address, peer.port);
+        let auth_key = peer.auth_key.clone();
+        futures.push(async move {
+            let result = http
+                .get(format!("{peer_url}/agentmux/reactive/agent"))
+                .query(&[("id", agent_id)])
+                .header("X-AuthKey", &auth_key)
+                .timeout(std::time::Duration::from_secs(LAN_PEER_QUERY_TIMEOUT_SECS))
+                .send()
+                .await;
+            (peer_url, auth_key, result)
+        });
+    }
+    futures
+}
+
 pub struct LanDiscovery {
     daemon: ServiceDaemon,
     instances: Arc<RwLock<HashMap<String, LanInstance>>>,
@@ -743,35 +793,32 @@ impl LanDiscoveryController {
             }
         }
 
-        // Slow path: query each peer. Use reqwest's .query() for safe
-        // percent-encoding of the agent_id (handles spaces, &, =, #, etc.).
+        // Slow path: fan out to every peer CONCURRENTLY and take the first
+        // 2xx. Use reqwest's .query() for safe percent-encoding of the
+        // agent_id (handles spaces, &, =, #, etc.) — see
+        // `query_peers_concurrently`, which also explains why this is a stream
+        // rather than a first-success-wins helper.
         let peers = self.get_instances();
-        for peer in &peers {
-            if peer.address.is_empty() || peer.auth_key.is_empty() {
-                continue;
-            }
-            let peer_url = format!("http://{}:{}", peer.address, peer.port);
-            let result = http
-                .get(format!("{}/agentmux/reactive/agent", peer_url))
-                .query(&[("id", agent_id)])
-                .header("X-AuthKey", &peer.auth_key)
-                .timeout(std::time::Duration::from_secs(LAN_PEER_QUERY_TIMEOUT_SECS))
-                .send()
-                .await;
-            if matches!(result, Ok(ref r) if r.status().is_success()) {
-                tracing::debug!(agent_id, peer_url = %peer_url, "LAN agent found on peer");
-                if let Ok(mut cache) = self.agent_cache.write() {
-                    cache.insert(
-                        agent_id.to_string(),
-                        LanCacheEntry {
-                            peer_url: Some(peer_url.clone()),
-                            auth_key: peer.auth_key.clone(),
-                            expires: std::time::Instant::now()
-                                + std::time::Duration::from_secs(LAN_AGENT_CACHE_TTL_SECS),
-                        },
-                    );
+        {
+            use futures_util::StreamExt as _;
+            let mut inflight = query_peers_concurrently(&peers, agent_id, http);
+            while let Some((peer_url, auth_key, result)) = inflight.next().await {
+                if matches!(result, Ok(ref r) if r.status().is_success()) {
+                    tracing::debug!(agent_id, peer_url = %peer_url, "LAN agent found on peer");
+                    if let Ok(mut cache) = self.agent_cache.write() {
+                        cache.insert(
+                            agent_id.to_string(),
+                            LanCacheEntry {
+                                peer_url: Some(peer_url.clone()),
+                                auth_key: auth_key.clone(),
+                                expires: std::time::Instant::now()
+                                    + std::time::Duration::from_secs(LAN_AGENT_CACHE_TTL_SECS),
+                            },
+                        );
+                    }
+                    // Dropping `inflight` here cancels the remaining requests.
+                    return Some((peer_url, auth_key));
                 }
-                return Some((peer_url, peer.auth_key.clone()));
             }
         }
 
@@ -839,41 +886,39 @@ impl LanDiscoveryController {
             return LanPubkeyLookup::RateLimited;
         }
 
+        // Concurrent fan-out, same as `find_agent` — but note the acceptance
+        // rule differs: a 2xx whose body has no `lan_public_key` means that
+        // peer hosts the agent but hasn't minted a key, so we must keep
+        // consuming the stream rather than stopping at the first 2xx.
         let peers = self.get_instances();
-        for peer in &peers {
-            if peer.address.is_empty() || peer.auth_key.is_empty() {
-                continue;
+        {
+            use futures_util::StreamExt as _;
+            let mut inflight = query_peers_concurrently(&peers, agent_id, http);
+            while let Some((peer_url, _auth_key, result)) = inflight.next().await {
+                let Ok(resp) = result else { continue };
+                if !resp.status().is_success() {
+                    continue;
+                }
+                let Ok(body) = resp.json::<serde_json::Value>().await else { continue };
+                let Some(pubkey_b64) = body.get("lan_public_key").and_then(|v| v.as_str()) else {
+                    continue; // this peer has the agent but no LAN key minted for it yet
+                };
+                use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+                let Ok(pubkey_bytes) = BASE64.decode(pubkey_b64) else { continue };
+                tracing::debug!(agent_id, peer_url = %peer_url, "LAN agent pubkey found on peer");
+                if let Ok(mut cache) = self.pubkey_cache.write() {
+                    cache.insert(
+                        agent_id.to_string(),
+                        LanPubkeyCacheEntry {
+                            public_key: Some(pubkey_bytes.clone()),
+                            expires: std::time::Instant::now()
+                                + std::time::Duration::from_secs(LAN_AGENT_CACHE_TTL_SECS),
+                        },
+                    );
+                }
+                // Dropping `inflight` here cancels the remaining requests.
+                return LanPubkeyLookup::Found(pubkey_bytes);
             }
-            let peer_url = format!("http://{}:{}", peer.address, peer.port);
-            let result = http
-                .get(format!("{}/agentmux/reactive/agent", peer_url))
-                .query(&[("id", agent_id)])
-                .header("X-AuthKey", &peer.auth_key)
-                .timeout(std::time::Duration::from_secs(LAN_PEER_QUERY_TIMEOUT_SECS))
-                .send()
-                .await;
-            let Ok(resp) = result else { continue };
-            if !resp.status().is_success() {
-                continue;
-            }
-            let Ok(body) = resp.json::<serde_json::Value>().await else { continue };
-            let Some(pubkey_b64) = body.get("lan_public_key").and_then(|v| v.as_str()) else {
-                continue; // this peer has the agent but no LAN key minted for it yet
-            };
-            use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
-            let Ok(pubkey_bytes) = BASE64.decode(pubkey_b64) else { continue };
-            tracing::debug!(agent_id, peer_url = %peer_url, "LAN agent pubkey found on peer");
-            if let Ok(mut cache) = self.pubkey_cache.write() {
-                cache.insert(
-                    agent_id.to_string(),
-                    LanPubkeyCacheEntry {
-                        public_key: Some(pubkey_bytes.clone()),
-                        expires: std::time::Instant::now()
-                            + std::time::Duration::from_secs(LAN_AGENT_CACHE_TTL_SECS),
-                    },
-                );
-            }
-            return LanPubkeyLookup::Found(pubkey_bytes);
         }
 
         if let Ok(mut cache) = self.pubkey_cache.write() {
@@ -1465,5 +1510,110 @@ mod lookup_rate_limiter_tests {
         // has no injectable clock.
         limiter.last_refill -= std::time::Duration::from_secs(2);
         assert!(limiter.check(), "must refill once a full second has elapsed");
+    }
+}
+
+#[cfg(test)]
+mod peer_fanout_tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// Spawn a minimal HTTP peer that waits `delay` before answering `status`.
+    /// Returns its `127.0.0.1:port`. Same raw-TCP shape as the mock servers in
+    /// `muxbus::pkce`'s tests — no extra dev-dependency needed.
+    async fn mock_peer(delay: std::time::Duration, status: &'static str, body: &'static str) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else { return };
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 2048];
+                    let _ = stream.read(&mut buf).await;
+                    tokio::time::sleep(delay).await;
+                    let resp = format!(
+                        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        body.len()
+                    );
+                    let _ = stream.write_all(resp.as_bytes()).await;
+                });
+            }
+        });
+        format!("127.0.0.1:{}", addr.port())
+    }
+
+    fn peer_at(addr: &str) -> LanInstance {
+        let (host, port) = addr.rsplit_once(':').unwrap();
+        LanInstance {
+            instance_id: format!("peer-{port}"),
+            hostname: "test".into(),
+            version: "0".into(),
+            address: host.to_string(),
+            port: port.parse().unwrap(),
+            auth_key: "k".into(),
+            agents: vec![],
+            first_seen: 0,
+            last_seen: 0,
+        }
+    }
+
+    /// The regression this fan-out exists to prevent: a slow peer listed BEFORE
+    /// the peer that actually has the agent must not delay the answer.
+    ///
+    /// Sequentially this took `LAN_PEER_QUERY_TIMEOUT_SECS` (2s) to time the
+    /// slow peer out before even trying the second one. Concurrently the fast
+    /// peer answers immediately. The 1500ms bound sits well clear of both the
+    /// ~0ms concurrent path and the ≥2000ms sequential one, so it discriminates
+    /// without being timing-fragile.
+    #[tokio::test]
+    async fn a_slow_peer_does_not_delay_a_fast_one() {
+        let slow = mock_peer(
+            std::time::Duration::from_secs(LAN_PEER_QUERY_TIMEOUT_SECS + 5),
+            "200 OK",
+            "{}",
+        )
+        .await;
+        let fast = mock_peer(std::time::Duration::from_millis(0), "200 OK", "{}").await;
+        // Slow first — the ordering that defeated the sequential loop.
+        let peers = vec![peer_at(&slow), peer_at(&fast)];
+        let http = reqwest::Client::new();
+
+        let started = std::time::Instant::now();
+        let mut inflight = query_peers_concurrently(&peers, "agent-x", &http);
+        let mut winner = None;
+        {
+            use futures_util::StreamExt as _;
+            while let Some((peer_url, _key, result)) = inflight.next().await {
+                if matches!(result, Ok(ref r) if r.status().is_success()) {
+                    winner = Some(peer_url);
+                    break;
+                }
+            }
+        }
+        let elapsed = started.elapsed();
+
+        assert_eq!(
+            winner.as_deref(),
+            Some(format!("http://{fast}").as_str()),
+            "the fast peer should win even though the slow peer was queried first"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_millis(1500),
+            "fan-out should not wait on the slow peer; took {elapsed:?}"
+        );
+    }
+
+    /// Peers with no address or no scoped lan_key are not queryable and must be
+    /// skipped — same eligibility rule the sequential loops applied.
+    #[tokio::test]
+    async fn ineligible_peers_are_skipped() {
+        let mut no_addr = peer_at("127.0.0.1:1");
+        no_addr.address = String::new();
+        let mut no_key = peer_at("127.0.0.1:2");
+        no_key.auth_key = String::new();
+        let peers = vec![no_addr, no_key];
+        let http = reqwest::Client::new();
+        let inflight = query_peers_concurrently(&peers, "agent-x", &http);
+        assert_eq!(inflight.len(), 0, "neither peer is eligible to be queried");
     }
 }

--- a/agentmux-srv/src/backend/lan_listeners.rs
+++ b/agentmux-srv/src/backend/lan_listeners.rs
@@ -1,0 +1,152 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! LAN-facing listener management.
+//!
+//! Background: `bootstrap.rs` resolves the srv bind address **once at
+//! startup** — `0.0.0.0` when `network:lan_discovery` is on, `127.0.0.1`
+//! otherwise. Toggling the setting at runtime therefore starts/stops mDNS
+//! (live, via `LanDiscoveryController::apply`) but leaves the listeners where
+//! they were, producing the worst possible state: peers discover this instance
+//! and then cannot reach it. See
+//! `docs/reports/REPORT_LAN_TOGGLE_WITHOUT_RESTART_2026_09_06.md` and
+//! `docs/reports/REPORT_NETWORK_ARCHITECTURE_DRYNESS_AND_ROBUST_LAN_2026_09_06.md`.
+//!
+//! The fix does **not** require rebinding an active axum server (the reason
+//! the in-code comment gave for deferring). `0.0.0.0:PORT` conflicts with
+//! `127.0.0.1:PORT`, but a *specific* non-loopback address plus the same port
+//! does not — so LAN reachability can be added by binding ADDITIONAL
+//! listeners alongside the untouched loopback one, and removed by dropping
+//! them.
+//!
+//! That claim is load-bearing for the whole design, so it is asserted by a
+//! test here (`loopback_and_specific_ip_can_share_a_port`) rather than
+//! assumed. It runs on every CI platform, so a platform where it does not
+//! hold fails the build instead of shipping a silently broken toggle.
+
+/// Best-effort discovery of this host's primary non-loopback IPv4 address.
+///
+/// Uses the standard "connect a UDP socket and read back its local address"
+/// trick: `connect` on UDP sends no packets, it only fixes the socket's
+/// peer so the kernel picks the outbound interface — which is exactly the
+/// address a LAN peer would reach us on. Chosen over an interface-enumeration
+/// crate deliberately: no new dependency, and it answers the question we
+/// actually care about (which local address routes outward) rather than
+/// handing back every virtual/container adapter to be filtered.
+///
+/// Returns `None` when there is no usable route (offline, or a CI container
+/// with loopback only) — callers must treat that as "no LAN address today",
+/// not as an error.
+// Currently exercised only by this module's tests: it is the verified
+// primitive the `LanListenerSupervisor` will use to pick bind addresses, and
+// it lands with the spike so the assumption and the helper that depends on it
+// are reviewed together. Remove this allow when the supervisor calls it.
+#[allow(dead_code)]
+pub fn primary_lan_ipv4() -> Option<std::net::IpAddr> {
+    // 203.0.113.0/24 is TEST-NET-3 (RFC 5737) — reserved for documentation and
+    // guaranteed never routable, so this cannot accidentally reach a real
+    // host. No packet is sent either way; only the routing decision matters.
+    let sock = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
+    sock.connect("203.0.113.1:80").ok()?;
+    let addr = sock.local_addr().ok()?.ip();
+    if addr.is_loopback() || addr.is_unspecified() {
+        return None;
+    }
+    Some(addr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+
+    /// **The one assumption the LAN-listener design rests on:** a specific
+    /// non-loopback address can be bound on a port already held by loopback.
+    ///
+    /// That is what lets us become LAN-reachable by ADDING a listener, rather
+    /// than rebinding the live server (which would drop the frontend's own
+    /// loopback WebSocket) or changing the port (which would invalidate the
+    /// mDNS TXT record and `authkey.dev`).
+    ///
+    /// Skips (rather than fails) when the host has no non-loopback address —
+    /// an offline machine or loopback-only CI container can't exercise it, and
+    /// failing there would be noise, not signal.
+    #[test]
+    fn loopback_and_specific_ip_can_share_a_port() {
+        let Some(lan_ip) = primary_lan_ipv4() else {
+            eprintln!("skipping: no non-loopback IPv4 on this host");
+            return;
+        };
+
+        // Hold loopback on an ephemeral port, exactly as srv does today when
+        // LAN discovery is off.
+        let loopback = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let port = loopback.local_addr().unwrap().port();
+
+        let lan = TcpListener::bind((lan_ip, port));
+        assert!(
+            lan.is_ok(),
+            "binding {lan_ip}:{port} alongside 127.0.0.1:{port} must succeed \
+             — the add-a-listener design depends on it; got {:?}",
+            lan.err()
+        );
+    }
+
+    /// Records a **platform difference**, deliberately without asserting a
+    /// universal rule — measured, 2026-09-06.
+    ///
+    /// The design docs originally claimed `0.0.0.0:PORT` universally conflicts
+    /// with an existing `127.0.0.1:PORT`. On Linux/macOS it does. **On Windows
+    /// it does not** — absent `SO_EXCLUSIVEADDRUSE`, the wildcard bind
+    /// succeeds alongside the loopback one. This test was written asserting
+    /// the conflict and failed on Windows, which is how the claim was caught
+    /// before it reached an implementation.
+    ///
+    /// Why it matters: it rules out "just bind the wildcard on toggle" as a
+    /// portable shortcut. On Windows two sockets would hold the same port with
+    /// ambiguous accept behaviour — precisely the port-hijack hazard
+    /// `SO_EXCLUSIVEADDRUSE` exists to prevent. Binding SPECIFIC addresses (the
+    /// chosen design) has no such ambiguity on any platform.
+    ///
+    /// Asserts nothing about which way it goes; it exists to keep the observed
+    /// behaviour visible and to fail loudly if it ever becomes uniform.
+    #[test]
+    fn wildcard_vs_loopback_conflict_is_platform_dependent() {
+        let loopback = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let port = loopback.local_addr().unwrap().port();
+        let wildcard = TcpListener::bind(("0.0.0.0".parse::<std::net::IpAddr>().unwrap(), port));
+
+        let conflicts = wildcard.is_err();
+        eprintln!(
+            "0.0.0.0:{port} vs existing 127.0.0.1:{port} — conflicts: {conflicts} \
+             (expected: true on Linux/macOS, false on Windows)"
+        );
+
+        #[cfg(windows)]
+        assert!(
+            !conflicts,
+            "Windows was measured as ALLOWING the wildcard bind alongside \
+             loopback; if it now conflicts, the platform note in \
+             REPORT_NETWORK_ARCHITECTURE_DRYNESS_AND_ROBUST_LAN_2026_09_06.md \
+             is stale"
+        );
+        #[cfg(not(windows))]
+        assert!(
+            conflicts,
+            "expected the wildcard bind to conflict with loopback on this \
+             platform; if it no longer does, the same report's platform note \
+             is stale"
+        );
+    }
+
+    /// `primary_lan_ipv4` must never hand back something unusable as a bind
+    /// target — loopback or unspecified would silently produce a listener
+    /// that adds no LAN reachability at all.
+    #[test]
+    fn primary_lan_ipv4_is_never_loopback_or_unspecified() {
+        if let Some(ip) = primary_lan_ipv4() {
+            assert!(!ip.is_loopback(), "returned loopback: {ip}");
+            assert!(!ip.is_unspecified(), "returned unspecified: {ip}");
+        }
+    }
+}

--- a/agentmux-srv/src/backend/mod.rs
+++ b/agentmux-srv/src/backend/mod.rs
@@ -31,6 +31,7 @@ pub mod agent_seed;
 pub mod history;
 pub mod skill_seed;
 pub mod lan_discovery;
+pub mod lan_listeners;
 pub mod lsp;
 pub mod messagebus;
 pub mod oref;

--- a/docs/reports/REPORT_NETWORK_ARCHITECTURE_DRYNESS_AND_ROBUST_LAN_2026_09_06.md
+++ b/docs/reports/REPORT_NETWORK_ARCHITECTURE_DRYNESS_AND_ROBUST_LAN_2026_09_06.md
@@ -65,11 +65,27 @@ Properties this buys, none of which the snapshot approach has:
   loopback; a rebind-based design (companion report's Option C) would drop it
   on every toggle.
 
-**Still requires the cross-platform spike** flagged in the companion report:
-that `127.0.0.1:PORT` and `<lan-ip>:PORT` can be bound simultaneously while
-`0.0.0.0:PORT` conflicts with both. Standard socket behaviour, but Windows
-`SO_EXCLUSIVEADDRUSE` semantics deserve an explicit check before this is built
-on. **This is the one assumption the whole design rests on.**
+**Spike done — assumption VERIFIED, and one stated claim was wrong.**
+Measured 2026-09-06 by `backend::lan_listeners::tests`:
+
+- ✅ **`127.0.0.1:PORT` + `<lan-ip>:PORT` bind simultaneously.** Confirmed on
+  Windows; asserted in CI on Linux too. This is the claim the design rests on,
+  and it holds.
+- ❌ **"`0.0.0.0:PORT` conflicts with both" was wrong.** True on Linux/macOS;
+  **false on Windows**, where absent `SO_EXCLUSIVEADDRUSE` the wildcard binds
+  happily alongside an existing loopback listener. The spike was written
+  asserting the conflict and *failed on Windows*, which is how the error was
+  caught before any implementation depended on it.
+
+The correction does not weaken the design — it strengthens the case for it.
+"Just bind the wildcard on toggle" is now ruled out as a portable shortcut: on
+Windows it would leave two sockets on one port with ambiguous accept
+behaviour, exactly the hijack hazard `SO_EXCLUSIVEADDRUSE` exists to prevent.
+Binding **specific** addresses has no such ambiguity anywhere.
+
+The platform difference is pinned by
+`wildcard_vs_loopback_conflict_is_platform_dependent`, which asserts the
+observed behaviour per-platform so it fails loudly if either ever changes.
 
 ### 3. The bigger performance win: peer lookup is sequential
 
@@ -241,9 +257,16 @@ cloud relay to three copy-pasted blocks is how this subsystem got here.
 `agentmux-mcp/src/main.rs:2266-2330` (no cloud fallback). Live `netstat`
 showing `127.0.0.1`-only binding with LAN discovery enabled.
 
-**Asserted, not tested:** simultaneous `127.0.0.1:PORT` + `<lan-ip>:PORT`
-binding (§2) — the load-bearing assumption; and that `if-watch`-style
-interface-change notification is available and adequate on all three targets.
+**Measured, 2026-09-06** (`backend::lan_listeners::tests`): simultaneous
+`127.0.0.1:PORT` + `<lan-ip>:PORT` binding — **holds** (the load-bearing
+assumption, verified on Windows, asserted in CI on Linux). And the wildcard
+conflict is **platform-dependent**, not universal: true on Linux/macOS, false
+on Windows. The first draft of this report asserted the universal version as
+fact; the spike disproved it. Recorded rather than silently corrected, because
+"standard socket behaviour" reasoning is exactly what produced the wrong claim.
+
+**Still asserted, not tested:** that `if-watch`-style interface-change
+notification is available and adequate on all three targets (§2).
 
 **Not investigated:** whether any middleware or handler assumes a loopback peer
 address (per-interface listeners would newly violate that); actual peer counts

--- a/docs/reports/REPORT_NETWORK_ARCHITECTURE_DRYNESS_AND_ROBUST_LAN_2026_09_06.md
+++ b/docs/reports/REPORT_NETWORK_ARCHITECTURE_DRYNESS_AND_ROBUST_LAN_2026_09_06.md
@@ -1,0 +1,252 @@
+# Report: Network system — architecture, DRYness, and a robust/high-performance LAN toggle
+
+**Date:** 2026-09-06
+**Status:** Draft — architecture review + design recommendation. Not implemented.
+**Author:** Agent2
+**Companion:** `REPORT_LAN_TOGGLE_WITHOUT_RESTART_2026_09_06.md` (current-state
+analysis of the toggle bug). This report supersedes that one's §6
+recommendation, which was written under an implicit
+minimise-engineering-cost constraint the operator has since lifted:
+
+> *"we want the most robust, high performance solution .. engineering cost is
+> not important"*
+
+---
+
+## Part I — The robust design
+
+### 1. Why the earlier recommendation isn't the right answer anymore
+
+The companion report recommended binding extra per-interface listeners on
+toggle. That is correct and cheap, but under a robustness objective it has two
+weaknesses:
+
+1. **Address churn.** It enumerates interfaces at toggle time. DHCP renewal,
+   Wi-Fi↔Ethernet handoff, VPN up/down, and container adapters all change the
+   set afterwards. This host alone has `192.168.1.230` plus WSL/Hyper-V
+   virtuals (`172.23.176.1`, `192.168.116.1`) and link-local IPv6 — a snapshot
+   is stale almost immediately on a laptop.
+2. **It leaves the real latency problem untouched** (§3), which is the larger
+   share of "the network feels broken."
+
+### 2. Recommended: an interface-aware listener supervisor
+
+A long-lived supervisor task owning the LAN-facing listener set, reconciling it
+against two inputs: **the setting** and **the current interface list**.
+
+```
+LanListenerSupervisor
+  inputs:  setting toggle (existing LanDiscoveryController::apply path)
+           interface-change events (netlink / SCNetworkReachability /
+                                    NotifyIpInterfaceChange — see `if-watch`)
+  state:   HashMap<IpAddr, ListenerHandle>   // handle = JoinHandle + CancellationToken
+  reconcile(desired: Set<IpAddr>):
+      bind + axum::serve(router.clone()) for (desired − current)
+      cancel graceful shutdown        for (current − desired)
+```
+
+Properties this buys, none of which the snapshot approach has:
+
+- **Self-healing.** Plug in Ethernet, join a VPN, renew a lease → the listener
+  set follows. No restart, no re-toggle.
+- **Correct in both directions.** Disable → cancel every LAN listener, loopback
+  untouched. This also closes the current ON→OFF exposure bug, where listeners
+  stay on `0.0.0.0` and remain LAN-reachable after the user turns the feature
+  off (`bootstrap.rs:1312-1319`).
+- **Partial failure is survivable.** One interface failing to bind (in use,
+  permission denied, link down mid-bind) degrades that address only. Contrast
+  the startup path's `.expect("failed to bind web listener")`, which is fine at
+  boot and unacceptable for a runtime toggle.
+- **Port stability preserved.** Ports are ephemeral (`:0`, `bootstrap.rs:1321`)
+  and already published in the mDNS TXT record and `authkey.dev`; every new
+  listener reuses the *existing* port on a different address, so neither
+  publication is ever invalidated.
+- **Loopback is never interrupted.** The frontend's own WebSocket rides
+  loopback; a rebind-based design (companion report's Option C) would drop it
+  on every toggle.
+
+**Still requires the cross-platform spike** flagged in the companion report:
+that `127.0.0.1:PORT` and `<lan-ip>:PORT` can be bound simultaneously while
+`0.0.0.0:PORT` conflicts with both. Standard socket behaviour, but Windows
+`SO_EXCLUSIVEADDRUSE` semantics deserve an explicit check before this is built
+on. **This is the one assumption the whole design rests on.**
+
+### 3. The bigger performance win: peer lookup is sequential
+
+`LanDiscoveryController::find_agent` (`lan_discovery.rs:745-775`) resolves
+"which peer hosts agent X" by querying peers **one at a time**:
+
+```rust
+for peer in &peers {
+    let result = http.get(...).timeout(LAN_PEER_QUERY_TIMEOUT_SECS).send().await;
+    if success { return Some(...) }
+}
+```
+
+With `LAN_PEER_QUERY_TIMEOUT_SECS = 2` (`lan_discovery.rs:26`), worst case is
+**2 × N seconds** before a message is delivered or falls through — 10s on five
+peers, and the pathological case (dead/slow peers ordered before the right one)
+is the *common* one on a laptop network where stale peers linger.
+
+**Fix: concurrent fan-out, first-success-wins.** `FuturesUnordered` over all
+peers, resolve on the first 2xx, drop the rest. Worst case becomes ~one timeout
+regardless of peer count.
+
+Worth doing carefully:
+
+- **Don't lose the negative-cache behaviour.** The current code caches negative
+  results too (`LAN_AGENT_CACHE_TTL_SECS = 60`) so cloud-only agents don't
+  re-fan-out on every inject. Concurrency must preserve that.
+- **Bound concurrency** if the peer set can get large, though on a home/office
+  LAN it won't.
+- **Cancellation on first win** matters — otherwise every peer is queried in
+  full anyway and only the latency, not the load, improves.
+
+This is a bigger perceived-performance win than the bind fix, and it is
+independent of it — shippable separately.
+
+---
+
+## Part II — Architecture and DRYness
+
+### 4. The delivery tier chain is copy-pasted three times
+
+`handle_reactive_inject` (`reactive.rs`, 2410 lines) walks: local → same-host
+same-channel → same-host cross-channel → LAN peer → (return error; cloud is the
+caller's job). Tiers 2a, 2b and 3 each contain a near-identical block at
+`reactive.rs:747`, `:876`, `:982`:
+
+```
+build forward_url  →  POST /agentmux/reactive/inject with X-AuthKey
+                   →  check body.success
+                   →  echo_jekt_to_sender(...11 args...)
+                   →  on failure: log + evict + fall through
+```
+
+Three hand-maintained copies of the same control flow, differing only in how
+the target URL and key are resolved. `echo_jekt_to_sender` is called from
+**four** places with the same twelve-positional-argument shape
+(`reactive.rs:49-62`).
+
+**Why this matters beyond tidiness:** this is exactly the shape that produced
+two separate bugs already documented this week — the provider auth-dir seeding
+gap and the settings-seeding gap both came from two independently-maintained
+copies of one operation drifting. A tier that forgets to call
+`echo_jekt_to_sender`, or passes `delivery_tier` wrong, fails silently and
+differently from its siblings.
+
+**Refactor:** one `forward_to(target: ForwardTarget) -> Option<Response>`
+helper, where `ForwardTarget { url, auth_key, tier_label, on_failure }`. The
+tier chain becomes a list of resolvers feeding one forwarder. `echo_jekt_to_sender`'s
+twelve positionals become a struct (several are `Option<bool>` in a row —
+`sig_verified`, `reagent_verified`, `lan_verified` — which is a swap waiting to
+happen; the compiler cannot help you there).
+
+### 5. Tier 4 exists in the comment and nowhere in the code
+
+`reactive.rs:1044`:
+
+```rust
+// 4. Return original error (muxbus-client will fall back to cloud relay).
+```
+
+But **the MCP `SendMessage` tool is not that client.** It POSTs to
+`/agentmux/reactive/inject` and bails on `success != true`
+(`agentmux-mcp/src/main.rs:2322-2330`). No cloud fallback anywhere on that
+path — while the tool's own description promises *"tries local → LAN → cloud in
+order."*
+
+So the documented four-tier model is really three tiers plus a comment, and the
+one caller most agents actually use silently stops at three. This is an
+architecture gap, not just a missing feature: **the tier chain has no single
+owner.** Parts live in `reactive.rs`, one part is delegated to an unnamed
+"muxbus-client," and the MCP tool re-implements the entry point.
+
+**Recommendation:** make the tier chain a single, complete, owned abstraction —
+if cloud relay is tier 4, `handle_reactive_inject` should perform it, and every
+caller inherits it. Failing that, the description must stop promising it.
+
+### 6. Discovery reports local truth as if it were global
+
+`DiscoverAgents` returns `wan.subscribed_agents`, which on inspection lists
+**this host's own** agents that are cloud-subscribed — not remote agents
+reachable via cloud. Verified: the list is exactly the local addressable set.
+
+An agent reading that output reasonably concludes "the WAN tier can reach these
+five agents," when it actually means "these five of mine are subscribed." There
+is no way to ask "who is reachable via cloud?" This directly caused a wrong
+diagnosis earlier today.
+
+**Recommendation:** either rename the field to what it is
+(`wan.local_agents_subscribed`) or make it answer the question its name
+implies.
+
+### 7. Two config-watching mechanisms
+
+`wconfig::watcher` (`ConfigWatcher`) is a state holder with no filesystem
+watching, despite the name; the actual watching is `config_watcher_fs.rs` on
+top of the shared `fs_watch::pool`. Two modules, similar names, only one
+watches. Minor, but it cost me a wrong turn while tracing the settings reload
+path today, and it will cost the next person the same.
+
+### 8. Credential surface
+
+Five distinct secrets appear across the network path: `auth_key` (full API),
+`lan_key` (scoped to LAN-forward routes), `host_reg_secret`, `ipc_token`, plus
+per-message `jekt_sig` / `lan_sig` / `reagent_sig`. Each has a real,
+well-documented reason to exist — this is **not** a call to consolidate them;
+scope separation is exactly right for a security boundary.
+
+The observation is narrower: there is no single document mapping which
+credential gates which route at which tier. `Config::lan_key`'s doc comment is
+the closest thing and only covers its own case. For a subsystem where the
+security argument is the reason several tiers exist at all, that map should be
+written down once.
+
+---
+
+## 9. Recommended sequencing
+
+Ordered by value-per-risk, each independently shippable:
+
+1. **Concurrent peer fan-out** (§3). Biggest perceived-latency win, smallest
+   blast radius, no new architecture.
+2. **Cross-platform bind spike** (§2). Cheap, and gates everything else in
+   Part I.
+3. **`LanListenerSupervisor`** (§2), ON→OFF first (closes the live exposure
+   bug and proves the shutdown plumbing), then OFF→ON with interface watching.
+4. **Gate mDNS advertising on a successful LAN bind** — eliminates the
+   discover-but-cannot-deliver state permanently rather than narrowing it.
+5. **Unify the tier-forward blocks** (§4) — do this *before* adding tier 4,
+   so cloud relay is added in one place instead of becoming a fourth copy.
+6. **Resolve tier 4** (§5): implement it in the chain, or correct the tool
+   description. Not both.
+7. **§6 naming fix**, **§7 rename**, **§8 credential map** — small, do
+   opportunistically.
+
+Note the ordering dependency: **§5 (tier 4) should follow §4 (unify)**. Adding
+cloud relay to three copy-pasted blocks is how this subsystem got here.
+
+---
+
+## 10. Provenance
+
+**Verified directly by reading code this session:** `bootstrap.rs:1305-1340`
+(startup-only bind, ephemeral port, documented limitation);
+`main.rs:173-193` (two listeners, cloned router); `websocket.rs:1582-1600`
+(live `apply()` on setconfig); `lan_discovery.rs:571-600`
+(`LanDiscoveryController` slot pattern), `:26` (2s timeout), `:745-775`
+(sequential fan-out); `reactive.rs:49-62` (12-arg echo), `:747/:876/:982`
+(three forward blocks), `:1044` (tier-4 comment);
+`agentmux-mcp/src/main.rs:2266-2330` (no cloud fallback). Live `netstat`
+showing `127.0.0.1`-only binding with LAN discovery enabled.
+
+**Asserted, not tested:** simultaneous `127.0.0.1:PORT` + `<lan-ip>:PORT`
+binding (§2) — the load-bearing assumption; and that `if-watch`-style
+interface-change notification is available and adequate on all three targets.
+
+**Not investigated:** whether any middleware or handler assumes a loopback peer
+address (per-interface listeners would newly violate that); actual peer counts
+in real deployments (§3's worst case assumes several); and the cloud relay
+client that `reactive.rs:1044` refers to — I confirmed the MCP tool isn't it,
+but did not establish whether some *other* caller implements tier 4 correctly.


### PR DESCRIPTION
**Step 1 of the network work.** Also lands the design report the rest of the series follows.

## The problem

Both LAN lookups — `find_agent` ("which peer hosts this agent") and `find_agent_lan_pubkey` ("that agent's Ed25519 key") — walked peers one at a time:

```rust
for peer in &peers { ... .timeout(LAN_PEER_QUERY_TIMEOUT_SECS).send().await; }
```

With a 2s timeout that's **2 × peer_count seconds worst case** before a message is delivered or falls through — 10s across five peers. And the pathological ordering (a dead or slow peer ahead of the right one) is the *common* case on a laptop network, where stale peers linger until their mDNS TTL expires.

## The change

Both now fan out concurrently through one shared `query_peers_concurrently`. Worst case becomes ~a single timeout regardless of peer count.

It returns a `FuturesUnordered` **stream** rather than a first-success-wins helper, because the two callers have genuinely different acceptance rules: `find_agent` takes any 2xx, while `find_agent_lan_pubkey` must keep going past a 2xx whose body has no `lan_public_key` (that peer hosts the agent but hasn't minted a key). Collapsing them into one "first success" helper would have silently broken the pubkey case — worth flagging since that's the obvious refactor and it's wrong.

Dropping the stream on the first accepted answer **cancels** the in-flight requests, so a win stops the remaining work rather than just ignoring it.

**Deliberately preserved:** the peer-eligibility rule (skip peers with no address or no scoped `lan_key`), and both positive *and* negative caching at the same TTL — the negative entry is what keeps cloud-only agents from re-fanning-out on every inject.

Side benefit: removes the duplicated query construction between the two lookups — the same copy-paste shape as the tier-forward blocks the report documents.

## Tests

- `a_slow_peer_does_not_delay_a_fast_one` — puts a 7s peer **first** and a fast peer second, asserts the fast one wins in <1500ms. That ordering is precisely what the sequential loop failed. The bound sits clear of both the ~0ms concurrent path and the ≥2000ms sequential one, so it discriminates without being timing-fragile.
- `ineligible_peers_are_skipped` — pins the eligibility rule.
- Mock peers reuse the raw-TCP pattern already in `muxbus::pkce`'s tests; no new dev-dependency.

## Also included

`docs/reports/REPORT_NETWORK_ARCHITECTURE_DRYNESS_AND_ROBUST_LAN_2026_09_06.md` — the design doc for the series:

- **Part I:** the robust LAN-toggle design — an interface-aware `LanListenerSupervisor` that reconciles listeners against *both* the setting and live interface-change events, rather than snapshotting interfaces at toggle time (DHCP/Wi-Fi↔Ethernet/VPN churn makes a snapshot stale immediately). Preserves the ephemeral port, never interrupts loopback, fixes the ON→OFF exposure bug.
- **Part II:** DRYness — three copy-pasted tier-forward blocks (`reactive.rs:747/:876/:982`), `echo_jekt_to_sender` called with 12 positional args including three consecutive `Option<bool>`s, tier 4 existing only in a comment, and discovery reporting local truth as global.

The report flags one untested load-bearing assumption (simultaneous `127.0.0.1:PORT` + `<lan-ip>:PORT` bind) that gates Part I — the spike for that is the next PR.

## Verification

`cargo check` clean · `cargo clippy` clean on the changed file · 28 existing `lan_discovery` tests pass (1 pre-existing ignored) · 2 new tests pass.

<!-- agentmux:agent_id=agent2 -->