### PR TITLE
chore: release v0.55.37

### DIFF
--- a/.changesets/1788664032-fix-agent-swap-the-remaining-tail-glyphs-from-the-weak-cover-bt9e.md
+++ b/.changesets/1788664032-fix-agent-swap-the-remaining-tail-glyphs-from-the-weak-cover-bt9e.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): swap the remaining tail glyphs from the weak-coverage arrow

--- a/.changesets/1788668658-fix-host-publish-the-ipc-port-file-where-the-launcher-reads--dtpk.md
+++ b/.changesets/1788668658-fix-host-publish-the-ipc-port-file-where-the-launcher-reads--dtpk.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(host): publish the ipc-port file where the launcher reads it in dev mode

--- a/.changesets/1788681796-fix-swarm-subagents-that-returned-are-no-longer-reported-as--4c4g.md
+++ b/.changesets/1788681796-fix-swarm-subagents-that-returned-are-no-longer-reported-as--4c4g.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(swarm): subagents that returned are no longer reported as interrupted

--- a/.changesets/1788682482-fix-tray-use-the-agentmux-brand-icon-instead-of-the-placehol-em0o.md
+++ b/.changesets/1788682482-fix-tray-use-the-agentmux-brand-icon-instead-of-the-placehol-em0o.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tray): use the AgentMux brand icon instead of the placeholder mark

--- a/.changesets/1788683053-docs-memory-carry-over-analysis-across-new-existing-compacte-86rf.md
+++ b/.changesets/1788683053-docs-memory-carry-over-analysis-across-new-existing-compacte-86rf.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: memory carry-over analysis across new/existing/compacted agent sessions

--- a/.changesets/1788683074-fix-agent-hover-peek-panel-now-respects-the-agent-pane-zoom--cp99.md
+++ b/.changesets/1788683074-fix-agent-hover-peek-panel-now-respects-the-agent-pane-zoom--cp99.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): hover peek panel now respects the agent pane zoom level

--- a/.changesets/1788686287-fix-agent-previews-now-zoom-with-the-pane-instead-of-their-o-apy2.md
+++ b/.changesets/1788686287-fix-agent-previews-now-zoom-with-the-pane-instead-of-their-o-apy2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): previews now zoom with the pane instead of their own broken font-scale

--- a/.changesets/1788686547-fix-tray-rename-open-agentmux-to-new-window-and-drop-the-pan-wien.md
+++ b/.changesets/1788686547-fix-tray-rename-open-agentmux-to-new-window-and-drop-the-pan-wien.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(tray): rename Open AgentMux to New Window and drop the panel entry

--- a/.changesets/1788690515-fix-settings-seed-settings-json-at-startup-instead-of-only-w-egie.md
+++ b/.changesets/1788690515-fix-settings-seed-settings-json-at-startup-instead-of-only-w-egie.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(settings): seed settings.json at startup instead of only when the Settings pane opens

--- a/.changesets/1788709326-fix-providers-bump-pinned-cli-versions-per-overnight-drift-r-giib.md
+++ b/.changesets/1788709326-fix-providers-bump-pinned-cli-versions-per-overnight-drift-r-giib.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(providers): bump pinned CLI versions per overnight drift report

--- a/.changesets/1788711237-docs-settings-surface-network-lan-discovery-in-the-settings--8r1j.md
+++ b/.changesets/1788711237-docs-settings-surface-network-lan-discovery-in-the-settings--8r1j.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(settings): surface network:lan_discovery in the settings template (default off)

--- a/.changesets/1788712277-perf-lan-query-lan-peers-concurrently-instead-of-sequentiall-a696.md
+++ b/.changesets/1788712277-perf-lan-query-lan-peers-concurrently-instead-of-sequentiall-a696.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-perf(lan): query LAN peers concurrently instead of sequentially

--- a/.changesets/1788712485-fix-wrr-stop-the-quit-watchdog-killing-a-resting-background--ufss.md
+++ b/.changesets/1788712485-fix-wrr-stop-the-quit-watchdog-killing-a-resting-background--ufss.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(wrr): stop the quit watchdog killing a resting background service

--- a/.changesets/1788712534-fix-window-centre-a-new-window-on-the-main-display-when-none-txyw.md
+++ b/.changesets/1788712534-fix-window-centre-a-new-window-on-the-main-display-when-none-txyw.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(window): centre a new window on the main display when none is open

--- a/.changesets/1788714253-fix-swarm-tool-rows-show-the-command-or-file-path-instead-of-1blg.md
+++ b/.changesets/1788714253-fix-swarm-tool-rows-show-the-command-or-file-path-instead-of-1blg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(swarm): tool rows show the command or file path instead of a raw JSON dump

--- a/.changesets/1788714560-fix-lan-lan-discovery-toggle-takes-effect-live-no-restart-x49p.md
+++ b/.changesets/1788714560-fix-lan-lan-discovery-toggle-takes-effect-live-no-restart-x49p.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(lan): LAN discovery toggle takes effect live, no restart

--- a/.changesets/1788716157-refactor-reactive-unify-the-three-jekt-forward-tiers-behind--8j4u.md
+++ b/.changesets/1788716157-refactor-reactive-unify-the-three-jekt-forward-tiers-behind--8j4u.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(reactive): unify the three jekt forward tiers behind one helper

--- a/.changesets/1788717537-feat-muxbus-jekt-delivery-tier-4-cloud-relay-is-now-performe-8gjt.md
+++ b/.changesets/1788717537-feat-muxbus-jekt-delivery-tier-4-cloud-relay-is-now-performe-8gjt.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(muxbus): jekt delivery tier 4 — cloud relay is now performed by srv

--- a/.changesets/1788719271-refactor-network-rename-configwatcher-and-wan-subscribed-age-zwhg.md
+++ b/.changesets/1788719271-refactor-network-rename-configwatcher-and-wan-subscribed-age-zwhg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(network): rename ConfigWatcher and wan.subscribed_agents; add credential map

--- a/.changesets/1788720284-fix-lan-stop-this-instance-discovering-itself-as-a-lan-peer-58f0.md
+++ b/.changesets/1788720284-fix-lan-stop-this-instance-discovering-itself-as-a-lan-peer-58f0.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(lan): stop this instance discovering itself as a LAN peer

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.36"
+version = "0.55.37"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.36"
+version = "0.55.37"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.36"
+version = "0.55.37"
 dependencies = [
  "base64",
  "dirs 5.0.1",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.36"
+version = "0.55.37"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.36"
+version = "0.55.37"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.36"
+version = "0.55.37"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.36"
+version = "0.55.37"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,28 @@
 # AgentMux Version History
 
+## 0.55.37 — 2026-09-06
+
+- fix(agent): swap the remaining tail glyphs from the weak-coverage arrow
+- fix(host): publish the ipc-port file where the launcher reads it in dev mode
+- fix(swarm): subagents that returned are no longer reported as interrupted
+- fix(tray): use the AgentMux brand icon instead of the placeholder mark
+- docs: memory carry-over analysis across new/existing/compacted agent sessions
+- fix(agent): hover peek panel now respects the agent pane zoom level
+- fix(agent): previews now zoom with the pane instead of their own broken font-scale
+- fix(tray): rename Open AgentMux to New Window and drop the panel entry
+- fix(settings): seed settings.json at startup instead of only when the Settings pane opens
+- fix(providers): bump pinned CLI versions per overnight drift report
+- docs(settings): surface network:lan_discovery in the settings template (default off)
+- perf(lan): query LAN peers concurrently instead of sequentially
+- fix(wrr): stop the quit watchdog killing a resting background service
+- fix(window): centre a new window on the main display when none is open
+- fix(swarm): tool rows show the command or file path instead of a raw JSON dump
+- fix(lan): LAN discovery toggle takes effect live, no restart
+- refactor(reactive): unify the three jekt forward tiers behind one helper
+- feat(muxbus): jekt delivery tier 4 — cloud relay is now performed by srv
+- refactor(network): rename ConfigWatcher and wan.subscribed_agents; add credential map
+- fix(lan): stop this instance discovering itself as a LAN peer
+
 ## 0.55.36 — 2026-09-05
 
 - fix(agent): provider_flags were dropped from cmd:args on every send

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.36",
+  "version": "0.55.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.36",
+      "version": "0.55.37",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.36",
+  "version": "0.55.37",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Release PR consuming the 20 changesets queued since v0.55.36.

## Bump: patch (forced)

Run as `task release -- --as patch`, per the patch override. One queued changeset is **minor** — `feat(muxbus): jekt delivery tier 4` — so this deliberately ships a minor-level change under a patch version. The script's own warning fired and is expected here, not an oversight:

```
NOTE: --as overrides the computed bump 'minor' with 'patch'.
WARNING: forcing a LOWER bump than the changesets request — some
         minor-level change(s) will ship under a patch version.
```

`0.55.36 -> 0.55.37`

## Version consistency invariant

Verified independently of the script's own self-check — all five agree at `0.55.37`:

| Location | Value |
|---|---|
| `VERSION_HISTORY.md` head | `## 0.55.37 — 2026-09-06` |
| `package.json` | `0.55.37` |
| `Cargo.toml [workspace.package]` | `0.55.37` |
| `Cargo.lock` (`agentmux-cef`) | `0.55.37` |
| `package-lock.json` root | `0.55.37` |

20 changesets consumed and deleted. (`.changesets/README.md` remains by design — it's the directory's documentation, not a changeset.)

## What's in it

Highlights of the 20 entries — the LAN/muxbus delivery work is the bulk:

- **`feat(muxbus)`** — jekt delivery tier 4: cloud relay is now performed by srv, so every caller inherits it instead of the tier chain silently stopping at three
- **`fix(lan)`** — LAN discovery toggle takes effect live, no restart
- **`fix(lan)`** — stop this instance discovering itself as a LAN peer
- **`perf(lan)`** — query LAN peers concurrently instead of sequentially
- **`refactor(reactive)`** — unify the three jekt forward tiers behind one helper
- **`refactor(network)`** — rename `ConfigWatcher`/`wan.subscribed_agents`, add the credential→route map
- **`fix(settings)`** — seed `settings.json` at startup instead of only when the Settings pane opens

Plus tray, swarm, window, agent-preview and provider-pin fixes from other agents. Full list in the `VERSION_HISTORY.md` diff.

## Note for anyone pulling this to test LAN

`network:lan_discovery` still defaults to **off** — that's intentional (don't trigger the OS firewall prompt unless the user needs it). Enabling it now applies live, no restart, which is new in this release.

<!-- agentmux:agent_id=agent2 -->