### PR TITLE
Posa@Area54: fix(swarm): tool rows show the command or file path, not a raw JSON dump

### DIFF
--- a/.changesets/1788714253-fix-swarm-tool-rows-show-the-command-or-file-path-instead-of-1blg.md
+++ b/.changesets/1788714253-fix-swarm-tool-rows-show-the-command-or-file-path-instead-of-1blg.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(swarm): tool rows show the command or file path instead of a raw JSON dump

--- a/agentmux-srv/src/backend/subagent_watcher/jsonl.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/jsonl.rs
@@ -234,12 +234,34 @@ impl SubagentWatcher {
                 state.events.drain(..excess);
             }
 
-            // Check last event for result type (completion). Keyed off the
-            // `Result` discriminant itself (a real `"result"`-typed JSONL
-            // line), not derived text content — real Claude Code result
-            // events populate `result`/`content`, so matching against the
-            // "Subagent completed" placeholder (only ever produced when
-            // both are absent) almost never fired.
+            // Completion by terminal `Result` line.
+            //
+            // ⚠ THIS NEVER FIRES ON ANY TRANSCRIPT AGENTMUX CURRENTLY WRITES.
+            // No `"type":"result"` line exists in the `entrypoint: sdk-cli`
+            // format — 0 of 11 subagent transcripts on the investigated
+            // machine, across CLI 2.1.198 and 2.1.247, and none in the parent
+            // session files either. Every completed subagent transcript ends
+            // on an `assistant` message. Evidence:
+            // docs/reports/REPORT_SUBAGENT_COMPLETION_NEVER_DETECTED_2026_09_05.md.
+            //
+            // Real completion is established by `completion.rs` instead,
+            // correlating the PARENT's `tool_result` for the dispatch's
+            // `tool_use_id` (#3007). If you are here because completions look
+            // wrong, that is the code path to read — not this one.
+            //
+            // Kept rather than deleted: it is not incorrect, only unreachable
+            // in a transcript format we don't control, and it would resume
+            // being the fastest completion signal (immediate, rather than
+            // waiting for the parent turn to end) if such lines ever appear.
+            // Deleting it would also strand `PendingCompletion` and the
+            // workflow-coalescing flush below.
+            //
+            // The history is worth keeping visible, because it is how the bug
+            // survived: #2283 replaced a placeholder-text match its own
+            // comment described as "almost never fired" with this discriminant
+            // check, which fires *never*. Both fail identically from outside —
+            // rows that simply never complete — so the regression read as the
+            // pre-existing flakiness.
             if let Some(last) = new_events.last() {
                 if matches!(&last.event_type, SubagentEventType::Result { .. }) {
                     completed = true;

--- a/agentmux-srv/src/backend/subagent_watcher/parse.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/parse.rs
@@ -13,6 +13,82 @@ use std::sync::Arc;
 use super::types::{SubagentEvent, SubagentEventType};
 use super::SubagentWatcher;
 
+// ── Tool-call display summaries ─────────────────────────────────────────
+//
+// Both limits are in CHARS. They used to be bare `200`/`500` literals that
+// tested a BYTE length (`s.len()`) and then cut by CHAR index — agreeing for
+// ASCII and disagreeing for anything else (a string over 200 bytes but under
+// 200 chars took the truncation branch, found no 200th char, and fell through
+// to no truncation at all). See
+// docs/reports/REPORT_TOOL_SUMMARY_FORMATTING_ARCHITECTURE_2026_09_06.md §4.1.
+
+/// Chars of a tool call's input kept for the Swarm feed's collapsed row.
+const MAX_INPUT_SUMMARY_CHARS: usize = 200;
+
+/// Chars of a tool result kept for the same feed. Larger than the input
+/// budget because a result is the thing a reader is usually scanning.
+const MAX_RESULT_PREVIEW_CHARS: usize = 500;
+
+/// Cut to `max` CHARS (never mid-codepoint), appending an ellipsis when it
+/// actually cut something.
+fn truncate_chars(s: &str, max: usize) -> String {
+    match s.char_indices().nth(max) {
+        Some((byte_idx, _)) => format!("{}...", &s[..byte_idx]),
+        None => s.to_string(),
+    }
+}
+
+/// The human-meaningful field of a tool call's `input`, by tool name.
+///
+/// Mirrors the frontend's `extractToolDetail`
+/// (`frontend/app/view/agent/stream-parser.ts`), which is what the Agent pane,
+/// the Activity Dock and the tool blocks have always used. The Swarm feed
+/// instead showed `serde_json::Value::to_string()` — the whole input object as
+/// compact JSON, cut mid-token — because summarising happens here, at parse
+/// time, and the structured input is dropped before it ever reaches a view
+/// that could format it properly.
+///
+/// **This duplicates the mapping in a second language, deliberately and
+/// temporarily.** It buys the readable output now; the real fix is to carry
+/// the structured input across the boundary and let the frontend's existing
+/// extractor (and its renderer registry) handle it, which deletes this
+/// function. Phases 1 and 2 of the report above.
+///
+/// Unknown tools fall back to compact JSON rather than an empty string: for a
+/// tool this doesn't know, the raw object is genuinely more useful than
+/// nothing, and `mcp__*`/provider-specific names are open-ended by design.
+/// (The frontend's version returns `""` there because its callers have the
+/// full node to fall back on; here there is nothing else to show.)
+fn tool_input_detail(tool: &str, input: &serde_json::Value) -> String {
+    let field = |key: &str| input.get(key).and_then(|v| v.as_str());
+    let pick = match tool {
+        "Read" | "Edit" | "Write" | "NotebookEdit" => field("file_path"),
+        "Bash" | "BashOutput" => field("command"),
+        "Grep" | "Glob" => field("pattern"),
+        "Agent" | "Task" => field("description").or_else(|| field("prompt")),
+        "Workflow" => field("title").or_else(|| field("description")),
+        "WebSearch" | "web_search" => field("query"),
+        "WebFetch" | "web_fetch" => field("url"),
+        _ => None,
+    };
+    match pick {
+        Some(s) if !s.is_empty() => s.to_string(),
+        // Either an unknown tool, or a known one whose expected field is
+        // missing/empty/non-string — in both cases the object beats nothing.
+        _ => input.to_string(),
+    }
+}
+
+/// A tool result's text. A plain string is used as-is; anything else (the
+/// common `[{"type":"text","text":…}]` block array, or a bare object) falls
+/// back to compact JSON, same as before.
+fn result_content_text(content: &serde_json::Value) -> String {
+    match content.as_str() {
+        Some(s) => s.to_string(),
+        None => content.to_string(),
+    }
+}
+
 // ── Block-delete cascade subscriber ─────────────────────────────────────
 
 /// Subscribe to the reducer's `srv_events_tx` broadcast and prune `watcher`'s
@@ -260,15 +336,7 @@ pub(super) fn parse_event_type(value: &serde_json::Value) -> Option<SubagentEven
                 .to_string();
             let input_summary = value
                 .get("input")
-                .map(|v| {
-                    let s = v.to_string();
-                    if s.len() > 200 {
-                        let end = s.char_indices().nth(200).map_or(s.len(), |(i, _)| i);
-                        format!("{}...", &s[..end])
-                    } else {
-                        s
-                    }
-                })
+                .map(|v| truncate_chars(&tool_input_detail(&name, v), MAX_INPUT_SUMMARY_CHARS))
                 .unwrap_or_default();
             Some(SubagentEventType::ToolUse {
                 name,
@@ -283,19 +351,7 @@ pub(super) fn parse_event_type(value: &serde_json::Value) -> Option<SubagentEven
             let preview = value
                 .get("content")
                 .or_else(|| value.get("output"))
-                .map(|v| {
-                    let s = if let Some(s) = v.as_str() {
-                        s.to_string()
-                    } else {
-                        v.to_string()
-                    };
-                    if s.len() > 500 {
-                        let end = s.char_indices().nth(500).map_or(s.len(), |(i, _)| i);
-                        format!("{}...", &s[..end])
-                    } else {
-                        s
-                    }
-                })
+                .map(|v| truncate_chars(&result_content_text(v), MAX_RESULT_PREVIEW_CHARS))
                 .unwrap_or_default();
             Some(SubagentEventType::ToolResult { is_error, preview })
         }
@@ -554,4 +610,106 @@ pub fn resolve_claude_config_dir(
                 .map(PathBuf::from)
         })
         .or_else(|| derive_claude_config_dir(agent_id))
+}
+
+#[cfg(test)]
+mod summary_tests {
+    use super::*;
+    use serde_json::json;
+
+    // The flagship case, taken verbatim from the transcript that prompted
+    // docs/reports/REPORT_TOOL_SUMMARY_FORMATTING_ARCHITECTURE_2026_09_06.md —
+    // the Swarm feed rendered the whole input object as escaped JSON.
+    #[test]
+    fn a_bash_call_shows_its_command_not_the_json_object() {
+        let input = json!({
+            "command": "ls /c/Users/area54/ 2>/dev/null | head -50",
+            "description": "List home directory contents",
+        });
+        let got = tool_input_detail("Bash", &input);
+        assert_eq!(got, "ls /c/Users/area54/ 2>/dev/null | head -50");
+        assert!(!got.contains('{'), "must not be a JSON dump: {got}");
+        assert!(!got.contains('"'), "must not carry JSON quoting: {got}");
+    }
+
+    #[test]
+    fn file_tools_show_the_path() {
+        for tool in ["Read", "Edit", "Write"] {
+            let input = json!({ "file_path": "/x/y.rs", "old_string": "…" });
+            assert_eq!(tool_input_detail(tool, &input), "/x/y.rs", "tool {tool}");
+        }
+    }
+
+    #[test]
+    fn search_tools_show_the_pattern() {
+        let input = json!({ "pattern": "fn main", "path": "/repo" });
+        assert_eq!(tool_input_detail("Grep", &input), "fn main");
+        assert_eq!(tool_input_detail("Glob", &input), "fn main");
+    }
+
+    #[test]
+    fn a_dispatch_prefers_its_description_over_the_whole_prompt() {
+        // An Agent prompt runs to tens of KB; the description is the one-line
+        // human summary the caller already wrote.
+        let input = json!({ "description": "Research the thing", "prompt": "x".repeat(5000) });
+        assert_eq!(tool_input_detail("Agent", &input), "Research the thing");
+    }
+
+    #[test]
+    fn a_dispatch_falls_back_to_the_prompt_when_undescribed() {
+        let input = json!({ "prompt": "do the thing" });
+        assert_eq!(tool_input_detail("Agent", &input), "do the thing");
+    }
+
+    #[test]
+    fn an_unknown_tool_keeps_the_raw_object_rather_than_showing_nothing() {
+        // Open-ended by design (`mcp__*`, provider-specific). The object is
+        // worse than a real field but strictly better than blank.
+        let input = json!({ "anything": 1 });
+        assert_eq!(tool_input_detail("mcp__whatever__do", &input), input.to_string());
+    }
+
+    #[test]
+    fn a_known_tool_missing_its_field_also_falls_back() {
+        // Guards the `Some(s) if !s.is_empty()` arm: a Bash call with no
+        // command must not render as an empty row.
+        assert_eq!(
+            tool_input_detail("Bash", &json!({ "description": "no command here" })),
+            json!({ "description": "no command here" }).to_string()
+        );
+        assert_eq!(
+            tool_input_detail("Bash", &json!({ "command": "" })),
+            json!({ "command": "" }).to_string()
+        );
+    }
+
+    #[test]
+    fn a_string_result_is_used_verbatim() {
+        assert_eq!(result_content_text(&json!("plain output")), "plain output");
+    }
+
+    #[test]
+    fn a_block_array_result_falls_back_to_json() {
+        let content = json!([{ "type": "text", "text": "hi" }]);
+        assert_eq!(result_content_text(&content), content.to_string());
+    }
+
+    #[test]
+    fn truncation_counts_chars_and_marks_that_it_cut() {
+        assert_eq!(truncate_chars("abcdef", 3), "abc...");
+        assert_eq!(truncate_chars("abc", 3), "abc", "exact length must not gain an ellipsis");
+        assert_eq!(truncate_chars("ab", 3), "ab");
+    }
+
+    #[test]
+    fn truncation_never_splits_a_multibyte_char() {
+        // The old code tested byte length and cut by char index, so a string
+        // over the byte budget but under the char budget silently escaped
+        // truncation entirely (§4.1 of the report).
+        let s = "é".repeat(150); // 300 bytes, 150 chars
+        assert_eq!(truncate_chars(&s, 200), s, "under the CHAR budget — unchanged");
+        let long = "é".repeat(250);
+        let got = truncate_chars(&long, 200);
+        assert_eq!(got.chars().count(), 203, "200 chars + the three-dot marker");
+    }
 }

--- a/agentmux-srv/src/backend/subagent_watcher/types.rs
+++ b/agentmux-srv/src/backend/subagent_watcher/types.rs
@@ -107,10 +107,15 @@ pub enum SubagentEventType {
     ToolUse { name: String, input_summary: String },
     ToolResult { is_error: bool, preview: String },
     Progress { output: String },
-    /// A JSONL `"result"`-typed line — the subagent's final output. Kept
-    /// distinct from `Text` so completion detection can key off the
-    /// discriminant directly instead of matching derived text content
-    /// (see `process_jsonl_change`'s completion check).
+    /// A JSONL `"result"`-typed line — the subagent's final output.
+    ///
+    /// **Never observed in practice.** No transcript AgentMux writes contains
+    /// a `"type":"result"` line (see `process_jsonl_change`'s completion
+    /// check for the evidence), so this variant is parse-only: the parser
+    /// handles it if it ever appears, and nothing depends on it today.
+    /// Completion is established by `completion.rs` from the parent's
+    /// `tool_result` instead. Do not treat the existence of this variant as
+    /// evidence that result-line completion works.
     Result { content: String },
 }
 

--- a/docs/reports/REPORT_TOOL_SUMMARY_FORMATTING_ARCHITECTURE_2026_09_06.md
+++ b/docs/reports/REPORT_TOOL_SUMMARY_FORMATTING_ARCHITECTURE_2026_09_06.md
@@ -1,0 +1,218 @@
+# Tool-call display: two implementations, one good, and the swarm can only reach the bad one
+
+**Status:** active
+**Author:** Posa
+**Date:** 2026-09-06
+**Investigated at:** `6601c7b22` (v0.55.36)
+**Trigger:** the Swarm pane's expanded Agent-tool row shows raw JSON. That symptom is a
+one-line fix; the reason it exists is architectural, which is what this report is about.
+**Related:** `SPEC_TOOL_RESULT_RENDERER_REGISTRY_2026_06_17.md` (the renderer registry the
+swarm path bypasses), `REPORT_SWARM_PANE_VS_ACTUAL_AGENT_CALLS_2026_09_05.md` (where the
+symptom surfaced), `REPORT_SUBAGENT_COMPLETION_NEVER_DETECTED_2026_09_05.md` (§5 below
+depends on its finding)
+
+---
+
+## 1. The symptom
+
+Expanding an Agent-tool row in Swarm shows this, verbatim:
+
+```
+{"command":"ls /c/Users/area54/ 2>/dev/null | head -50; echo \"---\"; ls /c/User…","description":"List home directory contents"}...
+```
+
+Escaped quotes, raw braces, hard-cut mid-token. What it should show is what the agent pane
+already shows for the identical call: `ls /c/Users/area54/ 2>/dev/null | head -50`.
+
+## 2. Two implementations of the same idea
+
+**A — `frontend/app/view/agent/stream-parser.ts:117`, `extractToolDetail`.** Typed,
+per-tool, covers 10 kinds, and picks the field a human actually wants:
+
+```ts
+case "Bash":  return params.command || "";
+case "Read": case "Edit": case "Write":  return params.file_path || "";
+case "Grep": case "Glob":  return params.pattern || "";
+case "Agent":  return params.description || params.prompt || "";
+case "WebFetch": …  return u.host + (u.pathname === "/" ? "" : u.pathname);
+```
+
+Three consumers: `ToolBlock.tsx:316`, `activity/tool-adapter.ts:202`, and `stream-parser`
+itself at `:734`. This is the codebase's real answer to "summarise a tool call."
+
+**B — `agentmux-srv/src/backend/subagent_watcher/parse.rs:261`.** `serde_json::Value::to_string()`
+— a compact JSON dump — truncated at a bare `200`:
+
+```rust
+let input_summary = value.get("input").map(|v| {
+    let s = v.to_string();
+    if s.len() > 200 { … format!("{}...", &s[..end]) } else { s }
+})
+```
+
+Same operation, opposite quality, opposite side of the process boundary. `tool_result`'s
+`preview` (`:283`) is the same shape at `500`.
+
+## 3. The actual architectural fault
+
+Not "B is sloppy" — **B formats too early, at the wrong layer, and destroys the input.**
+
+Summarisation happens at *parse* time on the backend. The structured `input` object is
+reduced to one display string and thrown away; `SubagentEvent` carries only
+`input_summary: String`. So the frontend **cannot** apply `extractToolDetail` to a subagent
+tool call even though the function is sitting right there — the data it needs never crosses
+the boundary.
+
+That is why the swarm feed also bypasses the whole renderer registry
+(`components/tool-renderers/registry.ts`, `SPEC_TOOL_RESULT_RENDERER_REGISTRY_2026_06_17.md`)
+— a priority-ordered, shape-matching system with rich per-tool UIs (`RecordTable`,
+`SearchResults`, `WebFetchResult`) built precisely so "the open-ended tool universe … can be
+routed by its real name or result shape." The swarm feed can't route anything: it receives a
+pre-flattened string and renders it through `AnsiText` as monospace lines.
+
+**The layering rule this breaks:** the backend's job is to observe and transport; deciding
+what a human should read is a view concern. Every consumer that comes along later inherits
+B's choices permanently, because the alternative was discarded upstream.
+
+## 4. Secondary findings in the same area
+
+**4.1 The magic numbers mix units.** `200`/`500` are inline and unnamed, and each pairs a
+**byte** length test with a **char** cut:
+
+```rust
+if s.len() > 200 {                                   // bytes
+    let end = s.char_indices().nth(200).map_or(s.len(), |(i, _)| i);   // chars
+```
+
+For ASCII these agree. For multi-byte content they don't: a string over 200 bytes but under
+200 chars takes the truncation branch, finds no 200th char, and falls back to `s.len()` — so
+it silently isn't truncated at all. Harmless today, but it is two different notions of
+"length" in one expression, and the repo already has `bounded_instructions_preview`
+(`bundle_import.rs:129`) as a named, tested precedent for exactly this.
+
+**4.2 The truncation cuts mid-token and appends `...` to broken JSON.** With B's output being
+JSON, a 200-byte cut routinely lands inside a string literal or before a closing brace, so the
+result is neither valid JSON nor readable prose. Fixing §3 dissolves this: truncating a plain
+command string is safe in a way truncating serialised JSON isn't.
+
+**4.3 Types are hand-mirrored across the boundary, twice, with no check.**
+`frontend/types/gotypes.d.ts` opens with *"Hand-maintained type bindings. Keep in sync with
+agentmux-srv … The original Go generator was removed with the Go backend."* But
+`SubagentEventType` isn't in that file at all — it's mirrored a second way, inline in
+`swarm-model.ts:140-146`, against `types.rs:105-115`. Two mirroring conventions for one
+boundary, neither enforced by anything.
+
+**4.4 A now-dead variant and a dead detector, with a comment that argues for keeping them.**
+`SubagentEventType::Result` exists so that "completion detection can key off the discriminant
+directly" (`types.rs:110-114`), and `jsonl.rs:243` still tests for it. Per
+`REPORT_SUBAGENT_COMPLETION_NEVER_DETECTED_2026_09_05.md`, **no AgentMux transcript contains a
+`"type":"result"` line** — 0 of 11 on this machine, across two CLI versions — so that branch
+is unreachable, and #3007 replaced its job with parent-`tool_result` correlation. Two
+completion mechanisms now exist, one provably dead, and its doc comment still reads as
+live justification. Whoever touches this next will believe it works.
+
+## 5. Proposed cleanup
+
+Ordered so each phase stands alone and none blocks the next.
+
+### Phase 1 — stop dumping JSON (small, self-contained, fixes the reported symptom)
+
+Replace `Value::to_string()` in `parse.rs` with a Rust port of `extractToolDetail`'s field
+selection, plus a named constant to replace `200`/`500` with a single unit (chars). Two tools
+cover most real traffic: `Bash → command`, `Agent → description`.
+
+Buys the visible fix immediately, and is revertible on its own. It does **not** fix §3 — it
+duplicates the mapping in a second language, which is a deliberate down-payment, not the
+destination. Phase 2 removes the duplicate.
+
+### Phase 2 — move formatting to the edge (the actual fix)
+
+Carry the structured input across the boundary — `input: serde_json::Value` (bounded) instead
+of, or alongside, the flattened string — and let the frontend call the `extractToolDetail`
+it already owns. The swarm feed then becomes eligible for the renderer registry for free,
+which is the real prize: `RecordTable`/`SearchResults`/`WebFetchResult` start working in
+Swarm with no new per-tool code.
+
+**The honest tension:** B's truncation is presumably there to bound WS payload size, and
+raw inputs are unbounded (an `Agent` prompt can be tens of KB). So this needs a size budget
+at the transport layer — bound the *payload*, not the *meaning* — rather than removing
+limits. Worth measuring real input sizes before committing to a number; I have not.
+
+### Phase 3 — one binding surface
+
+Fold `SubagentEventType` into `gotypes.d.ts` so there's one mirroring convention rather than
+two, and add a check that fails when the Rust and TS shapes diverge. A generator is the
+better answer but a far larger change; a diff-check is cheap and closes the silent-drift hole.
+
+### Phase 4 — delete the dead completion path
+
+Remove `SubagentEventType::Result`'s detector at `jsonl.rs:243` and either drop the variant or
+re-document it as parse-only. Keeping a second, unreachable completion mechanism next to the
+working one is how the original bug survived a refactor: #2283 replaced a heuristic that
+"almost never fired" with one that fires never, and the two look identical from outside.
+
+## 6. Recommendation
+
+**Phase 1 now, Phase 4 alongside it** — both are small, and Phase 4 removes a live trap for
+the next reader. Phase 2 is the one worth doing properly and shouldn't be rushed into the same
+change; it needs the payload-budget question answered with measurements. Phase 3 is
+independent housekeeping that can wait for someone touching those types anyway.
+
+## 7. What I did not verify
+
+- Real-world size distribution of tool `input` payloads. Phase 2's budget depends on it and I
+  am not guessing at a number.
+- Whether any consumer outside Swarm reads `input_summary`. I found none in
+  `frontend/` (only `swarm-model.ts`/`swarm-view.tsx`), but I did not audit MCP or external
+  RPC callers, which could make its shape a compatibility surface.
+- The blank-lines half of the original report. That is a rendering question in `AnsiText`, not
+  a formatting-layer one, and is deliberately out of scope here.
+
+---
+
+## 8. Shipped (2026-09-06)
+
+### Phase 1 — done as proposed
+
+`parse.rs` gains `tool_input_detail` (a Rust mirror of `extractToolDetail`),
+`result_content_text`, and `truncate_chars`, replacing both `Value::to_string()` dumps.
+`MAX_INPUT_SUMMARY_CHARS`/`MAX_RESULT_PREVIEW_CHARS` replace the bare `200`/`500` and are
+CHARS throughout, closing §4.1's byte-test/char-cut mismatch.
+
+The Bash case from §1 now renders as `ls /c/Users/area54/ 2>/dev/null | head -50`.
+
+One deliberate divergence from the frontend original: an **unknown tool falls back to the raw
+JSON object** rather than `""`. `extractToolDetail` can return empty because its callers still
+hold the full node; here there is nothing else to show, and `mcp__*`/provider-specific names
+are open-ended by design. A known tool whose expected field is missing or empty takes the same
+fallback.
+
+11 tests, mutation-checked — forcing the JSON-dump fallback fails 5 of them, including the
+flagship Bash case.
+
+### Phase 4 — NOT done as proposed; re-documented instead of deleted
+
+The proposal above said to delete the dead detector. **I didn't, and the reasoning is worth
+recording rather than quietly narrowing the scope.**
+
+Deleting `jsonl.rs`'s `Result`-discriminant check would strand `PendingCompletion`, the
+`pending_activity` coalescing buffer's `completed` vector, and two broadcast shapes — all of
+it *correct* code. Its only fault is being unreachable in a transcript format we don't
+control and which could change back; if `"type":"result"` lines ever appear it would resume
+being the **faster** completion signal (immediate, versus waiting for the parent turn to end).
+Deleting correct handling for an external format we don't own trades a real capability for
+tidiness.
+
+What actually caused harm was the doc comment asserting it works. Both sites now say
+plainly that it never fires, cite the evidence, point at `completion.rs` as the real path,
+and record the #2283 history — a placeholder match that "almost never fired" replaced by a
+discriminant check that fires *never*, indistinguishable from outside, which is precisely how
+the original bug survived a refactor.
+
+If a future reader disagrees and wants the deletion, §4.4 and this section are the argument
+either way; the trap (believing it works) is gone regardless.
+
+**Phases 2 and 3 remain open**, unchanged.
+
+**Verified:** full `agentmux-srv` suite 3030 passed / 0 failed. Not verified in a running app
+— the string this produces is unit-tested, but I have not watched a Swarm row render it.


### PR DESCRIPTION
Expanding an Agent-tool row in Swarm showed this, verbatim:

```
{"command":"ls /c/Users/area54/ 2>/dev/null | head -50; echo \"---\"; ls /c/User…","description":"List home directory contents"}...
```

Escaped quotes, raw braces, cut mid-token. It now shows what the Agent pane has always shown for the identical call:

```
ls /c/Users/area54/ 2>/dev/null | head -50
```

Phase 1 of `docs/reports/REPORT_TOOL_SUMMARY_FORMATTING_ARCHITECTURE_2026_09_06.md` (included).

## The fault is architectural, not cosmetic

Two implementations of "summarise a tool call" exist:

| | |
|---|---|
| **A** — `stream-parser.ts:117` `extractToolDetail` | typed, per-tool, 10 kinds, 3 consumers (`ToolBlock`, `tool-adapter`, `stream-parser`) |
| **B** — `parse.rs:261` | `serde_json::Value::to_string()`, truncated at a bare `200` |

**The swarm could only ever reach B.** Summarising happens at *parse* time on the backend and the structured `input` is discarded — `SubagentEvent` carries only `input_summary: String`. So the frontend cannot apply the good extractor even though it's sitting right there, and the entire tool-renderer registry (`RecordTable`/`SearchResults`/`WebFetchResult`, `SPEC_TOOL_RESULT_RENDERER_REGISTRY_2026_06_17`) is unreachable from that feed for the same reason.

**This PR does not fix that.** Phase 2 does, by carrying the structured input across the boundary. This ports the field selection into Rust as a deliberate, documented down-payment that Phase 2 deletes. I'd rather say that plainly than present a duplicated mapping as the destination.

## Also fixed: a byte/char mismatch

```rust
if s.len() > 200 {                                            // BYTES
    let end = s.char_indices().nth(200).map_or(s.len(), …);   // CHARS
```

A string over 200 **bytes** but under 200 **chars** took the truncation branch, found no 200th char, and fell through to no truncation at all. Now named constants, chars throughout.

## One deliberate divergence from the frontend original

An **unknown tool falls back to the raw JSON object** rather than `""`. `extractToolDetail` can return empty because its callers still hold the full node to fall back on; here there is nothing else to show, and `mcp__*`/provider-specific names are open-ended by design. A known tool whose expected field is missing or empty takes the same fallback.

## Phase 4 — not done as the report proposed

Worth stating rather than quietly narrowing scope: **the report said to delete the dead `Result`-discriminant completion check. I didn't.**

Deleting it would strand `PendingCompletion`, the coalescing buffer's `completed` vector, and two broadcast shapes — all *correct* code. Its only fault is being unreachable in a transcript format we don't control and which could change back; if `"type":"result"` lines ever appear it resumes being the **faster** completion signal (immediate, versus waiting for the parent turn to end). Deleting correct handling for an external format we don't own trades a real capability for tidiness.

What actually caused harm was the comment asserting it works. Both sites now state plainly that it never fires, cite the evidence, point at `completion.rs` as the real path, and record the #2283 history — a placeholder match that "almost never fired" replaced by a discriminant check that fires *never*, indistinguishable from outside, which is exactly how the original bug survived a refactor.

If a reviewer disagrees, §4.4 and §8 of the report lay out the argument both ways. The trap is gone either way.

## Testing

- **11 new tests**, fixture taken from the transcript that produced the reported symptom.
- **Mutation-checked:** forcing the JSON-dump fallback fails 5 of them, including the flagship Bash case; the fallback and truncation tests keep passing, confirming they guard preserved behaviour.
- Full `agentmux-srv` suite: **3030 passed, 0 failed**.

## Not verified

The produced string is unit-tested, but **I have not watched a Swarm row actually render it.** Flagging rather than implying otherwise.

Phases 2 and 3 (move formatting to the edge; one binding surface) remain open in the report.

<!-- agentmux:agent_id=posa -->
