### PR TITLE
chore: release v0.55.38

### DIFF
--- a/.changesets/1788726060-docs-stop-agents-sleep-polling-decision-table-for-waiting-wi-pn9b.md
+++ b/.changesets/1788726060-docs-stop-agents-sleep-polling-decision-table-for-waiting-wi-pn9b.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: stop agents sleep-polling — decision table for waiting without polling

--- a/.changesets/1788729452-docs-dry-and-modularity-audit-findings-and-a-phased-slimming-xg3c.md
+++ b/.changesets/1788729452-docs-dry-and-modularity-audit-findings-and-a-phased-slimming-xg3c.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: DRY and modularity audit — findings and a phased slimming plan

--- a/.changesets/1788729917-feat-app-api-agent-open-over-http-openagent-mcp-tool-muxopen-xszb.md
+++ b/.changesets/1788729917-feat-app-api-agent-open-over-http-openagent-mcp-tool-muxopen-xszb.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(app-api): agent.open over HTTP + OpenAgent MCP tool + muxopen — automation can now launch agents, not just stop them

--- a/.changesets/1788730452-refactor-common-lift-create-no-window-now-ms-event-log-proce-7pwb.md
+++ b/.changesets/1788730452-refactor-common-lift-create-no-window-now-ms-event-log-proce-7pwb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(common): lift CREATE_NO_WINDOW, now_ms, event_log, process-kill, and WindowKind into agentmux-common

--- a/.changesets/1788731115-refactor-frontend-collapse-the-three-byte-identical-zoom-win-d6r5.md
+++ b/.changesets/1788731115-refactor-frontend-collapse-the-three-byte-identical-zoom-win-d6r5.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(frontend): collapse the three byte-identical zoom.{win32,linux,darwin}.ts platform forks into one zoom.ts

--- a/.changesets/1788731291-fix-browser-pane-route-pane-nav-state-title-favicon-events-t-upti.md
+++ b/.changesets/1788731291-fix-browser-pane-route-pane-nav-state-title-favicon-events-t-upti.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(browser-pane): route pane nav-state/title/favicon events to the pane's owning window, not main

--- a/.changesets/1788732819-refactor-cef-one-raw-tcp-service-call-transport-for-the-ten--4osj.md
+++ b/.changesets/1788732819-refactor-cef-one-raw-tcp-service-call-transport-for-the-ten--4osj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(cef): one raw-TCP service_call transport for the ten backend_* helpers in client/helpers.rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.37"
+version = "0.55.38"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.37"
+version = "0.55.38"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.37"
+version = "0.55.38"
 dependencies = [
  "base64",
  "dirs 5.0.1",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.37"
+version = "0.55.38"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.37"
+version = "0.55.38"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.37"
+version = "0.55.38"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.37"
+version = "0.55.38"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,15 @@
 # AgentMux Version History
 
+## 0.55.38 — 2026-09-06
+
+- docs: stop agents sleep-polling — decision table for waiting without polling
+- docs: DRY and modularity audit — findings and a phased slimming plan
+- feat(app-api): agent.open over HTTP + OpenAgent MCP tool + muxopen — automation can now launch agents, not just stop them
+- refactor(common): lift CREATE_NO_WINDOW, now_ms, event_log, process-kill, and WindowKind into agentmux-common
+- refactor(frontend): collapse the three byte-identical zoom.{win32,linux,darwin}.ts platform forks into one zoom.ts
+- fix(browser-pane): route pane nav-state/title/favicon events to the pane's owning window, not main
+- refactor(cef): one raw-TCP service_call transport for the ten backend_* helpers in client/helpers.rs
+
 ## 0.55.37 — 2026-09-06
 
 - fix(agent): swap the remaining tail glyphs from the weak-coverage arrow

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.37",
+  "version": "0.55.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.37",
+      "version": "0.55.38",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.37",
+  "version": "0.55.38",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Release PR for v0.55.38, consuming the 7 changesets queued on `main` since v0.55.37 (shipped earlier today).

**Bump type forced to `patch` via `--as patch`**, overriding the computed `minor` (one queued changeset, `feat(app-api): agent.open over HTTP + OpenAgent MCP tool + muxopen`, requested minor). Accepted per the repo's documented override behavior in `AGENTS.md`/`CLAUDE.md`: *"Forcing a bump type: pass `--as <patch|minor|major>` to override the computed type ... Use it when you want a deliberate patch release and accept that queued minor work rides along under that patch."* `scripts/release.sh` printed the expected warning:

```
NOTE: --as overrides the computed bump 'minor' with 'patch'.
WARNING: forcing a LOWER bump than the changesets request — some
         minor-level change(s) will ship under a patch version.
```

## What's shipping in 0.55.38

- fix(browser-pane): route pane nav-state/title/favicon events to the pane's owning window, not main (#3035) — fixes the tab-tear-off stuck-loading-overlay bug
- feat(app-api): agent.open over HTTP + OpenAgent MCP tool + muxopen — automation can now launch agents, not just stop them
- refactor(common): lift CREATE_NO_WINDOW, now_ms, event_log, process-kill, and WindowKind into agentmux-common
- refactor(frontend): collapse the three byte-identical zoom.{win32,linux,darwin}.ts platform forks into one zoom.ts
- refactor(cef): one raw-TCP service_call transport for the ten backend_* helpers in client/helpers.rs
- docs: stop agents sleep-polling — decision table for waiting without polling
- docs: DRY and modularity audit — findings and a phased slimming plan

## Verification

- All five version locations agree at `0.55.38`: `package.json`, `package-lock.json`, `Cargo.toml` (`[workspace.package].version`), `Cargo.lock` workspace members, `VERSION_HISTORY.md` top section.
- `VERSION_HISTORY.md` lists all 7 consumed changesets under `## 0.55.38 — 2026-09-06`.
- All 7 `.changesets/*.md` entries deleted by the release script.
- Produced entirely by `task release -- --as patch` + `scripts/bump-wrapper.sh` — no manual edits.

<!-- agentmux:agent_id=agentx -->
