### PR TITLE
Camper@claudius: feat(app-api): agent.open over HTTP + OpenAgent MCP tool + muxopen — automation can launch agents, not just stop them

### DIFF
--- a/.changesets/1788729917-feat-app-api-agent-open-over-http-openagent-mcp-tool-muxopen-xszb.md
+++ b/.changesets/1788729917-feat-app-api-agent-open-over-http-openagent-mcp-tool-muxopen-xszb.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(app-api): agent.open over HTTP + OpenAgent MCP tool + muxopen — automation can now launch agents, not just stop them

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -332,6 +332,20 @@ const FLEET_BROADCAST_TOOL: &str = r#"{
   }
 }"#;
 
+const OPEN_AGENT_TOOL: &str = r#"{
+  "name": "OpenAgent",
+  "description": "Launch an agent into a pane by name or definition id (get these from FleetList/DiscoverAgents). Idempotent: if the agent is already open in the target tab, returns its existing pane with created:false instead of opening a second one. This spawns a real provider process (and, for container agents, execs into their container) — it consumes provider tokens like any human-opened pane. Returns JSON {block_id, tab_id, agent_id, provider, controller_type, status, created}. After a successful open the agent becomes addressable for SendMessage.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "agent_id": { "type": "string", "description": "Agent definition id or name (case-insensitive), e.g. from FleetList's host.agents[]" },
+      "tab_id": { "type": "string", "description": "Optional target tab id; defaults to the active tab" },
+      "focus": { "type": "boolean", "description": "Optional: focus the new pane (default true)" }
+    },
+    "required": ["agent_id"]
+  }
+}"#;
+
 const FLEET_BULK_STOP_TOOL: &str = r#"{
   "name": "FleetBulkStop",
   "description": "Stop many agent panes at once by block_id (get these from FleetList). Destructive — double-check your target list first. Returns JSON {succeeded, failed: [{id, error}...], aborted_early}. Optionally pass `staged` to cap blast radius on a bad selection: stops `batch_size` targets at a time, and if a batch's failure rate exceeds `max_fail_percentage`, the remaining targets are recorded as failed (untried) instead of being attempted — `aborted_early` will be true. Without `staged`, every target is attempted as one batch.",
@@ -857,6 +871,8 @@ async fn main() {
                     serde_json::from_str(FLEET_BROADCAST_TOOL).expect("static json");
                 let fleet_bulk_stop: Value =
                     serde_json::from_str(FLEET_BULK_STOP_TOOL).expect("static json");
+                let open_agent: Value =
+                    serde_json::from_str(OPEN_AGENT_TOOL).expect("static json");
                 let loop_tool: Value = serde_json::from_str(LOOP_TOOL).expect("static json");
                 let loop_stop: Value = serde_json::from_str(LOOP_STOP_TOOL).expect("static json");
                 let loop_list: Value = serde_json::from_str(LOOP_LIST_TOOL).expect("static json");
@@ -886,7 +902,7 @@ async fn main() {
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "tools": [shell, shell_stop, shell_input, shell_status, open_editor, open_media, send_message, discover_agents, get_agent_transcript, list_conversations, supervisor_nudge, whoami, layout, set_name, set_active_tab, new_tab, focus_window, ui_screenshot, ui_click, ui_query, capture_window, discover_windows, fleet_list, fleet_broadcast, fleet_bulk_stop, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, work_enqueue, work_claim, work_heartbeat, work_complete, work_release, work_list, memory_list, memory_read, memory_write, memory_history, memory_diff, memory_revert, preset_list, preset_get, identity_accounts, identity_validate] }
+                    "result": { "tools": [shell, shell_stop, shell_input, shell_status, open_editor, open_media, send_message, discover_agents, get_agent_transcript, list_conversations, supervisor_nudge, whoami, layout, set_name, set_active_tab, new_tab, focus_window, ui_screenshot, ui_click, ui_query, capture_window, discover_windows, fleet_list, fleet_broadcast, fleet_bulk_stop, open_agent, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, work_enqueue, work_claim, work_heartbeat, work_complete, work_release, work_list, memory_list, memory_read, memory_write, memory_history, memory_diff, memory_revert, preset_list, preset_get, identity_accounts, identity_validate] }
                 })
             }
             "tools/call" => {
@@ -2553,6 +2569,49 @@ async fn call_tool(
             }
 
             let result = json!({ "succeeded": succeeded, "failed": failed });
+            Ok(serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()))
+        }
+        "OpenAgent" => {
+            let agent_id = arguments
+                .get("agent_id")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: agent_id"))?;
+            let tab_id = arguments.get("tab_id").and_then(|v| v.as_str()).map(str::to_string);
+            let focus = arguments.get("focus").and_then(|v| v.as_bool());
+
+            if local_url.is_empty() || auth_key.is_empty() {
+                anyhow::bail!(
+                    "AGENTMUX_LOCAL_URL and AGENTMUX_AUTH_KEY must be set. \
+                     Is this agent pane opened via AgentMux?"
+                );
+            }
+
+            let url = format!("{}/api/v1/agent/open", local_url.trim_end_matches('/'));
+            let body = json!({
+                "agent_id": agent_id,
+                "tab_id": tab_id,
+                "focus": focus,
+            });
+            let resp = client
+                .post(&url)
+                .header("X-AuthKey", auth_key)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("agent open failed: HTTP {status} — {text}");
+            }
+
+            let result: Value = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+
             Ok(serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()))
         }
         "FleetBulkStop" => {
@@ -4492,6 +4551,7 @@ mod tests {
             FLEET_LIST_TOOL,
             FLEET_BROADCAST_TOOL,
             FLEET_BULK_STOP_TOOL,
+            OPEN_AGENT_TOOL,
             CAPTURE_WINDOW_TOOL,
             DISCOVER_WINDOWS_TOOL,
             LIST_CONVERSATIONS_TOOL,

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -4576,7 +4576,10 @@ mod tests {
         // added here too (REPORT_UNIVERSAL_AGENT_WORK_QUEUE_2026_09_01.md
         // slice 2) — same reasoning, not fixing the pre-existing drift between
         // this running total and the prose breakdown below it.
-        assert_eq!(defs.len(), 42, "tools/list advertises 27 tools (11 original + 1 OpenMedia + 3 Loop + 5 Cron + 7 agent-API) + 3 memory-version-history + 3 fleet-control tools + 1 CaptureWindow + 1 ListConversations + 1 DiscoverWindows + 6 Muxqueue");
+        // OPEN_AGENT_TOOL added (REPORT_AGENT_OPEN_API_GAP_2026_09_06.md) —
+        // same reasoning as the entries above, not fixing the pre-existing
+        // drift between this running total and the prose breakdown.
+        assert_eq!(defs.len(), 43, "tools/list advertises 27 tools (11 original + 1 OpenMedia + 3 Loop + 5 Cron + 7 agent-API) + 3 memory-version-history + 3 fleet-control tools + 1 OpenAgent + 1 CaptureWindow + 1 ListConversations + 1 DiscoverWindows + 6 Muxqueue");
         for d in defs {
             let v: Value = serde_json::from_str(d).expect("tool def must be valid JSON");
             assert!(

--- a/agentmux-srv/src/backend/shellintegration.rs
+++ b/agentmux-srv/src/backend/shellintegration.rs
@@ -25,6 +25,11 @@ const MUXLOG_JS: &str = include_str!("shellintegration/muxlog.mjs");
 /// at `<shell>/muxspect.mjs`; every shell's `muxspect` function delegates to
 /// it. See docs/specs/SPEC_MUXSPECT_LIVE_INTROSPECTION_TOOL_2026_08_01.md.
 const MUXSPECT_JS: &str = include_str!("shellintegration/muxspect.mjs");
+/// muxopen — launch an agent into a pane from a terminal (the constructive
+/// sibling of the stop verbs; REPORT_AGENT_OPEN_API_GAP_2026_09_06.md).
+/// Deployed beside muxlog.mjs/muxspect.mjs; shell `muxopen` functions
+/// delegate here.
+const MUXOPEN_JS: &str = include_str!("shellintegration/muxopen.mjs");
 
 /// Deployment marker: `<package version>-<content hash>`, NOT the bare
 /// package version alone (codex P2 on PR #2380). Local/dev builds routinely
@@ -132,6 +137,11 @@ pub fn deploy_scripts(wave_data_dir: &Path) {
     let muxspect_path = shell_base.join("muxspect.mjs");
     if let Err(e) = std::fs::write(&muxspect_path, MUXSPECT_JS) {
         tracing::warn!("shell integration: failed to write {}: {}", muxspect_path.display(), e);
+    }
+    // muxopen deploys the same way, next to its two siblings.
+    let muxopen_path = shell_base.join("muxopen.mjs");
+    if let Err(e) = std::fs::write(&muxopen_path, MUXOPEN_JS) {
+        tracing::warn!("shell integration: failed to write {}: {}", muxopen_path.display(), e);
         all_ok = false;
     }
 
@@ -287,8 +297,10 @@ mod tests {
         let shell_base = tmp.join("shell");
         let muxlog = shell_base.join("muxlog.mjs");
         let muxspect = shell_base.join("muxspect.mjs");
+        let muxopen = shell_base.join("muxopen.mjs");
         assert!(muxlog.exists(), "muxlog.mjs should be deployed");
         assert!(muxspect.exists(), "muxspect.mjs should be deployed alongside it");
+        assert!(muxopen.exists(), "muxopen.mjs should be deployed alongside them");
         assert_eq!(std::fs::read_to_string(&muxspect).unwrap(), MUXSPECT_JS);
 
         let _ = std::fs::remove_dir_all(&tmp);

--- a/agentmux-srv/src/backend/shellintegration/bash.sh
+++ b/agentmux-srv/src/backend/shellintegration/bash.sh
@@ -126,6 +126,20 @@ muxspect() {
     return 1
 }
 
+# ─── muxopen ────────────────────────────────────────────────────────────────
+# Launch an agent into a pane from the terminal (no GUI). Constructive
+# sibling of the stop verbs. Delegates to the shared Node core (muxopen.mjs,
+# deployed next to this rcfile). `muxopen help` for usage.
+_AGENTMUX_MUXOPEN_JS="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." 2>/dev/null && pwd)/muxopen.mjs"
+muxopen() {
+    if command -v node >/dev/null 2>&1 && [ -f "$_AGENTMUX_MUXOPEN_JS" ]; then
+        node "$_AGENTMUX_MUXOPEN_JS" "$@"
+        return
+    fi
+    echo "muxopen: Node unavailable or core missing at $_AGENTMUX_MUXOPEN_JS" >&2
+    return 1
+}
+
 # Append to PROMPT_COMMAND (array-safe)
 if [[ $(declare -p PROMPT_COMMAND 2>/dev/null) == "declare -a"* ]]; then
     PROMPT_COMMAND+=(_agentmux_si_prompt_command)

--- a/agentmux-srv/src/backend/shellintegration/fish.fish
+++ b/agentmux-srv/src/backend/shellintegration/fish.fish
@@ -104,6 +104,19 @@ function muxspect
     return 1
 end
 
+# ─── muxopen ────────────────────────────────────────────────────────────────
+# Launch an agent into a pane from the terminal (no GUI). Constructive
+# sibling of the stop verbs. `muxopen help` for usage.
+set -g _agentmux_muxopen_js (dirname (status -f))/../muxopen.mjs
+function muxopen
+    if command -q node; and test -f "$_agentmux_muxopen_js"
+        node "$_agentmux_muxopen_js" $argv
+        return
+    end
+    echo "muxopen: Node unavailable or core missing at $_agentmux_muxopen_js" >&2
+    return 1
+end
+
 function _agentmux_si_prompt --on-event fish_prompt
     _agentmux_si_osc7
     _agentmux_si_agent_env

--- a/agentmux-srv/src/backend/shellintegration/muxopen.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxopen.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// muxopen — launch an agent into a pane from a terminal, no GUI required.
+//
+// The constructive sibling of the stop verbs: muxspect answers "what is
+// running", FleetBulkStop stops things, and until this existed nothing on the
+// command line could START an agent — automation could stop cross-channel but
+// not launch anywhere (docs/reports/REPORT_AGENT_OPEN_API_GAP_2026_09_06.md).
+//
+// Thin wrapper over `POST /api/v1/agent/open` (the same `agent.open` impl the
+// UI uses, including its TOCTOU serialization), authenticated exactly the way
+// muxspect and agentmux-mcp already are: $AGENTMUX_LOCAL_URL +
+// $AGENTMUX_AUTH_KEY inherited from the pane environment. No new IPC, no new
+// auth scheme.
+//
+// Deployed by agentmux-srv next to muxlog.mjs/muxspect.mjs
+// (~/.agentmux/shell/muxopen.mjs); the shell `muxopen` functions delegate
+// here. From a tool-spawned subshell call the core directly:
+//   node ~/.agentmux/shell/muxopen.mjs <agent>
+//
+// Exit codes: 0 opened (or already open — idempotent, `created:false`),
+// 1 usage/environment error, 2 the server rejected the open or is unreachable.
+
+import { pathToFileURL } from "node:url";
+
+const HELP = `muxopen — launch an agent into a pane (no GUI required)
+
+usage:
+  muxopen <agent>              open by name (case-insensitive) or definition id
+  muxopen <agent> --tab <id>   target a specific tab (default: active tab)
+  muxopen <agent> --no-focus   open without focusing the new pane
+  muxopen help                 this text
+
+Idempotent: an agent already open in the target tab returns its existing
+pane ("already open") instead of opening a second one. On success the agent
+becomes addressable for agent-to-agent messages.
+
+Requires $AGENTMUX_LOCAL_URL and $AGENTMUX_AUTH_KEY (present in any
+AgentMux-opened pane). This opens the agent in the instance this pane
+belongs to; cross-instance opening is not implemented here.`;
+
+/** Parse argv (already stripped of node + script path).
+ *
+ * Returns `{help}` | `{error}` | `{agent, tabId, focus}`. Pure — no I/O, no
+ * process.exit — so the flag handling is unit-testable (same contract as
+ * muxspect's parseArgs, whose raw-index parser bug is why these are tested).
+ */
+export function parseArgs(argv) {
+    if (argv.length === 0) return { help: true, exitCode: 1 };
+    if (argv[0] === "help" || argv[0] === "--help" || argv[0] === "-h") {
+        return { help: true, exitCode: 0 };
+    }
+    const agent = argv[0];
+    if (agent.startsWith("-")) {
+        return { error: `first argument must be an agent name/id, got '${agent}'` };
+    }
+    let tabId = null;
+    let focus = true;
+    for (let i = 1; i < argv.length; i++) {
+        if (argv[i] === "--tab") {
+            tabId = argv[++i];
+            if (!tabId) return { error: "--tab requires a tab id" };
+        } else if (argv[i] === "--no-focus") {
+            focus = false;
+        } else {
+            return { error: `unknown argument '${argv[i]}'` };
+        }
+    }
+    return { agent, tabId, focus };
+}
+
+/** Render the success line(s) for an /api/v1/agent/open response body.
+ * Pure — returns the text rather than printing, for testability. */
+export function renderResult(body) {
+    const verb = body.created ? "opened" : "already open";
+    const lines = [
+        `${verb}: ${body.agent_id} (${body.provider}, ${body.controller_type})`,
+        `  block ${body.block_id}`,
+        `  tab   ${body.tab_id}`,
+    ];
+    if (!body.created) lines.push(`  status ${body.status}`);
+    return lines.join("\n");
+}
+
+function fail(msg, code = 1) {
+    process.stderr.write(`muxopen: ${msg}\n`);
+    process.exit(code);
+}
+
+async function main() {
+    const parsed = parseArgs(process.argv.slice(2));
+    if (parsed.help) {
+        console.log(HELP);
+        process.exit(parsed.exitCode);
+    }
+    if (parsed.error) fail(`${parsed.error}\n\n${HELP}`);
+
+    const url = process.env.AGENTMUX_LOCAL_URL;
+    const authKey = process.env.AGENTMUX_AUTH_KEY;
+    if (!url || !authKey) {
+        fail(
+            "AGENTMUX_LOCAL_URL / AGENTMUX_AUTH_KEY not set — run from a pane " +
+            "AgentMux opened (agent or shell), or export them from one.",
+        );
+    }
+
+    let resp;
+    try {
+        resp = await fetch(`${url.replace(/\/$/, "")}/api/v1/agent/open`, {
+            method: "POST",
+            headers: { "X-AuthKey": authKey, "Content-Type": "application/json" },
+            body: JSON.stringify({ agent_id: parsed.agent, tab_id: parsed.tabId, focus: parsed.focus }),
+        });
+    } catch (e) {
+        fail(`cannot reach ${url}: ${e.message ?? e}`, 2);
+    }
+
+    let body;
+    try {
+        body = await resp.json();
+    } catch {
+        body = {};
+    }
+
+    if (!resp.ok) {
+        // Surface the impl's own vocabulary (AGENT_NOT_FOUND / CLI_NOT_AVAILABLE
+        // / …) verbatim — it names the remedy better than a paraphrase would.
+        // A 404 here most likely means the running srv predates this route.
+        const hint = resp.status === 404
+            ? " (HTTP 404 — this AgentMux instance may predate /api/v1/agent/open)"
+            : "";
+        fail(`${body.error ?? `HTTP ${resp.status}`}${hint}`, 2);
+    }
+
+    console.log(renderResult(body));
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+    main().catch((e) => fail(e.message ?? String(e), 2));
+}

--- a/agentmux-srv/src/backend/shellintegration/muxopen.test.mjs
+++ b/agentmux-srv/src/backend/shellintegration/muxopen.test.mjs
@@ -1,0 +1,70 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Unit tests for muxopen.mjs's argument parsing and output rendering — pure,
+// no network, no running instance. Same vitest arrangement as
+// muxspect.test.mjs (NOT node:test — see that file's header for why).
+
+import { describe, expect, it } from "vitest";
+
+import { parseArgs, renderResult } from "./muxopen.mjs";
+
+describe("muxopen parseArgs", () => {
+    it("a bare agent name parses with defaults", () => {
+        expect(parseArgs(["Scouto"])).toEqual({ agent: "Scouto", tabId: null, focus: true });
+    });
+
+    it("no arguments is help with a failing exit code", () => {
+        expect(parseArgs([])).toEqual({ help: true, exitCode: 1 });
+    });
+
+    it("explicit help exits 0", () => {
+        expect(parseArgs(["help"])).toEqual({ help: true, exitCode: 0 });
+        expect(parseArgs(["--help"])).toEqual({ help: true, exitCode: 0 });
+    });
+
+    it("--tab captures the id and --no-focus clears focus", () => {
+        expect(parseArgs(["Scouto", "--tab", "t-1", "--no-focus"])).toEqual({
+            agent: "Scouto",
+            tabId: "t-1",
+            focus: false,
+        });
+    });
+
+    it("--tab without a value is an error, not a silent undefined", () => {
+        expect(parseArgs(["Scouto", "--tab"]).error).toMatch(/--tab requires/);
+    });
+
+    it("a flag in the agent position is an error rather than a bogus target", () => {
+        // `muxopen --no-focus` must not try to open an agent named "--no-focus".
+        expect(parseArgs(["--no-focus"]).error).toMatch(/first argument/);
+    });
+
+    it("an unknown flag is rejected loudly", () => {
+        expect(parseArgs(["Scouto", "--wat"]).error).toMatch(/unknown argument '--wat'/);
+    });
+});
+
+describe("muxopen renderResult", () => {
+    const base = {
+        agent_id: "Scouto",
+        provider: "claude",
+        controller_type: "subprocess",
+        block_id: "b-123",
+        tab_id: "t-456",
+        status: "running",
+    };
+
+    it("a fresh open says 'opened' without a status line", () => {
+        const out = renderResult({ ...base, created: true });
+        expect(out).toContain("opened: Scouto (claude, subprocess)");
+        expect(out).toContain("block b-123");
+        expect(out).not.toContain("status");
+    });
+
+    it("an idempotent hit says 'already open' and shows the live status", () => {
+        const out = renderResult({ ...base, created: false });
+        expect(out).toContain("already open: Scouto");
+        expect(out).toContain("status running");
+    });
+});

--- a/agentmux-srv/src/backend/shellintegration/pwsh.ps1
+++ b/agentmux-srv/src/backend/shellintegration/pwsh.ps1
@@ -98,6 +98,18 @@ function Global:muxspect {
     Write-Error "muxspect: Node unavailable or core missing at $global:AgentmuxMuxspectJs"
 }
 
+# ─── muxopen ────────────────────────────────────────────────────────────────
+# Launch an agent into a pane from the terminal (no GUI). Constructive
+# sibling of the stop verbs. `muxopen help` for usage.
+$global:AgentmuxMuxopenJs = Join-Path $PSScriptRoot "..\muxopen.mjs"
+function Global:muxopen {
+    if ((Get-Command node -ErrorAction SilentlyContinue) -and (Test-Path $global:AgentmuxMuxopenJs)) {
+        node $global:AgentmuxMuxopenJs @args
+        return
+    }
+    Write-Error "muxopen: Node unavailable or core missing at $global:AgentmuxMuxopenJs"
+}
+
 # Hook into the prompt function
 if (Test-Path Function:\prompt) {
     $global:_agentmux_original_prompt = $function:prompt

--- a/agentmux-srv/src/backend/shellintegration/zsh.sh
+++ b/agentmux-srv/src/backend/shellintegration/zsh.sh
@@ -120,6 +120,19 @@ muxspect() {
     return 1
 }
 
+# ─── muxopen ────────────────────────────────────────────────────────────────
+# Launch an agent into a pane from the terminal (no GUI). Constructive
+# sibling of the stop verbs. `muxopen help` for usage.
+_AGENTMUX_MUXOPEN_JS="${${(%):-%x}:A:h}/../muxopen.mjs"
+muxopen() {
+    if command -v node >/dev/null 2>&1 && [ -f "$_AGENTMUX_MUXOPEN_JS" ]; then
+        node "$_AGENTMUX_MUXOPEN_JS" "$@"
+        return
+    fi
+    echo "muxopen: Node unavailable or core missing at $_AGENTMUX_MUXOPEN_JS" >&2
+    return 1
+}
+
 autoload -U add-zsh-hook
 add-zsh-hook precmd _agentmux_si_precmd
 add-zsh-hook chpwd  _agentmux_si_osc7

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -626,7 +626,13 @@ pub(crate) async fn open_agent_impl(
                         nodesize: None,
                         nodesizefraction: None,
                         indexarr: None,
-                        focused: true,
+                        // Honors the request's `focus` (default true — the UI
+                        // flow's behavior). Was hardcoded `true` while the RPC
+                        // surface was the only caller and nothing set the
+                        // field; this PR documents `focus`/`--no-focus` on
+                        // OpenAgent/muxopen, so ignoring it would silently
+                        // contradict their own help text. reagent P1, PR #3032.
+                        focused: cmd.focus.unwrap_or(true),
                         magnified: false,
                         ephemeral: false,
                         targetblockid: String::new(),

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -137,27 +137,44 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
 }
 
 fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
-    let wstore = state.wstore.clone();
-    let broker = state.broker.clone();
-    let event_bus = state.event_bus.clone();
-    let filestore = state.filestore.clone();
-    // Capture the whole (Arc-backed, Clone) AppState so the block can be created
-    // through the reducer (#1681) — see the create-block site below.
     let app_state = state.clone();
 
     engine.register_handler(
         COMMAND_AGENT_OPEN,
         Box::new(move |data, _ctx| {
-            let wstore = wstore.clone();
-            let broker = broker.clone();
-            let event_bus = event_bus.clone();
-            let filestore = filestore.clone();
             let app_state = app_state.clone();
             Box::pin(async move {
                 let cmd: CommandAgentOpenData = serde_json::from_value(data)
                     .map_err(|e| format!("agent.open: {e}"))?;
+                let result = open_agent_impl(&app_state, cmd).await?;
+                Ok(Some(serde_json::to_value(&result).unwrap()))
+            })
+        }),
+    );
+}
 
-                tracing::info!(agent_id = %cmd.agent_id, "agent.open");
+/// The `agent.open` implementation — load the definition, resolve the
+/// provider/CLI, create the block, enqueue the layout insert, and register
+/// the controller. Extracted from the RPC closure so the HTTP surface
+/// (`POST /api/v1/agent/open`, backing the `OpenAgent` MCP tool) shares this
+/// exact code path instead of re-deriving it: the TOCTOU serialization via
+/// `AGENT_OPEN_LOCKS` (reagent P1 on PR #2059), the ABF provider shadowing,
+/// the resume-session seeding guard, and the CLI path resolution all live
+/// here once. Same extraction shape as `open_pane` / `handle_pane_open`.
+/// See docs/reports/REPORT_AGENT_OPEN_API_GAP_2026_09_06.md.
+pub(crate) async fn open_agent_impl(
+    state: &AppState,
+    cmd: CommandAgentOpenData,
+) -> Result<AgentOpenResult, String> {
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    let event_bus = state.event_bus.clone();
+    let filestore = state.filestore.clone();
+    // Owned handle so the reducer-dispatch sites below read exactly as they
+    // did inside the RPC closure (which captured an owned clone).
+    let app_state = state.clone();
+
+    tracing::info!(agent_id = %cmd.agent_id, "agent.open");
 
                 // 1. Load the agent definition (by id or name)
                 let agents = wstore.agent_def_list()
@@ -219,7 +236,7 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     let status = blockcontroller::get_block_controller_status(&existing.oid)
                         .map(|s| s.shellprocstatus)
                         .unwrap_or_else(|| "init".to_string());
-                    return Ok(Some(serde_json::to_value(&AgentOpenResult {
+                    return Ok(AgentOpenResult {
                         block_id: existing.oid,
                         tab_id,
                         agent_id: cmd.agent_id,
@@ -227,7 +244,7 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         controller_type: provider.controller_type_str().to_string(),
                         status,
                         created: false,
-                    }).unwrap()));
+                    });
                 }
 
                 // 5. Resolve CLI path.
@@ -690,7 +707,7 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     event_bus.broadcast_wave_obj_updates(&updates);
                 }
 
-                Ok(Some(serde_json::to_value(&AgentOpenResult {
+                Ok(AgentOpenResult {
                     block_id,
                     tab_id,
                     agent_id: cmd.agent_id,
@@ -698,10 +715,7 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     controller_type: controller_type.to_string(),
                     status: "init".to_string(),
                     created: true,
-                }).unwrap()))
-            })
-        }),
-    );
+                })
 }
 
 /// Write agent config files (CLAUDE.md, .mcp.json, etc.) to the working directory.

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -26,6 +26,11 @@ use super::AppState;
 use crate::server::cli_handlers::resolve_cli_on_path;
 
 mod agent_open;
+/// Re-exported for `server/mod.rs`'s `POST /api/v1/agent/open` handler (the
+/// `OpenAgent` MCP tool's backing route) — the HTTP surface must share the
+/// RPC path's exact implementation, including its AGENT_OPEN_LOCKS TOCTOU
+/// serialization. See REPORT_AGENT_OPEN_API_GAP_2026_09_06.md.
+pub(crate) use agent_open::open_agent_impl;
 // pub(crate): `server/mod.rs`'s `/agentmux/agent/stop` handler (the
 // cross-channel bulk-stop forward target,
 // SPEC_FLEET_BULK_STOP_CROSS_CHANNEL_2026_08_22.md) calls

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -430,6 +430,15 @@ pub fn build_router(state: AppState) -> Router {
         // shares the exact pane.open logic with the WebSocket RPC handler
         // (app_api::open_pane). See ANALYSIS_AGENT_APP_API_OPEN_IN_EDITOR_2026_05_30.
         .route("/api/v1/pane/open", post(handle_pane_open))
+        // Open (launch) an agent into a pane from an agent tool call —
+        // agentmux-mcp's OpenAgent tool POSTs `{agent_id, tab_id?, …}` here.
+        // Shares the exact agent.open logic (incl. its AGENT_OPEN_LOCKS
+        // TOCTOU serialization) with the WebSocket RPC handler via
+        // app_api::open_agent_impl. Until this route existed, automation
+        // could STOP an agent (/api/v1/fleet/bulk-stop, cross-channel) but
+        // could not START one anywhere — see
+        // REPORT_AGENT_OPEN_API_GAP_2026_09_06.md.
+        .route("/api/v1/agent/open", post(handle_agent_open))
         // Voice speech-to-text: the renderer POSTs mic audio (one
         // silence-bounded utterance per request); we forward to a Whisper
         // backend and return the transcript. Key stays server-side.
@@ -1018,6 +1027,38 @@ async fn handle_pane_open(
             // Argument/validation errors from build_pane_meta are the caller's
             // fault (400); everything else is a server-side failure (500).
             let status = if e.starts_with("MISSING_ARG") || e.starts_with("INVALID_VIEW") {
+                StatusCode::BAD_REQUEST
+            } else {
+                StatusCode::INTERNAL_SERVER_ERROR
+            };
+            (status, Json(json!({ "error": e }))).into_response()
+        }
+    }
+}
+
+/// `POST /api/v1/agent/open` — launch an agent into a pane (idempotent: an
+/// agent already open in the target tab returns its existing block with
+/// `created: false`, same as the RPC path).
+///
+/// Called by `agentmux-mcp`'s `OpenAgent` tool. Thin HTTP wrapper over
+/// `app_api::open_agent_impl` — the same logic the WebSocket `agent.open`
+/// RPC uses. Body is `CommandAgentOpenData` (`agent_id` by id or name;
+/// optional `tab_id`/`focus`/split placement).
+async fn handle_agent_open(
+    State(state): State<AppState>,
+    Json(req): Json<crate::backend::rpc_types::CommandAgentOpenData>,
+) -> impl IntoResponse {
+    match app_api::open_agent_impl(&state, req).await {
+        Ok(result) => (StatusCode::OK, Json(json!(result))).into_response(),
+        Err(e) => {
+            // The impl's own error vocabulary: AGENT_NOT_FOUND /
+            // INVALID_PROVIDER / CLI_NOT_AVAILABLE are the caller's problem
+            // (bad target or an uninstalled CLI they must remedy first);
+            // anything else is a server-side failure.
+            let status = if e.starts_with("AGENT_NOT_FOUND")
+                || e.starts_with("INVALID_PROVIDER")
+                || e.starts_with("CLI_NOT_AVAILABLE")
+            {
                 StatusCode::BAD_REQUEST
             } else {
                 StatusCode::INTERNAL_SERVER_ERROR

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -3219,3 +3219,51 @@ async fn work_complete_with_a_wrong_fence_is_conflict_not_not_found() {
     let resp = app.oneshot(done).await.unwrap();
     assert_eq!(resp.status(), StatusCode::CONFLICT);
 }
+
+// ── POST /api/v1/agent/open (REPORT_AGENT_OPEN_API_GAP_2026_09_06.md) ────────
+//
+// The route exists so automation can START an agent, not just stop one
+// (`/api/v1/fleet/bulk-stop`). These pin the wiring: the route is present,
+// behind the same X-AuthKey gate as every other /api/v1 route, and maps the
+// impl's caller-fault vocabulary (AGENT_NOT_FOUND) to 400 rather than 500.
+// A full successful-open test needs a real agent definition + installed CLI
+// + reducer round-trip and lives with the end-to-end coverage, not here.
+
+#[tokio::test]
+async fn agent_open_rejects_a_bad_auth_key() {
+    let app = test_router();
+    let req = Request::builder()
+        .uri("/api/v1/agent/open")
+        .method("POST")
+        .header("X-AuthKey", "wrong-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"agent_id":"anything"}"#))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn agent_open_unknown_agent_is_a_400_not_a_500() {
+    let app = test_router();
+    let req = Request::builder()
+        .uri("/api/v1/agent/open")
+        .method("POST")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(r#"{"agent_id":"no-such-agent-xyz"}"#))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "an unknown agent id is the caller's fault, not a server error"
+    );
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(
+        json["error"].as_str().unwrap_or("").starts_with("AGENT_NOT_FOUND"),
+        "error should carry the impl's AGENT_NOT_FOUND vocabulary, got: {}",
+        json["error"]
+    );
+}

--- a/docs/reports/REPORT_AGENT_OPEN_API_GAP_2026_09_06.md
+++ b/docs/reports/REPORT_AGENT_OPEN_API_GAP_2026_09_06.md
@@ -1,0 +1,235 @@
+# Report: no App API verb opens an agent — automation cannot start what it can stop
+
+**Date:** 2026-09-06
+**Status:** implemented — §5 steps 1, 2 and 4 (HTTP route, `OpenAgent` MCP tool, `muxopen`) shipped in the same PR as this report; cross-channel (step 3), the `muxspect` addressable column, LAN and WAN remain open
+**Author:** Camper
+**Repo state:** main @ `2c7604f1f` (v0.55.35)
+**Probed live** against a running instance (`v0.55.34`, `http://127.0.0.1:55019`)
+**Related:** `REPORT_CROSS_INSTANCE_CONTROL_ROBUSTNESS_AUDIT_2026_08_22.md`
+(four-tier audit — did not cover this gap),
+`SPEC_FLEET_BULK_STOP_CROSS_CHANNEL_2026_08_22.md`,
+`SPEC_FLEET_BROADCAST_CROSS_TIER_TARGETING_2026_08_22.md`
+**Blocks:** #2939 / #1400 (container agents) whenever a GUI is unavailable
+
+---
+
+## 1. The question, and the answer
+
+**Asked:** does the agent-facing App API let an agent (or any automation) launch
+an agent into a pane?
+
+**Answer: no.** The capability exists inside srv, but nothing an agent can reach
+exposes it.
+
+| Surface | Can it launch an agent? | Evidence |
+|---|---|---|
+| `agent.open` RPC | **Yes** — creates the block, seeds the resume session, registers the controller | `server/app_api/agent_open.rs:148`, `COMMAND_AGENT_OPEN = "agent.open"` (`rpc_types/commands.rs:333`) |
+| `/api/v1/*` HTTP (agent-facing, `X-AuthKey`) | **No such route** | Enumerated every `/api/v1/agent*` route: only `identity/*`, `memory/*`, `preset/*` |
+| MCP tools (55 exposed) | **No launch verb** | Full list from `agentmux-mcp/src/main.rs`; nearest is `NewTab`, which opens an *empty* tab |
+| `pane.open` (`/api/v1/pane/open`) | **No** — opens a *view* into a pane; does not create an agent or register a controller | `server/app_api/pane.rs` |
+
+`agent.open` is reachable only over the WebSocket RPC engine the **frontend**
+uses. It has no HTTP mapping and no MCP wrapper, so it is effectively
+GUI-only.
+
+### 1.1 How this was established
+
+Not by inspection alone. Against the live instance, using this agent's own
+`AGENTMUX_AUTH_KEY` / `AGENTMUX_LOCAL_URL`:
+
+- `GET /api/v1/self?block_id=…` → 200 with real block/tab/window/workspace ids,
+  proving the credential and the HTTP surface both work.
+- `GET /agentmux/reactive/agents` → `{"error":"unauthorized"}` — the reactive
+  routes take a *different* key, so raw curl is not a way around this.
+- `FleetList` → `Scouto` (`fb770209-…`) present with `addressable: false`,
+  `block_id: null`. Its container `agentmux-fb770209-…` has been **Up 5 days**.
+- `SendMessage → Scouto` → **`agent not found: Scouto`**.
+
+The last two together are the whole problem: a container agent can be running
+as a container, be visible in the directory, and still be unreachable — with no
+verb anywhere that would make it reachable.
+
+---
+
+## 2. Why it matters
+
+### 2.1 The lifecycle is asymmetric
+
+`FleetBulkStop` was deliberately extended to reach **cross-channel** targets
+(`SPEC_FLEET_BULK_STOP_CROSS_CHANNEL_2026_08_22.md`, "Implemented (cross-channel
+only)"). So today:
+
+> Automation can **stop** an agent in another channel. It cannot **start** an
+> agent anywhere — not cross-channel, not even in its own instance.
+
+That asymmetry is the finding. A destructive verb crossed the instance boundary
+before the constructive one existed at all.
+
+### 2.2 It blocks container agents specifically
+
+`agent not found` for `Scouto` is thrown at `backend/reactive/handler.rs:385` —
+the **registry lookup**, before any controller is consulted. A container agent
+with `block_id: null` is not in the delivery registry, so nothing can be
+injected into it.
+
+This is the third member of a known failure family, and the first two are fixed:
+
+| | Case | Status |
+|---|---|---|
+| #2930 | Subprocess agents dropped entirely | Fixed (for *running* agents) |
+| #2960 | Persistent agents that have not spawned | Fixed — spawn-on-demand |
+| — | **Container/subprocess agents with no block** | **Unfixed** |
+
+#2960's fix is persistent-only: the commit is *"deliver to persistent agents
+that have not spawned yet"* and all the "spawns on first message" machinery
+lives in `blockcontroller/persistent.rs`. There is no subprocess equivalent.
+
+**Consequence for #2939/#1400:** every headless verification of a container
+agent currently requires a human to open a pane first. On a machine where the
+GUI is in use by a person, that is not merely inconvenient — the work cannot
+proceed at all.
+
+### 2.3 The prior audit missed it
+
+`REPORT_CROSS_INSTANCE_CONTROL_ROBUSTNESS_AUDIT_2026_08_22.md` audited the four
+tiers and listed gaps 3.1–3.4 (broadcast reach, bulk-stop scope, muxspect
+Phase B/C, UI automation). It examined the control verbs that **exist** and
+never noted that no launch verb exists. Worth recording as a lesson: an audit
+scoped to "are the existing verbs correct?" will not surface "a verb is
+missing."
+
+---
+
+## 3. Proposal
+
+### 3.1 `agent.open` over the agent-facing HTTP surface
+
+Add `POST /api/v1/agent/open`, mapping to the same `agent_open` implementation
+the RPC command already calls — **not** a parallel implementation. `agent.open`
+carries real concurrency logic (the per-definition `AGENT_OPEN_LOCKS` guarding
+the check-live → seed-resume → create-block → register-controller sequence,
+added for the TOCTOU reagent flagged on #2059); a second code path would have to
+re-derive all of it.
+
+Request shape should mirror the RPC command's existing data type rather than
+inventing one, so the two cannot drift.
+
+### 3.2 An MCP verb
+
+Expose it as an MCP tool (working name `OpenAgent`) alongside `FleetList` /
+`SendMessage`. `FleetList` already returns exactly the identifiers such a call
+needs (`definition_id`, `block_id`, `addressable`, and per-target `channel` /
+`local_url` for cross-channel entries), so the discovery half is done.
+
+Minimum arguments: the target agent (by name or definition id), and an optional
+tab/workspace placement. Everything else should default to what the UI flow
+would do.
+
+### 3.3 Cross-tier reach
+
+The requirement is "openable on any instance, across any channel or the tiered
+networks." The tiers already have precedent to follow, and they are **not**
+equally ready:
+
+| Tier | Precedent | Assessment |
+|---|---|---|
+| **Same instance** | — | Straightforward: call the existing impl. |
+| **Cross-channel** (same host, different channel) | `FleetBulkStop` (implemented), `FleetBroadcast` | Follow the same resolution path. `FleetList.host.cross_channel[]` already yields each target's own `local_url`, so this is a forward to a sibling srv. |
+| **LAN** | `FleetBroadcast` cross-tier targeting; LAN peer visible in `FleetList.lan[]` with `auth_key` | Feasible, but see §4.1 — this is where opening stops resembling stopping. |
+| **WAN** | `wan.subscribed_agents`; muxbus | Deliberately deferred. `FleetBulkStop` deferred LAN/WAN too, for reasons that apply *more* strongly to a constructive verb. |
+
+**Recommendation: ship same-instance + cross-channel first; treat LAN as a
+second phase; do not do WAN in this work.** That mirrors the sequencing
+`FleetBulkStop` already chose, and each tier is independently useful.
+
+### 3.4 Auxiliary tooling
+
+- **`muxopen`** — a shell entry point beside `muxlog`/`muxspect`, for opening an
+  agent from a terminal without the GUI. `muxspect` already answers "what is
+  running"; this answers "make it run". Same core-invocation caveat applies
+  (`node ~/.agentmux/shell/muxopen.mjs` from a tool-spawned shell — see
+  `docs/MUXSPECT.md` and the known bare-function gap).
+- **`muxspect` cross-reference** — teach it to show `addressable` alongside
+  lifecycle, so "container up, agent unreachable" is visible in one place rather
+  than requiring `FleetList` + `docker ps` to be correlated by hand, as was
+  necessary to find this.
+- **A close/stop counterpart** already exists (`FleetBulkStop`, `/agentmux/agent/stop`);
+  no new work, but the pairing should be documented so the lifecycle reads as
+  symmetric.
+
+---
+
+## 4. Risks and open questions
+
+### 4.1 Opening is not the mirror image of stopping
+
+`FleetBulkStop`'s spec calls stopping "destructive" and scopes it carefully.
+Opening is destructive in a different, less obvious way: it **spawns a process,
+consumes provider tokens, and can bind credentials**. A remote open is closer to
+"execute code on that machine" than "stop something already running". The
+`ENFORCE_AGENT_BINDING` work (audit §4.2 — *"built, verified ~90%, never turned
+on"*) is directly relevant and should be settled before LAN/WAN, not after.
+
+### 4.2 Concurrency across instances is already unsolved
+
+`agent_open.rs`'s own doc: the `AGENT_OPEN_LOCKS` guard *"only serializes calls
+handled by THIS process — it can't see a genuinely different AgentMux
+instance/channel racing the same registry entry."* A cross-channel open verb
+makes that pre-existing race **reachable on purpose** rather than by accident.
+This needs an explicit decision — accept it, or add a cross-instance guard — and
+must not be discovered later.
+
+### 4.3 Unverified
+
+- That a *running* container agent is reachable via `SendMessage` (i.e. that
+  #2930 holds for containers). None of the four currently-addressable agents are
+  containers, and neither live container maps to an addressable agent, so this
+  was **not** confirmed — only the unspawned case was.
+- Whether opening an agent whose container predates #2933 triggers the
+  mount-drift recreate path (#2939 workstream 4, still unobserved in a real app).
+
+### 4.4 Deliberately not proposed
+
+- **Driving the GUI** (`UIClick`/`UIQuery`) to open a pane. It works, but it
+  mutates what a human sitting at the machine sees, which is precisely the
+  constraint that motivated this report.
+- **A second `agent.open` implementation** on the HTTP path. See §3.1.
+
+---
+
+## 5. Suggested order
+
+1. `POST /api/v1/agent/open` → existing impl, same instance only.
+2. MCP `OpenAgent` verb over it. **At this point the container work in #2939/#1400
+   is unblocked headlessly** — everything after is reach, not capability.
+3. Cross-channel reach, following `FleetBulkStop`'s resolution path.
+4. `muxopen` + the `muxspect` addressable column.
+5. LAN — only after §4.1 is settled.
+6. WAN — out of scope here.
+
+---
+
+## 6. Appendix: probe transcript
+
+```
+$ curl -H "X-AuthKey: $AGENTMUX_AUTH_KEY" "$AGENTMUX_LOCAL_URL/api/v1/self?block_id=$AGENTMUX_BLOCKID"
+{"block_id":"a7759b9c-…","tab_id":"24c454e9-…","window_id":"22e115ce-…",
+ "workspace_id":"f01e97cb-…","workspace_name":"Starter workspace"}
+
+$ curl "$AGENTMUX_LOCAL_URL/agentmux/reactive/agents"
+{"error":"unauthorized"}
+
+FleetList → Scouto: { addressable: false, block_id: null,
+                      definition_id: "fb770209-2029-4100-b01e-16fa89904cac" }
+
+$ docker ps -a --filter name=agentmux-
+agentmux-fb770209-2029-4100-b01e-16fa89904cac   Up 5 days   ghcr.io/agentmuxai/agent-claude:latest
+
+SendMessage(to: "Scouto") → Message delivery failed: agent not found: Scouto
+
+$ docker inspect agentmux-fb770209-… --format '{{range .Config.Env}}{{println .}}{{end}}'
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+CLAUDE_CONFIG_DIR=/home/agent/.claude
+      # no AGENTMUX_* env at all; no bashwrap on PATH; no /workspace mount
+      # (this container predates #2933)
+```


### PR DESCRIPTION
## Summary

Automation could **stop** an agent (`FleetBulkStop` reaches cross-channel targets) but could not **start** one anywhere — `agent.open` existed only on the frontend's WebSocket RPC engine, with no HTTP mapping and no MCP verb. A destructive verb crossed the instance boundary before the constructive one existed at all.

Found while working the container-agent effort (#2939/#1400) under a hard no-GUI constraint: `Scouto`'s container had been **Up 5 days**, visible in `FleetList`, and `SendMessage` still failed with `agent not found` — an unspawned agent isn't in the delivery registry, and nothing an agent could reach would open it. Full diagnosis + live probe transcript in the included `docs/reports/REPORT_AGENT_OPEN_API_GAP_2026_09_06.md`.

## What this adds (same-instance scope)

**1. `POST /api/v1/agent/open`** — the RPC closure's ~550-line body is extracted into `open_agent_impl`, and *both* surfaces call it. That keeps the `AGENT_OPEN_LOCKS` TOCTOU serialization (reagent P1, PR #2059), ABF provider shadowing, resume-session seeding guard, and CLI resolution in exactly one place — same extraction shape `open_pane`/`handle_pane_open` already uses. Caller-fault errors (`AGENT_NOT_FOUND`/`INVALID_PROVIDER`/`CLI_NOT_AVAILABLE`) map to 400, everything else 500.

**2. `OpenAgent` MCP tool** — `agent_id` (name or definition id), optional `tab_id`/`focus`. Wired into `tools/list` and the drift-check array, following `FleetBulkStop`'s request pattern exactly. Idempotent like the RPC path (`created: false` on an already-open agent).

**3. `muxopen`** — third sibling to `muxlog`/`muxspect`: deployed to `~/.agentmux/shell/muxopen.mjs` with bash/zsh/fish/pwsh functions. `parseArgs`/`renderResult` are exported pure and vitest-covered (same arrangement as `muxspect.test.mjs`, per reagent P1 on PR #2380). A 404 from an older srv gets an explicit *"this instance may predate /api/v1/agent/open"* hint.

## Deliberately deferred (report §3.3/§4.1)

Cross-channel, LAN and WAN reach. Opening is **not** the mirror image of stopping — a remote open spawns a process, consumes provider tokens, and can bind credentials, and `agent_open`'s own concurrency guard documents that it cannot see a different instance racing the same registry entry. Cross-channel should follow `FleetBulkStop`'s resolution path as a follow-up; LAN is gated on the `ENFORCE_AGENT_BINDING` decision.

## Verification

- [x] `cargo test -p agentmux-srv` — **3021 passed** (2 new: route is auth-gated; unknown agent → 400 carrying the impl's `AGENT_NOT_FOUND` vocabulary, not a 500)
- [x] `cargo check -p agentmux-mcp` — clean
- [x] `npx vitest run …/muxopen.test.mjs` — 9 passed
- [x] Deploy test extended: `muxopen.mjs` lands beside `muxlog.mjs`/`muxspect.mjs`
- [x] **Live smoke against the running v0.55.34**: `node muxopen.mjs Scouto` → the 404 version-hint path, exit 2 — which is also independent confirmation the route genuinely didn't exist before this PR
- [ ] Live successful open — requires a restarted srv carrying this route; will be exercised as the first step of the #2939/#1400 container work this unblocks

<!-- agentmux:agent_id=camper -->