### PR TITLE
Manoz@Area54: refactor: fold same-file clones (flyoutmenu, file-tree, PreLaunchAuthPanel), migrations freeze-copy policy, DRY audit corrections

### DIFF
--- a/.changesets/1788750245-dry-contained-cleanups-one-menurows-renderer-in-flyoutmenu-t-plab.md
+++ b/.changesets/1788750245-dry-contained-cleanups-one-menurows-renderer-in-flyoutmenu-t-plab.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+DRY contained cleanups: one MenuRows renderer in flyoutmenu, TreeNode prop pass-through in file-tree, single Connect-CTA arm in PreLaunchAuthPanel, migrations freeze-copy policy, audit report corrections

--- a/agentmux-srv/src/migrations/mod.rs
+++ b/agentmux-srv/src/migrations/mod.rs
@@ -14,6 +14,21 @@
 //! (use the `NNNN_slug` convention). Retiring old migrations: remove from
 //! [`REGISTRY`] once the minimum supported upgrade path passes the migration's
 //! origin version — the `db_migrations` row stays as a permanent record.
+//!
+//! # Migrations freeze copies of live logic on purpose
+//!
+//! Some migrations carry verbatim copies of helpers that also exist in live
+//! code: `m0017_ambient_login_grandfather` mirrors ~35 lines of
+//! `backend/blockcontroller/core.rs`; `m0020_agent_color_backfill` and
+//! `m0021_backfill_agent_bundles` mirror 25–30 lines each of
+//! `backend/storage/mcp_servers.rs` and `def_registry_mirror.rs`. That is
+//! deliberate, not accidental duplication. A migration must produce the same
+//! rows on every machine it ever runs on, so it cannot call a live helper
+//! whose behaviour a later release may change; the copy pins the logic as it
+//! was at the migration's origin version. Do not "deduplicate" a migration
+//! against live code. When you copy logic into a new migration, say so next
+//! to the copy — `// frozen copy of <path>::<fn> as of <version>` — so the
+//! next reader can tell a freeze from a drift.
 
 mod m0000_bootstrap;
 mod m0001_legacy_data_dir;

--- a/docs/reports/REPORT_DRY_AND_MODULARITY_AUDIT_2026_09_06.md
+++ b/docs/reports/REPORT_DRY_AND_MODULARITY_AUDIT_2026_09_06.md
@@ -137,9 +137,9 @@ Two teams (or one team at two times) built the same *idea* twice with the same *
 
 ### 3.2 Same-file repetition
 
-- **`frontend/app/view/agent/components/PreLaunchAuthPanel.tsx`** — *corrected 2026-09-07.* The first draft of this report called this a **378-line** render tree appearing twice (`:239` / `:313`). That was a tooling artifact: `jscpd`'s `javascript` tokenizer mis-parses TSX and matched a 377-line span against a 12-line one, while the `tsx` tokenizer finds **no** clone in the file. The real duplication was two identical 7-line `<ConnectCta …/>` invocations in the first and last `<Match>` arms — folded into one arm in PR-TBD. There is no legacy render path to delete.
+- **`frontend/app/view/agent/components/PreLaunchAuthPanel.tsx`** — *corrected 2026-09-07.* The first draft of this report called this a **378-line** render tree appearing twice (`:239` / `:313`). That was a tooling artifact: `jscpd`'s `javascript` tokenizer mis-parses TSX and matched a 377-line span against a 12-line one, while the `tsx` tokenizer finds **no** clone in the file. The real duplication was two identical 7-line `<ConnectCta …/>` invocations in the first and last `<Match>` arms — folded into one arm in #3039. There is no legacy render path to delete.
 - **`agentmux-cef/src/client/helpers.rs`** — one ~25-line block repeated **seven times** (`:196, :281, :361, :428, :492, :684, :756`); 287 duplicated lines in a 1-file cluster. Reads as a copy-pasted "open socket to srv with timeout, send, read" sequence that wants to be one function with a payload parameter.
-- `frontend/app/element/flyoutmenu.tsx` (`:295`/`:497`, `:323`/`:515` — 62 + 68 lines), `frontend/app/view/editor/file-tree.tsx` (`:76`/`:280`, 57 lines), `agentmux-srv/src/server/service/session_restore.rs` (`:504`/`:671`, 45 lines), `tab_move.rs`, `window_mutate.rs`, `backend/history/mod.rs` (three internal clones). *(`flyoutmenu` and `file-tree` folded in PR-TBD: one `MenuRows` level renderer, and a `{...props}` pass-through for `TreeNode`.)*
+- `frontend/app/element/flyoutmenu.tsx` (`:295`/`:497`, `:323`/`:515` — 62 + 68 lines), `frontend/app/view/editor/file-tree.tsx` (`:76`/`:280`, 57 lines), `agentmux-srv/src/server/service/session_restore.rs` (`:504`/`:671`, 45 lines), `tab_move.rs`, `window_mutate.rs`, `backend/history/mod.rs` (three internal clones). *(`flyoutmenu` and `file-tree` folded in #3039: one `MenuRows` level renderer, and a `{...props}` pass-through for `TreeNode`.)*
 
 ### 3.3 Smaller cross-file pairs worth a look
 
@@ -151,7 +151,7 @@ Two teams (or one team at two times) built the same *idea* twice with the same *
 
 ### 3.4 Migrations that copy live logic — probably right, but undocumented
 
-`m0020_agent_color_backfill.rs`, `m0021_backfill_agent_bundles.rs`, `m0017_ambient_login_grandfather.rs` carry 30–45-line clones of live code in `def_registry_mirror.rs`, `mcp_servers.rs`, `blockcontroller/core.rs`. Freezing a snapshot of live logic inside a migration is a *legitimate* pattern — a migration must not change meaning when the live code later does. But **no migration or `migrations.rs` states that policy**; a grep for `frozen | snapshot of | must not import | deliberately duplicated` finds nothing about it. Un-annotated, it's indistinguishable from accidental copying, and the next contributor will "helpfully" dedupe it. **Recommendation: write the rule down, not remove the copies.** *(Done in PR-TBD — the policy lives in `agentmux-srv/src/migrations/mod.rs`, the framework module that owns the `m00NN_*` files. The pairs were re-verified with `jscpd --format rust` first: m0021 ↔ `mcp_servers.rs` 24 + 28 lines, m0021 ↔ `def_registry_mirror.rs` 30, m0020 ↔ `mcp_servers.rs` 25, m0017 ↔ `blockcontroller/core.rs` 16 + 19.)*
+`m0020_agent_color_backfill.rs`, `m0021_backfill_agent_bundles.rs`, `m0017_ambient_login_grandfather.rs` carry 30–45-line clones of live code in `def_registry_mirror.rs`, `mcp_servers.rs`, `blockcontroller/core.rs`. Freezing a snapshot of live logic inside a migration is a *legitimate* pattern — a migration must not change meaning when the live code later does. But **no migration or `migrations.rs` states that policy**; a grep for `frozen | snapshot of | must not import | deliberately duplicated` finds nothing about it. Un-annotated, it's indistinguishable from accidental copying, and the next contributor will "helpfully" dedupe it. **Recommendation: write the rule down, not remove the copies.** *(Done in #3039 — the policy lives in `agentmux-srv/src/migrations/mod.rs`, the framework module that owns the `m00NN_*` files. The pairs were re-verified with `jscpd --format rust` first: m0021 ↔ `mcp_servers.rs` 24 + 28 lines, m0021 ↔ `def_registry_mirror.rs` 30, m0020 ↔ `mcp_servers.rs` 25, m0017 ↔ `blockcontroller/core.rs` 16 + 19.)*
 
 ### 3.5 Test-fixture builders
 
@@ -169,7 +169,7 @@ Two teams (or one team at two times) built the same *idea* twice with the same *
 
 Ordered by payoff ÷ risk. Each step is independently shippable.
 
-**Progress (2026-09-07):** Phase 1 steps 1–4 and 6 merged in #3033 (step 5, the ObjC externs, waits on a macOS build); Phase 3 step 10 merged in #3034; step 16 merged in #3036; steps 15 (as corrected) and 18, plus the `flyoutmenu` / `file-tree` clones from §3.2, landed in PR-TBD. Step 11 is next: `TileLayout` measures **437 of 598 lines identical across all three platform files** (73%), so the shared core is real; the platform-specific remainder is the animate delay, the Win11 `dragend` safety net, the reflow notification, the `canDrag` resize-zone guard, `preventUnhandled`, `setJsDragActive`, and three different `ResizeHandle` pointer models.
+**Progress (2026-09-07):** Phase 1 steps 1–4 and 6 merged in #3033 (step 5, the ObjC externs, waits on a macOS build); Phase 3 step 10 merged in #3034; step 16 merged in #3036; steps 15 (as corrected) and 18, plus the `flyoutmenu` / `file-tree` clones from §3.2, landed in #3039. Step 11 is next: `TileLayout` measures **437 of 598 lines identical across all three platform files** (73%), so the shared core is real; the platform-specific remainder is the animate delay, the Win11 `dragend` safety net, the reflow notification, the `canDrag` resize-zone guard, `preventUnhandled`, `setJsDragActive`, and three different `ResizeHandle` pointer models.
 
 ### Phase 1 — mechanical lifts into `agentmux-common` (low risk, immediate)
 
@@ -207,7 +207,7 @@ Expected: ~1,200 lines removed, seven sync comments retired, and — more import
 15. `PreLaunchAuthPanel.tsx`: ~~finish the migration to controller state and delete the 378-line legacy render path~~ — **withdrawn**; see the corrected §3.2 row. The two-arm `ConnectCta` fold is done.
 16. `client/helpers.rs`: fold the seven repeats into one function. **Done in #3036** — it was ten repeats, not seven; `backend_close_window` was left alone on purpose.
 17. Split `persistent.rs` (7,151) along the seams it already has (`persistent_resume.rs` and `session_recovery.rs` were split out; continue). Split `agentmux-mcp/src/main.rs` into `tools/` by tool family.
-18. Add a one-paragraph policy to `migrations.rs` stating that migrations deliberately freeze copies of live logic and must not be "deduplicated." **Done in PR-TBD** — in `agentmux-srv/src/migrations/mod.rs` (the module that owns the migrations), not `backend/storage/migrations.rs` (schema DDL).
+18. Add a one-paragraph policy to `migrations.rs` stating that migrations deliberately freeze copies of live logic and must not be "deduplicated." **Done in #3039** — in `agentmux-srv/src/migrations/mod.rs` (the module that owns the migrations), not `backend/storage/migrations.rs` (schema DDL).
 
 ## 6. Limits of this audit
 

--- a/docs/reports/REPORT_DRY_AND_MODULARITY_AUDIT_2026_09_06.md
+++ b/docs/reports/REPORT_DRY_AND_MODULARITY_AUDIT_2026_09_06.md
@@ -137,9 +137,9 @@ Two teams (or one team at two times) built the same *idea* twice with the same *
 
 ### 3.2 Same-file repetition
 
-- **`frontend/app/view/agent/components/PreLaunchAuthPanel.tsx`** — a **378-line** render tree appears twice (`:239` keyed on `props.accountStatus?.() === "expired"`, `:313` keyed on `controller.state().kind === "expired"`). That is a legacy-prop path and a controller-state path each carrying a full copy of the same JSX — a half-finished migration. Largest single clone in the frontend.
+- **`frontend/app/view/agent/components/PreLaunchAuthPanel.tsx`** — *corrected 2026-09-07.* The first draft of this report called this a **378-line** render tree appearing twice (`:239` / `:313`). That was a tooling artifact: `jscpd`'s `javascript` tokenizer mis-parses TSX and matched a 377-line span against a 12-line one, while the `tsx` tokenizer finds **no** clone in the file. The real duplication was two identical 7-line `<ConnectCta …/>` invocations in the first and last `<Match>` arms — folded into one arm in PR-TBD. There is no legacy render path to delete.
 - **`agentmux-cef/src/client/helpers.rs`** — one ~25-line block repeated **seven times** (`:196, :281, :361, :428, :492, :684, :756`); 287 duplicated lines in a 1-file cluster. Reads as a copy-pasted "open socket to srv with timeout, send, read" sequence that wants to be one function with a payload parameter.
-- `frontend/app/element/flyoutmenu.tsx` (`:295`/`:497`, `:323`/`:515` — 62 + 68 lines), `frontend/app/view/editor/file-tree.tsx` (`:76`/`:280`, 57 lines), `agentmux-srv/src/server/service/session_restore.rs` (`:504`/`:671`, 45 lines), `tab_move.rs`, `window_mutate.rs`, `backend/history/mod.rs` (three internal clones).
+- `frontend/app/element/flyoutmenu.tsx` (`:295`/`:497`, `:323`/`:515` — 62 + 68 lines), `frontend/app/view/editor/file-tree.tsx` (`:76`/`:280`, 57 lines), `agentmux-srv/src/server/service/session_restore.rs` (`:504`/`:671`, 45 lines), `tab_move.rs`, `window_mutate.rs`, `backend/history/mod.rs` (three internal clones). *(`flyoutmenu` and `file-tree` folded in PR-TBD: one `MenuRows` level renderer, and a `{...props}` pass-through for `TreeNode`.)*
 
 ### 3.3 Smaller cross-file pairs worth a look
 
@@ -151,7 +151,7 @@ Two teams (or one team at two times) built the same *idea* twice with the same *
 
 ### 3.4 Migrations that copy live logic — probably right, but undocumented
 
-`m0020_agent_color_backfill.rs`, `m0021_backfill_agent_bundles.rs`, `m0017_ambient_login_grandfather.rs` carry 30–45-line clones of live code in `def_registry_mirror.rs`, `mcp_servers.rs`, `blockcontroller/core.rs`. Freezing a snapshot of live logic inside a migration is a *legitimate* pattern — a migration must not change meaning when the live code later does. But **no migration or `migrations.rs` states that policy**; a grep for `frozen | snapshot of | must not import | deliberately duplicated` finds nothing about it. Un-annotated, it's indistinguishable from accidental copying, and the next contributor will "helpfully" dedupe it. **Recommendation: write the rule down, not remove the copies.**
+`m0020_agent_color_backfill.rs`, `m0021_backfill_agent_bundles.rs`, `m0017_ambient_login_grandfather.rs` carry 30–45-line clones of live code in `def_registry_mirror.rs`, `mcp_servers.rs`, `blockcontroller/core.rs`. Freezing a snapshot of live logic inside a migration is a *legitimate* pattern — a migration must not change meaning when the live code later does. But **no migration or `migrations.rs` states that policy**; a grep for `frozen | snapshot of | must not import | deliberately duplicated` finds nothing about it. Un-annotated, it's indistinguishable from accidental copying, and the next contributor will "helpfully" dedupe it. **Recommendation: write the rule down, not remove the copies.** *(Done in PR-TBD — the policy lives in `agentmux-srv/src/migrations/mod.rs`, the framework module that owns the `m00NN_*` files. The pairs were re-verified with `jscpd --format rust` first: m0021 ↔ `mcp_servers.rs` 24 + 28 lines, m0021 ↔ `def_registry_mirror.rs` 30, m0020 ↔ `mcp_servers.rs` 25, m0017 ↔ `blockcontroller/core.rs` 16 + 19.)*
 
 ### 3.5 Test-fixture builders
 
@@ -168,6 +168,8 @@ Two teams (or one team at two times) built the same *idea* twice with the same *
 ## 5. DRY → modularity: the plan
 
 Ordered by payoff ÷ risk. Each step is independently shippable.
+
+**Progress (2026-09-07):** Phase 1 steps 1–4 and 6 merged in #3033 (step 5, the ObjC externs, waits on a macOS build); Phase 3 step 10 merged in #3034; step 16 merged in #3036; steps 15 (as corrected) and 18, plus the `flyoutmenu` / `file-tree` clones from §3.2, landed in PR-TBD. Step 11 is next: `TileLayout` measures **437 of 598 lines identical across all three platform files** (73%), so the shared core is real; the platform-specific remainder is the animate delay, the Win11 `dragend` safety net, the reflow notification, the `canDrag` resize-zone guard, `preventUnhandled`, `setJsDragActive`, and three different `ResizeHandle` pointer models.
 
 ### Phase 1 — mechanical lifts into `agentmux-common` (low risk, immediate)
 
@@ -202,10 +204,10 @@ Expected: ~1,200 lines removed, seven sync comments retired, and — more import
 
 ### Anytime — contained cleanups
 
-15. `PreLaunchAuthPanel.tsx`: finish the migration to controller state and delete the 378-line legacy render path.
-16. `client/helpers.rs`: fold the seven repeats into one function.
+15. `PreLaunchAuthPanel.tsx`: ~~finish the migration to controller state and delete the 378-line legacy render path~~ — **withdrawn**; see the corrected §3.2 row. The two-arm `ConnectCta` fold is done.
+16. `client/helpers.rs`: fold the seven repeats into one function. **Done in #3036** — it was ten repeats, not seven; `backend_close_window` was left alone on purpose.
 17. Split `persistent.rs` (7,151) along the seams it already has (`persistent_resume.rs` and `session_recovery.rs` were split out; continue). Split `agentmux-mcp/src/main.rs` into `tools/` by tool family.
-18. Add a one-paragraph policy to `migrations.rs` stating that migrations deliberately freeze copies of live logic and must not be "deduplicated."
+18. Add a one-paragraph policy to `migrations.rs` stating that migrations deliberately freeze copies of live logic and must not be "deduplicated." **Done in PR-TBD** — in `agentmux-srv/src/migrations/mod.rs` (the module that owns the migrations), not `backend/storage/migrations.rs` (schema DDL).
 
 ## 6. Limits of this audit
 

--- a/frontend/app/element/flyoutmenu.tsx
+++ b/frontend/app/element/flyoutmenu.tsx
@@ -243,12 +243,12 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
     );
 };
 
-type MenuBodyProps = {
-    className?: string;
-    mirrored?: boolean;
-    style: string;
-    registerFloating: (el: HTMLElement) => void;
-    items: MenuItem[];
+/**
+ * Props every menu level needs and forwards unchanged to the next one.
+ * FlyoutMenu owns all of this state; MenuBody, MenuRows and SubMenu only
+ * pass it down.
+ */
+type MenuLevelProps = {
     hoveredItems: string[];
     visibleSubMenus: { [key: string]: any };
     subMenuPosition: SubMenuPositionMap;
@@ -263,6 +263,14 @@ type MenuBodyProps = {
     closeSubMenu: (key: string) => void;
     renderMenu?: (subMenu: JSX.Element, props: any) => JSX.Element;
     renderMenuItem?: (item: MenuItem, props: any) => JSX.Element;
+    mirrored?: boolean;
+};
+
+type MenuBodyProps = MenuLevelProps & {
+    className?: string;
+    style: string;
+    registerFloating: (el: HTMLElement) => void;
+    items: MenuItem[];
 };
 
 /**
@@ -283,8 +291,6 @@ const MenuBody = (props: MenuBodyProps): JSX.Element => {
         props.registerFloating(el);
     };
 
-    const peers = createPeerRegistry();
-
     return (
         <div
             class={clsx("menu", props.className, { "menu--mirrored": props.mirrored })}
@@ -292,99 +298,110 @@ const MenuBody = (props: MenuBodyProps): JSX.Element => {
             style={props.style}
             data-pane-overlay
         >
-            <For each={props.items}>
-                {(item, index) => {
-                    const key = `${index()}`;
-                    const isActive = () => props.hoveredItems.includes(key);
-
-                    // One hover-intent controller per row that has a submenu,
-                    // for the lifetime of this row in the list (disposed when
-                    // the row leaves the array or the whole menu unmounts).
-                    // Open/close timing (delay + safe-triangle) lives here;
-                    // rendering the submenu is still driven by visibleSubMenus
-                    // via openSubMenu/closeSubMenu, which this controller is
-                    // the only caller of for this key.
-                    const hover: SubmenuHoverController | null = item.subItems
-                        ? createSubmenuHover({
-                              onOpen: () => props.openSubMenu(key, item.label),
-                              onClose: () => props.closeSubMenu(key),
-                          })
-                        : null;
-                    if (hover) onCleanup(peers.register(key, hover));
-                    onCleanup(() => hover?.dispose());
-
-                    const menuItemProps = {
-                        class: clsx("menu-item", { active: isActive() }),
-                        onMouseEnter: (event: MouseEvent) => {
-                            props.handleMouseEnterItem(event, null, index(), item);
-                            // An explicit new selection at this level closes any
-                            // other open peer submenu right away — no triangle to
-                            // protect toward a row the cursor isn't heading for.
-                            peers.closeOthers(key);
-                            hover?.onTriggerEnter();
-                        },
-                        onMouseLeave: (event: MouseEvent) => hover?.onTriggerLeave(event),
-                        onClick: (e: MouseEvent) => props.handleOnClick(e, item),
-                    };
-
-                    if (item.divider) {
-                        return <div class="menu-divider" aria-hidden="true" />;
-                    }
-
-                    const renderedItem = props.renderMenuItem ? (
-                        props.renderMenuItem(item, menuItemProps)
-                    ) : (
-                        <div {...menuItemProps}>
-                            <Show
-                                when={item.checked === undefined}
-                                fallback={
-                                    <i
-                                        class={clsx(
-                                            "fa-solid fa-fw menu-item-icon menu-item-check",
-                                            { "fa-check": item.checked === true },
-                                        )}
-                                    />
-                                }
-                            >
-                                <Show when={item.icon}>
-                                    <i class={clsx("fa-solid fa-fw", `fa-${item.icon}`, "menu-item-icon")} />
-                                </Show>
-                            </Show>
-                            <span class="label">{item.label}</span>
-                            <Show when={item.shortcut && !item.subItems}>
-                                <span class="menu-item-shortcut">{item.shortcut}</span>
-                            </Show>
-                            <Show when={item.subItems}>
-                                <i class="fa-sharp fa-solid fa-chevron-right" />
-                            </Show>
-                        </div>
-                    );
-
-                    return (
-                        <>
-                            {renderedItem}
-                            <Show when={props.visibleSubMenus[key]?.visible && item.subItems && hover}>
-                                <SubMenu
-                                    subItems={item.subItems!}
-                                    parentKey={key}
-                                    subMenuPosition={props.subMenuPosition}
-                                    hover={hover!}
-                                    visibleSubMenus={props.visibleSubMenus}
-                                    hoveredItems={props.hoveredItems}
-                                    handleMouseEnterItem={props.handleMouseEnterItem}
-                                    handleOnClick={props.handleOnClick}
-                                    openSubMenu={props.openSubMenu}
-                                    closeSubMenu={props.closeSubMenu}
-                                    renderMenu={props.renderMenu}
-                                    renderMenuItem={props.renderMenuItem}
-                                    mirrored={props.mirrored}
-                                />
-                            </Show>
-                        </>
-                    );
-                }}
-            </For>
+            <MenuRows {...props} parentKey={null} />
         </div>
+    );
+};
+
+type MenuRowsProps = MenuLevelProps & {
+    items: MenuItem[];
+    /** `null` for the top-level menu; the owning row's key inside a submenu. */
+    parentKey: string | null;
+};
+
+/**
+ * One level of menu rows. MenuBody (the top level) and SubMenu (every
+ * nested level) render exactly this; the only per-level differences are
+ * the row-key scheme — `${index}` at the top, `${parentKey}-${index}`
+ * below — and the parentKey reported to handleMouseEnterItem, both
+ * derived from `parentKey` here. Row keys are what FlyoutMenu's
+ * hoveredItems / visibleSubMenus / subMenuPosition maps are keyed on,
+ * so the scheme must not change.
+ */
+const MenuRows = (props: MenuRowsProps): JSX.Element => {
+    // One peer registry per level: opening a row's submenu closes any
+    // sibling's, never a cousin's.
+    const peers = createPeerRegistry();
+
+    return (
+        <For each={props.items}>
+            {(item, index) => {
+                const key = props.parentKey === null ? `${index()}` : `${props.parentKey}-${index()}`;
+                const isActive = () => props.hoveredItems.includes(key);
+
+                // One hover-intent controller per row that has a submenu,
+                // for the lifetime of this row in the list (disposed when
+                // the row leaves the array or the whole menu unmounts).
+                // Open/close timing (delay + safe-triangle) lives here;
+                // rendering the submenu is still driven by visibleSubMenus
+                // via openSubMenu/closeSubMenu, which this controller is
+                // the only caller of for this key.
+                const hover: SubmenuHoverController | null = item.subItems
+                    ? createSubmenuHover({
+                          onOpen: () => props.openSubMenu(key, item.label),
+                          onClose: () => props.closeSubMenu(key),
+                      })
+                    : null;
+                if (hover) onCleanup(peers.register(key, hover));
+                onCleanup(() => hover?.dispose());
+
+                const menuItemProps = {
+                    class: clsx("menu-item", { active: isActive() }),
+                    onMouseEnter: (event: MouseEvent) => {
+                        props.handleMouseEnterItem(event, props.parentKey, index(), item);
+                        // An explicit new selection at this level closes any
+                        // other open peer submenu right away — no triangle to
+                        // protect toward a row the cursor isn't heading for.
+                        peers.closeOthers(key);
+                        hover?.onTriggerEnter();
+                    },
+                    onMouseLeave: (event: MouseEvent) => hover?.onTriggerLeave(event),
+                    onClick: (e: MouseEvent) => props.handleOnClick(e, item),
+                };
+
+                if (item.divider) {
+                    return <div class="menu-divider" aria-hidden="true" />;
+                }
+
+                const renderedItem = props.renderMenuItem ? (
+                    props.renderMenuItem(item, menuItemProps)
+                ) : (
+                    <div {...menuItemProps}>
+                        <Show
+                            when={item.checked === undefined}
+                            fallback={
+                                <i
+                                    class={clsx(
+                                        "fa-solid fa-fw menu-item-icon menu-item-check",
+                                        { "fa-check": item.checked === true },
+                                    )}
+                                />
+                            }
+                        >
+                            <Show when={item.icon}>
+                                <i class={clsx("fa-solid fa-fw", `fa-${item.icon}`, "menu-item-icon")} />
+                            </Show>
+                        </Show>
+                        <span class="label">{item.label}</span>
+                        <Show when={item.shortcut && !item.subItems}>
+                            <span class="menu-item-shortcut">{item.shortcut}</span>
+                        </Show>
+                        <Show when={item.subItems}>
+                            <i class="fa-sharp fa-solid fa-chevron-right" />
+                        </Show>
+                    </div>
+                );
+
+                return (
+                    <>
+                        {renderedItem}
+                        <Show when={props.visibleSubMenus[key]?.visible && item.subItems && hover}>
+                            <SubMenu {...props} subItems={item.subItems!} parentKey={key} hover={hover!} />
+                        </Show>
+                    </>
+                );
+            }}
+        </For>
     );
 };
 
@@ -392,26 +409,11 @@ type SubMenuPositionMap = {
     [key: string]: { anchorRect: DOMRect; label: string };
 };
 
-type SubMenuProps = {
+type SubMenuProps = MenuLevelProps & {
     subItems: MenuItem[];
     parentKey: string;
-    subMenuPosition: SubMenuPositionMap;
     /** This SubMenu's own hover controller (owned/disposed by the row that renders it). */
     hover: SubmenuHoverController;
-    visibleSubMenus: { [key: string]: any };
-    hoveredItems: string[];
-    handleMouseEnterItem: (
-        event: MouseEvent,
-        parentKey: string | null,
-        index: number,
-        item: MenuItem
-    ) => void;
-    handleOnClick: (e: MouseEvent, item: MenuItem) => void;
-    openSubMenu: (key: string, label: string) => void;
-    closeSubMenu: (key: string) => void;
-    renderMenu?: (subMenu: JSX.Element, props: any) => JSX.Element;
-    renderMenuItem?: (item: MenuItem, props: any) => JSX.Element;
-    mirrored?: boolean;
 };
 
 const SubMenu = (props: SubMenuProps): JSX.Element => {
@@ -483,8 +485,6 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
 
     onCleanup(() => cleanupAutoUpdate?.());
 
-    const peers = createPeerRegistry();
-
     const subMenu = (
         <div
             ref={registerSubMenu}
@@ -494,88 +494,7 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
             onMouseEnter={() => props.hover.onSubmenuEnter()}
             onMouseLeave={(e) => props.hover.onSubmenuLeave(e)}
         >
-            <For each={props.subItems}>
-                {(item, idx) => {
-                    const newKey = `${props.parentKey}-${idx()}`;
-                    const isActive = () => props.hoveredItems.includes(newKey);
-
-                    const hover: SubmenuHoverController | null = item.subItems
-                        ? createSubmenuHover({
-                              onOpen: () => props.openSubMenu(newKey, item.label),
-                              onClose: () => props.closeSubMenu(newKey),
-                          })
-                        : null;
-                    if (hover) onCleanup(peers.register(newKey, hover));
-                    onCleanup(() => hover?.dispose());
-
-                    const menuItemProps = {
-                        class: clsx("menu-item", { active: isActive() }),
-                        onMouseEnter: (event: MouseEvent) => {
-                            props.handleMouseEnterItem(event, props.parentKey, idx(), item);
-                            peers.closeOthers(newKey);
-                            hover?.onTriggerEnter();
-                        },
-                        onMouseLeave: (event: MouseEvent) => hover?.onTriggerLeave(event),
-                        onClick: (e: MouseEvent) => props.handleOnClick(e, item),
-                    };
-
-                    if (item.divider) {
-                        return <div class="menu-divider" aria-hidden="true" />;
-                    }
-
-                    const renderedItem = props.renderMenuItem ? (
-                        props.renderMenuItem(item, menuItemProps)
-                    ) : (
-                        <div {...menuItemProps}>
-                            <Show
-                                when={item.checked === undefined}
-                                fallback={
-                                    <i
-                                        class={clsx(
-                                            "fa-solid fa-fw menu-item-icon menu-item-check",
-                                            { "fa-check": item.checked === true },
-                                        )}
-                                    />
-                                }
-                            >
-                                <Show when={item.icon}>
-                                    <i class={clsx("fa-solid fa-fw", `fa-${item.icon}`, "menu-item-icon")} />
-                                </Show>
-                            </Show>
-                            <span class="label">{item.label}</span>
-                            <Show when={item.shortcut && !item.subItems}>
-                                <span class="menu-item-shortcut">{item.shortcut}</span>
-                            </Show>
-                            <Show when={item.subItems}>
-                                <i class="fa-sharp fa-solid fa-chevron-right" />
-                            </Show>
-                        </div>
-                    );
-
-                    return (
-                        <>
-                            {renderedItem}
-                            <Show when={props.visibleSubMenus[newKey]?.visible && item.subItems && hover}>
-                                <SubMenu
-                                    subItems={item.subItems!}
-                                    parentKey={newKey}
-                                    subMenuPosition={props.subMenuPosition}
-                                    hover={hover!}
-                                    visibleSubMenus={props.visibleSubMenus}
-                                    hoveredItems={props.hoveredItems}
-                                    handleMouseEnterItem={props.handleMouseEnterItem}
-                                    handleOnClick={props.handleOnClick}
-                                    openSubMenu={props.openSubMenu}
-                                    closeSubMenu={props.closeSubMenu}
-                                    renderMenu={props.renderMenu}
-                                    renderMenuItem={props.renderMenuItem}
-                                    mirrored={props.mirrored}
-                                />
-                            </Show>
-                        </>
-                    );
-                }}
-            </For>
+            <MenuRows {...props} items={props.subItems} parentKey={props.parentKey} />
         </div>
     );
 

--- a/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
+++ b/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
@@ -216,29 +216,32 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
     // briefly flips false (the root cause of the "memory change forgot
     // login" bug fixed in this PR).
 
+    // The Connect CTA has two triggers and one arm:
+    //   - the controller has no usable credentials (`unauthenticated`) or
+    //     the probe said the session is gone (`expired`), or
+    //   - the controller is `ready` — outcomeFor() only asks "does the
+    //     account supply this provider?" — but the backend's expiry probe
+    //     flagged the account itself `needs_reauth` / `expired`. Without
+    //     this the panel would render <ReadyBanner /> and ConnectCta's
+    //     reconnect wording would never be seen; the user would have no
+    //     signal their credentials need refreshing. Clicking Connect
+    //     re-runs OAuth into the SAME account's isolation dir
+    //     (existingAccountId in auth-flow-controller.ts's connect()),
+    //     refreshing the token in place. codex P1 on #982.
+    // The arm is listed first so the stale-ready case wins over the
+    // generic ready arm; `unauthenticated` / `expired` match no other arm,
+    // so folding them in here changes which arm renders for no state.
+    const showConnectCta = () => {
+        const kind = controller.state().kind;
+        if (kind === "unauthenticated" || kind === "expired") return true;
+        const status = props.accountStatus?.();
+        return kind === "ready" && (status === "needs_reauth" || status === "expired");
+    };
+
     return (
         <div class="pre-launch-auth-panel">
             <Switch>
-                {/* An account the backend's expiry probe flagged stale
-                    (`needs_reauth` / `expired`) lands the controller in
-                    `ready` because outcomeFor() only looks at "does the
-                    account supply this provider?". Without this arm the
-                    panel would render <ReadyBanner /> and the
-                    reconnect wording in ConnectCta would never be
-                    seen — the user would have no signal their
-                    credentials need refreshing. Match BEFORE the
-                    generic ready arm so the reconnect CTA wins.
-                    Clicking Connect re-runs OAuth into the SAME
-                    account's isolation dir (existingAccountId in
-                    auth-flow-controller.ts's connect()), refreshing the
-                    token in place. codex P1 on #982. */}
-                <Match
-                    when={
-                        controller.state().kind === "ready" &&
-                        (props.accountStatus?.() === "needs_reauth" ||
-                            props.accountStatus?.() === "expired")
-                    }
-                >
+                <Match when={showConnectCta()}>
                     <ConnectCta
                         provider={props.provider}
                         state={controller.state()}
@@ -305,21 +308,6 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
                         state={controller.state()}
                         onRetry={() => handleConnect()}
                         canRetry={!props.disabled}
-                    />
-                </Match>
-                <Match
-                    when={
-                        controller.state().kind === "unauthenticated" ||
-                        controller.state().kind === "expired"
-                    }
-                >
-                    <ConnectCta
-                        provider={props.provider}
-                        state={controller.state()}
-                        accountStatus={props.accountStatus?.() ?? null}
-                        hasAccount={props.accountSuppliesProvider()}
-                        onConnect={() => handleConnect()}
-                        disabled={props.disabled ?? false}
                     />
                 </Match>
             </Switch>

--- a/frontend/app/view/editor/file-tree.tsx
+++ b/frontend/app/view/editor/file-tree.tsx
@@ -68,23 +68,12 @@ export function FileTree(props: FileTreeProps): JSX.Element {
                 <For each={props.model.rootsAtom()}>
                     {(root: Root) => (
                         <TreeNode
-                            model={props.model}
+                            {...props}
                             path={root.path}
                             name={root.name}
                             depth={0}
                             isDir={true}
                             isSymlink={false}
-                            activeFilePath={props.activeFilePath}
-                            showHidden={props.showHidden}
-                            onFileClick={props.onFileClick}
-                            onFileDblClick={props.onFileDblClick}
-                            onContextMenu={props.onContextMenu}
-                            renamingPath={props.renamingPath}
-                            onRenameConfirm={props.onRenameConfirm}
-                            onRenameCancel={props.onRenameCancel}
-                            newEntry={props.newEntry}
-                            onNewEntryConfirm={props.onNewEntryConfirm}
-                            onNewEntryCancel={props.onNewEntryCancel}
                         />
                     )}
                 </For>
@@ -134,6 +123,11 @@ function FileTreeToolbar(props: FileTreeToolbarProps): JSX.Element {
     );
 }
 
+/**
+ * Everything except `path` / `name` / `depth` / `isDir` / `isSymlink` is
+ * per-tree state that every node forwards unchanged to its children; the
+ * two `<TreeNode {...props} …/>` sites spread it rather than re-listing it.
+ */
 interface TreeNodeProps {
     model: FileTreeModel;
     path: string;
@@ -272,23 +266,12 @@ function TreeNode(props: TreeNodeProps): JSX.Element {
                 <For each={filteredEntries()}>
                     {(entry) => (
                         <TreeNode
-                            model={props.model}
+                            {...props}
                             path={joinPath(props.path, entry.name)}
                             name={entry.name}
                             depth={props.depth + 1}
                             isDir={entry.is_dir}
                             isSymlink={entry.is_symlink}
-                            activeFilePath={props.activeFilePath}
-                            showHidden={props.showHidden}
-                            onFileClick={props.onFileClick}
-                            onFileDblClick={props.onFileDblClick}
-                            onContextMenu={props.onContextMenu}
-                            renamingPath={props.renamingPath}
-                            onRenameConfirm={props.onRenameConfirm}
-                            onRenameCancel={props.onRenameCancel}
-                            newEntry={props.newEntry}
-                            onNewEntryConfirm={props.onNewEntryConfirm}
-                            onNewEntryCancel={props.onNewEntryCancel}
                         />
                     )}
                 </For>


### PR DESCRIPTION
## Summary

The "anytime — contained cleanups" items from `docs/reports/REPORT_DRY_AND_MODULARITY_AUDIT_2026_09_06.md` §5, the two same-file frontend clones from §3.2, and one correction to the report itself. **No behavior change.** Net −93 lines.

| File | What was duplicated | Now |
|---|---|---|
| `frontend/app/element/flyoutmenu.tsx` | `MenuBody` and `SubMenu` each carried the same 85-line `<For>` row renderer — same hover-intent wiring, same item markup, same nested `<SubMenu>` hand-off — differing only in the row-key scheme (`${i}` vs `${parentKey}-${i}`) and the `parentKey` passed to `handleMouseEnterItem`. The 13-line pass-through prop list was declared twice as well. | one `MenuRows` component renders every level; `MenuLevelProps` is the one prop list. 589 → 509 lines |
| `frontend/app/view/editor/file-tree.tsx` | the root `<TreeNode>` and the recursive one re-listed the same twelve pass-through props | both spread `{...props}` and set only the five per-node values. 366 → 350 |
| `frontend/app/view/agent/components/PreLaunchAuthPanel.tsx` | the first and last `<Match>` arms rendered an identical `<ConnectCta …/>` | one arm keyed on `showConnectCta()`; the JSX comment explaining the stale-`ready` case moved next to the predicate. 833 → 822 |
| `agentmux-srv/src/migrations/mod.rs` | — (report step 18) | the module doc now states that migrations deliberately freeze copies of live helpers and must not be "deduplicated", and names the pairs |

## The report correction

The audit called `PreLaunchAuthPanel.tsx` "a 378-line render tree appearing twice … largest single clone in the frontend." Re-measuring with the right tokenizer shows that was an artifact: `jscpd`'s `javascript` mode mis-parses TSX and matched a 377-line span against a 12-line one, while `--format tsx` finds no clone in the file at all. The real duplication was the two 7-line `<ConnectCta>` invocations above. §3.2 and step 15 are corrected in this PR rather than left standing, and a progress note records what #3033 / #3034 / #3036 landed. The clone pairs named in the new policy paragraph (report §3.4) were re-verified with `jscpd --format rust` before being written down.

## Why the folds are safe

- **flyoutmenu** — the transform script diffed the two `<For>` blocks after normalising names and refused to run unless zero non-comment lines differed (zero did). The per-level `createPeerRegistry()` moves into `MenuRows`, so there is still exactly one registry per level. Row keys are unchanged; they are what `hoveredItems` / `visibleSubMenus` / `subMenuPosition` are keyed on.
- **PreLaunchAuthPanel** — `<Switch>` renders the first matching arm. The folded arm matches `unauthenticated`, `expired`, and stale-`ready`; the remaining arms match generic `ready`, `waiting`, `authenticated|saving`, `failed`. The sets are disjoint, so every controller state renders the arm it did before. The script asserted both `<ConnectCta>` elements were prop-for-prop identical before folding.
- **file-tree** — Solid's `{...props}` keeps the getters reactive and the five explicit props win. The two extra `FileTreeProps` callbacks (`onToggleHidden`, `onStartRename`) ride along unused at the root, as any spread would.

## Verification

- `tsc --noEmit -p tsconfig.json` — clean
- `vitest run` on the launch-modal integration test and the auth-flow / auth-state suites — **3 files, 77/77 passed**
- Prettier: all three files were already non-conforming on `main`; the edited lines follow the surrounding style and no unrelated hunks were reformatted (same rule as #2984).

Follow-up to #3031 (the audit), #3033, #3034, #3036.

<!-- agentmux:agent_id=manoz -->
