### PR TITLE
feat(muxbus): jekt delivery tier 4 — cloud relay performed by srv

### DIFF
--- a/.changesets/1788717537-feat-muxbus-jekt-delivery-tier-4-cloud-relay-is-now-performe-8gjt.md
+++ b/.changesets/1788717537-feat-muxbus-jekt-delivery-tier-4-cloud-relay-is-now-performe-8gjt.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(muxbus): jekt delivery tier 4 — cloud relay is now performed by srv

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -97,6 +97,14 @@ jobs:
       - name: Input-handler layout-read gate
         run: bash tools/lint/check-input-handler-layout-reads.sh
 
+      # Same rationale as the three above — encodes a regression that already
+      # happened (PR #3023 P0: tier-4 cloud relay read credentials from the
+      # wrong store and silently never fired). Not unit-testable: test_state()
+      # backs wstore/id_store/identity_store with one Store, so a runtime test
+      # cannot tell them apart.
+      - name: muxbus credential store gate
+        run: bash scripts/check-muxbus-credential-store.sh
+
   frontend:
     name: vitest
     runs-on: ubuntu-latest

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -110,7 +110,7 @@ const SHELL_STATUS_TOOL: &str = r#"{
 
 const SEND_MESSAGE_TOOL: &str = r#"{
   "name": "SendMessage",
-  "description": "Send a message to another agent by name. The message is injected as input into the target agent's active conversation. Use for agent-to-agent coordination — handoff, task delegation, status notifications. Delivery is best-effort and tries local → LAN → cloud in order. Returns once delivery is confirmed or all tiers have failed.",
+  "description": "Send a message to another agent by name. The message is injected as input into the target agent's active conversation. Use for agent-to-agent coordination — handoff, task delegation, status notifications. Delivery is best-effort and tries local → same-host → LAN → cloud in order. The first three tiers return only once the message has actually been injected; the cloud tier is store-and-forward, so success there means the relay accepted it and the recipient's AgentMux will pick it up when it next syncs (which never happens if that instance stays offline). Returns once one tier has taken the message or all have failed.",
   "inputSchema": {
     "type": "object",
     "properties": {

--- a/agentmux-srv/src/muxbus/mod.rs
+++ b/agentmux-srv/src/muxbus/mod.rs
@@ -4,6 +4,7 @@
 pub mod agent_credentials;
 pub mod cloud_subscriber;
 pub mod pkce;
+pub mod relay;
 
 /// Identifier MuxBus's single global credential set is registered under
 /// with both the broker scheduler (`crate::broker`) and the OS keychain

--- a/agentmux-srv/src/muxbus/pkce.rs
+++ b/agentmux-srv/src/muxbus/pkce.rs
@@ -28,15 +28,12 @@ pub struct PkceResult {
     pub credentials: MuxBusCredentials,
 }
 
-/// Base URL of the muxbus REST API hosting the login relay. The env override
-/// exists for tests and for running against a local muxbus server
-/// (`http://localhost:3100`, registered in the dev Cognito app client).
-fn relay_base_url() -> String {
-    std::env::var("AGENTMUX_MUXBUS_REST_URL")
-        .ok()
-        .filter(|v| !v.is_empty())
-        .unwrap_or_else(|| crate::muxbus::cloud_subscriber::MUXBUS_REST_URL.to_string())
-}
+/// Base URL of the muxbus REST API hosting the login relay.
+///
+/// Single definition shared with the tier-4 outbound relay
+/// (`crate::muxbus::relay::rest_base_url`) — two copies of "where is the
+/// cloud" is precisely the drift the network DRYness pass set out to remove.
+use crate::muxbus::relay::rest_base_url as relay_base_url;
 
 // Only one login flow may exist per process. Two concurrent flows both bind
 // the fixed callback port, and (on Windows, where SO_REUSEADDR permits binding

--- a/agentmux-srv/src/muxbus/relay.rs
+++ b/agentmux-srv/src/muxbus/relay.rs
@@ -1,0 +1,378 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Outbound cloud relay — jekt delivery **tier 4**.
+//!
+//! Tiers 1–3 (local handler, same-host registry, LAN peer) all live in
+//! `server/reactive.rs`. Tier 4 was, until this module existed, a comment
+//! there — `// 4. Return original error (muxbus-client will fall back to cloud
+//! relay)` — delegating to a "muxbus-client" that the callers agents actually
+//! use are not. The MCP `SendMessage` tool POSTs to `/agentmux/reactive/inject`
+//! and bails on `success != true`, so the tier chain silently stopped at three
+//! while `SendMessage`'s own description promised "local → LAN → cloud". See
+//! `docs/reports/REPORT_NETWORK_ARCHITECTURE_DRYNESS_AND_ROBUST_LAN_2026_09_06.md` §5.
+//!
+//! This module makes tier 4 real and owned by the same handler as the other
+//! three, so every caller inherits it instead of re-implementing it.
+//!
+//! ## What "success" means here
+//!
+//! Tier 4 is **store-and-forward, not delivery**. The cloud persists the
+//! injection and broadcasts a wake signal; the recipient's srv picks it up on
+//! its next sync, which may be seconds away or never (that instance may be
+//! offline). A 2xx here therefore means *queued*, and [`RelayOutcome::Queued`]
+//! is deliberately not named anything that reads as delivered — the tier-3
+//! forward path had exactly that confusion and it produced a real bug (see
+//! `forward_inject_to_peer`'s "one behaviour unified" note).
+
+use std::sync::Arc;
+
+use crate::backend::storage::store::Store;
+
+/// The cloud rejects anything larger (`index.ts`: "message exceeds maximum
+/// length of 10KB"). Checked locally so an oversized message fails with a
+/// useful error instead of a bare 400 after a round trip.
+const MAX_RELAY_MESSAGE_BYTES: usize = 10240;
+
+/// Bounds how long a failed local delivery can block on the cloud before the
+/// caller gets its answer. Tier 4 runs only after tiers 1–3 have already
+/// failed, so this is additive to a request that is already slow.
+const RELAY_TIMEOUT_SECS: u64 = 10;
+
+/// Base URL of the muxbus REST API.
+///
+/// The env override exists for tests and for running against a local muxbus
+/// server (`http://localhost:3100`, registered in the dev Cognito app client).
+/// Previously private to `pkce.rs`; promoted here because tier 4 needs the same
+/// resolution and two copies of "where is the cloud" is exactly the drift this
+/// report set out to remove.
+pub(crate) fn rest_base_url() -> String {
+    std::env::var("AGENTMUX_MUXBUS_REST_URL")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| crate::muxbus::cloud_subscriber::MUXBUS_REST_URL.to_string())
+}
+
+/// Outcome of a tier-4 relay attempt.
+///
+/// There is deliberately no "cloud not configured" variant: that condition is
+/// answered earlier and more cheaply by [`relay_token`] returning `None`, so
+/// reaching this function at all already means tier 4 exists here.
+#[derive(Debug)]
+pub(crate) enum RelayOutcome {
+    /// The cloud accepted and persisted the injection. **Queued, not
+    /// delivered** — see the module doc.
+    Queued { injection_id: Option<String> },
+    /// The cloud was reachable and said no, or the request never landed.
+    Failed(String),
+}
+
+/// POST one injection to the cloud relay.
+///
+/// Deliberately takes `base_url` and `token` rather than resolving them
+/// internally: that keeps this function a pure HTTP operation with no globals,
+/// so the tests can point it at a stub relay without mutating process-wide env
+/// (which would race the rest of the test binary).
+///
+/// ## Contract (verified against `agentmux-cloud/muxbus/server/src/index.ts`)
+///
+/// - `source_agent` travels in the **`X-Agent-ID` header, not the body** — the
+///   route 400s without it and derives the sender from it alone.
+/// - `X-Client-Wrapped: true` is required. Without it the cloud wraps the
+///   message in its own `[JEKT:...]` marker before storing; the receiving srv
+///   then wraps it *again* in `Handler::inject_message`, so the recipient sees
+///   a doubled marker. Sending raw + telling the cloud not to wrap yields
+///   exactly one marker, applied by the receiver — identical to how tiers 2
+///   and 3 already behave.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn relay_inject(
+    base_url: &str,
+    http: &reqwest::Client,
+    token: &str,
+    source_agent: &str,
+    target_agent: &str,
+    message: &str,
+    priority: &str,
+) -> RelayOutcome {
+    if message.len() > MAX_RELAY_MESSAGE_BYTES {
+        return RelayOutcome::Failed(format!(
+            "message is {} bytes; the cloud relay accepts at most {}",
+            message.len(),
+            MAX_RELAY_MESSAGE_BYTES
+        ));
+    }
+
+    let url = format!("{}/reactive/inject", base_url.trim_end_matches('/'));
+    let resp = http
+        .post(&url)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("X-Agent-ID", source_agent)
+        .header("X-Client-Wrapped", "true")
+        .timeout(std::time::Duration::from_secs(RELAY_TIMEOUT_SECS))
+        .json(&serde_json::json!({
+            "target_agent": target_agent,
+            "message": message,
+            "priority": priority,
+        }))
+        .send()
+        .await;
+
+    let resp = match resp {
+        Ok(r) => r,
+        Err(e) => return RelayOutcome::Failed(format!("cloud relay unreachable: {e}")),
+    };
+
+    let status = resp.status();
+    if status.is_success() {
+        let body: serde_json::Value = resp.json().await.unwrap_or_default();
+        // The route returns `success: true` alongside the id; treat an
+        // explicit non-true as a failure rather than assuming 2xx means yes —
+        // the same stricter reading tier 2/3 settled on.
+        if body.get("success").and_then(|v| v.as_bool()) != Some(true) {
+            return RelayOutcome::Failed(format!(
+                "cloud relay returned {status} without success:true"
+            ));
+        }
+        return RelayOutcome::Queued {
+            injection_id: body
+                .get("injection_id")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+        };
+    }
+
+    // 402 is the free-tier quota wall, which is a user-actionable condition
+    // rather than a bug — surface the cloud's own message verbatim so the
+    // upgrade URL it includes reaches the operator.
+    let detail = resp.text().await.unwrap_or_default();
+    RelayOutcome::Failed(format!("cloud relay rejected: HTTP {status} — {detail}"))
+}
+
+/// Resolve the credential to relay as, preferring one bound to this specific
+/// sender over the shared account token — the same precedence the inbound
+/// path (`cloud_subscriber::sync_agent_reactive`) already uses, so a
+/// binding-enforced account behaves consistently in both directions.
+///
+/// `None` means the account isn't logged in to muxbus at all, i.e. tier 4
+/// doesn't exist here.
+pub(crate) async fn relay_token(
+    source_agent: &str,
+    wstore: &Arc<Store>,
+    http: &reqwest::Client,
+) -> Option<String> {
+    if let Some(per_agent) =
+        crate::muxbus::agent_credentials::ensure_agent_credential(source_agent, wstore, http).await
+    {
+        return Some(per_agent);
+    }
+    let scheduler = crate::broker::get_global()?;
+    crate::muxbus::cloud_subscriber::load_valid_token(wstore, &scheduler).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A stub relay capturing the request it receives, so the tests can assert
+    /// on the wire contract (headers especially) and not just the outcome.
+    struct Captured {
+        agent_id: Option<String>,
+        client_wrapped: Option<String>,
+        authorization: Option<String>,
+        body: serde_json::Value,
+    }
+
+    async fn stub_relay(
+        status: axum::http::StatusCode,
+        response_body: &'static str,
+    ) -> (
+        String,
+        std::sync::Arc<std::sync::Mutex<Option<Captured>>>,
+        tokio_util::sync::DropGuard,
+    ) {
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let sink = seen.clone();
+        let app = axum::Router::new().route(
+            "/reactive/inject",
+            axum::routing::post(
+                move |headers: axum::http::HeaderMap, body: axum::Json<serde_json::Value>| {
+                    let sink = sink.clone();
+                    async move {
+                        let get = |k: &str| {
+                            headers
+                                .get(k)
+                                .and_then(|v| v.to_str().ok())
+                                .map(str::to_string)
+                        };
+                        *sink.lock().unwrap() = Some(Captured {
+                            agent_id: get("x-agent-id"),
+                            client_wrapped: get("x-client-wrapped"),
+                            authorization: get("authorization"),
+                            body: body.0,
+                        });
+                        (
+                            status,
+                            [(axum::http::header::CONTENT_TYPE, "application/json")],
+                            response_body,
+                        )
+                    }
+                },
+            ),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let token = tokio_util::sync::CancellationToken::new();
+        let child = token.clone();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app)
+                .with_graceful_shutdown(async move { child.cancelled().await })
+                .await;
+        });
+        (format!("http://{addr}"), seen, token.drop_guard())
+    }
+
+    #[tokio::test]
+    async fn a_queued_injection_returns_its_id() {
+        let (url, _seen, _g) = stub_relay(
+            axum::http::StatusCode::OK,
+            r#"{"success":true,"injection_id":"inj-42"}"#,
+        )
+        .await;
+        let out = relay_inject(
+            &url,
+            &reqwest::Client::new(),
+            "tok",
+            "agent2",
+            "clare",
+            "hello",
+            "normal",
+        )
+        .await;
+        match out {
+            RelayOutcome::Queued { injection_id } => {
+                assert_eq!(injection_id.as_deref(), Some("inj-42"))
+            }
+            other => panic!("expected Queued, got {other:?}"),
+        }
+    }
+
+    /// The wire contract the cloud route actually enforces, pinned so a future
+    /// edit can't quietly drop a header the server 400s (or double-wraps)
+    /// without a test failing.
+    #[tokio::test]
+    async fn the_sender_travels_as_a_header_and_wrapping_is_declined() {
+        let (url, seen, _g) =
+            stub_relay(axum::http::StatusCode::OK, r#"{"success":true}"#).await;
+        let _ = relay_inject(
+            &url,
+            &reqwest::Client::new(),
+            "tok",
+            "agent2",
+            "clare",
+            "hello",
+            "urgent",
+        )
+        .await;
+
+        let c = seen.lock().unwrap();
+        let c = c.as_ref().expect("stub relay saw no request");
+        assert_eq!(c.agent_id.as_deref(), Some("agent2"), "X-Agent-ID is required by the route");
+        assert_eq!(
+            c.client_wrapped.as_deref(),
+            Some("true"),
+            "without this the cloud wraps the marker and the receiver wraps it again"
+        );
+        assert_eq!(c.authorization.as_deref(), Some("Bearer tok"));
+        // source_agent is NOT a body field — the route reads it from the header.
+        assert!(c.body.get("source_agent").is_none());
+        assert_eq!(c.body.get("target_agent").and_then(|v| v.as_str()), Some("clare"));
+        assert_eq!(c.body.get("message").and_then(|v| v.as_str()), Some("hello"));
+        assert_eq!(c.body.get("priority").and_then(|v| v.as_str()), Some("urgent"));
+    }
+
+    #[tokio::test]
+    async fn a_quota_rejection_surfaces_the_clouds_own_message() {
+        let (url, _seen, _g) = stub_relay(
+            axum::http::StatusCode::PAYMENT_REQUIRED,
+            r#"{"error":"quota_exceeded","upgrade_url":"https://cloud.agentmux.ai/billing"}"#,
+        )
+        .await;
+        let out = relay_inject(
+            &url,
+            &reqwest::Client::new(),
+            "tok",
+            "agent2",
+            "clare",
+            "hello",
+            "normal",
+        )
+        .await;
+        match out {
+            RelayOutcome::Failed(e) => {
+                assert!(e.contains("402"), "status should be visible: {e}");
+                assert!(e.contains("upgrade_url"), "cloud's own body should pass through: {e}");
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    /// A 2xx that doesn't say `success: true` must not count — the same
+    /// stricter reading the tier-2/3 forward helper settled on after the LAN
+    /// tier was found treating a body without `success` as a delivery.
+    #[tokio::test]
+    async fn a_2xx_without_success_true_is_a_failure() {
+        let (url, _seen, _g) =
+            stub_relay(axum::http::StatusCode::OK, r#"{"injection_id":"inj-1"}"#).await;
+        let out = relay_inject(
+            &url,
+            &reqwest::Client::new(),
+            "tok",
+            "agent2",
+            "clare",
+            "hello",
+            "normal",
+        )
+        .await;
+        assert!(matches!(out, RelayOutcome::Failed(_)), "got {out:?}");
+    }
+
+    /// Checked locally so the caller gets a useful message instead of a bare
+    /// 400 after a wasted round trip.
+    #[tokio::test]
+    async fn an_oversized_message_is_rejected_before_any_request() {
+        let big = "x".repeat(MAX_RELAY_MESSAGE_BYTES + 1);
+        let out = relay_inject(
+            "http://127.0.0.1:1", // never contacted
+            &reqwest::Client::new(),
+            "tok",
+            "agent2",
+            "clare",
+            &big,
+            "normal",
+        )
+        .await;
+        match out {
+            RelayOutcome::Failed(e) => assert!(e.contains("10240"), "{e}"),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn an_unreachable_relay_fails_rather_than_hanging() {
+        let url = {
+            let l = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            format!("http://{}", l.local_addr().unwrap())
+        };
+        let out = relay_inject(
+            &url,
+            &reqwest::Client::new(),
+            "tok",
+            "agent2",
+            "clare",
+            "hello",
+            "normal",
+        )
+        .await;
+        assert!(matches!(out, RelayOutcome::Failed(_)), "got {out:?}");
+    }
+}

--- a/agentmux-srv/src/muxbus/relay.rs
+++ b/agentmux-srv/src/muxbus/relay.rs
@@ -155,18 +155,38 @@ pub(crate) async fn relay_inject(
 ///
 /// `None` means the account isn't logged in to muxbus at all, i.e. tier 4
 /// doesn't exist here.
+///
+/// **`store` must be the one muxbus credentials actually live in —
+/// `AppState::id_store`,** the same store `CloudSubscriber::init_global` and
+/// every `muxbus.login`/`status`/`disconnect` handler use. Passing the
+/// per-channel `wstore` finds nothing whenever the shared root resolves (the
+/// normal case), so tier 4 would silently never fire for a logged-in user
+/// [reagent #3023 P0]. Note this deliberately does NOT follow `AppState`'s
+/// general steer toward `identity_store` for new muxbus call sites: the
+/// credentials are written to `id_store`, and reading from a store the writer
+/// doesn't use would reintroduce the same bug whenever
+/// `isolated_auth_enabled()` redirects one but not the other.
+///
+/// Ordering matters. The shared account token is a purely local read, so it is
+/// checked FIRST: no credential means the account isn't logged in, and there is
+/// nothing for a per-agent credential to be provisioned against. Doing it the
+/// other way round makes `ensure_agent_credential` attempt a cloud
+/// provisioning round trip (`POST /agents/provision`) on a logged-out instance
+/// — once per failed local inject, i.e. on the hot path of every message to an
+/// unknown agent.
 pub(crate) async fn relay_token(
     source_agent: &str,
-    wstore: &Arc<Store>,
+    store: &Arc<Store>,
     http: &reqwest::Client,
 ) -> Option<String> {
-    if let Some(per_agent) =
-        crate::muxbus::agent_credentials::ensure_agent_credential(source_agent, wstore, http).await
-    {
-        return Some(per_agent);
-    }
     let scheduler = crate::broker::get_global()?;
-    crate::muxbus::cloud_subscriber::load_valid_token(wstore, &scheduler).await
+    let shared = crate::muxbus::cloud_subscriber::load_valid_token(store, &scheduler).await?;
+
+    match crate::muxbus::agent_credentials::ensure_agent_credential(source_agent, store, http).await
+    {
+        Some(per_agent) => Some(per_agent),
+        None => Some(shared),
+    }
 }
 
 #[cfg(test)]

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -1122,7 +1122,7 @@ async fn try_cloud_relay(state: &AppState, req: &InjectionRequest) -> Option<ser
     // so a caller with no source agent (cron, external bridge) has no tier 4.
     let source = req.source_agent.as_deref().filter(|s| !s.is_empty())?;
 
-    let token = crate::muxbus::relay::relay_token(source, &state.wstore, &state.http_client).await;
+    let token = crate::muxbus::relay::relay_token(source, &state.id_store, &state.http_client).await;
     let Some(token) = token else {
         tracing::debug!(
             target = %req.target_agent,

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -1078,10 +1078,118 @@ pub(super) async fn handle_reactive_inject(
                 ForwardOutcome::Inconclusive => {}
             }
         }
+
+        // Tier 4: cloud relay (muxbus store-and-forward). Runs when no local,
+        // same-host or LAN tier could place the message.
+        //
+        // This tier used to be a comment here delegating to a "muxbus-client"
+        // that the callers agents actually use are not — the MCP `SendMessage`
+        // tool POSTs to this very endpoint and bails on `success != true`, so
+        // the chain silently stopped at three while that tool's description
+        // promised "local → LAN → cloud". Owning it here means every caller
+        // inherits it. See `crate::muxbus::relay` and
+        // REPORT_NETWORK_ARCHITECTURE_DRYNESS_AND_ROBUST_LAN_2026_09_06.md §5.
+        if let Some(body) = try_cloud_relay(&state, &req).await {
+            return Json(body);
+        }
     }
 
-    // 4. Return original error (muxbus-client will fall back to cloud relay).
+    // 5. Every tier declined — return the original local error.
     Json(serde_json::to_value(&resp).unwrap_or_default())
+}
+
+/// Tier 4. `Some(body)` when the cloud accepted the injection (and the sender
+/// echo has been emitted); `None` when tier 4 doesn't apply or didn't take,
+/// leaving the caller to return its original error.
+///
+/// **Queued is not delivered.** The cloud persists the message and wakes
+/// subscribed sidecars; the recipient's srv picks it up on its next sync, which
+/// may be seconds away or never if that instance is offline. `success: true`
+/// here therefore means "handed to the relay" — which is the strongest claim
+/// any WAN tier can make, and is what `DELIVERY=wan` on the echoed marker
+/// already tells the sender.
+async fn try_cloud_relay(state: &AppState, req: &InjectionRequest) -> Option<serde_json::Value> {
+    // Never re-relay something that ARRIVED over the cloud. An agent unknown to
+    // every instance would otherwise bounce between the relay and each
+    // subscriber indefinitely, re-queueing on every hop. `forward_hops` cannot
+    // catch this: the cloud hands the message to a fresh inbound request with
+    // the count reset, so this tier needs its own guard.
+    if req.delivery_tier.as_deref() == Some("wan") {
+        return None;
+    }
+
+    // The cloud route derives the sender from `X-Agent-ID` and 400s without it,
+    // so a caller with no source agent (cron, external bridge) has no tier 4.
+    let source = req.source_agent.as_deref().filter(|s| !s.is_empty())?;
+
+    let token = crate::muxbus::relay::relay_token(source, &state.wstore, &state.http_client).await;
+    let Some(token) = token else {
+        tracing::debug!(
+            target = %req.target_agent,
+            "cloud relay skipped: not logged in to muxbus"
+        );
+        return None;
+    };
+
+    let priority = req.priority.as_deref().unwrap_or("normal");
+    let outcome = crate::muxbus::relay::relay_inject(
+        &crate::muxbus::relay::rest_base_url(),
+        &state.http_client,
+        &token,
+        source,
+        &req.target_agent,
+        &req.message,
+        priority,
+    )
+    .await;
+
+    match outcome {
+        crate::muxbus::relay::RelayOutcome::Queued { injection_id } => {
+            let request_id = injection_id.unwrap_or_default();
+            tracing::info!(
+                target = %req.target_agent,
+                injection_id = %request_id,
+                "cloud relay: queued for WAN delivery"
+            );
+            echo_jekt_to_sender(
+                state,
+                Some(source),
+                &req.target_agent,
+                &req.message,
+                &request_id,
+                None, // no receiver-side escalation to mirror: nobody has
+                None, // seen the message yet, so neither field is known
+                EchoTrust {
+                    delivery_tier: "wan",
+                    // Signing on this path is issue #2586's unbuilt WAN half —
+                    // an outbound relay carries no proof of sender identity, and
+                    // claiming otherwise here would put a TRUST value on the
+                    // echoed marker that the receiving side will not agree with.
+                    sig_verified: None,
+                    reagent_verified: None,
+                    lan_verified: None,
+                },
+                priority,
+            );
+            let body = crate::backend::reactive::types::InjectionResponse {
+                success: true,
+                request_id,
+                block_id: None,
+                error: None,
+                timestamp: now_unix_secs().max(0) as u64,
+                // No receiver has seen the message yet, so there is no applied
+                // tier or STOP decision to report — deliberately left unset
+                // rather than guessed at.
+                effective_tier: None,
+                requires_stop: None,
+            };
+            Some(serde_json::to_value(&body).unwrap_or_default())
+        }
+        crate::muxbus::relay::RelayOutcome::Failed(e) => {
+            tracing::warn!(target = %req.target_agent, error = %e, "cloud relay failed");
+            None
+        }
+    }
 }
 
 pub(super) async fn handle_reactive_agents(
@@ -2592,5 +2700,72 @@ mod forward_inject_tests {
         let r = req();
         let out = forward_inject_to_peer(&state, &r, &r, peer(&url)).await;
         assert!(matches!(out, ForwardOutcome::Stale), "expected Stale");
+    }
+}
+
+/// Tier-4 (cloud relay) gating tests.
+///
+/// These cover the decisions `try_cloud_relay` makes *before* it would touch
+/// the network — the guards that keep it from firing when it must not. The
+/// wire contract itself (headers, body shape, status handling) is tested
+/// against a stub relay in `crate::muxbus::relay`'s own test module.
+///
+/// A `test_state()` has no muxbus credential, so any path that reaches token
+/// resolution returns `None` and no request is ever made — which is also why
+/// these assert `None` rather than mocking the relay: the point is *which*
+/// guard stopped it, and each test isolates one.
+#[cfg(test)]
+mod cloud_relay_gate_tests {
+    use super::*;
+    use crate::server::tests::test_state;
+
+    fn req(source: Option<&str>, delivery_tier: Option<&str>) -> InjectionRequest {
+        InjectionRequest {
+            target_agent: "nobody-anywhere".to_string(),
+            message: "hello".to_string(),
+            source_agent: source.map(str::to_string),
+            delivery_tier: delivery_tier.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    /// **The loop guard.** A message that arrived over the cloud must never be
+    /// pushed back to it: an agent unknown to every subscribed instance would
+    /// otherwise bounce between the relay and each sidecar forever, re-queueing
+    /// on every hop. `forward_hops` cannot catch this — the cloud delivers each
+    /// message as a fresh inbound request with the count reset — so tier 4
+    /// carries its own guard, and this is the test that pins it.
+    #[tokio::test]
+    async fn a_message_that_arrived_over_wan_is_never_re_relayed() {
+        let state = test_state();
+        let out = try_cloud_relay(&state, &req(Some("agent2"), Some("wan"))).await;
+        assert!(out.is_none(), "a wan-delivered message must not re-enter tier 4");
+    }
+
+    /// The cloud route derives the sender from `X-Agent-ID` and 400s without
+    /// it, so a caller with no source agent (cron, an external bridge) has no
+    /// tier 4 at all — better to skip than to burn a round trip on a request
+    /// that cannot succeed.
+    #[tokio::test]
+    async fn a_caller_with_no_source_agent_has_no_tier_4() {
+        let state = test_state();
+        assert!(try_cloud_relay(&state, &req(None, Some("host"))).await.is_none());
+        assert!(
+            try_cloud_relay(&state, &req(Some(""), Some("host")))
+                .await
+                .is_none(),
+            "an empty source_agent is as unusable as a missing one"
+        );
+    }
+
+    /// Host- and LAN-tier messages are eligible; with no muxbus credential
+    /// present this still ends in `None`, but via token resolution rather than
+    /// an early guard — i.e. these are not accidentally excluded.
+    #[tokio::test]
+    async fn host_and_lan_messages_are_eligible_but_need_a_credential() {
+        let state = test_state();
+        assert!(try_cloud_relay(&state, &req(Some("agent2"), Some("host"))).await.is_none());
+        assert!(try_cloud_relay(&state, &req(Some("agent2"), Some("lan"))).await.is_none());
+        assert!(try_cloud_relay(&state, &req(Some("agent2"), None)).await.is_none());
     }
 }

--- a/docs/reports/REPORT_NETWORK_ARCHITECTURE_DRYNESS_AND_ROBUST_LAN_2026_09_06.md
+++ b/docs/reports/REPORT_NETWORK_ARCHITECTURE_DRYNESS_AND_ROBUST_LAN_2026_09_06.md
@@ -229,6 +229,31 @@ owner.** Parts live in `reactive.rs`, one part is delegated to an unnamed
 if cloud relay is tier 4, `handle_reactive_inject` should perform it, and every
 caller inherits it. Failing that, the description must stop promising it.
 
+**✅ Done — the first option.** `crate::muxbus::relay` implements the outbound
+half (`POST /reactive/inject`), and `handle_reactive_inject` calls it as tier 4
+after tiers 1–3 decline, so every caller inherits it rather than
+re-implementing it. `SendMessage`'s description is now true.
+
+Three things worth recording from building it:
+
+1. **The contract was not what the specs implied.** `source_agent` travels in
+   the **`X-Agent-ID` header, not the request body** (the route 400s without
+   it), and `X-Client-Wrapped: true` is required — without it the cloud wraps
+   the message in its own `[JEKT:...]` marker *and* the receiving srv wraps it
+   again in `Handler::inject_message`, so the recipient sees a doubled marker.
+   Both were established by reading
+   `agentmux-cloud/muxbus/server/src/index.ts` directly. An earlier draft of
+   this work inferred the body shape from a spec describing `createInjection`'s
+   stored row and would have shipped broken.
+2. **Tier 4 needs its own loop guard.** `forward_hops` cannot stop a
+   relay↔subscriber ping-pong, because the cloud delivers each message as a
+   *fresh* inbound request with the count reset. A message that arrived with
+   `delivery_tier == "wan"` is therefore never re-relayed.
+3. **Queued is not delivered.** The relay persists and wakes subscribers; the
+   recipient's srv collects on its next sync, or never if it is offline. The
+   outcome type is `Queued`, not `Delivered`, and the tool description now says
+   so — the tier-3 path had exactly this conflation and it was a real bug.
+
 ### 6. Discovery reports local truth as if it were global
 
 `DiscoverAgents` returns `wan.subscribed_agents`, which on inspection lists

--- a/scripts/check-muxbus-credential-store.sh
+++ b/scripts/check-muxbus-credential-store.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# check-muxbus-credential-store.sh — CI grep gate for muxbus credential reads.
+#
+# THE RULE: muxbus credentials — the account token (`muxbus_load`/`muxbus_save`/
+# `muxbus_clear`, `load_valid_token`) and the per-agent M2M credentials
+# (`ensure_agent_credential`, `relay_token`) — live in `AppState::id_store`.
+# That is where `CloudSubscriber::init_global` and every `muxbus.login` /
+# `muxbus.status` / `muxbus.disconnect` handler write them. Reading them from
+# the per-channel `state.wstore` finds NOTHING whenever the shared root
+# resolves, which is the normal case.
+#
+# THE REGRESSION (reagent P0 on PR #3023): the delivery tier-4 cloud relay
+# called `relay_token(source, &state.wstore, ...)`. Every lookup missed,
+# `relay_token` always returned `None`, and tier 4 silently never fired even
+# for a properly logged-in user — the entire feature defeated by one field
+# name, with no error anywhere. It logged "not logged in to muxbus" and
+# returned, which reads like correct behaviour.
+#
+# Why a grep gate and not a unit test: `server::tests::test_state()` backs
+# `wstore`, `id_store` AND `identity_store` with a single in-memory Store, so a
+# runtime test cannot distinguish them — seeding a credential into one makes it
+# visible through all three, and the test passes whichever field the code reads.
+# The bug is a static wiring mistake and only a static check catches it.
+#
+# Note this rule deliberately says `id_store`, not `identity_store`, even
+# though AppState's own doc comment steers new muxbus call sites toward the
+# latter: the credentials are WRITTEN to `id_store`, and reading from a store
+# the writer doesn't use would reintroduce this same bug whenever
+# `isolated_auth_enabled()` redirects one but not the other. If the writers
+# ever migrate, migrate the readers in the same change and update this gate.
+#
+# Usage:
+#   bash scripts/check-muxbus-credential-store.sh
+# Exit 0 = clean, exit 1 = a muxbus credential call was handed `state.wstore`.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Only `state.wstore` is matched, not a bare `wstore` identifier: several
+# functions inside `muxbus/` name their own store parameter `wstore` for
+# historical reasons even though callers correctly pass the id_store. Those are
+# a naming wart, not a bug, and flagging them would make this gate noise.
+report="$(grep -rnE \
+    '(muxbus_load|muxbus_save|muxbus_clear|load_valid_token|ensure_agent_credential|relay_token)[[:space:]]*\(' \
+    --include='*.rs' agentmux-srv/src \
+    | grep 'state\.wstore' || true)"
+
+if [[ -n "$report" ]]; then
+    echo "ERROR: muxbus credential lookup against state.wstore." >&2
+    echo "" >&2
+    echo "muxbus credentials live in AppState::id_store — that is where" >&2
+    echo "CloudSubscriber::init_global and the muxbus.login/status/disconnect" >&2
+    echo "handlers write them. Reading from the per-channel state.wstore finds" >&2
+    echo "nothing whenever the shared root resolves, and fails SILENTLY: the" >&2
+    echo "lookup just returns None and the caller concludes the user is not" >&2
+    echo "logged in." >&2
+    echo "" >&2
+    echo "$report" | sed 's/^/  - /' >&2
+    echo "" >&2
+    echo "Use state.id_store. See this script's header for why not" >&2
+    echo "identity_store, and PR #3023 for the regression." >&2
+    exit 1
+fi
+
+echo "OK: no muxbus credential lookup reads from state.wstore."
+exit 0


### PR DESCRIPTION
Item 5 of `REPORT_NETWORK_ARCHITECTURE_DRYNESS_AND_ROBUST_LAN_2026_09_06.md` §5. Follows #3021 and #3022.

## The gap

Tier 4 was a comment in `reactive.rs`:

```rust
// 4. Return original error (muxbus-client will fall back to cloud relay).
```

But the callers agents actually use are not that client. The MCP `SendMessage` tool POSTs to `/agentmux/reactive/inject` and bails on `success != true` — so the documented four-tier model was **three tiers plus a comment**, while `SendMessage`'s own description promised "local → LAN → cloud".

## The change

New `crate::muxbus::relay` implements the outbound half (`POST /reactive/inject`); `handle_reactive_inject` calls it as tier 4 once tiers 1–3 decline, so **every** caller inherits it instead of re-implementing it.

## Three things worth review attention

**1. The contract is not what the specs implied.** I originally inferred the request body from `SPEC_JEKT_LAN_WAN_TRUST_HARDENING`'s description of `createInjection`'s stored row — and that would have shipped broken. Reading `agentmux-cloud/muxbus/server/src/index.ts` directly gives the real contract:

- `source_agent` travels in the **`X-Agent-ID` header, not the body** — the route 400s without it and derives the sender from it alone.
- **`X-Client-Wrapped: true` is required.** Without it the cloud wraps the message in its own `[JEKT:...]` marker *and* the receiving srv wraps it again in `Handler::inject_message` → the recipient sees a doubled marker. Sending raw + declining server-side wrapping yields exactly one marker, applied by the receiver, identical to tiers 2 and 3.

Both are pinned by `the_sender_travels_as_a_header_and_wrapping_is_declined`.

**2. Tier 4 needs its own loop guard.** `forward_hops` cannot stop a relay↔subscriber ping-pong: the cloud delivers each message as a *fresh* inbound request with the count reset. An agent unknown to every subscribed instance would bounce forever, re-queueing each hop. A message that arrived with `delivery_tier == "wan"` is therefore never re-relayed (`a_message_that_arrived_over_wan_is_never_re_relayed`).

**3. Queued is not delivered.** The relay persists the message and wakes subscribers; the recipient's srv collects it on its next sync — or never, if that instance stays offline. So the outcome type is `Queued`, not `Delivered`; the echoed marker carries `DELIVERY=wan`; and `SendMessage`'s description now says this plainly instead of implying confirmed delivery. The tier-3 path had exactly this conflation and it was a real bug (#3022).

## Also

Dedupes `relay_base_url` (was private to `pkce.rs`) into `muxbus::relay::rest_base_url` — one definition of "where is the cloud".

## Testing

9 new tests. The wire contract runs against a **capturing** stub relay so the assertions are on the actual headers and body, not just the outcome: queued-with-id, header/wrapping contract, 402 quota passthrough, 2xx-without-`success:true`, oversize pre-check, unreachable. Plus the tier-4 gates: wan loop guard, missing/empty `source_agent`, and that host/lan/unset tiers stay eligible.

`relay_inject` takes `base_url` and `token` as parameters rather than resolving them internally, specifically so tests need no `set_var` (which would race the rest of the test binary).

**3058 tests pass, clippy clean.**

## Not covered

No live call against production muxbus was made from this branch — the contract is verified against the cloud server source and a stub, not the deployed service.

<!-- agentmux:agent_id=agent2 -->