### PR TITLE
fix(browser-pane): route pane nav-state/title/favicon events to the pane's owning window, not main

### DIFF
--- a/.changesets/1788731291-fix-browser-pane-route-pane-nav-state-title-favicon-events-t-upti.md
+++ b/.changesets/1788731291-fix-browser-pane-route-pane-nav-state-title-favicon-events-t-upti.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(browser-pane): route pane nav-state/title/favicon events to the pane's owning window, not main

--- a/agentmux-cef/src/browser_pane/callbacks.rs
+++ b/agentmux-cef/src/browser_pane/callbacks.rs
@@ -212,8 +212,9 @@ pub(crate) fn set_pane_main_frame_loading(
         loading,
         url,
     );
-    crate::events::emit_event_from_state(
+    crate::events::emit_browser_pane_event(
         state,
+        block_id,
         "browser-pane-nav-state",
         &serde_json::json!({
             "block_id": block_id,
@@ -532,8 +533,9 @@ pub fn on_load_end_browser_pane(state: &Arc<AppState>, browser: &Browser) {
             "[browser-pane:diag][{}] emit-nav-state url={:?} url_only=true",
             block_id_short, url,
         );
-        crate::events::emit_event_from_state(
+        crate::events::emit_browser_pane_event(
             state,
+            &block_id,
             "browser-pane-nav-state",
             &serde_json::json!({
                 "block_id": block_id,
@@ -613,8 +615,9 @@ pub fn on_loading_state_change_browser_pane(
             "[browser-pane:diag][{}] emit-nav-state url={:?} url_only=false is_loading={} (raw_cef_is_loading={}) can_back={} can_forward={}",
             block_id_short, url, corrected_is_loading, is_loading, can_go_back, can_go_forward,
         );
-        crate::events::emit_event_from_state(
+        crate::events::emit_browser_pane_event(
             state,
+            &block_id,
             "browser-pane-nav-state",
             &serde_json::json!({
                 "block_id": block_id,

--- a/agentmux-cef/src/client/display.rs
+++ b/agentmux-cef/src/client/display.rs
@@ -83,8 +83,9 @@ impl AgentMuxHandler {
                         block_id_short,
                         title_str,
                     );
-                    crate::events::emit_event_from_state(
+                    crate::events::emit_browser_pane_event(
                         &self.state,
+                        &block_id,
                         "browser-pane-title-change",
                         &serde_json::json!({ "block_id": block_id, "title": title_str }),
                     );
@@ -151,8 +152,9 @@ impl AgentMuxHandler {
             urls.len(),
             urls.first(),
         );
-        crate::events::emit_event_from_state(
+        crate::events::emit_browser_pane_event(
             &self.state,
+            &block_id,
             "browser-pane-favicon-urls",
             &serde_json::json!({ "block_id": block_id, "urls": urls }),
         );

--- a/agentmux-cef/src/events.rs
+++ b/agentmux-cef/src/events.rs
@@ -32,15 +32,23 @@ pub fn emit_event(browser: &Browser, event: &str, payload: &serde_json::Value) {
 
 /// Emit an event to the "main" browser stored in AppState.
 /// This is a convenience wrapper for use from command handlers and background tasks.
-pub fn emit_event_from_state(state: &crate::state::AppState, event: &str, payload: &serde_json::Value) {
+/// Returns whether a browser was found to deliver to.
+pub fn emit_event_from_state(
+    state: &crate::state::AppState,
+    event: &str,
+    payload: &serde_json::Value,
+) -> bool {
     // Phase H.2.b — reducer-aware lookup with fallback.
     if let Some(browser) = state.get_browser("main") {
         emit_event(&browser, event, payload);
+        true
     } else if let Some((_label, browser)) = state.first_browser() {
         // Fallback: emit to any available browser
         emit_event(&browser, event, payload);
+        true
     } else {
         tracing::warn!("Cannot emit event '{}': no browser handle in state", event);
+        false
     }
 }
 
@@ -142,8 +150,7 @@ pub fn emit_browser_pane_event(
                 block_id,
                 event
             );
-            emit_event_from_state(state, event, payload);
-            true
+            emit_event_from_state(state, event, payload)
         }
     }
 }

--- a/agentmux-cef/src/events.rs
+++ b/agentmux-cef/src/events.rs
@@ -103,3 +103,62 @@ pub fn emit_event_to_window(
         }
     }
 }
+
+/// Emit a browser-pane event to the top-level window that OWNS the pane.
+///
+/// `emit_event_from_state` always delivers into the window labelled `main`
+/// (first-available fallback). A pane living in any OTHER top-level window
+/// -- recreated in a promoted pool window after a tab tear-off, or opened
+/// directly in a second window -- has its view model in THAT window's
+/// renderer, so an event pushed to `main` is dropped on the floor: no
+/// listener for that `block_id` exists there, and no warning fires because
+/// `main` resolves fine. Symptom: the pane's loading overlay never clears
+/// and its address bar / tab title never update, while outbound navigation
+/// (request/response, window-agnostic) keeps working. PR #2597 fixed the
+/// same class of bug for `browser-pane-clicked` / shortcut / context-menu;
+/// this covers the remaining push sites (nav-state x3, title, favicon).
+///
+/// Falls back to the legacy `main` routing (with a warning) only when the
+/// pane has no reducer entry or its `window_label` is empty (the legacy
+/// `EnqueueBrowserPaneCreate` path), so nothing that worked before regresses.
+/// Returns whether a browser was found to deliver to.
+pub fn emit_browser_pane_event(
+    state: &crate::state::AppState,
+    block_id: &str,
+    event: &str,
+    payload: &serde_json::Value,
+) -> bool {
+    // Resolve under the lock, then DROP it before emitting: `emit_event_to_window`
+    // re-locks `host_state` for its own browser lookup.
+    let target = {
+        let host = state.host_state.lock();
+        browser_pane_event_target(&host, block_id)
+    };
+    match target {
+        Some(label) => emit_event_to_window(state, &label, event, payload),
+        None => {
+            tracing::warn!(
+                "[browser-pane] no owning window recorded for block_id={} -- falling back to legacy main-window routing for '{}'",
+                block_id,
+                event
+            );
+            emit_event_from_state(state, event, payload);
+            true
+        }
+    }
+}
+
+/// Pure routing decision behind `emit_browser_pane_event`: the label of the
+/// top-level window a pane's events must be delivered to, or `None` when the
+/// pane is unknown or recorded no window (caller falls back). Kept free of
+/// CEF handles so the reducer tests can pin it.
+pub(crate) fn browser_pane_event_target(
+    host: &crate::reducer::HostState,
+    block_id: &str,
+) -> Option<String> {
+    host.browser_panes
+        .get(block_id)
+        .map(|e| e.window_label.as_str())
+        .filter(|label| !label.is_empty())
+        .map(str::to_string)
+}

--- a/agentmux-cef/src/reducer/tests.rs
+++ b/agentmux-cef/src/reducer/tests.rs
@@ -1476,3 +1476,52 @@ fn reconcile_quit_poke_is_quit_relevant() {
     use super::is_quit_relevant;
     assert!(is_quit_relevant(&HostCommand::ReconcileQuit));
 }
+
+// ── Browser-pane host→JS event routing ──────────────────────────────────────
+// A pane's push events (nav-state / title-change / favicon-urls) must be
+// delivered to the top-level window that OWNS the pane, never blindly to
+// `main`: after a tab tear-off recreates the pane in a promoted pool window,
+// `main` has no listener for that block_id, the events are silently dropped,
+// and the pane's loading overlay never clears. See
+// docs/reports/REPORT_BROWSER_PANE_EVENTS_MISROUTED_TO_MAIN_WINDOW_2026_09_06.md.
+
+#[test]
+fn browser_pane_event_target_is_the_owning_window_not_main() {
+    let mut state = HostState::default();
+    // The reported repro: pane recreated in a promoted pool window while
+    // `main` is still alive.
+    let out = update(
+        &mut state,
+        HostCommand::TryRegisterBrowserPaneLive {
+            block_id: "b1".into(),
+            pending: Some(pending_in("window-pool-930b71ac")),
+        },
+    );
+    assert!(matches!(
+        out.browser_pane_register_result,
+        Some(RegisterResult::Fresh(_))
+    ));
+    assert_eq!(
+        crate::events::browser_pane_event_target(&state, "b1").as_deref(),
+        Some("window-pool-930b71ac"),
+    );
+}
+
+#[test]
+fn browser_pane_event_target_is_none_for_unknown_or_windowless_pane() {
+    let mut state = HostState::default();
+    assert_eq!(
+        crate::events::browser_pane_event_target(&state, "nope"),
+        None
+    );
+    // The legacy enqueue path records no window: the emitter must fall back
+    // to its previous behaviour rather than try to deliver to an empty label.
+    update(
+        &mut state,
+        browser_pane_request("legacy", "browser-pane-legacy-1"),
+    );
+    assert_eq!(
+        crate::events::browser_pane_event_target(&state, "legacy"),
+        None
+    );
+}

--- a/docs/reports/REPORT_BROWSER_PANE_EVENTS_MISROUTED_TO_MAIN_WINDOW_2026_09_06.md
+++ b/docs/reports/REPORT_BROWSER_PANE_EVENTS_MISROUTED_TO_MAIN_WINDOW_2026_09_06.md
@@ -1,0 +1,103 @@
+# REPORT — browser pane stuck on the loading brain after a tab tear-off: host events delivered to the wrong window
+
+**Date:** 2026-09-06
+**Author:** AgentX
+**Status:** root-caused and fixed in this repo's `main` (fix PR linked in §5). Not yet live-verified in the reporting instance — the fix is host-side (Rust) and needs a rebuilt host to take effect.
+**Instance:** `channel:local-main-b28b7a-2cd6e3d7`, v0.55.37, Windows 11.
+**Platform:** all — the misrouted call sites are platform-independent Rust.
+
+---
+
+## 1. The report, restated precisely
+
+The operator tore a tab containing a browser pane (claude.ai) off the main window into a second window. From then on the pane showed the loading "brain" overlay permanently. Typing a new URL in the address bar did navigate (the page behind the overlay changed), but the overlay never cleared, the address bar never updated to the landed URL, and the tab title stayed at the optimistic `claude.ai` rather than the page's real title. No error was shown and nothing crashed.
+
+## 2. What the logs proved before any code was read
+
+Host log: `~/.agentmux/channels/local-main-b28b7a-2cd6e3d7/versions/0.55.37/logs/agentmux-host-v0.55.37.log.2026-09-06`. Pane block `2ac146c2-097b-4a17-89b8-fc548e09f5b5` (`2ac146c` below).
+
+| Time | Side | Observation |
+|---|---|---|
+| 21:09:33 | host | Pane `2ac146c` created in window `main`, browser label `browser-pane-2ac146c2-…-1`. |
+| 21:09:33 → 21:24:45 | frontend | View model `yuurk6` in `main`'s renderer receives 42 `browser-pane-nav-state` events. Overlay behaves normally. |
+| 21:24:45 | host | `[dnd:cef] start_cross_drag drag_type=Tab source_window=main`. Pane closed in `main`; pool window promoted (`WindowInstanceAssigned num: 2`). |
+| 21:24:45 | host | Pane `2ac146c` re-registered with `window_label=window-pool-930b71ac8b86455eaf3a785f2f2e247d`, browser label `…-2`. |
+| 21:24:45.397 | frontend | `yuurk6` disposed cleanly; its listener unsubscribed. |
+| 21:24:45.906 | frontend | New view model `4az61e` constructed in window 2's renderer; subscribes to `browser-pane-nav-state`. |
+| 21:24:46 → 21:24:48 | host | Host emits `emit-nav-state … is_loading=false` and `emit-title-change title="Sign in - Claude"` for `2ac146c` — the host side is healthy and did finish the load. |
+| 21:24:46 → end | frontend | `4az61e` receives **zero** host events of any kind. Outbound `invokeCommand` (navigate) succeeds. |
+
+So the host produced the load-end; the pane's live view model never got it. The gap is delivery.
+
+## 3. Root cause
+
+All five host→page push sites for browser panes call `emit_event_from_state`
+(`agentmux-cef/src/events.rs`), which delivers to **the window labelled `main`**,
+falling back to "any browser" only if `main` is absent:
+
+| Site | Event |
+|---|---|
+| `agentmux-cef/src/browser_pane/callbacks.rs` (main-frame loading tracker) | `browser-pane-nav-state` |
+| `agentmux-cef/src/browser_pane/callbacks.rs` (`on_load_end`, url-only) | `browser-pane-nav-state` |
+| `agentmux-cef/src/browser_pane/callbacks.rs` (`on_loading_state_change`) | `browser-pane-nav-state` |
+| `agentmux-cef/src/client/display.rs` (`on_title_change`) | `browser-pane-title-change` |
+| `agentmux-cef/src/client/display.rs` (`on_favicon_urlchange`) | `browser-pane-favicon-urls` |
+
+After the tear-off the pane's view model lives in window 2's renderer. `main` still exists, so the lookup succeeds, `execute_java_script` runs in `main`'s renderer, and the `agentmux-event` `CustomEvent` fires there — where no view model for that `block_id` is subscribed any more. The event is dropped silently: no warning on the host (the target browser was found), no log on the frontend (nobody is listening).
+
+Why that presents as a stuck brain: `frontend/app/view/browser/browser-view.tsx` clears the overlay only on a true→false transition of the pane's `loadingAtom`, which is driven solely by the `is_loading` field of `browser-pane-nav-state`. Navigation still works because `invokeCommand` is request/response and window-agnostic — which is exactly the "navigates but never finishes" shape reported.
+
+The pane registry already knows the right answer. `HostState.browser_panes[block_id].window_label` is written by the reducer (`reducer/panes.rs`, `TryRegisterBrowserPaneLive`) before the CEF browser is created, and the log confirms it held `window-pool-930b71ac…` for the recreated pane. `AppState::browser_pane_window_label` exposes it. Nothing in the five sites consulted it.
+
+## 4. This is a known bug class that was half-fixed
+
+PR #2597 (2026-08) hit the identical problem for `browser-pane-clicked` and left this comment in `browser_pane/hwnd.rs`:
+
+> Route to the pane's ACTUAL owning window, not "main" — a pane torn off into its own floating window has its own JS context; `emit_event_from_state`'s "main"/first-available fallback delivered this to the wrong window (or none) for floating panes …
+
+It rerouted three events (click, shortcut, context menu) via `browser_pane_window_label` + `emit_event_to_window`. The five events that drive the loading overlay, address bar, title and favicon were never touched. `git log -S` puts the nav-state site's `emit_event_from_state` call at 2026-05-02 (#667), re-touched by #2642 (2026-08-17, brain-flicker fix) without changing the routing. **Not a 0.55.37 regression** — latent since May, surfacing whenever a browser pane lives in any window other than `main` while `main` is still open. Tear-off is the common way to get there; opening a browser widget directly in a second window hits the same path.
+
+## 5. Fix
+
+Host-side only; no frontend change (the frontend already filters by `block_id`).
+
+- New `events::emit_browser_pane_event(state, block_id, event, payload)`: resolves the pane's owning window from the reducer entry and delivers with `emit_event_to_window`. If the pane has no entry, or the entry's `window_label` is empty (the legacy `EnqueueBrowserPaneCreate` path, which has no production caller), it warns and falls back to the previous `main` routing so nothing that worked before regresses. The reducer lock is released before emitting, since `emit_event_to_window` re-locks it for its own lookup.
+- The routing decision is a pure function, `events::browser_pane_event_target(&HostState, block_id)`, so the reducer tests pin it without CEF handles.
+- All five sites above now call the new helper.
+- Targeted delivery was chosen over `emit_event_to_top_level_windows` deliberately: `state/mod.rs` documents that per-pane events are routed per-window so a hostile page in one pane cannot observe another pane's traffic, and broadcast would widen that.
+
+Tests added (`agentmux-cef/src/reducer/tests.rs`):
+- `browser_pane_event_target_is_the_owning_window_not_main` — pane registered in `window-pool-930b71ac` resolves to that label.
+- `browser_pane_event_target_is_none_for_unknown_or_windowless_pane` — unknown block and legacy empty-label entry both return `None` (fallback path).
+
+**Fix PR:** see the PR that introduced this report (linked below once opened).
+
+## 6. Workaround in a running unpatched instance
+
+The pane in the second window will never recover on its own. Drag the tab back into the main window, or close it and open a fresh browser pane there; events route correctly again because pane and `main` coincide.
+
+## 7. Open-issue canvas (browser pane, as of 2026-09-06)
+
+Surveyed all open issues in `agentmuxai/agentmux` for browser-pane topics (browser, brain, overlay, favicon, tear-off, floating, nav-state, address bar, webview, CEF, multi-window, title). **No open issue describes this symptom; the misrouting was untracked.**
+
+| # | Title | Relation to this root cause |
+|---|---|---|
+| #768 | Phantom browser pane (orphan + tearoff): host/frontend lifecycle divergence | **Possibly related.** Same scenario (browser panes landing in a second window and never coming alive) but attributed to HWND reparenting: "host reparented the HWNDs but frontend never re-handshook against the new chrome." Its last comment (07-11) says the repro predates pool-served tear-off and must be re-reproduced. **Re-test against this fix.** |
+| #2908 | Ctrl+Wheel zoom does not work in floating panes | Unrelated — input delivery into child-HWND floaters, not host→page routing. |
+| #2551 | OAuth sign-in popup sizing | Unrelated — Chrome-runtime popup. |
+| #1190 | Wire keyboard shortcuts (Ctrl+L/T/W/F) | Unrelated feature request; may be partly stale after #2597 shipped shortcut routing. |
+| #1569 | macOS/Linux orphan reconciler can't detect crash-orphans | Unrelated. |
+| #2873 | Tear-off silently fails when another floating pane sits under the drop point | Unrelated (DnD target resolution); multi-window. |
+| #3028 | Cold-path `open_new_window` creates a window that is never shown | Unrelated; open PR #3030 targets it. |
+
+Closed sibling: #1461 (redock black page) — HWND lifecycle, not event routing.
+No open PR touches `emit_event_from_state`, nav-state, title-change or favicon routing.
+
+## 8. Separate cosmetic finding
+
+The `{"isTrusted":true}` unhandled-rejection lines in the frontend log during this session are `favicon-load fail` for the claude.ai favicon. Cosmetic and unrelated to the overlay; not addressed here.
+
+## 9. Follow-ups
+
+- Live-verify in a rebuilt host: tear a browser-pane tab into a second window; overlay must clear, address bar and title must update. Then re-run #768's tear-off repro.
+- `emit_event_from_state` still has other callers outside the pane paths. Each is a candidate for the same class of bug if its payload is per-pane or per-window; worth a sweep, out of scope here.

--- a/docs/reports/REPORT_BROWSER_PANE_EVENTS_MISROUTED_TO_MAIN_WINDOW_2026_09_06.md
+++ b/docs/reports/REPORT_BROWSER_PANE_EVENTS_MISROUTED_TO_MAIN_WINDOW_2026_09_06.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-09-06
 **Author:** AgentX
-**Status:** root-caused; fix in PR #3035 (§5), pending review and merge. Not yet live-verified in the reporting instance — the fix is host-side (Rust) and needs a rebuilt host to take effect.
+**Status:** implemented — fix in PR #3035 (§5), pending review/merge. Not yet live-verified in the reporting instance — the fix is host-side (Rust) and needs a rebuilt host to take effect.
 **Instance:** `channel:local-main-b28b7a-2cd6e3d7`, v0.55.37, Windows 11.
 **Platform:** all — the misrouted call sites are platform-independent Rust.
 

--- a/docs/reports/REPORT_BROWSER_PANE_EVENTS_MISROUTED_TO_MAIN_WINDOW_2026_09_06.md
+++ b/docs/reports/REPORT_BROWSER_PANE_EVENTS_MISROUTED_TO_MAIN_WINDOW_2026_09_06.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-09-06
 **Author:** AgentX
-**Status:** root-caused and fixed in this repo's `main` (fix PR linked in §5). Not yet live-verified in the reporting instance — the fix is host-side (Rust) and needs a rebuilt host to take effect.
+**Status:** root-caused; fix in PR #3035 (§5), pending review and merge. Not yet live-verified in the reporting instance — the fix is host-side (Rust) and needs a rebuilt host to take effect.
 **Instance:** `channel:local-main-b28b7a-2cd6e3d7`, v0.55.37, Windows 11.
 **Platform:** all — the misrouted call sites are platform-independent Rust.
 
@@ -70,7 +70,7 @@ Tests added (`agentmux-cef/src/reducer/tests.rs`):
 - `browser_pane_event_target_is_the_owning_window_not_main` — pane registered in `window-pool-930b71ac` resolves to that label.
 - `browser_pane_event_target_is_none_for_unknown_or_windowless_pane` — unknown block and legacy empty-label entry both return `None` (fallback path).
 
-**Fix PR:** see the PR that introduced this report (linked below once opened).
+**Fix PR:** #3035 — https://github.com/agentmuxai/agentmux/pull/3035
 
 ## 6. Workaround in a running unpatched instance
 


### PR DESCRIPTION
## Summary

A browser pane torn off into a second window (or opened in any window other than `main`) gets stuck on the loading brain overlay forever: its address bar and tab title never update, while navigation itself still works. Root cause: the five host→page push sites for browser panes (`browser-pane-nav-state` ×3, `browser-pane-title-change`, `browser-pane-favicon-urls`) all used `emit_event_from_state`, which always delivers into the window labelled `main`. After a tear-off the pane's view model lives in the new window's renderer, so every event was dropped silently — `main` resolves fine, nobody there listens for that `block_id`.

Full diagnosis with the host/frontend log timeline, bisection, and an open-issue canvas: `docs/reports/REPORT_BROWSER_PANE_EVENTS_MISROUTED_TO_MAIN_WINDOW_2026_09_06.md` (in this PR).

## Fix

- New `events::emit_browser_pane_event(state, block_id, event, payload)`: resolves the pane's owning window from its reducer entry (`HostState.browser_panes[block_id].window_label`, written by `TryRegisterBrowserPaneLive` before the CEF browser exists) and delivers via `emit_event_to_window`. Falls back to the legacy `main` routing, with a warning, only when the pane has no entry or an empty `window_label` (the legacy enqueue path) — nothing that worked before regresses. The reducer lock is dropped before emitting since `emit_event_to_window` re-locks.
- The routing decision is a pure `browser_pane_event_target(&HostState, block_id)` so reducer tests can pin it without CEF handles.
- All five sites rerouted. Same shape PR #2597 used for `browser-pane-clicked` / shortcut / context-menu.
- Targeted delivery rather than broadcast to all top-level windows, on purpose: `state/mod.rs` documents per-window routing so a hostile page in one pane cannot observe another pane's traffic.

No frontend change — the frontend already filters by `block_id`.

## Not a 0.55.37 regression

`git log -S` dates the nav-state site's `emit_event_from_state` call to 2026-05-02 (#667); #2642 re-touched it without changing routing. Latent since May; surfaces whenever a browser pane lives outside `main` while `main` is still open.

## Tests

- `reducer::tests::browser_pane_event_target_is_the_owning_window_not_main` — pane registered in `window-pool-…` resolves to that label.
- `reducer::tests::browser_pane_event_target_is_none_for_unknown_or_windowless_pane` — unknown block and legacy empty-label entry both fall back.
- `cargo test -p agentmux-cef`: 391 passed.

## Follow-ups

- Live-verify in a rebuilt host (tear a browser-pane tab into a second window; overlay must clear, URL/title must update), then re-run #768's tear-off repro — its "black browsers in the new window" symptom was never re-reproduced on pool-served tear-off and may be this.
- `emit_event_from_state` has other callers outside the pane paths; any with per-pane/per-window payloads are candidates for the same bug. Out of scope here.

<!-- agentmux:agent_id=agentx -->
