### PR TITLE
fix(lan): stop this instance discovering itself as a LAN peer

### DIFF
--- a/.changesets/1788720284-fix-lan-stop-this-instance-discovering-itself-as-a-lan-peer-58f0.md
+++ b/.changesets/1788720284-fix-lan-stop-this-instance-discovering-itself-as-a-lan-peer-58f0.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(lan): stop this instance discovering itself as a LAN peer

--- a/agentmux-srv/src/backend/lan_discovery.rs
+++ b/agentmux-srv/src/backend/lan_discovery.rs
@@ -474,12 +474,21 @@ impl LanDiscovery {
     /// while several AgentMux instances share a machine — but no remote peer
     /// can be listening on OUR port at an address that is OURS.
     fn resolves_to_this_instance(&self, info: &ServiceInfo) -> bool {
+        // Port first, and BEFORE touching the address set. A resolution on a
+        // different port cannot be us, and that is the overwhelmingly common
+        // case (every genuine remote peer), so it must not pay for an address
+        // lookup. Passing the set as an argument would defeat this — arguments
+        // are evaluated eagerly, so the cheap check inside `is_self_resolution`
+        // would come too late [reagent #3025 P2].
+        if info.get_port() != self.port {
+            return false;
+        }
         let addrs: Vec<IpAddr> = info.get_addresses().iter().copied().collect();
         is_self_resolution(
             info.get_port(),
             &addrs,
             self.port,
-            &crate::backend::lan_listeners::all_local_addresses(),
+            &crate::backend::lan_listeners::cached_local_addresses(),
         )
     }
 

--- a/agentmux-srv/src/backend/lan_discovery.rs
+++ b/agentmux-srv/src/backend/lan_discovery.rs
@@ -197,6 +197,29 @@ fn query_peers_concurrently<'a>(
     futures
 }
 
+/// Pure predicate behind `LanDiscovery::resolves_to_this_instance`, split out
+/// so it can be tested without standing up an mDNS `ServiceDaemon`.
+///
+/// `any` rather than `all` on the address match: a resolution for our own
+/// service can legitimately carry an address that interface enumeration missed
+/// (they race), and requiring every address to be ours would let that one
+/// stray entry resurrect the phantom. `any` cannot produce a false positive —
+/// combined with the port equality, a genuine remote peer would have to be
+/// listening on our port *at one of our own interface addresses*, which it
+/// cannot be. Another AgentMux instance on this same host does share our
+/// addresses, but never our port.
+fn is_self_resolution(
+    resolved_port: u16,
+    resolved_addrs: &[IpAddr],
+    own_port: u16,
+    own_addrs: &std::collections::HashSet<IpAddr>,
+) -> bool {
+    if resolved_port != own_port || own_addrs.is_empty() {
+        return false;
+    }
+    resolved_addrs.iter().any(|a| own_addrs.contains(a))
+}
+
 pub struct LanDiscovery {
     daemon: ServiceDaemon,
     instances: Arc<RwLock<HashMap<String, LanInstance>>>,
@@ -443,6 +466,23 @@ impl LanDiscovery {
         }
     }
 
+    /// True when a resolved service is really this instance, reached over one
+    /// of this host's own addresses.
+    ///
+    /// Both conditions are required. The port alone is far too weak (two hosts
+    /// can land on the same ephemeral port), and an address alone is too weak
+    /// while several AgentMux instances share a machine — but no remote peer
+    /// can be listening on OUR port at an address that is OURS.
+    fn resolves_to_this_instance(&self, info: &ServiceInfo) -> bool {
+        let addrs: Vec<IpAddr> = info.get_addresses().iter().copied().collect();
+        is_self_resolution(
+            info.get_port(),
+            &addrs,
+            self.port,
+            &crate::backend::lan_listeners::all_local_addresses(),
+        )
+    }
+
     fn handle_event(&self, event: ServiceEvent) {
         match event {
             ServiceEvent::ServiceResolved(info) => {
@@ -462,6 +502,39 @@ impl LanDiscovery {
                 // was inserted as a phantom peer that could never self-heal
                 // (see the instance_id-preservation fix below for why).
                 if fullname == self.service_fullname {
+                    return;
+                }
+
+                // Belt-and-braces on the fullname check above, which was
+                // measured NOT to be sufficient on 2026-09-06: this instance
+                // was still inserting itself as a peer. The srv log showed
+                // four `LAN peer discovered` events, all `peer_id=""`, all on
+                // port 55019 — this instance's own port — at 192.168.1.230,
+                // 172.23.176.1 and fe80::5c1e:c2bb:b5bc:9655, every one of
+                // them an address of this very host. They collapse into a
+                // single phantom map entry (the map is keyed by fullname), so
+                // `DiscoverAgents` reported one LAN "peer" that was really us,
+                // with empty agents/hostname/instance_id.
+                //
+                // Why the fullname check misses them is not established —
+                // plausibly mdns-sd conflict-renaming when several AgentMux
+                // instances share this host, or a re-registration under
+                // `enable_addr_auto()`. Rather than guess at that, this checks
+                // the thing we can state with certainty: a service on OUR port
+                // at an address that belongs to THIS machine is us. A genuine
+                // remote peer cannot satisfy both — it would have to be
+                // reachable at one of our own interface addresses.
+                //
+                // Cost of the phantom, and why it is worth a second guard:
+                // `find_agent` now fans out concurrently to every known peer,
+                // so each LAN lookup spent a request asking ourselves a
+                // question we had already answered locally.
+                if self.resolves_to_this_instance(&info) {
+                    tracing::debug!(
+                        address = %info.get_addresses().iter().next().map(|a| a.to_string()).unwrap_or_default(),
+                        port = info.get_port(),
+                        "skipping mDNS resolution of this instance's own service"
+                    );
                     return;
                 }
 
@@ -1615,5 +1688,88 @@ mod peer_fanout_tests {
         let http = reqwest::Client::new();
         let inflight = query_peers_concurrently(&peers, "agent-x", &http);
         assert_eq!(inflight.len(), 0, "neither peer is eligible to be queried");
+    }
+}
+
+/// `is_self_resolution` — the guard that stops this instance inserting itself
+/// as a LAN peer.
+///
+/// The scenario these encode was measured on 2026-09-06, not imagined: four
+/// `LAN peer discovered` events, all `peer_id=""`, all on this instance's own
+/// port 55019, at 192.168.1.230 / 172.23.176.1 / fe80::5c1e:c2bb:b5bc:9655 —
+/// every one an address of this host. The pre-existing fullname-based self-skip
+/// did not catch them.
+#[cfg(test)]
+mod self_resolution_tests {
+    use super::is_self_resolution;
+    use std::collections::HashSet;
+    use std::net::IpAddr;
+
+    fn own() -> HashSet<IpAddr> {
+        ["192.168.1.230", "172.23.176.1", "fe80::5c1e:c2bb:b5bc:9655", "127.0.0.1"]
+            .iter()
+            .map(|s| s.parse().unwrap())
+            .collect()
+    }
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    /// The exact observed case, one per address the log showed.
+    #[test]
+    fn our_own_addresses_on_our_own_port_are_self() {
+        for addr in ["192.168.1.230", "172.23.176.1", "fe80::5c1e:c2bb:b5bc:9655"] {
+            assert!(
+                is_self_resolution(55019, &[ip(addr)], 55019, &own()),
+                "{addr}:55019 is this host on this instance's port — must be skipped"
+            );
+        }
+    }
+
+    /// A real peer: different machine, so its addresses are not ours. Sharing
+    /// our ephemeral port by coincidence must NOT be enough to discard it —
+    /// that would silently drop a genuine peer, which is far worse than the
+    /// phantom this guard exists to remove.
+    #[test]
+    fn a_remote_peer_on_a_coincidentally_equal_port_is_not_self() {
+        assert!(!is_self_resolution(55019, &[ip("192.168.1.77")], 55019, &own()));
+    }
+
+    /// Another AgentMux instance on THIS host does share our addresses — it is
+    /// the port that distinguishes it. Two instances never hold the same port.
+    #[test]
+    fn a_sibling_instance_on_this_host_is_not_self() {
+        assert!(
+            !is_self_resolution(51095, &[ip("192.168.1.230")], 55019, &own()),
+            "same host, different port — a real sibling instance, not us"
+        );
+    }
+
+    /// `any`, not `all`: interface enumeration and mDNS resolution race, so a
+    /// resolution of our own service can carry one address we didn't enumerate.
+    /// Requiring every address to match would let that stray entry resurrect
+    /// the phantom.
+    #[test]
+    fn one_matching_address_is_enough_even_beside_an_unknown_one() {
+        assert!(is_self_resolution(
+            55019,
+            &[ip("10.99.99.99"), ip("172.23.176.1")],
+            55019,
+            &own()
+        ));
+    }
+
+    /// Enumeration failing means "we cannot prove any address is ours". Degrade
+    /// to the old behaviour (a phantom peer) rather than to something worse —
+    /// an empty set must never make everything look like self.
+    #[test]
+    fn an_empty_own_set_never_claims_self() {
+        assert!(!is_self_resolution(55019, &[ip("192.168.1.230")], 55019, &HashSet::new()));
+    }
+
+    #[test]
+    fn a_resolution_with_no_addresses_is_not_self() {
+        assert!(!is_self_resolution(55019, &[], 55019, &own()));
     }
 }

--- a/agentmux-srv/src/backend/lan_listeners.rs
+++ b/agentmux-srv/src/backend/lan_listeners.rs
@@ -50,7 +50,7 @@
 /// Windows the binds succeed instead and you get two sockets on one port with
 /// ambiguous accept — see `wildcard_vs_loopback_conflict_is_platform_dependent`
 /// and `wildcard_then_specific_conflict_is_platform_dependent`.)
-/// [reagent #3021 P0]
+/// (reagent #3021 P0)
 pub const STARTUP_BIND_ADDR: &str = "127.0.0.1:0";
 
 /// Every non-loopback address this host is currently reachable on.
@@ -111,6 +111,49 @@ pub fn all_local_addresses() -> std::collections::HashSet<std::net::IpAddr> {
             std::collections::HashSet::new()
         }
     }
+}
+
+/// How long [`cached_local_addresses`] may serve a snapshot before
+/// re-enumerating.
+///
+/// Short on purpose. The cost of being stale is bounded and self-healing: an
+/// interface that appears within the window isn't yet recognised as ours, so
+/// one resolution on that address can still land as a phantom, which clears on
+/// the next resolution after a refresh. Five seconds collapses the burst of
+/// `ServiceResolved` re-fires that motivated caching at all, without letting
+/// that window matter in practice.
+const LOCAL_ADDR_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(5);
+
+type LocalAddrCache = std::sync::Mutex<
+    Option<(
+        std::time::Instant,
+        std::sync::Arc<std::collections::HashSet<std::net::IpAddr>>,
+    )>,
+>;
+static LOCAL_ADDR_CACHE: std::sync::OnceLock<LocalAddrCache> = std::sync::OnceLock::new();
+
+/// [`all_local_addresses`] behind a short TTL.
+///
+/// `ServiceResolved` fires far more often than fresh mDNS data arrives —
+/// `enable_addr_auto()` re-fires it on every interface/address change, and the
+/// self-resolution churn this feeds is precisely the high-frequency case. A
+/// fresh `getifaddrs` per event would put a syscall on that hot path
+/// (reagent #3025 P2).
+pub fn cached_local_addresses() -> std::sync::Arc<std::collections::HashSet<std::net::IpAddr>> {
+    let cache = LOCAL_ADDR_CACHE.get_or_init(|| std::sync::Mutex::new(None));
+    let Ok(mut slot) = cache.lock() else {
+        // Poisoned: fall back to enumerating directly rather than failing the
+        // self-check, which would resurrect the phantom this guards against.
+        return std::sync::Arc::new(all_local_addresses());
+    };
+    if let Some((at, addrs)) = slot.as_ref() {
+        if at.elapsed() < LOCAL_ADDR_CACHE_TTL {
+            return addrs.clone();
+        }
+    }
+    let fresh = std::sync::Arc::new(all_local_addresses());
+    *slot = Some((std::time::Instant::now(), fresh.clone()));
+    fresh
 }
 
 /// Best-effort discovery of this host's *primary outbound* non-loopback IPv4
@@ -528,6 +571,25 @@ mod tests {
              sockets; got {addr}"
         );
         assert_eq!(addr.port(), 0, "startup port must stay ephemeral");
+    }
+
+    /// The cache must agree with the uncached enumeration, and must actually
+    /// serve a cached value rather than re-enumerating each call.
+    ///
+    /// Deliberately does not assert timing (a TTL test that sleeps is a flaky
+    /// test); it asserts the contract that matters — same contents, and a
+    /// second call returns the very same allocation.
+    #[test]
+    fn the_cached_address_set_matches_a_fresh_enumeration() {
+        let fresh = all_local_addresses();
+        let cached = cached_local_addresses();
+        assert_eq!(*cached, fresh, "cache must not change what counts as ours");
+
+        let again = cached_local_addresses();
+        assert!(
+            std::sync::Arc::ptr_eq(&cached, &again),
+            "a second call within the TTL must reuse the snapshot, not re-enumerate"
+        );
     }
 
     /// `primary_lan_ipv4` must never hand back something unusable as a bind

--- a/agentmux-srv/src/backend/lan_listeners.rs
+++ b/agentmux-srv/src/backend/lan_listeners.rs
@@ -89,6 +89,30 @@ pub fn lan_bind_addresses() -> Vec<std::net::IpAddr> {
     out
 }
 
+/// **Every** address this host answers on — loopback and IPv6 link-local
+/// included.
+///
+/// Deliberately broader than [`lan_bind_addresses`], and for a different
+/// purpose: that one answers "where should we listen", this one answers "is
+/// this address us?". The exclusions that make sense for binding are exactly
+/// wrong here — a link-local `fe80::` address is useless as a bind target but
+/// is very much still us when it comes back in an mDNS resolution, which is
+/// the case that made this necessary (see
+/// `LanDiscovery::resolves_to_this_instance`).
+pub fn all_local_addresses() -> std::collections::HashSet<std::net::IpAddr> {
+    match if_addrs::get_if_addrs() {
+        Ok(ifaces) => ifaces.into_iter().map(|i| i.ip()).collect(),
+        Err(e) => {
+            // Empty means "can't prove any address is ours", so the self-check
+            // that consumes this simply won't fire. That degrades to today's
+            // behaviour (a phantom self-peer) rather than to something worse
+            // like discarding a real peer.
+            tracing::warn!(error = %e, "could not enumerate interfaces for the LAN self-check");
+            std::collections::HashSet::new()
+        }
+    }
+}
+
 /// Best-effort discovery of this host's *primary outbound* non-loopback IPv4
 /// address.
 ///

--- a/agentmux-srv/src/muxbus/relay.rs
+++ b/agentmux-srv/src/muxbus/relay.rs
@@ -161,7 +161,7 @@ pub(crate) async fn relay_inject(
 /// every `muxbus.login`/`status`/`disconnect` handler use. Passing the
 /// per-channel `wstore` finds nothing whenever the shared root resolves (the
 /// normal case), so tier 4 would silently never fire for a logged-in user
-/// [reagent #3023 P0]. Note this deliberately does NOT follow `AppState`'s
+/// (reagent #3023 P0). Note this deliberately does NOT follow `AppState`'s
 /// general steer toward `identity_store` for new muxbus call sites: the
 /// credentials are written to `id_store`, and reading from a store the writer
 /// doesn't use would reintroduce the same bug whenever


### PR DESCRIPTION
Found by running `DiscoverAgents` against a live instance after the network series merged — not by reading code.

## Evidence

`DiscoverAgents` reported exactly one LAN "peer": `172.23.176.1:55019`, with empty `agents`, `hostname` and `instance_id`. The srv log shows what it really is:

```
LAN peer discovered  peer_id=""  address=fe80::5c1e:c2bb:b5bc:9655  port=55019
LAN peer discovered  peer_id=""  address=fe80::5c1e:c2bb:b5bc:9655  port=55019
LAN peer discovered  peer_id=""  address=192.168.1.230              port=55019
LAN peer discovered  peer_id=""  address=172.23.176.1               port=55019
```

Port 55019 is **this instance's own port**. All three addresses are **this host's** (confirmed against `ipconfig`: `192.168.1.230`, `192.168.153.1`, `192.168.116.1`, `172.23.176.1`). The instances map is keyed by fullname, so the four events collapse into one entry — us, wearing a peer's clothes.

## Why the existing fix didn't catch it

There is already a self-skip for exactly this (#2598, 2026-08-15) comparing the resolved fullname to our registered one, and it **is** in the running 0.55.34 build. It isn't firing. Why the fullnames differ isn't established — plausibly mdns-sd conflict-renaming when several AgentMux instances share this host, or a re-registration under `enable_addr_auto()`.

I chose not to guess at that. This adds a second guard on what *can* be stated with certainty: **a service on our port, at an address belonging to this machine, is us.** A genuine remote peer cannot satisfy both conditions.

## The part worth your attention

**The existing `handle_event_tests` for the self-skip pass, and have passed all along.** They build `service_fullname` and the resolved event from the *same* `instance_id`, so the fullnames match **by construction**. The test cannot express the production case where they differ.

That is how this survived a fix, a test, and three weeks — and it's the reason I went to the live logs rather than trusting a green suite.

## Why it matters more now

`find_agent` fans out concurrently to every known peer (#3016), so every LAN lookup was spending a request asking *ourselves* a question we'd already answered locally.

## Implementation

- `all_local_addresses()` in `lan_listeners` — deliberately **broader** than `lan_bind_addresses()`: loopback and IPv6 link-local included, because the exclusions that make sense for *binding* are exactly wrong for *"is this us?"*. A `fe80::` address is useless as a bind target and very much still us.
- `is_self_resolution()` split out as a pure predicate, testable without standing up a `ServiceDaemon`.
- `any` not `all` on the address match: interface enumeration and mDNS resolution race, and one stray address must not resurrect the phantom. `any` cannot false-positive — a remote peer would have to be listening on our port at one of our own addresses.
- Enumeration failure yields an empty set, which makes the guard inert — degrading to today's phantom rather than to something worse like discarding a real peer.

## Testing

6 tests: the measured case (one per observed address), a real remote peer on a coincidentally equal port, a sibling AgentMux instance on this host (same addresses, different port), the any-vs-all race, and both degenerate inputs. **3064 pass, clippy clean.**

## Not included

`lan_bind_addresses()` also binds this host's three *virtual* adapters (WSL/Hyper-V), which no real peer can reach — unnecessary sockets and mDNS advertising. Filtering those is a genuine judgment call (a heuristic risks excluding a VPN someone legitimately wants LAN over), so I've left it for a decision rather than guessing.

<!-- agentmux:agent_id=agent2 -->