### PR TITLE
fix(window): a cold-path window inherits is_browser_pane from a cloned floater client and is never revealed

### DIFF
--- a/.changesets/1788729056-fix-window-reveal-a-cold-path-window-even-when-cef-views-mis-coej.md
+++ b/.changesets/1788729056-fix-window-reveal-a-cold-path-window-even-when-cef-views-mis-coej.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(window): reveal a cold-path window even when CEF Views misreports it visible

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -330,6 +330,51 @@ const SHOW_WINDOW_MAX_RETRIES: u32 = 10;
 /// two later, long enough not to busy-loop the UI thread.
 const SHOW_WINDOW_RETRY_DELAY_MS: i64 = 50;
 
+/// Should `on_load_end` run the reveal path for a resolved top-level window?
+///
+/// The Views-layer answer alone is NOT trustworthy on Windows. Observed live
+/// (issue #3028, 2026-09-06, cold-path `open_new_window` with the pool
+/// bypassed): `Window::is_visible()` returned nonzero for a freshly created
+/// cold-path window whose native HWND was `IsWindowVisible == FALSE` — so this
+/// branch silently skipped, the paint gate was never armed, and the window
+/// stayed hidden forever. The frontend's `report_first_paint` arrived with the
+/// correct label and no-opped (`reveal_gated_window` returns when nothing is
+/// pending), and the 4s safety timeout was never scheduled: every backstop
+/// hangs off arming, so "skip arming" defeated all of them at once. Same
+/// Views-vs-HWND mismatch class as `POOL_HWND_CACHE`
+/// (`SPEC_POOL_WINDOW_HWND_NULL_2026_05_06.md`) and cef#3638.
+///
+/// `views_visible` is the Views-layer claim; `native_visible` is
+/// `IsWindowVisible` on the HWND when we have one (None on non-Windows, or
+/// when no HWND is bound for the label). Reveal when EITHER layer says the
+/// window is not visible: revealing an actually-visible window is harmless
+/// (`try_show_resolved_window` treats already-visible as resolved), while
+/// skipping a hidden one strands it permanently.
+fn should_run_reveal(views_visible: bool, native_visible: Option<bool>) -> bool {
+    !views_visible || native_visible == Some(false)
+}
+
+/// Native-layer visibility for a label's bound HWND. `None` when no HWND is
+/// bound (or off Windows) — callers must treat that as "no extra information",
+/// not as hidden.
+#[cfg(target_os = "windows")]
+fn native_window_visible(state: &Arc<AppState>, label: Option<&str>) -> Option<bool> {
+    let label = label?;
+    let hwnd = *state.window_hwnds.lock().get(label)?;
+    // SAFETY: IsWindowVisible tolerates stale/invalid handles (returns FALSE).
+    let vis = unsafe {
+        windows_sys::Win32::UI::WindowsAndMessaging::IsWindowVisible(
+            hwnd as windows_sys::Win32::Foundation::HWND,
+        )
+    };
+    Some(vis != 0)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn native_window_visible(_state: &Arc<AppState>, _label: Option<&str>) -> Option<bool> {
+    None
+}
+
 /// Show (or, on Linux, arm the startup-paint gate for) a top-level window's
 /// Views `Window`, once confirmed not yet visible. Shared by `on_load_end`'s
 /// primary resolution path and `ShowWindowRetryTask`'s retry path so BOTH
@@ -653,7 +698,30 @@ impl AgentMuxHandler {
             if let Some(bv) = browser_view_get_for_browser(browser_cloned.as_mut()) {
                 if let Some(window) = bv.window() {
                     resolved = true;
-                    if window.is_visible() == 0 {
+                    let views_visible = window.is_visible() != 0;
+                    let native_visible =
+                        native_window_visible(&self.state, browser_label.as_deref());
+                    if views_visible && native_visible != Some(false) {
+                        // Genuinely visible (or no native evidence otherwise).
+                        // Log it: the silent version of this skip is what made
+                        // issue #3028 undiagnosable from the field.
+                        tracing::debug!(
+                            target: "startup-paint",
+                            label = ?browser_label,
+                            "[on_load_end] window already visible — reveal skipped"
+                        );
+                    } else if views_visible {
+                        // The mismatch case from issue #3028: Views claims
+                        // visible, the native HWND is hidden. Loud, because it
+                        // means the Views layer cannot be trusted for this
+                        // window and only this check saved it.
+                        tracing::warn!(
+                            target: "startup-paint",
+                            label = ?browser_label,
+                            "[on_load_end] Views reports visible but native HWND is hidden — revealing anyway (issue #3028)"
+                        );
+                    }
+                    if should_run_reveal(views_visible, native_visible) {
                         // Linux: defer the actual show()/focus (and the splash
                         // dismiss above) until the frontend confirms a real
                         // compositor paint, instead of doing it here on mere
@@ -954,4 +1022,35 @@ pub(crate) fn show_load_error_page(
     let data_uri = format!("data:text/html;base64,{}", b64_str);
     let uri = CefString::from(data_uri.as_str());
     frame.load_url(Some(&uri));
+}
+
+#[cfg(test)]
+mod reveal_decision_tests {
+    use super::should_run_reveal;
+
+    /// The normal deferred-show case: nothing claims the window is visible.
+    #[test]
+    fn a_hidden_window_is_revealed() {
+        assert!(should_run_reveal(false, None));
+        assert!(should_run_reveal(false, Some(false)));
+    }
+
+    /// Issue #3028: Views said visible, the native HWND said hidden, and the
+    /// old `window.is_visible() == 0` gate silently skipped — never arming the
+    /// paint gate, so the paint signal AND the 4s timeout both no-opped and
+    /// the window stayed hidden forever. Native evidence must win.
+    #[test]
+    fn views_visible_but_native_hidden_still_reveals() {
+        assert!(should_run_reveal(true, Some(false)));
+    }
+
+    /// A genuinely visible window must not be re-revealed: the reveal path
+    /// also focuses, and stealing focus on every load-end would be a
+    /// regression for real visible windows.
+    #[test]
+    fn a_genuinely_visible_window_is_left_alone() {
+        assert!(!should_run_reveal(true, Some(true)));
+        // No native evidence => trust the Views layer, as before this fix.
+        assert!(!should_run_reveal(true, None));
+    }
 }

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -126,7 +126,21 @@ fn try_show_resolved_window(state: &Arc<AppState>, label: &str) -> bool {
     let Some(mut browser) = state.get_browser(label) else { return false };
     let Some(bv) = browser_view_get_for_browser(Some(&mut browser)) else { return false };
     let Some(window) = bv.window() else { return false };
-    if window.is_visible() == 0 {
+    // Same native-vs-Views check as `on_load_end`'s arming site (issue #3028):
+    // trusting Views alone here would resolve the gate as "done" while the
+    // native HWND stays hidden — the reveal's very last step silently
+    // no-opping. Views claiming visible while native says hidden is exactly
+    // the misreport this exists to override.
+    let views_visible = window.is_visible() != 0;
+    let native_visible = native_window_visible(state, Some(label));
+    if should_run_reveal(views_visible, native_visible) {
+        if views_visible {
+            tracing::warn!(
+                target: "startup-paint",
+                label = %label,
+                "[startup-paint] Views reports visible but native HWND is hidden at gate-fire — showing anyway (issue #3028)"
+            );
+        }
         window.show();
         if let Some(host) = browser.host() {
             host.set_focus(1);
@@ -457,7 +471,20 @@ fn try_show_top_level_window(state: &std::sync::Arc<crate::state::AppState>, lab
     let Some(mut browser) = state.get_browser(label) else { return false };
     let Some(bv) = browser_view_get_for_browser(Some(&mut browser)) else { return false };
     let Some(window) = bv.window() else { return false };
-    if window.is_visible() == 0 {
+    // ReAgent P1 on #3030: this retry path exists precisely to ride out CEF
+    // Views timing quirks, so gating it on the Views layer alone reproduces
+    // issue #3028 through the one path meant to rescue it. Same predicate as
+    // the initial on_load_end pass.
+    let views_visible = window.is_visible() != 0;
+    let native_visible = native_window_visible(state, Some(label));
+    if should_run_reveal(views_visible, native_visible) {
+        if views_visible {
+            tracing::warn!(
+                target: "startup-paint",
+                label = %label,
+                "[on_load_end] retry: Views reports visible but native HWND is hidden — revealing anyway (issue #3028)"
+            );
+        }
         reveal_top_level_window(state, Some(label), &window, Some(&mut browser));
     }
     true

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -368,6 +368,48 @@ fn should_run_reveal(views_visible: bool, native_visible: Option<bool>) -> bool 
     !views_visible || native_visible == Some(false)
 }
 
+/// Does this browser take `on_load_end`'s browser-pane path (pane-specific
+/// work, then return) instead of the top-level reveal path?
+///
+/// The `AgentMuxClient`'s own `is_browser_pane` flag is NOT trustworthy for
+/// this decision, because a client is shared by every browser created from
+/// it. `CreateWindowTask::execute` clones its client from an arbitrary
+/// browser returned by `list_top_level_browsers()`, and that helper
+/// deliberately includes `Floater`s ("they ARE trusted top-level renderers,
+/// so `list_top_level_browsers` includes them for host JS-event emission" —
+/// `BrowserKind`'s own doc comment). Every floater client is built with
+/// `is_browser_pane = true` (`floating_pane.rs`), so a cold-path top-level
+/// window that happens to clone a floater's client inherits `true` and
+/// returned out of `on_load_end` above the whole reveal block — issue #3028.
+/// `browsers` is a `HashMap`, so which client gets cloned varies per run:
+/// exactly the intermittency that made #3028 reproduce every time under the
+/// issue's repro (all windows closed, only pool + `floating-pool-*` browsers
+/// alive) and not at all under a three-rapid-clicks repro with `main` open.
+///
+/// This is the same "the inherited flag lies, the registered kind doesn't"
+/// hazard already documented at `client/lifecycle.rs`'s `BrowserKind`
+/// classification ("LABEL is the source of truth ... if the iteration happens
+/// to pick a pane, the new window inherits `is_browser_pane=true`"). That fix
+/// corrected the *classification*; the flag itself was left wrong and
+/// `on_load_end` still branched on it.
+///
+/// `kind` is this browser's own registered `BrowserKind`. `None` (not
+/// registered yet, or identity lookup missed) falls back to the client flag —
+/// the pre-fix behaviour — rather than guessing on missing evidence.
+fn takes_pane_path(kind: Option<&crate::state::BrowserKind>, client_is_browser_pane: bool) -> bool {
+    use crate::state::BrowserKind;
+    match kind {
+        // Genuine pane-like renderers: panes and floating panes/tear-offs.
+        // Floaters host panes and need the focus-subclass re-install, which
+        // is why their clients set the flag in the first place.
+        Some(BrowserKind::Pane { .. }) | Some(BrowserKind::Floater { .. }) => true,
+        // A real top-level window (or a CEF-owned popup) — never the pane
+        // path, no matter what client it was cloned from.
+        Some(BrowserKind::TopLevel { .. }) | Some(BrowserKind::Popup) => false,
+        None => client_is_browser_pane,
+    }
+}
+
 /// Native-layer visibility for a label's bound HWND. `None` when no HWND is
 /// bound (or off Windows) — callers must treat that as "no extra information",
 /// not as hidden.
@@ -662,7 +704,29 @@ impl AgentMuxHandler {
         // Runs AFTER cred injection so a floating-pane window gets BOTH the
         // bridge and its focus fix; a real remote browser pane falls through
         // here having received no creds (origin didn't match above).
-        if self.is_browser_pane {
+        // Decide the pane branch from what this browser actually IS (its
+        // registered `BrowserKind`), not from the shared client's
+        // `is_browser_pane` flag, which a cloned client can carry in from an
+        // unrelated floater — issue #3028's root cause, see `takes_pane_path`.
+        let resolved_kind = {
+            let mut owned = browser.as_deref().cloned();
+            owned
+                .as_mut()
+                .and_then(|b| self.window_label_for(b))
+                .and_then(|label| self.state.browser_kind_for_label(&label))
+        };
+        let is_pane_path = takes_pane_path(resolved_kind.as_ref(), self.is_browser_pane);
+        if self.is_browser_pane && !is_pane_path {
+            // The exact #3028 condition. Loud: this window would have been
+            // stranded hidden forever before this fix, with no log at all.
+            tracing::warn!(
+                target: "startup-paint",
+                kind = ?resolved_kind,
+                "[on_load_end] client claims browser-pane but this browser is a top-level \
+                 window (cloned client) — taking the reveal path (issue #3028)"
+            );
+        }
+        if is_pane_path {
             if let Some(b) = browser.as_deref() {
                 crate::browser_pane::callbacks::on_load_end_browser_pane(&self.state, b);
             }
@@ -1049,6 +1113,63 @@ pub(crate) fn show_load_error_page(
     let data_uri = format!("data:text/html;base64,{}", b64_str);
     let uri = CefString::from(data_uri.as_str());
     frame.load_url(Some(&uri));
+}
+
+#[cfg(test)]
+mod pane_path_tests {
+    use super::takes_pane_path;
+    use crate::state::BrowserKind;
+
+    /// Issue #3028's actual root cause. `CreateWindowTask` clones its CEF
+    /// `Client` from an arbitrary browser in `list_top_level_browsers()`,
+    /// which deliberately includes `Floater`s — and every floater client is
+    /// built with `is_browser_pane = true`. A cold-path top-level window that
+    /// happens to clone a floater's client inherits that flag, and the old
+    /// `if self.is_browser_pane { .. return }` gate then returned out of
+    /// `on_load_end` ABOVE the entire reveal block: paint gate never armed,
+    /// `report_first_paint` no-opped, the 4s safety timeout never scheduled.
+    /// What this browser IS must win over what its cloned client claims.
+    #[test]
+    fn a_top_level_window_with_an_inherited_pane_flag_is_not_a_pane() {
+        assert!(!takes_pane_path(
+            Some(&BrowserKind::TopLevel { is_pool: false }),
+            true,
+        ));
+        assert!(!takes_pane_path(
+            Some(&BrowserKind::TopLevel { is_pool: true }),
+            true,
+        ));
+    }
+
+    /// The converse must keep working: genuine panes and floaters take the
+    /// pane path even if they were somehow handed a non-pane client. Floaters
+    /// are pane-like here by design — they host panes and need the focus
+    /// subclass re-install, which is why their clients set the flag at all.
+    #[test]
+    fn genuine_panes_and_floaters_still_take_the_pane_path() {
+        assert!(takes_pane_path(
+            Some(&BrowserKind::Pane { block_id: "b".into() }),
+            false,
+        ));
+        assert!(takes_pane_path(Some(&BrowserKind::Floater { is_pool: false }), false));
+        assert!(takes_pane_path(Some(&BrowserKind::Floater { is_pool: true }), false));
+    }
+
+    /// Unresolvable kind (browser not registered yet / identity lookup miss)
+    /// must fall back to the client flag — the pre-fix behaviour — rather
+    /// than guessing. Never silently reclassify on missing evidence.
+    #[test]
+    fn an_unresolvable_kind_falls_back_to_the_client_flag() {
+        assert!(takes_pane_path(None, true));
+        assert!(!takes_pane_path(None, false));
+    }
+
+    /// A popup is CEF-owned and Chrome-style (shown at creation); it was not
+    /// on the pane path before this change and must not move onto it.
+    #[test]
+    fn a_popup_is_unchanged_by_this_gate() {
+        assert!(!takes_pane_path(Some(&BrowserKind::Popup), false));
+    }
 }
 
 #[cfg(test)]

--- a/agentmux-cef/src/state/mod.rs
+++ b/agentmux-cef/src/state/mod.rs
@@ -962,6 +962,32 @@ impl AppState {
             .collect()
     }
 
+    /// This browser's own registered `BrowserKind`, by label. The
+    /// authoritative answer to "what is this browser", as opposed to whatever
+    /// its (possibly cloned, possibly shared) `AgentMuxClient` claims — see
+    /// `client::navigation::takes_pane_path` and issue #3028. `None` when the
+    /// label isn't registered (yet).
+    pub fn browser_kind_for_label(&self, label: &str) -> Option<BrowserKind> {
+        self.host_state.lock().browsers.get(label).map(|h| h.kind.clone())
+    }
+
+    /// Browsers that are genuinely `BrowserKind::TopLevel` — no floaters.
+    /// `list_top_level_browsers` deliberately includes floaters because its
+    /// callers emit host JS events, but a caller that needs a *window-shaped*
+    /// browser (notably `CreateWindowTask`, which CLONES the browser's CEF
+    /// client into a brand-new top-level window) must not pick a floater: a
+    /// floater's client carries `is_browser_pane = true`, which the new window
+    /// then inherits. Issue #3028.
+    pub fn list_full_top_level_browsers(&self) -> Vec<(String, Browser)> {
+        self.host_state
+            .lock()
+            .browsers
+            .iter()
+            .filter(|(_, h)| matches!(h.kind, BrowserKind::TopLevel { .. }))
+            .map(|(k, h)| (k.clone(), h.browser.clone()))
+            .collect()
+    }
+
     /// Count of live, user-visible top-level windows — the authoritative
     /// last-window quit gate (`client::on_before_close` +
     /// `wrr::win_event::maybe_quit_on_last_user_window`). Delegates to

--- a/agentmux-cef/src/ui_tasks/window.rs
+++ b/agentmux-cef/src/ui_tasks/window.rs
@@ -1541,7 +1541,10 @@ wrap_task! {
             use std::cell::RefCell;
 
             // Phase 1 diagnostic tracing — see
-            // docs/specs/SPEC_HOST_WINDOW_CREATION_RUNNER_2026-05-02.md.
+            // docs/specs/SPEC_HOST_REDUCER_PHASE_H_2026-05-02.md, which
+            // superseded the never-landed SPEC_HOST_WINDOW_CREATION_RUNNER
+            // this used to cite (that spec's own companion-doc list records
+            // the supersession; PR #651 was closed).
             // Identify which exact CEF call wedges the UI thread under
             // concurrent window creation.
             let t0 = std::time::Instant::now();

--- a/agentmux-cef/src/ui_tasks/window.rs
+++ b/agentmux-cef/src/ui_tasks/window.rs
@@ -1580,10 +1580,32 @@ wrap_task! {
             // CrBrowserMain. A graceful return here lets the launcher's crash-
             // budget supervisor retry (with --disable-gpu) only on real CEF
             // faults, not on this transient race.
+            //
+            // Issue #3028: prefer a GENUINE `BrowserKind::TopLevel` browser.
+            // `list_top_level_browsers()` also includes `Floater`s (by design
+            // — its other callers emit host JS events and floaters are
+            // trusted renderers), and every floater's client is built with
+            // `is_browser_pane = true`. Cloning a floater's client here hands
+            // that flag to a brand-new top-level window, whose `on_load_end`
+            // then took the browser-pane early-return ABOVE the reveal block:
+            // paint gate never armed, `report_first_paint` no-opped, 4s
+            // safety timeout never scheduled, window hidden forever. Because
+            // `browsers` is a `HashMap`, which client got cloned varied per
+            // run — the intermittency that made #3028 reproduce every time
+            // with all windows closed (only pool + `floating-pool-*` alive)
+            // and not at all with `main` open. `on_load_end` no longer trusts
+            // the inherited flag either (`takes_pane_path`), but picking the
+            // right client here keeps the flag honest in the first place.
+            //
+            // Falls back to the floater-inclusive list rather than aborting:
+            // a floater-only population is still a live renderer to clone
+            // from, and a window that opens with a stale flag is now handled
+            // correctly downstream — strictly better than no window at all.
             let client = self
                 .state
-                .list_top_level_browsers()
+                .list_full_top_level_browsers()
                 .into_iter()
+                .chain(self.state.list_top_level_browsers())
                 .find_map(|(_, b)| {
                     b.host().and_then(|h| h.client())
                 });


### PR DESCRIPTION
## Summary

Fixes #3028: a cold-path `open_new_window` (pool empty) creates a window that
loads, round-trips IPC (`register_backend_window received`), reports first
paint — and **stays hidden forever**.

> **Note:** the root cause below replaces the one this PR originally shipped.
> The first diagnosis (CEF Views misreporting `is_visible()`) was wrong; it is
> documented in the comments as a corrected mis-diagnosis, not quietly dropped.

## Root cause — proven from the repro's own host log

`CreateWindowTask::execute` clones its CEF `Client` from an arbitrary browser
returned by `list_top_level_browsers()`. That helper **deliberately includes
`Floater`s** (its other callers emit host JS events, and floaters are trusted
renderers — see `BrowserKind`'s own doc comment), and **every floater client is
built with `is_browser_pane = true`** (`floating_pane.rs`).

A cold-path top-level window that clones a floater's client inherits that flag.
`on_load_end` then returns at:

```rust
if self.is_browser_pane { /* pane work */ return; }
```

which sits **above the entire reveal block**. So the paint gate is never armed —
and every backstop hangs off arming:

- `report_first_paint` arrives with the correct label and no-ops
  (`reveal_gated_window` returns when nothing is pending);
- the 4s safety timeout is never *scheduled*, because scheduling happens inside
  the block that never runs.

No log is emitted from any reveal branch, which is exactly what made this
undiagnosable from the field.

### The proof

Host log of the original #3028 repro, at `20:13:19.309` — the **same
`on_load_end` invocation** as the cred injection, for the top-level
`window-7f73cb1b…`:

```
Injected IPC port 61928 into page: …windowLabel=window-7f73cb1b…
[pane-load-end] pane page loaded; reinstalling focus subclass
[pane-subclass] subclassed child HWND 0xa10cae class=Chrome_RenderWidgetHostHWND
[pane-load-end] couldn't resolve block_id for nav-state emit         (WARN)
[pane-loading-state] couldn't resolve block_id for nav-state emit    (WARN)
```

A browser registered as `TopLevel { is_pool: false }` ran the **browser-pane
path**, and the pane code could not resolve a `block_id` *precisely because it
is not a pane*. The only floater alive at creation time was
`floating-pool-55a5994…`.

### Why it looked intermittent

`browsers` is a `HashMap`: which client gets cloned is arbitrary, but **stable
within a process**. That is why it reproduced on every New Window in the
issue's run (all windows closed under background-service — only pool +
`floating-pool-*` browsers alive) and not at all in a later three-rapid-clicks
run with `main` open, where the clone happened to pick a non-floater client and
the window showed normally (`EVENT_SYSTEM_FOREGROUND` in the host log).

### Not a new class of bug

The same "the inherited flag lies, the registered kind doesn't" hazard is
already documented at `client/lifecycle.rs:189`:

> *…`CreateWindowTask::execute` reuses an existing browser's CEF Client via
> `first_browser()` — if the iteration happens to pick a pane, the new window
> inherits `is_browser_pane=true`… LABEL is the source of truth.*

That fix corrected the downstream **`BrowserKind` classification**. The flag
itself was left wrong, and `on_load_end` still branched on it.

## The fix — both ends

1. **`on_load_end` stops trusting the flag** (`takes_pane_path`): the pane
   branch is decided by this browser's own registered `BrowserKind`. Panes and
   floaters still take the pane path (floaters host panes and need the
   focus-subclass re-install — that's why their clients set the flag at all);
   a `TopLevel` or `Popup` never does, no matter what client it cloned. An
   **unresolvable** kind falls back to the flag — the pre-fix behaviour — so
   nothing is reclassified on missing evidence. Logs at `warn` when the flag
   and the kind disagree, since the silent version is what hid this.
2. **`CreateWindowTask` picks a better client**: prefers a genuine
   `BrowserKind::TopLevel` browser (`list_full_top_level_browsers`), falling
   back to the floater-inclusive list rather than aborting creation. This keeps
   the flag honest at the source and removes the `HashMap`-order flakiness.

## Also included (secondary hardening, NOT the fix)

The three-site `should_run_reveal(views_visible, native_visible)` change from
the first round. It came from the wrong diagnosis, but stands on its own terms:
the retry path was inconsistent with the initial pass, and
`try_show_resolved_window` could resolve a gate as "done" without showing.
**Happy to split this out** if a reviewer would rather this PR do exactly one
thing.

## Verification

- **Falsified**: reverting `takes_pane_path` to the flag-only behaviour fails
  `a_top_level_window_with_an_inherited_pane_flag_is_not_a_pane` (and the
  pane/floater test); restoring it passes.
- `cef 396 passed` (392 + 4 new).
- **Root cause is established from the recorded host log of the original
  repro**, not from a hypothesis — see the proof above.
- **Live re-verification of the issue's exact repro (background-service mode,
  all windows closed, empty pool) has NOT been run on this build.** Last round
  I let an approval plus four green checks stand in for that and nearly merged
  a non-fix, so I am stating the gap plainly rather than implying coverage I
  don't have.

<!-- agentmux:agent_id=agent5 -->
