### PR TITLE
docs(tray): implementation status in the design doc (issue #2977)

### DIFF
--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -317,7 +317,7 @@ partial list.
 | [`jekt-visibility-completion`](jekt-visibility-completion.md) | Spec: Jekt Visibility Completion — persistent-agent visibility + outgoing echo |
 | [`swarm-active-pane-sync`](swarm-active-pane-sync.md) | Swarm ↔ Pane Two-Way Active-Row Sync |
 
-### active (15)
+### active (16)
 
 | Spec | Title |
 |---|---|
@@ -335,9 +335,10 @@ partial list.
 | [`SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02`](SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md) | SPEC: Cross-channel jekt trust — closing the last unverifiable same-machine tier |
 | [`SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03`](SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03.md) | Migration System Audit & Hardening Plan |
 | [`SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29`](SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29.md) | Spec: multi-tier discovery + remote API invocation over muxbus |
+| [`SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04`](SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md) | Spec: optional system-tray + persistent background service, cross-platform |
 | [`SPEC_WINDOW_NAME_API_HARDENING_2026_08_08`](SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md) | SPEC: Window-name App API hardening (phantom-id success + status codes) |
 
-### proposed (97)
+### proposed (96)
 
 | Spec | Title |
 |---|---|
@@ -416,7 +417,6 @@ partial list.
 | [`SPEC_TOOL_BLOCK_SINGLE_LEFT_BAR_2026_06_27`](SPEC_TOOL_BLOCK_SINGLE_LEFT_BAR_2026_06_27.md) | SPEC: Tool Block Single Left Bar |
 | [`SPEC_TOOL_RESULT_RENDERER_REGISTRY_2026_06_17`](SPEC_TOOL_RESULT_RENDERER_REGISTRY_2026_06_17.md) | SPEC: Tool-result renderer registry (rich, per-tool result UIs that scale) |
 | [`SPEC_TRANSPARENCY_MACOS_LINUX_2026_07_01`](SPEC_TRANSPARENCY_MACOS_LINUX_2026_07_01.md) | SPEC: Window Transparency on macOS and Linux |
-| [`SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04`](SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md) | Spec: optional system-tray + persistent background service, cross-platform |
 | [`SPEC_UNIFIED_MENU_SYSTEM_2026_05_11`](SPEC_UNIFIED_MENU_SYSTEM_2026_05_11.md) | Unified menu system |
 | [`SPEC_WEBSEARCH_CARD_FULL_CONTENT_AND_STYLING_2026_08_13`](SPEC_WEBSEARCH_CARD_FULL_CONTENT_AND_STYLING_2026_08_13.md) | Spec: WebSearch tool-card — full (unclamped) content + styling fixes |
 | [`SPEC_WIDGET_BAR_HOVER_CLICK_PREMATURE_CLOSE_2026_08_20`](SPEC_WIDGET_BAR_HOVER_CLICK_PREMATURE_CLOSE_2026_08_20.md) | SPEC: Widget bar "More" / pinned-parent flyout closes on its first click when hover already opened it |

--- a/docs/specs/SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md
+++ b/docs/specs/SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md
@@ -194,8 +194,8 @@ Kept deliberately short — issue #2977 has the per-box detail and the correctio
 | WS1 macOS menu-bar item | Done; glyph + a real Quit click seen by the repo owner (`tray: quit_app forwarded`) | #3037 |
 | WS1 Linux (`ksni`) | **Not started.** After #3037 only `tray/linux.rs`, the dep and one `cfg` arm in `start_if_enabled` are missing; the Unix supervisor already calls `spawn_action_loop`. Needs a real desktop session, with/without the GNOME AppIndicator extension | — |
 | WS2 auto-start | Done on all three, with two deviations: no Windows code signing (blocks shipping), macOS writes a LaunchAgent plist rather than `SMAppService` | #2999 |
-| WS3 panel | Done as a CEF window at panel size; not reachable from the tray menu for now | #3002, #3013 |
-| WS4 consent / indicator / uninstall | Done; unattended *activity* audit still only records lifecycle | #2996, #2999, #3001 |
+| WS3 panel | **Partial.** The `open_panel` host IPC and a CEF window at panel dimensions exist, but it shows the normal UI (no simplified panel design yet) and the tray menu entry was removed per the repo owner, so it is not reachable from the tray | #3002, #3013 |
+| WS4 consent / indicator / uninstall | **Partial.** Opt-in pairing, honest running indicator and a real uninstall path are done; the unattended-activity audit still records only lifecycle, not what the service did, so that box stays open | #2996, #2999, #3001 |
 
 **§7.5.1's macOS gap is closed by #3037.** With the splash disabled, background-service mode now runs a headless accessory `NSApplication` pump on the main thread (`splash_mac::prepare_headless_app` + `pump_forever`), with the supervisor on a worker thread — the same layout the splash path uses — so the reopen delegate and the menu-bar item exist without a splash. That path is compiled and unit-tested but has not been run live.
 

--- a/docs/specs/SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md
+++ b/docs/specs/SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md
@@ -1,6 +1,6 @@
 # Spec: optional system-tray + persistent background service, cross-platform
 
-**Status:** proposed — design only, nothing implemented.
+**Status:** in progress — Windows and macOS tray backends shipped, auto-start shipped with deviations, Linux tray pending. See §7.6 for the running status; issue #2977 is the box-level tracker.
 **Author:** Agent5
 **Tracking issue:** [agentmuxai/agentmux#2977](https://github.com/agentmuxai/agentmux/issues/2977)
 **Verified against:** `main` @ (2026-09-04 pull), codebase research + external best-practices research, no live prototype built.
@@ -182,6 +182,24 @@ with the Workstream 1 macOS work.
 Implication for the tray work: the tray's "open AgentMux" menu item does not
 need a new mechanism — it can invoke the same `open_new_window` path both
 routes already use. That removes a chunk of assumed scope from Workstream 3.
+
+## 7.6. Implementation status (2026-09-06)
+
+Kept deliberately short — issue #2977 has the per-box detail and the corrections.
+
+| Area | State | Where |
+|---|---|---|
+| WS0 decouple last-window-close from teardown | Done, verified live on Windows after a real bug (#3018) | #2983, #2987, #3018 |
+| WS1 Windows tray | Done; icon + click seen by the repo owner | #2996, #3006, #3008, #3013, #3019 |
+| WS1 macOS menu-bar item | Done; glyph + a real Quit click seen by the repo owner (`tray: quit_app forwarded`) | #3037 |
+| WS1 Linux (`ksni`) | **Not started.** After #3037 only `tray/linux.rs`, the dep and one `cfg` arm in `start_if_enabled` are missing; the Unix supervisor already calls `spawn_action_loop`. Needs a real desktop session, with/without the GNOME AppIndicator extension | — |
+| WS2 auto-start | Done on all three, with two deviations: no Windows code signing (blocks shipping), macOS writes a LaunchAgent plist rather than `SMAppService` | #2999 |
+| WS3 panel | Done as a CEF window at panel size; not reachable from the tray menu for now | #3002, #3013 |
+| WS4 consent / indicator / uninstall | Done; unattended *activity* audit still only records lifecycle | #2996, #2999, #3001 |
+
+**§7.5.1's macOS gap is closed by #3037.** With the splash disabled, background-service mode now runs a headless accessory `NSApplication` pump on the main thread (`splash_mac::prepare_headless_app` + `pump_forever`), with the supervisor on a worker thread — the same layout the splash path uses — so the reopen delegate and the menu-bar item exist without a splash. That path is compiled and unit-tested but has not been run live.
+
+**One macOS-specific finding worth keeping next to §7.5:** the main-thread pump assumption held, but AppKit also requires the status item to be *created* on the main thread, so the macOS backend owns no thread at all — the supervisor thread queues a request and the pump services it each tick. It is the inverse of Windows, where the pump had to be introduced on a dedicated thread. `tray-icon`'s `rect()` is meaningless on the first tick after creation (height 0, origin at the screen bottom); the status window is laid out a beat later.
 
 ## 8. What this spec does not decide
 

--- a/docs/specs/SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md
+++ b/docs/specs/SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md
@@ -1,6 +1,6 @@
 # Spec: optional system-tray + persistent background service, cross-platform
 
-**Status:** in progress — Windows and macOS tray backends shipped, auto-start shipped with deviations, Linux tray pending. See §7.6 for the running status; issue #2977 is the box-level tracker.
+**Status:** active — Windows and macOS tray backends shipped, auto-start shipped with deviations, Linux tray pending. See §7.6 for the running status; issue #2977 is the box-level tracker.
 **Author:** Agent5
 **Tracking issue:** [agentmuxai/agentmux#2977](https://github.com/agentmuxai/agentmux/issues/2977)
 **Verified against:** `main` @ (2026-09-04 pull), codebase research + external best-practices research, no live prototype built.


### PR DESCRIPTION
Docs only. `SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md` still said "design only, nothing implemented" and described the §7.5.1 macOS gap as open. Adds a §7.6 status table pointing at the PRs, marks §7.5.1 closed by #3037, and records the one macOS event-loop finding that belongs next to §7.5 (status item must be created on the main thread, so the macOS backend owns no thread; `rect()` is meaningless on the first tick). Issue #2977 keeps the box-level detail.

<!-- agentmux:agent_id=agento -->