### PR TITLE
refactor(network): fix three misleading names + write the credential map

### DIFF
--- a/.changesets/1788719271-refactor-network-rename-configwatcher-and-wan-subscribed-age-zwhg.md
+++ b/.changesets/1788719271-refactor-network-rename-configwatcher-and-wan-subscribed-age-zwhg.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(network): rename ConfigWatcher and wan.subscribed_agents; add credential map

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -123,7 +123,7 @@ const SEND_MESSAGE_TOOL: &str = r#"{
 
 const DISCOVER_AGENTS_TOOL: &str = r#"{
   "name": "DiscoverAgents",
-  "description": "List the agents and instances reachable from here across the muxbus delivery tiers (host, LAN, cloud), so you can pick a valid target before SendMessage. Returns JSON: host.addressable (agents reachable right now via local delivery), host.agents (this host's agent directory, each with an `addressable` flag), lan (LAN peers and the agents on them), and wan.subscribed_agents (cloud-subscribed agents). Addressing is by agent name, case-insensitive. Takes no arguments.",
+  "description": "List the agents and instances reachable from here across the muxbus delivery tiers (host, LAN, cloud), so you can pick a valid target before SendMessage. Returns JSON: host.addressable (agents reachable right now via local delivery), host.agents (this host's agent directory, each with an `addressable` flag), lan (LAN peers and the agents on them), and wan.local_agents_subscribed (THIS host's own agents that are subscribed to the cloud relay — not a list of remote agents you can reach over WAN; the relay exposes no such directory, so a cloud-only target simply won't appear anywhere in this output). Addressing is by agent name, case-insensitive. Takes no arguments.",
   "inputSchema": {
     "type": "object",
     "properties": {}
@@ -4619,7 +4619,7 @@ mod tests {
         let discovery = serde_json::json!({
             "host": { "addressable": [] },
             "lan": [{ "instance_id": "x", "agents": ["RemoteAgent"] }],
-            "wan": { "subscribed_agents": ["CloudAgent"] },
+            "wan": { "local_agents_subscribed": ["CloudAgent"] },
         });
         let map = build_block_to_agent_map(&discovery);
         assert!(map.is_empty());

--- a/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
@@ -438,7 +438,7 @@ impl Controller for ShellController {
             let mut has_agent_id = false;
 
             // Settings (global defaults, lowest priority)
-            let config = crate::backend::wconfig::ConfigWatcher::with_config(
+            let config = crate::backend::wconfig::ConfigState::with_config(
                 crate::backend::wconfig::build_default_config(),
             );
             let settings = config.get_settings();

--- a/agentmux-srv/src/backend/blockcontroller/watchdog.rs
+++ b/agentmux-srv/src/backend/blockcontroller/watchdog.rs
@@ -15,14 +15,14 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::time::interval;
 
-use crate::backend::wconfig::ConfigWatcher;
+use crate::backend::wconfig::ConfigState;
 use super::{get_all_controllers, STATUS_RUNNING};
 
 /// Check interval for the watchdog loop.
 const WATCHDOG_INTERVAL_SECS: u64 = 60;
 
 /// Run the agent watchdog loop. Never returns.
-pub async fn run_watchdog_loop(config: Arc<ConfigWatcher>) {
+pub async fn run_watchdog_loop(config: Arc<ConfigState>) {
     let mut ticker = interval(Duration::from_secs(WATCHDOG_INTERVAL_SECS));
     loop {
         ticker.tick().await;

--- a/agentmux-srv/src/backend/config_watcher_fs.rs
+++ b/agentmux-srv/src/backend/config_watcher_fs.rs
@@ -19,7 +19,7 @@ use tokio::sync::broadcast;
 
 use super::eventbus::{EventBus, WSEventType, WS_EVENT_RPC};
 use super::fs_watch::{FsWatchEvent, FsWatchEventKind, FsWatchPool};
-use super::wconfig::{self, ConfigWatcher, SettingsType};
+use super::wconfig::{self, ConfigState, SettingsType};
 
 /// Resolve the directory containing settings.json.
 ///
@@ -65,9 +65,9 @@ pub fn resolve_settings_dir() -> PathBuf {
     dirs::home_dir().unwrap_or_default().join(".agentmux")
 }
 
-/// Load settings.json from disk into the ConfigWatcher.
+/// Load settings.json from disk into the ConfigState.
 /// Called once at startup so the backend has the user's saved settings.
-pub fn load_settings_from_disk(config_watcher: &ConfigWatcher) {
+pub fn load_settings_from_disk(config_watcher: &ConfigState) {
     let settings_dir = resolve_settings_dir();
     let settings_path = settings_dir.join(wconfig::SETTINGS_FILE);
 
@@ -130,7 +130,7 @@ fn is_settings_file_event(event: &FsWatchEvent) -> bool {
 /// caller to keep alive: the pool itself owns that now.
 pub fn spawn_settings_watcher(
     pool: Arc<FsWatchPool>,
-    config_watcher: Arc<ConfigWatcher>,
+    config_watcher: Arc<ConfigState>,
     event_bus: Arc<EventBus>,
 ) {
     let settings_dir = resolve_settings_dir();
@@ -199,7 +199,7 @@ pub fn spawn_settings_watcher(
 /// Merge new keys into the current in-memory SettingsType and return the result.
 /// Used by the setconfig handler to update in-memory state before the fs watcher fires.
 pub fn merge_settings_into_current(
-    config_watcher: &wconfig::ConfigWatcher,
+    config_watcher: &wconfig::ConfigState,
     new_keys: serde_json::Map<String, serde_json::Value>,
 ) -> wconfig::SettingsType {
     let mut current = config_watcher.get_settings();
@@ -241,7 +241,7 @@ pub fn merge_settings_to_disk(new_keys: serde_json::Map<String, serde_json::Valu
 
 fn reload_and_broadcast(
     settings_path: &PathBuf,
-    config_watcher: &Arc<ConfigWatcher>,
+    config_watcher: &Arc<ConfigState>,
     event_bus: &Arc<EventBus>,
 ) {
     tracing::info!(path = %settings_path.display(), "settings.json changed, reloading");
@@ -285,7 +285,7 @@ mod tests {
 
     /// End-to-end regression for the migration onto `FsWatchPool`: a real
     /// on-disk settings.json change is detected via the shared pool,
-    /// debounced, reloaded, and lands in `ConfigWatcher`. This is new
+    /// debounced, reloaded, and lands in `ConfigState`. This is new
     /// coverage — `spawn_settings_watcher` had no test before this module
     /// existed to migrate onto.
     #[tokio::test]
@@ -304,7 +304,7 @@ mod tests {
         std::fs::write(&settings_path, wconfig::SETTINGS_TEMPLATE).unwrap();
 
         let pool = FsWatchPool::new();
-        let config_watcher = Arc::new(ConfigWatcher::new());
+        let config_watcher = Arc::new(ConfigState::new());
         let event_bus = Arc::new(EventBus::new());
         spawn_settings_watcher(pool.clone(), config_watcher.clone(), event_bus.clone());
 

--- a/agentmux-srv/src/backend/sysinfo.rs
+++ b/agentmux-srv/src/backend/sysinfo.rs
@@ -15,7 +15,7 @@ use tokio::time::MissedTickBehavior;
 use crate::backend::blockcontroller::pidregistry;
 use crate::backend::blockcontroller::process_tree;
 use crate::backend::rpc_types::TimeSeriesData;
-use crate::backend::wconfig::ConfigWatcher;
+use crate::backend::wconfig::ConfigState;
 use crate::backend::wps::{Broker, WaveEvent, EVENT_BLOCK_STATS, EVENT_SYS_INFO};
 
 const BYTES_PER_GB: f64 = 1_073_741_824.0;
@@ -961,7 +961,7 @@ fn get_disk_data(disks: &Disks, elapsed_secs: f64, values: &mut HashMap<String, 
 }
 
 /// Read the telemetry interval from config, clamped to [MIN, MAX].
-fn get_interval_secs(config_watcher: &ConfigWatcher) -> f64 {
+fn get_interval_secs(config_watcher: &ConfigState) -> f64 {
     let val = config_watcher.get_settings().telemetry_interval;
     if val <= 0.0 {
         return DEFAULT_INTERVAL_SECS;
@@ -972,7 +972,7 @@ fn get_interval_secs(config_watcher: &ConfigWatcher) -> f64 {
 /// Run the sysinfo collection loop. Uses `tokio::time::interval` for steady
 /// tick rate regardless of refresh duration. Interval is re-read from config
 /// each tick and the timer is reset if it changes.
-pub async fn run_sysinfo_loop(broker: Arc<Broker>, config_watcher: Arc<ConfigWatcher>, conn_name: String) {
+pub async fn run_sysinfo_loop(broker: Arc<Broker>, config_watcher: Arc<ConfigState>, conn_name: String) {
     let mut sys = sysinfo::System::new_all();
     let mut networks = Networks::new_with_refreshed_list();
     let mut net_state = NetState::new();

--- a/agentmux-srv/src/backend/wconfig/mod.rs
+++ b/agentmux-srv/src/backend/wconfig/mod.rs
@@ -5,18 +5,24 @@
 //! Port of Go's pkg/wconfig/.
 //!
 //! Provides the full configuration type hierarchy and a thread-safe
-//! config watcher.
+//! in-memory config holder (`ConfigState`).
+//!
+//! Note `ConfigState` does NOT watch the filesystem, despite the name this
+//! module's type carried until 2026-09-06. Filesystem watching lives in
+//! `backend::config_watcher_fs`, on top of the shared `fs_watch::pool`. Two
+//! similarly-named modules where only one watched cost real debugging time;
+//! see REPORT_NETWORK_ARCHITECTURE_DRYNESS_AND_ROBUST_LAN_2026_09_06.md §7.
 
 mod loader;
 pub mod redact;
 pub mod types;
-mod watcher;
+mod state;
 
 // Re-export all public APIs so callers can continue using `wconfig::Type`.
 pub use loader::*;
 pub use redact::redact_full_config_for_renderer;
 pub use types::*;
-pub use watcher::*;
+pub use state::*;
 
 // ---- Config file constants ----
 
@@ -389,11 +395,11 @@ mod tests {
         assert!(json.contains("\"cloudEndpoint\":\"wss://cloud.example.com\""));
     }
 
-    // -- ConfigWatcher --
+    // -- ConfigState --
 
     #[test]
     fn test_config_watcher_default() {
-        let watcher = ConfigWatcher::new();
+        let watcher = ConfigState::new();
         let config = watcher.get_full_config();
         assert!(config.settings.term_theme.is_empty());
     }
@@ -402,13 +408,13 @@ mod tests {
     fn test_config_watcher_with_initial() {
         let mut config = FullConfigType::default();
         config.settings.term_theme = "dracula".to_string();
-        let watcher = ConfigWatcher::with_config(config);
+        let watcher = ConfigState::with_config(config);
         assert_eq!(watcher.get_settings().term_theme, "dracula");
     }
 
     #[test]
     fn test_config_watcher_set_config() {
-        let watcher = ConfigWatcher::new();
+        let watcher = ConfigState::new();
         let mut config = FullConfigType::default();
         config.settings.term_font_size = 16.0;
         watcher.set_config(config);
@@ -417,7 +423,7 @@ mod tests {
 
     #[test]
     fn test_config_watcher_update_settings() {
-        let watcher = ConfigWatcher::new();
+        let watcher = ConfigState::new();
         let settings = SettingsType {
             term_theme: "solarized-dark".to_string(),
             ..Default::default()
@@ -431,7 +437,7 @@ mod tests {
         use std::sync::Arc;
         use std::thread;
 
-        let watcher = Arc::new(ConfigWatcher::new());
+        let watcher = Arc::new(ConfigState::new());
         let handles: Vec<_> = (0..4)
             .map(|i| {
                 let w = watcher.clone();

--- a/agentmux-srv/src/backend/wconfig/redact.rs
+++ b/agentmux-srv/src/backend/wconfig/redact.rs
@@ -35,7 +35,7 @@ const REDACTED_PLACEHOLDER: &str = "\u{2022}\u{2022}\u{2022}\u{2022}\u{2022}\u{2
 
 /// Redact known-secret keys in-place on an already-serialized full-config
 /// JSON value. Call this on every path that sends config to a renderer;
-/// never on the in-memory `ConfigWatcher` state or the on-disk file.
+/// never on the in-memory `ConfigState` state or the on-disk file.
 pub fn redact_full_config_for_renderer(v: &mut Value) {
     let Some(settings) = v.get_mut("settings").and_then(|s| s.as_object_mut()) else {
         return;

--- a/agentmux-srv/src/backend/wconfig/state.rs
+++ b/agentmux-srv/src/backend/wconfig/state.rs
@@ -1,20 +1,32 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Thread-safe configuration holder with change notification.
+//! Thread-safe in-memory configuration holder.
 
 use std::sync::{Arc, RwLock};
 
 use super::types::{FullConfigType, SettingsType};
 
-/// Thread-safe configuration holder with change notification.
-/// The actual file system watching will be integrated with the
-/// event loop in a later phase.
-pub struct ConfigWatcher {
+/// Thread-safe in-memory holder for the live configuration.
+///
+/// **This does not watch anything.** It was called `ConfigWatcher` until
+/// 2026-09-06, on the strength of a comment promising that "the actual file
+/// system watching will be integrated with the event loop in a later phase" —
+/// which never happened. Watching was instead built separately in
+/// `backend::config_watcher_fs`, on top of the shared `fs_watch::pool`, and the
+/// two have coexisted since: similar names, one module doing the thing the
+/// other is named for. That cost real time while tracing the settings-reload
+/// path; see
+/// `docs/reports/REPORT_NETWORK_ARCHITECTURE_DRYNESS_AND_ROBUST_LAN_2026_09_06.md` §7.
+///
+/// Readers get a cheap `Arc` clone of the current snapshot; writers swap the
+/// whole `Arc` under the lock, so no reader ever observes a half-applied
+/// config.
+pub struct ConfigState {
     config: RwLock<Arc<FullConfigType>>,
 }
 
-impl ConfigWatcher {
+impl ConfigState {
     /// Create a new config watcher with default config.
     pub fn new() -> Self {
         Self {
@@ -55,7 +67,7 @@ impl ConfigWatcher {
     }
 }
 
-impl Default for ConfigWatcher {
+impl Default for ConfigState {
     fn default() -> Self {
         Self::new()
     }

--- a/agentmux-srv/src/bootstrap.rs
+++ b/agentmux-srv/src/bootstrap.rs
@@ -901,7 +901,7 @@ pub struct BackgroundSubsystems {
     pub editor_file_watcher: Arc<backend::editor_file_watcher::EditorFileWatcher>,
     pub media_file_watcher: Arc<backend::media_file_watcher::MediaFileWatcher>,
     pub fs_watch_pool: Arc<backend::fs_watch::FsWatchPool>,
-    pub config_watcher: Arc<wconfig::ConfigWatcher>,
+    pub config_watcher: Arc<wconfig::ConfigState>,
     pub reactive_handler: &'static reactive::ReactiveHandler,
     pub poller: Arc<Poller>,
     pub messagebus: Arc<backend::messagebus::MessageBus>,
@@ -961,7 +961,7 @@ pub fn spawn_background_subsystems(
     backend::shellintegration::deploy_scripts(&backend::base::get_home_dir().join(".agentmux"));
 
     // Config watcher (created before sysinfo loop so it can read telemetry:interval)
-    let config_watcher = Arc::new(wconfig::ConfigWatcher::with_config(wconfig::build_default_config()));
+    let config_watcher = Arc::new(wconfig::ConfigState::with_config(wconfig::build_default_config()));
 
     // Load user's settings.json from disk (merges with defaults)
     backend::config_watcher_fs::load_settings_from_disk(&config_watcher);

--- a/agentmux-srv/src/server/agent_handlers/mod.rs
+++ b/agentmux-srv/src/server/agent_handlers/mod.rs
@@ -313,7 +313,7 @@ mod recent_sessions_tests {
             reactive_handler,
         ));
         crate::backend::wcore::ensure_initial_data(&wstore).unwrap();
-        let config_watcher = Arc::new(crate::backend::wconfig::ConfigWatcher::new());
+        let config_watcher = Arc::new(crate::backend::wconfig::ConfigState::new());
         let process_tracker = Arc::new(
             crate::backend::process_tracker::registry::AgentProcessRegistry::new(Some(broker.clone())),
         );
@@ -652,7 +652,7 @@ mod recent_sessions_tests {
             reactive_handler,
         ));
         crate::backend::wcore::ensure_initial_data(&wstore).unwrap();
-        let config_watcher = Arc::new(crate::backend::wconfig::ConfigWatcher::new());
+        let config_watcher = Arc::new(crate::backend::wconfig::ConfigState::new());
         let process_tracker = Arc::new(
             crate::backend::process_tracker::registry::AgentProcessRegistry::new(Some(broker.clone())),
         );

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -136,7 +136,7 @@ pub struct AppState {
     pub broker: Arc<Broker>,
     pub reactive_handler: &'static ReactiveHandler,
     pub poller: Arc<Poller>,
-    pub config_watcher: Arc<wconfig::ConfigWatcher>,
+    pub config_watcher: Arc<wconfig::ConfigState>,
     pub messagebus: Arc<MessageBus>,
     pub subagent_watcher: Arc<SubagentWatcher>,
     pub history_service: Arc<HistoryService>,
@@ -708,7 +708,14 @@ async fn handle_lan_instances(State(state): State<AppState>) -> Json<serde_json:
 ///   - `host.agents`: this host's agent directory (SQLite `instance_list`),
 ///     each flagged `addressable` iff its name is in the reachable set.
 ///   - `lan`: Tier-3 mDNS peers (each `LanInstance` carries its own `agents`).
-///   - `wan.subscribed_agents`: Tier-4 cloud subscriptions (empty when no token).
+///   - `wan.local_agents_subscribed`: **this host's own** agents that are
+///     subscribed to the Tier-4 cloud relay (empty when no token). It is NOT a
+///     list of remote agents reachable over WAN — nothing here can answer that
+///     question, because the relay exposes no directory. Named
+///     `wan.subscribed_agents` until 2026-09-06, which read as "agents
+///     reachable via cloud" under a heading called `wan` in a response whose
+///     whole purpose is reachability, and produced a wrong diagnosis. See
+///     REPORT_NETWORK_ARCHITECTURE_DRYNESS_AND_ROBUST_LAN_2026_09_06.md §6.
 /// Addressing is case-insensitive (registration lowercases the key). Authed like
 /// the other reactive routes; agents reach it via AGENTMUX_LOCAL_URL + X-AuthKey.
 /// See SPEC_MUXBUS_AGENT_DISCOVERY_AND_PERSISTENT_DELIVERY_2026_06_16.
@@ -786,7 +793,7 @@ async fn handle_discovery(State(state): State<AppState>) -> Json<serde_json::Val
             "cross_channel": cross_channel,
         },
         "lan": lan,
-        "wan": { "subscribed_agents": wan_agents },
+        "wan": { "local_agents_subscribed": wan_agents },
     }))
 }
 

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -35,7 +35,7 @@ pub(crate) fn test_state() -> AppState {
     // Bootstrap initial data
     wcore::ensure_initial_data(&wstore).unwrap();
 
-    let config_watcher = Arc::new(wconfig::ConfigWatcher::new());
+    let config_watcher = Arc::new(wconfig::ConfigState::new());
 
     let process_tracker = Arc::new(
         crate::backend::process_tracker::registry::AgentProcessRegistry::new(Some(broker.clone())),

--- a/docs/specs/ARCHITECTURE_NETWORK_CREDENTIAL_MAP_2026_09_06.md
+++ b/docs/specs/ARCHITECTURE_NETWORK_CREDENTIAL_MAP_2026_09_06.md
@@ -1,0 +1,99 @@
+# Architecture: network credential → route map
+
+**Status:** Living
+**Date:** 2026-09-06
+**Author:** Agent2
+**Origin:** `docs/reports/REPORT_NETWORK_ARCHITECTURE_DRYNESS_AND_ROBUST_LAN_2026_09_06.md` §8
+
+Several distinct secrets appear across srv's network surface. Each has a real,
+well-documented reason to exist, and this document is **not** an argument to
+consolidate them — scope separation is exactly right for a security boundary.
+The gap it fills is narrower: there was no single place saying *which credential
+gates which route at which tier*. `Config::lan_key`'s doc comment was the
+closest thing and only covered its own case.
+
+## The distinction that matters most
+
+Two different things are easy to conflate, and conflating them is how you end up
+reasoning about the wrong control:
+
+- **Route gates** decide *whether a request is allowed to reach a handler at
+  all*. They are HTTP-level, checked by middleware, and know nothing about
+  message content.
+- **Message authentication** decides *who sent a particular jekt*. It is
+  evaluated **after** the route gate has already let the request in, and it
+  never grants or denies access — it only sets the `TRUST=` field the receiving
+  agent sees.
+
+A valid `lan_key` gets a peer through the door; it says nothing about who sent
+the message it carries. That is what `lan_sig` is for.
+
+## Route gates
+
+| Credential | Transport | Gates | Held by |
+|---|---|---|---|
+| `auth_key` | `X-AuthKey` header | Everything under `authed_routes`, via `auth_middleware` — the full API surface | srv, launcher, frontend, and **every agent process** (`AGENTMUX_AUTH_KEY`) |
+| `lan_key` | `X-AuthKey` header | Exactly two routes, via `lan_or_full_auth_middleware`: `POST /agentmux/reactive/inject` and `GET /agentmux/reactive/agent` | srv only, plus whoever receives the mDNS TXT record it is broadcast in |
+| `host_reg_secret` | `host_ipc.Register` argument | That one call — nothing else | srv and the paired CEF host only; **never** an agent |
+| `ipc_token` (+ `ipc_port`) | Pushed to srv by the host; replayed by srv when proxying | `/agentmux/browser/*` **on the host's own IPC server**, backing the `/api/v1/ui/{screenshot,click,query}` proxy routes | The CEF host generates it for itself and is the sole source of truth |
+| muxbus account token / per-agent M2M credential | `Authorization: Bearer` + `X-Agent-ID` | The **cloud's** routes (`/reactive/inject`, `/reactive/pending/*`, `/reactive/ack`, `/reactive/release`, `/agents/provision`) — outbound only; gates nothing on this srv | Stored in `AppState::id_store`; see the note below |
+
+### Why `lan_key` exists separately from `auth_key`
+
+`lan_key` is minted fresh per launch and is broadcast in the mDNS TXT record, so
+anything that can receive a multicast packet on the LAN can read it. Before it
+existed, that broadcast carried the full `auth_key` — meaning a passive LAN
+listener gained standing access to the entire `/agentmux/service` surface. The
+scoped key shrinks a captured value's blast radius to "can forward jekts to this
+instance, and can ask which agents live here." See
+`SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md` §2.1/§3 LAN P0-1.
+
+The two-route set is deliberately kept **out** of `authed_routes` and merged at
+the top level with its own middleware, rather than nested — nesting would put
+`route_layer(auth_middleware)` on the outside and reject the LAN key before the
+inner layer ever saw it.
+
+### Why `host_reg_secret` exists on top of `auth_key`
+
+Agents share the instance-wide `auth_key`, so `X-AuthKey` alone cannot
+distinguish the paired CEF host from any agent process running under it.
+`host_reg_secret` is the thing only srv and the host know. When it is unset,
+`handle_register` refuses **every** registration rather than accepting one
+unauthenticated — an absent secret means there is nothing to check against, not
+that checking is optional.
+
+### Where muxbus credentials live
+
+`AppState::id_store` — the same store `CloudSubscriber::init_global` and the
+`muxbus.login` / `status` / `disconnect` handlers write to. Not `wstore` (a
+per-channel store, where the lookup silently finds nothing whenever the shared
+root resolves), and not `identity_store` (which `isolated_auth_enabled()` can
+redirect independently of `id_store`, so a reader using it can diverge from the
+writer). Enforced by `scripts/check-muxbus-credential-store.sh`; the regression
+that motivated the gate is PR #3023.
+
+## Message authentication
+
+None of these gate a route. All three are evaluated after the request is
+already in, and only affect the `TRUST=` field on the marker the receiving agent
+reads. The authoritative rules for how each maps to `TIER=`/`ESCALATE=` are in
+CLAUDE.md's "Jekt security rules" section and the specs it cites — this table
+only says what each signature *is*.
+
+| Signature | Tier | Scheme | Proves |
+|---|---|---|---|
+| `jekt_sig` | host | HMAC-SHA256, per-agent key (`AGENTMUX_JEKT_KEY`, injected into that agent's MCP process env only) | The claimed `source_agent` really sent it → `TRUST=host-verified` |
+| `lan_sig` | LAN | Ed25519, per-agent keypair; the public half is fetched from whichever LAN peer hosts that agent | Same claim, across the machine boundary → `TRUST=lan-verified` |
+| `reagent_sig` | WAN | Ed25519 against a **pinned service** key | Only that the message came from AgentMux's own GitHub-review service — not per-agent identity → `SIG=verified` |
+
+General agent-to-agent **WAN** signing does not exist (issue #2586's unbuilt
+half). An arbitrary non-reagent WAN jekt's `source_agent` is exactly as
+forgeable as it always was, which is why tier 4's outbound relay
+(`muxbus::relay`) sets no verification fields on the echoed marker rather than
+claiming any.
+
+## Keeping this current
+
+If you add a credential, a middleware, or a route to a gated set, add the row
+here in the same change. A map that is 80% right is worse than none, because it
+gets trusted.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -686,10 +686,11 @@ partial list.
 | [`web-widget`](web-widget.md) | Web Widget Implementation Spec - Tauri v2 |
 | [`widget-dnd-reorder`](widget-dnd-reorder.md) | Widget Drag-and-Drop Reorder |
 
-### living (2)
+### living (3)
 
 | Spec | Title |
 |---|---|
+| [`ARCHITECTURE_NETWORK_CREDENTIAL_MAP_2026_09_06`](ARCHITECTURE_NETWORK_CREDENTIAL_MAP_2026_09_06.md) | Architecture: network credential → route map |
 | [`SPEC_DECISION_PROMPT_DESIGN_2026_04_25`](SPEC_DECISION_PROMPT_DESIGN_2026_04_25.md) | Decision Prompt — Cohesive Design (Step-Back Doc) |
 | [`SPEC_POOL_COVERAGE_AND_ROADMAP_2026_06_20`](SPEC_POOL_COVERAGE_AND_ROADMAP_2026_06_20.md) | Pre-warmed Window Pool — Coverage Map and Implementation Roadmap |
 


### PR DESCRIPTION
Item 7 of `REPORT_NETWORK_ARCHITECTURE_DRYNESS_AND_ROBUST_LAN_2026_09_06.md` — §6, §7 and §8, the "small, do opportunistically" tail of the network series. Completes it (after #3021, #3022, #3023).

No behaviour changes. One wire-field rename, one type rename, one new doc.

---

### §6 — `wan.subscribed_agents` → `wan.local_agents_subscribed`

The field lists **this host's own** cloud-subscribed agents, not remote agents reachable over WAN. Under a `wan` heading, in a response whose entire purpose is reachability, the old name reads as the opposite of what it means — and it directly caused a wrong diagnosis while I was debugging cloud delivery earlier in this series.

The report offered an alternative — make it answer the question its name implies — but that isn't available: the relay exposes no directory, so nothing can list who is reachable via cloud. So: rename, **and** make `DiscoverAgents`' description say outright that a cloud-only target will not appear anywhere in its output. That last part is what actually misled; the field name alone was only half the problem.

`CloudSubscriber::subscribed_agents()` is deliberately *not* renamed — it's accurate on the subscriber itself. Only the wire field was ambiguous.

### §7 — `wconfig::watcher::ConfigWatcher` → `wconfig::state::ConfigState`

It watches nothing. The name came from a comment promising that "the actual file system watching will be integrated with the event loop in a later phase" — that never happened; watching was built separately in `config_watcher_fs.rs` on top of `fs_watch::pool`, and the placeholder name outlived the plan. Two similarly-named modules where only one watches cost a wrong turn tracing the settings-reload path.

Pure rename, compiler-checked. Both the module doc and the type doc now state plainly that this holds config and watches nothing, with a pointer to where watching actually lives.

### §8 — `docs/specs/ARCHITECTURE_NETWORK_CREDENTIAL_MAP_2026_09_06.md`

Writing it surfaced a distinction the report hadn't separated cleanly, and it's the easiest thing in this area to get wrong:

- **Route gates** (`auth_key`, `lan_key`, `host_reg_secret`, `ipc_token`, the muxbus tokens) decide whether a request reaches a handler at all.
- **Message signatures** (`jekt_sig`, `lan_sig`, `reagent_sig`) are evaluated *after* it already has, and never grant or deny access — they only set `TRUST=`.

A valid `lan_key` gets a peer through the door and says nothing about who sent the message it carries; that's what `lan_sig` is for. The doc leads with that, then maps each credential to the exact routes it gates, and records where muxbus credentials live (`id_store`, per #3023) and why the tier-4 relay sets no verification fields.

Explicitly **not** an argument to consolidate any of these — scope separation is right for a security boundary. The gap was that no single place said which gates what.

---

## Testing

3057 pass, clippy clean, doc gates pass (index regenerated for the new spec).

**One pre-existing failure, not from this PR:** `backend::sysinfo::handle_anomaly_tests::refresh_processes_specifics_does_not_leak_a_handle_per_call`. I verified it fails identically on unmodified `main` on this machine (grew by 468 there vs 446 here), and my only change to `sysinfo.rs` is three type annotations from the rename. It passes in CI. The threshold appears calibrated for a quieter host than this one, which is currently running several AgentMux instances and builds — flagging it as worth a look separately rather than silently ignoring it.

<!-- agentmux:agent_id=agent2 -->