### PR TITLE
docs: stop agents sleep-polling for things that already notify

### DIFF
--- a/.changesets/1788726060-docs-stop-agents-sleep-polling-decision-table-for-waiting-wi-pn9b.md
+++ b/.changesets/1788726060-docs-stop-agents-sleep-polling-decision-table-for-waiting-wi-pn9b.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs: stop agents sleep-polling — decision table for waiting without polling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,34 @@ Same idea as `task dev` above, but `mcp__agentmux__Shell` spawns Windows command
 { "cmd": "C:\\<repo>\\scripts\\package-agent.cmd > C:\\<repo>\\pkg-build.log 2>&1" }
 ```
 
-Then poll `ShellStatus` for `running: false` and `Read` the log file for progress/results. `task package` (full CEF host build) routinely exceeds the Bash tool's own timeout — this is the only reliable way to run it from an agent. See `docs/retro/retro-task-package-mcp-timeout-and-shell-output-gap-2026-08-06.md` for the full investigation (Bash-tool timeout, `nohup` not detaching, and this gap all confirmed there).
+Then poll `ShellStatus` for `running: false` and `Read` the log file for progress/results. See `docs/retro/retro-task-package-mcp-timeout-and-shell-output-gap-2026-08-06.md` for the original investigation (Bash-tool timeout, `nohup` not detaching, and the output gap all confirmed there).
+
+**Prefer the Bash tool with `run_in_background: true` unless you specifically need a `shell_id`.** This paragraph used to say MCP Shell was "the only reliable way to run `task package` from an agent," because the build exceeds the Bash tool's timeout. That rationale no longer holds and contradicted the `task dev` section above: a `run_in_background` invocation is exempt from the timeout entirely (`effective_idle_timeout` returns `u64::MAX` for `--declared-background`, `agentmux-bashwrap/src/bash_wrap.rs`). More importantly, `ShellStatus` is **poll-only** — following the old advice forces a `sleep`-loop, which is exactly what "Waiting without polling" below exists to stop. Reach for MCP Shell when you want a durable `shell_id` another turn or agent can `ShellStop`; reach for `run_in_background` when you just want the thing to finish and to be told when it did.
+
+#### Waiting without polling
+
+**A `sleep` in a tool call is almost always a bug.** It burns a call, blocks the
+turn, and — because sleeps get picked to fit a timeout rather than the work —
+either wakes too early (so you sleep again) or too late. Pick by what you are
+actually waiting on:
+
+| Waiting on | Do this | Not this |
+|---|---|---|
+| A long local command (build, packaging, full test suite) | Bash tool, `run_in_background: true`, **no `&`**. You are re-invoked when it exits. | `sleep N; check` |
+| CI on a PR | `scripts/gh-agent.sh pr checks <n> --watch --fail-fast` (or `gh run watch <id>`) in a background Bash call. It blocks until checks settle, so its exit *is* the notification. | polling `pr checks` on a timer |
+| A review verdict, or CI's own result | **Nothing.** muxbus already pushes `[ReAgent] … reviewed` and `[CI] … PASSED` jekts to you. | polling `pr view --json reviews` |
+| Another agent's reply | **Nothing.** Their jekt arrives as a message. | polling their transcript |
+| External state with no watcher, inside `/loop` | `ScheduleWakeup`, delay matched to how fast that state really moves | a chain of 60s sleeps |
+
+Two traps worth naming, both hit in practice:
+
+- **Never append `&`** to a `run_in_background` command. The tracked process
+  becomes the launcher shell that exits in milliseconds, and the real work is
+  orphaned out from under the protection you asked for — see the `task dev`
+  section above for the full failure mode.
+- **A `[CI] PASSED` jekt is not the same as all checks being green.** A repo
+  with several workflows fires the notification per workflow; `pr checks` can
+  still show other legs pending. Confirm before merging on it.
 
 ### Build Prerequisites
 


### PR DESCRIPTION
Agents reach for `sleep N; check` constantly. The primitives to avoid it already exist — the guidance didn't, and one section of `CLAUDE.md` actively steered the wrong way.

## The stale steer

The `task package` section claimed MCP Shell was *"the only reliable way to run it from an agent"* because the build exceeds the Bash tool's timeout. That **contradicted the `task dev` section in the same file**, and is no longer true:

```rust
// agentmux-bashwrap/src/bash_wrap.rs:322
fn effective_idle_timeout(args: &Args) -> Duration {
    if args.declared_background {
        Duration::from_secs(u64::MAX)   // no idle kill at all
    } else {
        idle_kill_timeout()
    }
}
```

A `run_in_background` call is `setsid()`-detached and exempt from the timeout entirely. And since `ShellStatus` is **poll-only**, following the old advice *forced* a sleep loop. I hit this today packaging v0.55.37 and burned six sleep calls watching a build that would have simply notified me.

The paragraph now recommends `run_in_background` by default and scopes MCP Shell to what it's actually better at: a durable `shell_id` another turn or agent can `ShellStop`.

## The general fix

A "Waiting without polling" decision table, because the right answer differs by what you're waiting on:

| Waiting on | Do this |
|---|---|
| Long local command (build, packaging, full test suite) | Bash `run_in_background: true` — you're re-invoked on exit |
| CI on a PR | `gh pr checks <n> --watch --fail-fast` backgrounded; it blocks until checks settle, so **its exit is the notification** |
| Review verdict, or CI's result | **Nothing** — muxbus already pushes those jekts |
| Another agent's reply | **Nothing** — their jekt arrives as a message |
| External state with no watcher, inside `/loop` | `ScheduleWakeup`, sized to how fast that state really moves |

The middle rows are the ones I got wrong most today: I polled `pr checks` on a timer for five PRs while muxbus was *already* pushing me `[CI] … PASSED` and `[ReAgent] … reviewed` for every one of them.

This isn't new policy — `ScheduleWakeup`'s own tool doc already says *"Do NOT schedule a short-interval wakeup to poll for background work you started — when harness-tracked work finishes, you are re-invoked automatically, so polling is wasted."* It just wasn't written anywhere agents read by default.

## Two traps, both hit in practice

- **Never append `&`** to a backgrounded command — the tracked process becomes the launcher shell that exits in milliseconds, and the real work is orphaned out from under the protection you asked for. Cross-referenced to the existing `task dev` write-up.
- **A `[CI] PASSED` jekt is not the same as all checks green.** It fires per workflow; `pr checks` can still show other legs pending. That happened on #3027 today — the notification arrived while the Rust legs were still running.

Docs only, no code change.

<!-- agentmux:agent_id=agent2 -->