### PR TITLE
Manoz@Area54: refactor(cef): one raw-TCP service_call transport for the ten backend_* helpers

### DIFF
--- a/.changesets/1788732819-refactor-cef-one-raw-tcp-service-call-transport-for-the-ten--4osj.md
+++ b/.changesets/1788732819-refactor-cef-one-raw-tcp-service-call-transport-for-the-ten--4osj.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(cef): one raw-TCP service_call transport for the ten backend_* helpers in client/helpers.rs

--- a/agentmux-cef/src/client/helpers.rs
+++ b/agentmux-cef/src/client/helpers.rs
@@ -384,6 +384,11 @@ pub(crate) fn backend_get_window_pos_and_size(web_endpoint: &str, auth_key: &str
     let width = data.get("winsize")?.get("width")?.as_i64()?;
     let height = data.get("winsize")?.get("height")?.as_i64()?;
     if width <= 0 || height <= 0 {
+        // Never-written Window.pos/winsize default to zero (Point/WinSize's
+        // #[derive(Default)]), which is indistinguishable from "this row
+        // predates the write-through" — treat a zero-or-negative size as
+        // "no real geometry persisted" rather than recreating a
+        // zero-sized window.
         return None;
     }
     Some(agentmux_common::ipc::Rect {
@@ -566,12 +571,12 @@ pub(crate) fn register_ipc_with_backend(
         Ok(r) if r.status_ok() => dlog("register_ipc_with_backend: srv acknowledged host_ipc.Register"),
         Ok(r) => tracing::error!(
             response = %r.first_line(),
-            "[register_ipc_with_backend] Register did not succeed — srv will not be able to proxy UI-automation calls to this host"
+            "[register_ipc_with_backend] host_ipc.Register did not succeed — srv will not be able to proxy UI-automation calls to this host"
         ),
         // A read failure used to fall through to the "(empty)" status line.
         Err(ServiceCallError::Read(_)) => tracing::error!(
             response = "(empty)",
-            "[register_ipc_with_backend] Register did not succeed — srv will not be able to proxy UI-automation calls to this host"
+            "[register_ipc_with_backend] host_ipc.Register did not succeed — srv will not be able to proxy UI-automation calls to this host"
         ),
         Err(ServiceCallError::Write(e)) => tracing::error!(
             error = %e,

--- a/agentmux-cef/src/client/helpers.rs
+++ b/agentmux-cef/src/client/helpers.rs
@@ -9,6 +9,7 @@
 /// `format!`. Used by the recovery page to inject the app URL for the
 /// Reload button's navigation target.
 use super::dlog;
+use super::service_call::{service_body, service_call, ServiceCallError};
 
 pub(crate) fn js_string_literal(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 2);
@@ -184,67 +185,34 @@ fn parse_web_endpoint(web_endpoint: &str, caller: &str) -> Option<std::net::Sock
 /// `WindowOpacityApplied`/`WindowOpacityCleared` distinction (the caller in
 /// `transparency.rs` maps `Cleared` to `None`, not `Some(1.0)`).
 pub(crate) fn backend_set_window_opacity(web_endpoint: &str, auth_key: &str, window_id: &str, opacity: Option<f32>) {
-    use std::io::Write;
-
     let Some(addr) = parse_web_endpoint(web_endpoint, "backend_set_window_opacity") else {
         return;
     };
-
-    let body = serde_json::json!({
-        "service": "window",
-        "method": "SetWindowOpacity",
-        "args": [window_id, opacity],
-        "uicontext": null,
-    })
-    .to_string();
-    let request = format!(
-        "POST /agentmux/service HTTP/1.1\r\n\
-         Host: 127.0.0.1\r\n\
-         X-AuthKey: {}\r\n\
-         Content-Type: application/json\r\n\
-         Content-Length: {}\r\n\
-         Connection: close\r\n\
-         \r\n\
-         {}",
-        auth_key, body.len(), body
-    );
-
-    let timeout = std::time::Duration::from_millis(2000);
-    match std::net::TcpStream::connect_timeout(&addr, timeout) {
-        Ok(mut stream) => {
-            stream.set_write_timeout(Some(timeout)).ok();
-            stream.set_read_timeout(Some(timeout)).ok();
-            if let Err(e) = stream.write_all(request.as_bytes()) {
-                tracing::warn!(
-                    window_id = %window_id,
-                    error = %e,
-                    "[backend_set_window_opacity] write failed — opacity mirror not persisted"
-                );
-                return;
-            }
-            // Drain the response so the connection closes cleanly; only the
-            // status line matters here (best-effort, unlike
-            // backend_close_window this isn't gating a user-visible retry).
-            use std::io::Read;
-            let mut resp = String::new();
-            let _ = stream.read_to_string(&mut resp);
-            let first_line = resp.lines().next().unwrap_or("(empty)");
-            if !first_line.contains(" 200 ") && !first_line.starts_with("HTTP/1.1 200") {
-                tracing::warn!(
-                    window_id = %window_id,
-                    response = %first_line,
-                    "[backend_set_window_opacity] SetWindowOpacity did not succeed — opacity mirror not persisted"
-                );
-            }
-        }
-        Err(e) => {
-            tracing::warn!(
-                window_id = %window_id,
-                addr = %addr,
-                error = %e,
-                "[backend_set_window_opacity] connect failed — opacity mirror not persisted"
-            );
-        }
+    let body = service_body("window", "SetWindowOpacity", serde_json::json!([window_id, opacity]));
+    match service_call(addr, auth_key, &body) {
+        Ok(r) if r.status_ok() => {}
+        Ok(r) => tracing::warn!(
+            window_id = %window_id,
+            response = %r.first_line(),
+            "[backend_set_window_opacity] SetWindowOpacity did not succeed — opacity mirror not persisted"
+        ),
+        // A read failure used to fall through to the "(empty)" status line.
+        Err(ServiceCallError::Read(_)) => tracing::warn!(
+            window_id = %window_id,
+            response = "(empty)",
+            "[backend_set_window_opacity] SetWindowOpacity did not succeed — opacity mirror not persisted"
+        ),
+        Err(ServiceCallError::Write(e)) => tracing::warn!(
+            window_id = %window_id,
+            error = %e,
+            "[backend_set_window_opacity] write failed — opacity mirror not persisted"
+        ),
+        Err(ServiceCallError::Connect(e)) => tracing::warn!(
+            window_id = %window_id,
+            addr = %addr,
+            error = %e,
+            "[backend_set_window_opacity] connect failed — opacity mirror not persisted"
+        ),
     }
 }
 
@@ -265,68 +233,38 @@ pub(crate) fn backend_set_window_opacity(web_endpoint: &str, auth_key: &str, win
 /// `Point`/`WinSize`) since the two crates don't share these types directly
 /// — the wire format is plain JSON either way.
 pub(crate) fn backend_set_window_pos_and_size(web_endpoint: &str, auth_key: &str, window_id: &str, rect: agentmux_common::ipc::Rect) {
-    use std::io::Write;
-
     let Some(addr) = parse_web_endpoint(web_endpoint, "backend_set_window_pos_and_size") else {
         return;
     };
-
-    let body = serde_json::json!({
-        "service": "window",
-        "method": "SetWindowPosAndSize",
-        "args": [
-            window_id,
-            { "x": rect.left, "y": rect.top },
-            { "width": rect.right - rect.left, "height": rect.bottom - rect.top },
-        ],
-        "uicontext": null,
-    })
-    .to_string();
-    let request = format!(
-        "POST /agentmux/service HTTP/1.1\r\n\
-         Host: 127.0.0.1\r\n\
-         X-AuthKey: {}\r\n\
-         Content-Type: application/json\r\n\
-         Content-Length: {}\r\n\
-         Connection: close\r\n\
-         \r\n\
-         {}",
-        auth_key, body.len(), body
-    );
-
-    let timeout = std::time::Duration::from_millis(2000);
-    match std::net::TcpStream::connect_timeout(&addr, timeout) {
-        Ok(mut stream) => {
-            stream.set_write_timeout(Some(timeout)).ok();
-            stream.set_read_timeout(Some(timeout)).ok();
-            if let Err(e) = stream.write_all(request.as_bytes()) {
-                tracing::warn!(
-                    window_id = %window_id,
-                    error = %e,
-                    "[backend_set_window_pos_and_size] write failed — position mirror not persisted"
-                );
-                return;
-            }
-            use std::io::Read;
-            let mut resp = String::new();
-            let _ = stream.read_to_string(&mut resp);
-            let first_line = resp.lines().next().unwrap_or("(empty)");
-            if !first_line.contains(" 200 ") && !first_line.starts_with("HTTP/1.1 200") {
-                tracing::warn!(
-                    window_id = %window_id,
-                    response = %first_line,
-                    "[backend_set_window_pos_and_size] SetWindowPosAndSize did not succeed — position mirror not persisted"
-                );
-            }
-        }
-        Err(e) => {
-            tracing::warn!(
-                window_id = %window_id,
-                addr = %addr,
-                error = %e,
-                "[backend_set_window_pos_and_size] connect failed — position mirror not persisted"
-            );
-        }
+    let body = service_body("window", "SetWindowPosAndSize", serde_json::json!([
+        window_id,
+        { "x": rect.left, "y": rect.top },
+        { "width": rect.right - rect.left, "height": rect.bottom - rect.top },
+    ]));
+    match service_call(addr, auth_key, &body) {
+        Ok(r) if r.status_ok() => {}
+        Ok(r) => tracing::warn!(
+            window_id = %window_id,
+            response = %r.first_line(),
+            "[backend_set_window_pos_and_size] SetWindowPosAndSize did not succeed — position mirror not persisted"
+        ),
+        // A read failure used to fall through to the "(empty)" status line.
+        Err(ServiceCallError::Read(_)) => tracing::warn!(
+            window_id = %window_id,
+            response = "(empty)",
+            "[backend_set_window_pos_and_size] SetWindowPosAndSize did not succeed — position mirror not persisted"
+        ),
+        Err(ServiceCallError::Write(e)) => tracing::warn!(
+            window_id = %window_id,
+            error = %e,
+            "[backend_set_window_pos_and_size] write failed — position mirror not persisted"
+        ),
+        Err(ServiceCallError::Connect(e)) => tracing::warn!(
+            window_id = %window_id,
+            addr = %addr,
+            error = %e,
+            "[backend_set_window_pos_and_size] connect failed — position mirror not persisted"
+        ),
     }
 }
 
@@ -349,64 +287,34 @@ pub(crate) fn backend_set_window_topology(
     kind: &str,
     parent_window_id: Option<&str>,
 ) {
-    use std::io::Write;
-
     let Some(addr) = parse_web_endpoint(web_endpoint, "backend_set_window_topology") else {
         return;
     };
-
-    let body = serde_json::json!({
-        "service": "window",
-        "method": "SetWindowTopology",
-        "args": [window_id, kind, parent_window_id],
-        "uicontext": null,
-    })
-    .to_string();
-    let request = format!(
-        "POST /agentmux/service HTTP/1.1\r\n\
-         Host: 127.0.0.1\r\n\
-         X-AuthKey: {}\r\n\
-         Content-Type: application/json\r\n\
-         Content-Length: {}\r\n\
-         Connection: close\r\n\
-         \r\n\
-         {}",
-        auth_key, body.len(), body
-    );
-
-    let timeout = std::time::Duration::from_millis(2000);
-    match std::net::TcpStream::connect_timeout(&addr, timeout) {
-        Ok(mut stream) => {
-            stream.set_write_timeout(Some(timeout)).ok();
-            stream.set_read_timeout(Some(timeout)).ok();
-            if let Err(e) = stream.write_all(request.as_bytes()) {
-                tracing::warn!(
-                    window_id = %window_id,
-                    error = %e,
-                    "[backend_set_window_topology] write failed — topology mirror not persisted"
-                );
-                return;
-            }
-            use std::io::Read;
-            let mut resp = String::new();
-            let _ = stream.read_to_string(&mut resp);
-            let first_line = resp.lines().next().unwrap_or("(empty)");
-            if !first_line.contains(" 200 ") && !first_line.starts_with("HTTP/1.1 200") {
-                tracing::warn!(
-                    window_id = %window_id,
-                    response = %first_line,
-                    "[backend_set_window_topology] SetWindowTopology did not succeed — topology mirror not persisted"
-                );
-            }
-        }
-        Err(e) => {
-            tracing::warn!(
-                window_id = %window_id,
-                addr = %addr,
-                error = %e,
-                "[backend_set_window_topology] connect failed — topology mirror not persisted"
-            );
-        }
+    let body = service_body("window", "SetWindowTopology", serde_json::json!([window_id, kind, parent_window_id]));
+    match service_call(addr, auth_key, &body) {
+        Ok(r) if r.status_ok() => {}
+        Ok(r) => tracing::warn!(
+            window_id = %window_id,
+            response = %r.first_line(),
+            "[backend_set_window_topology] SetWindowTopology did not succeed — topology mirror not persisted"
+        ),
+        // A read failure used to fall through to the "(empty)" status line.
+        Err(ServiceCallError::Read(_)) => tracing::warn!(
+            window_id = %window_id,
+            response = "(empty)",
+            "[backend_set_window_topology] SetWindowTopology did not succeed — topology mirror not persisted"
+        ),
+        Err(ServiceCallError::Write(e)) => tracing::warn!(
+            window_id = %window_id,
+            error = %e,
+            "[backend_set_window_topology] write failed — topology mirror not persisted"
+        ),
+        Err(ServiceCallError::Connect(e)) => tracing::warn!(
+            window_id = %window_id,
+            addr = %addr,
+            error = %e,
+            "[backend_set_window_topology] connect failed — topology mirror not persisted"
+        ),
     }
 }
 
@@ -423,53 +331,22 @@ pub(crate) fn backend_set_window_topology(
 /// identically, so there's no need to distinguish "srv has no value" from
 /// "couldn't reach srv" here.
 pub(crate) fn backend_get_window_opacity(web_endpoint: &str, auth_key: &str, window_id: &str) -> Option<f32> {
-    use std::io::Write;
-
     let addr = parse_web_endpoint(web_endpoint, "backend_get_window_opacity")?;
-
-    let body = serde_json::json!({
-        "service": "window",
-        "method": "GetWindow",
-        "args": [window_id],
-        "uicontext": null,
-    })
-    .to_string();
-    let request = format!(
-        "POST /agentmux/service HTTP/1.1\r\n\
-         Host: 127.0.0.1\r\n\
-         X-AuthKey: {}\r\n\
-         Content-Type: application/json\r\n\
-         Content-Length: {}\r\n\
-         Connection: close\r\n\
-         \r\n\
-         {}",
-        auth_key, body.len(), body
-    );
-
-    let timeout = std::time::Duration::from_millis(2000);
-    let mut stream = std::net::TcpStream::connect_timeout(&addr, timeout)
-        .map_err(|e| tracing::warn!(window_id = %window_id, error = %e, "[backend_get_window_opacity] connect failed"))
-        .ok()?;
-    stream.set_write_timeout(Some(timeout)).ok();
-    stream.set_read_timeout(Some(timeout)).ok();
-    stream
-        .write_all(request.as_bytes())
-        .map_err(|e| tracing::warn!(window_id = %window_id, error = %e, "[backend_get_window_opacity] write failed"))
-        .ok()?;
-
-    use std::io::Read;
-    let mut resp = String::new();
-    stream.read_to_string(&mut resp).ok()?;
-
-    // Split the raw HTTP/1.1 response into headers and body on the blank
-    // line (matches the request format written above — no chunked
-    // encoding involved, srv's axum response is a single JSON payload).
-    let body_str = resp.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("");
-    let parsed: serde_json::Value = serde_json::from_str(body_str).ok()?;
-    if parsed.get("success").and_then(|v| v.as_bool()) != Some(true) {
-        return None;
-    }
-    parsed.get("data")?.get("opacity")?.as_f64().map(|o| o as f32)
+    let body = service_body("window", "GetWindow", serde_json::json!([window_id]));
+    let data = match service_call(addr, auth_key, &body) {
+        Ok(r) => r.data_if_success()?,
+        Err(ServiceCallError::Connect(e)) => {
+            tracing::warn!(window_id = %window_id, error = %e, "[backend_get_window_opacity] connect failed");
+            return None;
+        }
+        Err(ServiceCallError::Write(e)) => {
+            tracing::warn!(window_id = %window_id, error = %e, "[backend_get_window_opacity] write failed");
+            return None;
+        }
+        // A read failure returned None silently before, too.
+        Err(ServiceCallError::Read(_)) => return None,
+    };
+    data.get("opacity")?.as_f64().map(|o| o as f32)
 }
 
 /// Read back the last-persisted position/size for `window_id` from srv —
@@ -487,60 +364,26 @@ pub(crate) fn backend_get_window_opacity(web_endpoint: &str, auth_key: &str, win
 /// `open_window_with_kind`), same as it does today when this function
 /// doesn't exist at all.
 pub(crate) fn backend_get_window_pos_and_size(web_endpoint: &str, auth_key: &str, window_id: &str) -> Option<agentmux_common::ipc::Rect> {
-    use std::io::Write;
-
     let addr = parse_web_endpoint(web_endpoint, "backend_get_window_pos_and_size")?;
-
-    let body = serde_json::json!({
-        "service": "window",
-        "method": "GetWindow",
-        "args": [window_id],
-        "uicontext": null,
-    })
-    .to_string();
-    let request = format!(
-        "POST /agentmux/service HTTP/1.1\r\n\
-         Host: 127.0.0.1\r\n\
-         X-AuthKey: {}\r\n\
-         Content-Type: application/json\r\n\
-         Content-Length: {}\r\n\
-         Connection: close\r\n\
-         \r\n\
-         {}",
-        auth_key, body.len(), body
-    );
-
-    let timeout = std::time::Duration::from_millis(2000);
-    let mut stream = std::net::TcpStream::connect_timeout(&addr, timeout)
-        .map_err(|e| tracing::warn!(window_id = %window_id, error = %e, "[backend_get_window_pos_and_size] connect failed"))
-        .ok()?;
-    stream.set_write_timeout(Some(timeout)).ok();
-    stream.set_read_timeout(Some(timeout)).ok();
-    stream
-        .write_all(request.as_bytes())
-        .map_err(|e| tracing::warn!(window_id = %window_id, error = %e, "[backend_get_window_pos_and_size] write failed"))
-        .ok()?;
-
-    use std::io::Read;
-    let mut resp = String::new();
-    stream.read_to_string(&mut resp).ok()?;
-
-    let body_str = resp.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("");
-    let parsed: serde_json::Value = serde_json::from_str(body_str).ok()?;
-    if parsed.get("success").and_then(|v| v.as_bool()) != Some(true) {
-        return None;
-    }
-    let data = parsed.get("data")?;
+    let body = service_body("window", "GetWindow", serde_json::json!([window_id]));
+    let data = match service_call(addr, auth_key, &body) {
+        Ok(r) => r.data_if_success()?,
+        Err(ServiceCallError::Connect(e)) => {
+            tracing::warn!(window_id = %window_id, error = %e, "[backend_get_window_pos_and_size] connect failed");
+            return None;
+        }
+        Err(ServiceCallError::Write(e)) => {
+            tracing::warn!(window_id = %window_id, error = %e, "[backend_get_window_pos_and_size] write failed");
+            return None;
+        }
+        // A read failure returned None silently before, too.
+        Err(ServiceCallError::Read(_)) => return None,
+    };
     let x = data.get("pos")?.get("x")?.as_i64()?;
     let y = data.get("pos")?.get("y")?.as_i64()?;
     let width = data.get("winsize")?.get("width")?.as_i64()?;
     let height = data.get("winsize")?.get("height")?.as_i64()?;
     if width <= 0 || height <= 0 {
-        // Never-written Window.pos/winsize default to zero (Point/WinSize's
-        // #[derive(Default)]), which is indistinguishable from "this row
-        // predates the write-through" — treat a zero-or-negative size as
-        // "no real geometry persisted" rather than recreating a
-        // zero-sized window.
         return None;
     }
     Some(agentmux_common::ipc::Rect {
@@ -558,50 +401,22 @@ pub(crate) fn backend_get_window_pos_and_size(web_endpoint: &str, auth_key: &str
 /// MUST invoke this off the UI thread (`reproject_from_srv` spawns a
 /// `std::thread`, mirroring `register_backend_window`'s write-through).
 pub(crate) fn backend_get_client_window_ids(web_endpoint: &str, auth_key: &str) -> Option<Vec<String>> {
-    use std::io::Write;
-
     let addr = parse_web_endpoint(web_endpoint, "backend_get_client_window_ids")?;
-
-    let body = serde_json::json!({
-        "service": "client",
-        "method": "GetClientData",
-        "args": [],
-        "uicontext": null,
-    })
-    .to_string();
-    let request = format!(
-        "POST /agentmux/service HTTP/1.1\r\n\
-         Host: 127.0.0.1\r\n\
-         X-AuthKey: {}\r\n\
-         Content-Type: application/json\r\n\
-         Content-Length: {}\r\n\
-         Connection: close\r\n\
-         \r\n\
-         {}",
-        auth_key, body.len(), body
-    );
-
-    let timeout = std::time::Duration::from_millis(2000);
-    let mut stream = std::net::TcpStream::connect_timeout(&addr, timeout)
-        .map_err(|e| tracing::warn!(error = %e, "[backend_get_client_window_ids] connect failed"))
-        .ok()?;
-    stream.set_write_timeout(Some(timeout)).ok();
-    stream.set_read_timeout(Some(timeout)).ok();
-    stream
-        .write_all(request.as_bytes())
-        .map_err(|e| tracing::warn!(error = %e, "[backend_get_client_window_ids] write failed"))
-        .ok()?;
-
-    use std::io::Read;
-    let mut resp = String::new();
-    stream.read_to_string(&mut resp).ok()?;
-
-    let body_str = resp.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("");
-    let parsed: serde_json::Value = serde_json::from_str(body_str).ok()?;
-    if parsed.get("success").and_then(|v| v.as_bool()) != Some(true) {
-        return None;
-    }
-    let ids = parsed.get("data")?.get("windowids")?.as_array()?;
+    let body = service_body("client", "GetClientData", serde_json::json!([]));
+    let data = match service_call(addr, auth_key, &body) {
+        Ok(r) => r.data_if_success()?,
+        Err(ServiceCallError::Connect(e)) => {
+            tracing::warn!(error = %e, "[backend_get_client_window_ids] connect failed");
+            return None;
+        }
+        Err(ServiceCallError::Write(e)) => {
+            tracing::warn!(error = %e, "[backend_get_client_window_ids] write failed");
+            return None;
+        }
+        // A read failure returned None silently before, too.
+        Err(ServiceCallError::Read(_)) => return None,
+    };
+    let ids = data.get("windowids")?.as_array()?;
     Some(
         ids.iter()
             .filter_map(|v| v.as_str().map(str::to_string))
@@ -620,50 +435,22 @@ pub(crate) fn backend_find_window_by_label(
     auth_key: &str,
     label: &str,
 ) -> Option<Vec<String>> {
-    use std::io::Write;
-
     let addr = parse_web_endpoint(web_endpoint, "backend_find_window_by_label")?;
-
-    let body = serde_json::json!({
-        "service": "window",
-        "method": "FindWindowByLabel",
-        "args": [label],
-        "uicontext": null,
-    })
-    .to_string();
-    let request = format!(
-        "POST /agentmux/service HTTP/1.1\r\n\
-         Host: 127.0.0.1\r\n\
-         X-AuthKey: {}\r\n\
-         Content-Type: application/json\r\n\
-         Content-Length: {}\r\n\
-         Connection: close\r\n\
-         \r\n\
-         {}",
-        auth_key, body.len(), body
-    );
-
-    let timeout = std::time::Duration::from_millis(2000);
-    let mut stream = std::net::TcpStream::connect_timeout(&addr, timeout)
-        .map_err(|e| tracing::warn!(error = %e, "[backend_find_window_by_label] connect failed"))
-        .ok()?;
-    stream.set_write_timeout(Some(timeout)).ok();
-    stream.set_read_timeout(Some(timeout)).ok();
-    stream
-        .write_all(request.as_bytes())
-        .map_err(|e| tracing::warn!(error = %e, "[backend_find_window_by_label] write failed"))
-        .ok()?;
-
-    use std::io::Read;
-    let mut resp = String::new();
-    stream.read_to_string(&mut resp).ok()?;
-
-    let body_str = resp.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("");
-    let parsed: serde_json::Value = serde_json::from_str(body_str).ok()?;
-    if parsed.get("success").and_then(|v| v.as_bool()) != Some(true) {
-        return None;
-    }
-    let ids = parsed.get("data")?.as_array()?;
+    let body = service_body("window", "FindWindowByLabel", serde_json::json!([label]));
+    let data = match service_call(addr, auth_key, &body) {
+        Ok(r) => r.data_if_success()?,
+        Err(ServiceCallError::Connect(e)) => {
+            tracing::warn!(error = %e, "[backend_find_window_by_label] connect failed");
+            return None;
+        }
+        Err(ServiceCallError::Write(e)) => {
+            tracing::warn!(error = %e, "[backend_find_window_by_label] write failed");
+            return None;
+        }
+        // A read failure returned None silently before, too.
+        Err(ServiceCallError::Read(_)) => return None,
+    };
+    let ids = data.as_array()?;
     Some(
         ids.iter()
             .filter_map(|v| v.as_str().map(str::to_string))
@@ -679,50 +466,21 @@ pub(crate) fn backend_get_window_topology(
     auth_key: &str,
     window_id: &str,
 ) -> Option<(Option<String>, Option<String>)> {
-    use std::io::Write;
-
     let addr = parse_web_endpoint(web_endpoint, "backend_get_window_topology")?;
-
-    let body = serde_json::json!({
-        "service": "window",
-        "method": "GetWindow",
-        "args": [window_id],
-        "uicontext": null,
-    })
-    .to_string();
-    let request = format!(
-        "POST /agentmux/service HTTP/1.1\r\n\
-         Host: 127.0.0.1\r\n\
-         X-AuthKey: {}\r\n\
-         Content-Type: application/json\r\n\
-         Content-Length: {}\r\n\
-         Connection: close\r\n\
-         \r\n\
-         {}",
-        auth_key, body.len(), body
-    );
-
-    let timeout = std::time::Duration::from_millis(2000);
-    let mut stream = std::net::TcpStream::connect_timeout(&addr, timeout)
-        .map_err(|e| tracing::warn!(window_id = %window_id, error = %e, "[backend_get_window_topology] connect failed"))
-        .ok()?;
-    stream.set_write_timeout(Some(timeout)).ok();
-    stream.set_read_timeout(Some(timeout)).ok();
-    stream
-        .write_all(request.as_bytes())
-        .map_err(|e| tracing::warn!(window_id = %window_id, error = %e, "[backend_get_window_topology] write failed"))
-        .ok()?;
-
-    use std::io::Read;
-    let mut resp = String::new();
-    stream.read_to_string(&mut resp).ok()?;
-
-    let body_str = resp.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("");
-    let parsed: serde_json::Value = serde_json::from_str(body_str).ok()?;
-    if parsed.get("success").and_then(|v| v.as_bool()) != Some(true) {
-        return None;
-    }
-    let data = parsed.get("data")?;
+    let body = service_body("window", "GetWindow", serde_json::json!([window_id]));
+    let data = match service_call(addr, auth_key, &body) {
+        Ok(r) => r.data_if_success()?,
+        Err(ServiceCallError::Connect(e)) => {
+            tracing::warn!(window_id = %window_id, error = %e, "[backend_get_window_topology] connect failed");
+            return None;
+        }
+        Err(ServiceCallError::Write(e)) => {
+            tracing::warn!(window_id = %window_id, error = %e, "[backend_get_window_topology] write failed");
+            return None;
+        }
+        // A read failure returned None silently before, too.
+        Err(ServiceCallError::Read(_)) => return None,
+    };
     let kind = data.get("kind").and_then(|v| v.as_str()).map(str::to_string);
     let parent_window_id = data.get("parent_window_id").and_then(|v| v.as_str()).map(str::to_string);
     Some((kind, parent_window_id))
@@ -743,65 +501,35 @@ pub(crate) fn backend_get_window_topology(
 /// triggering. No debounce (unlike opacity): this fires once per button
 /// click, not once per drag tick, so there's no burst to collapse.
 pub(crate) fn backend_update_block_meta(web_endpoint: &str, auth_key: &str, block_id: &str, meta_patch: serde_json::Value) {
-    use std::io::Write;
-
     let Some(addr) = parse_web_endpoint(web_endpoint, "backend_update_block_meta") else {
         return;
     };
-
     let oref = format!("block:{block_id}");
-    let body = serde_json::json!({
-        "service": "object",
-        "method": "UpdateObjectMeta",
-        "args": [oref, meta_patch],
-        "uicontext": null,
-    })
-    .to_string();
-    let request = format!(
-        "POST /agentmux/service HTTP/1.1\r\n\
-         Host: 127.0.0.1\r\n\
-         X-AuthKey: {}\r\n\
-         Content-Type: application/json\r\n\
-         Content-Length: {}\r\n\
-         Connection: close\r\n\
-         \r\n\
-         {}",
-        auth_key, body.len(), body
-    );
-
-    let timeout = std::time::Duration::from_millis(2000);
-    match std::net::TcpStream::connect_timeout(&addr, timeout) {
-        Ok(mut stream) => {
-            stream.set_write_timeout(Some(timeout)).ok();
-            stream.set_read_timeout(Some(timeout)).ok();
-            if let Err(e) = stream.write_all(request.as_bytes()) {
-                tracing::warn!(
-                    block_id = %block_id,
-                    error = %e,
-                    "[backend_update_block_meta] write failed — floating-pane placement not persisted"
-                );
-                return;
-            }
-            use std::io::Read;
-            let mut resp = String::new();
-            let _ = stream.read_to_string(&mut resp);
-            let first_line = resp.lines().next().unwrap_or("(empty)");
-            if !first_line.contains(" 200 ") && !first_line.starts_with("HTTP/1.1 200") {
-                tracing::warn!(
-                    block_id = %block_id,
-                    response = %first_line,
-                    "[backend_update_block_meta] UpdateObjectMeta did not succeed — floating-pane placement not persisted"
-                );
-            }
-        }
-        Err(e) => {
-            tracing::warn!(
-                block_id = %block_id,
-                addr = %addr,
-                error = %e,
-                "[backend_update_block_meta] connect failed — floating-pane placement not persisted"
-            );
-        }
+    let body = service_body("object", "UpdateObjectMeta", serde_json::json!([oref, meta_patch]));
+    match service_call(addr, auth_key, &body) {
+        Ok(r) if r.status_ok() => {}
+        Ok(r) => tracing::warn!(
+            block_id = %block_id,
+            response = %r.first_line(),
+            "[backend_update_block_meta] UpdateObjectMeta did not succeed — floating-pane placement not persisted"
+        ),
+        // A read failure used to fall through to the "(empty)" status line.
+        Err(ServiceCallError::Read(_)) => tracing::warn!(
+            block_id = %block_id,
+            response = "(empty)",
+            "[backend_update_block_meta] UpdateObjectMeta did not succeed — floating-pane placement not persisted"
+        ),
+        Err(ServiceCallError::Write(e)) => tracing::warn!(
+            block_id = %block_id,
+            error = %e,
+            "[backend_update_block_meta] write failed — floating-pane placement not persisted"
+        ),
+        Err(ServiceCallError::Connect(e)) => tracing::warn!(
+            block_id = %block_id,
+            addr = %addr,
+            error = %e,
+            "[backend_update_block_meta] connect failed — floating-pane placement not persisted"
+        ),
     }
 }
 
@@ -830,65 +558,29 @@ pub(crate) fn register_ipc_with_backend(
     ipc_token: &str,
     host_reg_secret: &str,
 ) {
-    use std::io::Write;
-
     let Some(addr) = parse_web_endpoint(web_endpoint, "register_ipc_with_backend") else {
         return;
     };
-
-    let body = serde_json::json!({
-        "service": "host_ipc",
-        "method": "Register",
-        "args": [ipc_port, ipc_token, host_reg_secret],
-        "uicontext": null,
-    })
-    .to_string();
-    let request = format!(
-        "POST /agentmux/service HTTP/1.1\r\n\
-         Host: 127.0.0.1\r\n\
-         X-AuthKey: {}\r\n\
-         Content-Type: application/json\r\n\
-         Content-Length: {}\r\n\
-         Connection: close\r\n\
-         \r\n\
-         {}",
-        auth_key, body.len(), body
-    );
-
-    let timeout = std::time::Duration::from_millis(2000);
-    match std::net::TcpStream::connect_timeout(&addr, timeout) {
-        Ok(mut stream) => {
-            stream.set_write_timeout(Some(timeout)).ok();
-            stream.set_read_timeout(Some(timeout)).ok();
-            if let Err(e) = stream.write_all(request.as_bytes()) {
-                tracing::error!(
-                    error = %e,
-                    "[register_ipc_with_backend] write failed — srv will not be able to \
-                     proxy UI-automation calls to this host until a future retry succeeds"
-                );
-                return;
-            }
-            use std::io::Read;
-            let mut resp = String::new();
-            let _ = stream.read_to_string(&mut resp);
-            let first_line = resp.lines().next().unwrap_or("(empty)");
-            if first_line.contains(" 200 ") || first_line.starts_with("HTTP/1.1 200") {
-                dlog("register_ipc_with_backend: srv acknowledged host_ipc.Register");
-            } else {
-                tracing::error!(
-                    response = %first_line,
-                    "[register_ipc_with_backend] host_ipc.Register did not succeed — \
-                     srv will not be able to proxy UI-automation calls to this host"
-                );
-            }
-        }
-        Err(e) => {
-            tracing::error!(
-                addr = %addr,
-                error = %e,
-                "[register_ipc_with_backend] connect failed — srv will not be able to \
-                 proxy UI-automation calls to this host until a future retry succeeds"
-            );
-        }
+    let body = service_body("host_ipc", "Register", serde_json::json!([ipc_port, ipc_token, host_reg_secret]));
+    match service_call(addr, auth_key, &body) {
+        Ok(r) if r.status_ok() => dlog("register_ipc_with_backend: srv acknowledged host_ipc.Register"),
+        Ok(r) => tracing::error!(
+            response = %r.first_line(),
+            "[register_ipc_with_backend] Register did not succeed — srv will not be able to proxy UI-automation calls to this host"
+        ),
+        // A read failure used to fall through to the "(empty)" status line.
+        Err(ServiceCallError::Read(_)) => tracing::error!(
+            response = "(empty)",
+            "[register_ipc_with_backend] Register did not succeed — srv will not be able to proxy UI-automation calls to this host"
+        ),
+        Err(ServiceCallError::Write(e)) => tracing::error!(
+            error = %e,
+            "[register_ipc_with_backend] write failed — srv will not be able to proxy UI-automation calls to this host until a future retry succeeds"
+        ),
+        Err(ServiceCallError::Connect(e)) => tracing::error!(
+            addr = %addr,
+            error = %e,
+            "[register_ipc_with_backend] connect failed — srv will not be able to proxy UI-automation calls to this host until a future retry succeeds"
+        ),
     }
 }

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -52,6 +52,9 @@ const MEMORY_PAUSE_WINDOW: Duration = Duration::from_secs(30);
 mod handlers;
 pub(crate) mod helpers;
 mod lifecycle;
+// The one raw-TCP `/agentmux/service` transport `helpers.rs`'s backend_*
+// wrappers share — see service_call.rs's module doc.
+mod service_call;
 mod display;
 pub(crate) mod navigation;
 mod crash_recovery;

--- a/agentmux-cef/src/client/service_call.rs
+++ b/agentmux-cef/src/client/service_call.rs
@@ -1,0 +1,228 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The one raw-TCP `POST /agentmux/service` transport the host uses to
+//! reach srv from contexts that have no async runtime — CEF lifecycle
+//! callbacks, background `std::thread`s, `spawn_blocking` bodies.
+//!
+//! Before this module, `client/helpers.rs` carried **eleven** hand-rolled
+//! copies of the same sequence — build a `{service, method, args,
+//! uicontext}` JSON body, format an HTTP/1.1 request with `X-AuthKey`,
+//! `connect_timeout` 2000 ms, set both timeouts, `write_all`,
+//! `read_to_string` — one ~25-line block repeated per function, and the
+//! largest single-file duplication cluster in the Rust workspace
+//! (`docs/reports/REPORT_DRY_AND_MODULARITY_AUDIT_2026_09_06.md` §3.2).
+//!
+//! **This module owns the transport only.** It deliberately does *no*
+//! logging: every caller keeps its own `tracing::warn!`/`error!` lines
+//! byte-for-byte, because several of those messages are operator-facing
+//! and cited by specs and retros (e.g. the `backend_close_window` wording
+//! in `SPEC_WINDOW_LIFECYCLE_CLOSE_RELIABILITY_2026_07_04.md`). The error
+//! enum is granular so a caller can log connect vs. write vs. read
+//! failures exactly as it did before — the pre-existing copies were not
+//! uniform on that point (setters ignored read errors and then reported
+//! the empty status line as "did not succeed"; getters returned `None`
+//! silently), and that asymmetry is preserved by the callers, not
+//! flattened here.
+//!
+//! `backend_close_window` is intentionally **not** routed through here:
+//! it interleaves `dlog` tracing between the write and the read and
+//! escalates to `error!`, and it is the one call gating a user-visible
+//! close path. Leaving it self-contained keeps its reliability story
+//! reviewable on its own.
+
+use std::io::{self, Read, Write};
+use std::net::{SocketAddr, TcpStream};
+use std::time::Duration;
+
+/// Connect / write / read budget, each. Matches every prior copy.
+const TIMEOUT: Duration = Duration::from_millis(2000);
+
+/// Where the round-trip failed. `Read` is separate from the others on
+/// purpose — see the module doc for why callers treat it differently.
+#[derive(Debug)]
+pub(crate) enum ServiceCallError {
+    Connect(io::Error),
+    Write(io::Error),
+    Read(io::Error),
+}
+
+impl std::fmt::Display for ServiceCallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Connect(e) => write!(f, "connect failed: {e}"),
+            Self::Write(e) => write!(f, "write failed: {e}"),
+            Self::Read(e) => write!(f, "read failed: {e}"),
+        }
+    }
+}
+
+/// The raw HTTP/1.1 response, plus the two views every caller wanted.
+#[derive(Debug)]
+pub(crate) struct ServiceResponse {
+    pub(crate) raw: String,
+}
+
+impl ServiceResponse {
+    /// The status line, or `"(empty)"` — the exact placeholder the prior
+    /// copies logged when srv sent nothing back.
+    pub(crate) fn first_line(&self) -> &str {
+        self.raw.lines().next().unwrap_or("(empty)")
+    }
+
+    /// The same 200-check every prior copy performed.
+    pub(crate) fn status_ok(&self) -> bool {
+        let l = self.first_line();
+        l.contains(" 200 ") || l.starts_with("HTTP/1.1 200")
+    }
+
+    /// The JSON `data` field of a `{ "success": true, "data": … }` reply,
+    /// or `None` if the body is missing, unparseable, or `success` is not
+    /// exactly `true`. Splits headers from body on the blank line — the
+    /// request is `Connection: close` with no chunked encoding, so srv's
+    /// axum reply is one JSON payload after the headers.
+    pub(crate) fn data_if_success(&self) -> Option<serde_json::Value> {
+        let body = self.raw.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("");
+        let parsed: serde_json::Value = serde_json::from_str(body).ok()?;
+        if parsed.get("success").and_then(|v| v.as_bool()) != Some(true) {
+            return None;
+        }
+        parsed.get("data").cloned()
+    }
+}
+
+/// Build the `/agentmux/service` request body. `uicontext` is always
+/// `null` from the host — it has no UI context of its own to attach.
+pub(crate) fn service_body(service: &str, method: &str, args: serde_json::Value) -> String {
+    serde_json::json!({
+        "service": service,
+        "method": method,
+        "args": args,
+        "uicontext": null,
+    })
+    .to_string()
+}
+
+/// One blocking round-trip. Callers resolve `addr` first (see
+/// `helpers::parse_web_endpoint`) so an unparseable endpoint is reported
+/// by the caller's own message, as before.
+pub(crate) fn service_call(
+    addr: SocketAddr,
+    auth_key: &str,
+    body: &str,
+) -> Result<ServiceResponse, ServiceCallError> {
+    // Auth via the X-AuthKey HEADER. The legacy `?authkey=` query param
+    // was deliberately disabled for HTTP routes in the 2026-05-11
+    // security audit (srv test `auth_rejects_query_param_on_http_routes`;
+    // only /ws still honors it).
+    let request = format!(
+        "POST /agentmux/service HTTP/1.1\r\n\
+         Host: 127.0.0.1\r\n\
+         X-AuthKey: {}\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {}",
+        auth_key,
+        body.len(),
+        body
+    );
+
+    let mut stream = TcpStream::connect_timeout(&addr, TIMEOUT).map_err(ServiceCallError::Connect)?;
+    stream.set_write_timeout(Some(TIMEOUT)).ok();
+    stream.set_read_timeout(Some(TIMEOUT)).ok();
+    stream
+        .write_all(request.as_bytes())
+        .map_err(ServiceCallError::Write)?;
+
+    let mut raw = String::new();
+    stream.read_to_string(&mut raw).map_err(ServiceCallError::Read)?;
+    Ok(ServiceResponse { raw })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+
+    fn resp(raw: &str) -> ServiceResponse {
+        ServiceResponse { raw: raw.to_string() }
+    }
+
+    #[test]
+    fn service_body_has_the_wire_shape_with_null_uicontext() {
+        let b = service_body("window", "GetWindow", serde_json::json!(["w1"]));
+        let v: serde_json::Value = serde_json::from_str(&b).unwrap();
+        assert_eq!(v["service"], "window");
+        assert_eq!(v["method"], "GetWindow");
+        assert_eq!(v["args"], serde_json::json!(["w1"]));
+        assert!(v["uicontext"].is_null());
+    }
+
+    #[test]
+    fn status_ok_matches_the_prior_copies_check() {
+        assert!(resp("HTTP/1.1 200 OK\r\n\r\n{}").status_ok());
+        assert!(resp("HTTP/1.0 200 OK\r\n").status_ok(), "' 200 ' anywhere in the line");
+        assert!(!resp("HTTP/1.1 401 Unauthorized\r\n").status_ok());
+        assert!(!resp("").status_ok());
+        assert_eq!(resp("").first_line(), "(empty)", "the placeholder every prior copy logged");
+    }
+
+    #[test]
+    fn data_if_success_requires_success_true_and_a_body() {
+        let ok = resp("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\"success\":true,\"data\":{\"opacity\":0.5}}");
+        assert_eq!(ok.data_if_success().unwrap()["opacity"], 0.5);
+
+        let failed = resp("HTTP/1.1 200 OK\r\n\r\n{\"success\":false,\"data\":{\"opacity\":0.5}}");
+        assert!(failed.data_if_success().is_none());
+
+        let no_blank_line = resp("HTTP/1.1 200 OK\r\n{\"success\":true}");
+        assert!(no_blank_line.data_if_success().is_none(), "no header/body split → no body");
+
+        let garbage = resp("HTTP/1.1 200 OK\r\n\r\nnot json");
+        assert!(garbage.data_if_success().is_none());
+    }
+
+    /// End-to-end against a real socket: the request carries the auth
+    /// header and the exact body, and the canned reply comes back intact.
+    /// The eleven prior copies had no transport test at all.
+    #[test]
+    fn service_call_round_trips_over_a_real_socket() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut s, _) = listener.accept().unwrap();
+            let mut buf = vec![0u8; 4096];
+            let n = s.read(&mut buf).unwrap();
+            let req = String::from_utf8_lossy(&buf[..n]).into_owned();
+            let reply = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\"success\":true,\"data\":{\"ok\":1}}";
+            s.write_all(reply.as_bytes()).unwrap();
+            req
+        });
+
+        let body = service_body("client", "GetClientData", serde_json::json!([]));
+        let r = service_call(addr, "sekrit-key", &body).unwrap();
+        let req = server.join().unwrap();
+
+        assert!(req.starts_with("POST /agentmux/service HTTP/1.1\r\n"), "{req}");
+        assert!(req.contains("X-AuthKey: sekrit-key\r\n"), "{req}");
+        assert!(req.contains(&format!("Content-Length: {}\r\n", body.len())), "{req}");
+        assert!(req.ends_with(&body), "body must be the last thing on the wire: {req}");
+        assert!(r.status_ok());
+        assert_eq!(r.data_if_success().unwrap()["ok"], 1);
+    }
+
+    #[test]
+    fn service_call_reports_connect_failure_distinctly() {
+        // A port nobody is listening on. Bind-then-drop to find one.
+        let addr = {
+            let l = TcpListener::bind("127.0.0.1:0").unwrap();
+            l.local_addr().unwrap()
+        };
+        match service_call(addr, "k", "{}") {
+            Err(ServiceCallError::Connect(_)) => {}
+            other => panic!("expected Connect error, got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`agentmux-cef/src/client/helpers.rs` carried **eleven** hand-rolled copies of the same raw-TCP `POST /agentmux/service` sequence — build the JSON body, format the HTTP/1.1 request with `X-AuthKey`, `connect_timeout` 2000 ms, write, read — one ~25-line block per function. It was the largest single-file duplication cluster in the Rust workspace (`docs/reports/REPORT_DRY_AND_MODULARITY_AUDIT_2026_09_06.md` §3.2). **Zero behavior change**; `helpers.rs` goes from 895 to 583 lines.

## What changed

- **New `client/service_call.rs`** — the transport only: `service_body()`, `service_call()` returning a `ServiceResponse` with the two views every caller wanted (`first_line`/`status_ok`, `data_if_success`), and a granular `ServiceCallError { Connect, Write, Read }`.
- **It does no logging on purpose.** Every wrapper keeps its own `tracing::warn!`/`error!` lines byte-for-byte, because several are operator-facing and cited by specs and retros. The error enum is granular precisely so callers can keep distinguishing connect vs. write vs. read failures the way they already did — the prior copies were *not* uniform on that (setters ignored read errors and reported the empty status line as "did not succeed"; getters returned `None` silently), and that asymmetry is preserved by the callers rather than flattened.
- **Ten wrappers rewritten** — five setters (`set_window_opacity`, `set_window_pos_and_size`, `set_window_topology`, `update_block_meta`, `register_ipc_with_backend`) and five getters (`get_window_opacity`, `get_window_pos_and_size`, `get_client_window_ids`, `find_window_by_label`, `get_window_topology`). Signatures unchanged; the `client/mod.rs` re-exports are untouched.
- **`backend_close_window` is deliberately left as-is.** It interleaves `dlog` tracing between the write and the read, escalates to `error!`, and gates a user-visible close path with `SPEC_WINDOW_LIFECYCLE_CLOSE_RELIABILITY_2026_07_04.md` behind it. Keeping it self-contained keeps that reliability story reviewable on its own.

## One documented near-equivalence

On a *mid-response* read error, the setters used to log whatever partial status line had arrived before the error (the `read_to_string` buffer contents are unspecified after an error). They now log the `(empty)` placeholder. Log text only, in a corner case; getters returned `None` silently on read error before and still do.

## Verification

- `cargo check -p agentmux-cef --tests` — clean (all warnings pre-existing)
- `cargo test -p agentmux-cef service_call` — **5/5**: body shape, the 200-check, `data_if_success` on success/failure/malformed, a **real `TcpListener` round trip** asserting the auth header and body on the wire, and distinct connect-failure reporting. The eleven prior copies had no transport test at all.
- The rewrite was generated from a table + two templates keyed on each exact signature, so a mismatch would have failed loudly rather than silently skipping a function (10/10 matched).

Independent of #3033 (Phase 1) — disjoint files.

## Review history (for the record)

ReAgent's first pass caught three things, all fixed in the follow-up commit:

1. **P1 — no changeset.** Added. My omission.
2. **P2 — one log line was not byte-for-byte.** The setter template built the "did not succeed" message from the RPC *method* name, so `register_ipc_with_backend`'s `host_ipc.Register did not succeed` briefly became `Register did not succeed`. Restored. A mechanical diff of every `"[backend_…]"` / `"[register_…]"` string literal on `main` vs. this branch confirms this was the **only** divergence across all ten functions — the other nine match exactly.
3. **P2 — a dropped invariant comment.** The getter template emitted `if width <= 0 || height <= 0 { return None; }` bare, losing the five-line explanation of *why* (never-written `Window.pos`/`winsize` default to zero via `#[derive(Default)]`, indistinguishable from "row predates the write-through"). Restored inside the block where it lived.

<!-- agentmux:agent_id=manoz -->
