### PR TITLE
Manoz@Area54: refactor(layout): one TileLayout core with per-platform hook objects instead of three near-identical copies

### DIFF
--- a/.changesets/1788751173-tilelayout-one-shared-core-createtilelayout-with-per-platfor-jnel.md
+++ b/.changesets/1788751173-tilelayout-one-shared-core-createtilelayout-with-per-platfor-jnel.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+TileLayout: one shared core (createTileLayout) with per-platform hook objects for win32/linux/darwin instead of three near-identical copies; no behavior change

--- a/docs/reports/REPORT_DRY_AND_MODULARITY_AUDIT_2026_09_06.md
+++ b/docs/reports/REPORT_DRY_AND_MODULARITY_AUDIT_2026_09_06.md
@@ -169,7 +169,7 @@ Two teams (or one team at two times) built the same *idea* twice with the same *
 
 Ordered by payoff ÷ risk. Each step is independently shippable.
 
-**Progress (2026-09-07):** Phase 1 steps 1–4 and 6 merged in #3033 (step 5, the ObjC externs, waits on a macOS build); Phase 3 step 10 merged in #3034; step 16 merged in #3036; steps 15 (as corrected) and 18, plus the `flyoutmenu` / `file-tree` clones from §3.2, landed in #3039. Step 11 is next: `TileLayout` measures **437 of 598 lines identical across all three platform files** (73%), so the shared core is real; the platform-specific remainder is the animate delay, the Win11 `dragend` safety net, the reflow notification, the `canDrag` resize-zone guard, `preventUnhandled`, `setJsDragActive`, and three different `ResizeHandle` pointer models.
+**Progress (2026-09-07):** Phase 1 steps 1–4 and 6 merged in #3033 (step 5, the ObjC externs, waits on a macOS build); Phase 3 step 10 merged in #3034; step 16 merged in #3036; steps 15 (as corrected) and 18, plus the `flyoutmenu` / `file-tree` clones from §3.2, landed in #3039. Step 11 landed in #3041: `TileLayout` measured **437 of 598 lines identical across all three platform files** (73%); the shared body is now `TileLayout.core.tsx` + three `TileLayoutPlatform` hook objects (1,652 → 957 lines), and the platform-specific remainder is the animate delay, the Win11 `dragend` safety net, the reflow notification, the `canDrag` resize-zone guard, `preventUnhandled`, `setJsDragActive`, and three different `ResizeHandle` pointer models.
 
 ### Phase 1 — mechanical lifts into `agentmux-common` (low risk, immediate)
 

--- a/frontend/layout/lib/TileLayout.core.tsx
+++ b/frontend/layout/lib/TileLayout.core.tsx
@@ -1,0 +1,592 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// TileLayout core — everything the three platform builds share.
+//
+// TileLayout.{win32,linux,darwin}.tsx used to be three ~550-line copies that
+// differed in about a dozen places (437 of 598 lines were byte-identical
+// across all three). Each platform file is now a `TileLayoutPlatform` object
+// — the animate delay, the drag-start/drop side effects its browser engine
+// needs, the resize-handle pointer model — handed to `createTileLayout()`.
+//
+// The drag REGISTRATION strategy is the same on every engine and so lives
+// here: pragmatic-dnd's `dragHandle` option writes draggable="true" on the
+// handle AND draggable="false" on the tile root, and WebView2, WebKitGTK and
+// WKWebView all refuse to start a drag from a draggable="true" child inside a
+// draggable="false" parent. So `draggable()` is registered directly on the
+// live header element instead; only the header gets draggable="true", the
+// tile root carries no drag attribute, and clicks, text selection and widget
+// interaction in pane bodies keep working. No canDrag() tricks, no
+// preventDefault() on dragstart.
+//
+// Vite's platformResolve plugin maps `TileLayout.platform` to one of the
+// three platform files; this file is never platform-resolved.
+
+import { atoms } from "@/app/store/global";
+import { gatingNodeIds } from "@/app/store/tab-reveal";
+import { draggable } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import clsx from "clsx";
+import { toPng } from "html-to-image";
+import { createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js";
+import type { JSX } from "solid-js";
+import { Key } from "@solid-primitives/keyed";
+import { debounce } from "throttle-debounce";
+import { LayoutModel } from "./layoutModel";
+import { useNodeModel, useTileLayout } from "./layoutModelHooks";
+import "./tilelayout.scss";
+import { LayoutNode, LayoutTreeActionType, ResizeHandleProps, TileLayoutContents } from "./types";
+import { setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
+import { setTileDragInFlight } from "./dragInFlight";
+import { clearCrossTabDrop } from "./crossTabDrag";
+import { dragState } from "./tilelayout-drag-state";
+import {
+    computeDragPreviewSize,
+    dragPreviewCursorOffset,
+    DRAG_PREVIEW_FALLBACK,
+    type DragPreviewSize,
+} from "./drag-preview-size";
+import {
+    DisplayNodesWrapper,
+    MagnifiedPaneOverlay,
+    NodeBackdrops,
+    OverlayNodeWrapper,
+    Placeholder,
+    tileItemType,
+} from "./tilelayout-shared";
+
+export { tileItemType };
+
+export interface TileLayoutProps {
+    /**
+     * The accessor returning the current tab.
+     */
+    tabAtom: () => Tab;
+
+    /**
+     * callbacks and information about the contents (or styling) of the TileLayout or contents
+     */
+    contents: TileLayoutContents;
+
+    /**
+     * A callback for getting the cursor point in reference to the current window.
+     * @returns The cursor position relative to the current window.
+     */
+    getCursorPoint?: () => { x: number; y: number };
+}
+
+export interface ResizeHandleComponentProps {
+    resizeHandleProps: ResizeHandleProps;
+    layoutModel: LayoutModel;
+}
+
+/**
+ * What a platform build supplies to `createTileLayout()`. Every member is
+ * exactly the code that differed between the three former copies; the doc
+ * on each says which platform sets it and why. Booleans and optional hooks
+ * default to "off" — a platform that leaves one out gets the behaviour the
+ * other platforms had without it.
+ */
+export interface TileLayoutPlatform {
+    /**
+     * ms after mount before CSS transitions enable and `layoutModel.ready`
+     * flips. win32: 150 — Issue #774 / SPEC_TAB_CONTENT_REVEAL_GATE: block
+     * measurements (block.tsx `getBoundingClientRect`, virtual-list
+     * `measureElement`) haven't completed at the 50 ms mark, so transitions
+     * enabled mid-settle and panes snapped-then-animated. linux/darwin: 50.
+     */
+    animateDelayMs: number;
+    /**
+     * Runs inside the root component's onMount, so `onCleanup` works. win32
+     * installs its Windows 11 `dragend` safety net here.
+     */
+    onRootMount?: () => void;
+    /**
+     * linux: the debounced dragover bounds check only fires during an active
+     * tile drag (`dragState.nodeId` set). Tab DnD must not trigger
+     * persistToBackend via treeReducer — that crashed on Linux (see drag.rs
+     * notes).
+     */
+    boundsCheckRequiresTileDrag: boolean;
+    /**
+     * win32: called whenever a leaf's geometry changes outside the first-paint
+     * reveal gate and a resize drag. Native browser panes read the settle
+     * signal to re-sample + SetWindowPos their HWND onto the new rect
+     * (SPEC_PANE_REFLOW_ANIMATION_2026_05_29.md).
+     */
+    onLeafGeometryChange?: () => void;
+    /**
+     * win32: clear a tile's `.dragging` class when activeDrag goes false
+     * without onDrop having fired (the Win11 safety-net path), which would
+     * otherwise leave the tile stuck with the class.
+     */
+    clearDraggingWhenInactive: boolean;
+    /**
+     * Extra veto for canDrag, evaluated after the shared ephemeral/magnified
+     * check. win32 rejects presses that land inside a resize-handle zone.
+     */
+    rejectDragAt?: (layoutModel: LayoutModel, input: { clientX: number; clientY: number }) => boolean;
+    /**
+     * Drag-lifecycle side effects, at the positions the per-platform copies
+     * had them: linux/darwin call `preventUnhandled.start()` before the shared
+     * onDragStart body and `.stop()` before the shared onDrop body; linux also
+     * tells the host about the JS drag after each.
+     */
+    beforeDragStart?: () => void;
+    afterDragStart?: () => void;
+    beforeDrop?: () => void;
+    afterDrop?: () => void;
+    /**
+     * The resize divider. Three pointer models: win32 and darwin use pointer
+     * capture; linux (CEF on Wayland) cannot, because pointerId is not stable
+     * across press → move there, and drives the resize from `window`
+     * listeners instead.
+     */
+    ResizeHandle: (props: ResizeHandleComponentProps) => JSX.Element;
+}
+
+interface DisplayNodeProps {
+    layoutModel: LayoutModel;
+    node: LayoutNode;
+}
+
+interface ResizeHandleWrapperProps {
+    layoutModel: LayoutModel;
+}
+
+/**
+ * Build the platform-bound `TileLayout` component. `DisplayNode` and
+ * `ResizeHandleWrapper` close over `platform` so the shared wrappers in
+ * tilelayout-shared.tsx can keep taking plain components.
+ */
+export function createTileLayout(platform: TileLayoutPlatform) {
+    function TileLayoutComponent(props: TileLayoutProps) {
+        const layoutModel = useTileLayout(props.tabAtom, props.contents);
+        const overlayTransform = () => layoutModel.overlayTransform();
+        const isResizing = () => layoutModel.isResizing();
+
+        // Issue #836: hold the on-screen overlayTransform for 150ms after
+        // activeDrag flips false, so the Placeholder's inner-div exit fade
+        // (also 150ms) stays visible. Without this, overlayTransform()
+        // recomputes the moment onDrop fires and moves the entire
+        // .placeholder-container off-screen (top = 2*height) before the
+        // .exiting CSS transition can play. We cache the last in-drag
+        // transform and serve it during the hold window, then release.
+        const [heldOverlayTransform, setHeldOverlayTransform] = createSignal<JSX.CSSProperties | undefined>(undefined);
+        const [overlayHold, setOverlayHold] = createSignal(false);
+        let overlayHoldTimer: ReturnType<typeof setTimeout> | null = null;
+        createEffect(() => {
+            const active = layoutModel.activeDrag();
+            const xf = overlayTransform();
+            if (active) {
+                // Drag in progress: cache the live transform and clear any pending release.
+                setHeldOverlayTransform(xf as JSX.CSSProperties);
+                if (overlayHoldTimer) { clearTimeout(overlayHoldTimer); overlayHoldTimer = null; }
+                setOverlayHold(false);
+            } else if (heldOverlayTransform()) {
+                // Drag just ended (or page initial state with no cached value, skip).
+                // Hold the last in-drag transform for 150ms to match the Placeholder
+                // exit-fade duration, then release. A new drag during the hold window
+                // resets cleanly via the active branch above.
+                if (overlayHoldTimer) clearTimeout(overlayHoldTimer);
+                setOverlayHold(true);
+                overlayHoldTimer = setTimeout(() => {
+                    setOverlayHold(false);
+                    setHeldOverlayTransform(undefined);
+                    overlayHoldTimer = null;
+                }, 150);
+            }
+        });
+        onCleanup(() => { if (overlayHoldTimer) clearTimeout(overlayHoldTimer); });
+        // Effective transform for overlay-positioned surfaces: hold the last
+        // in-drag transform during the exit window, otherwise use the live one.
+        const effectiveOverlayTransform = (): JSX.CSSProperties | undefined =>
+            overlayHold() ? heldOverlayTransform() ?? undefined : (overlayTransform() as JSX.CSSProperties | undefined);
+
+        // Track animate state. The delay is per platform — see
+        // `TileLayoutPlatform.animateDelayMs`.
+        const [animate, setAnimate] = createSignal(false);
+        onMount(() => {
+            setTimeout(() => {
+                setAnimate(true);
+                layoutModel.ready._set(true);
+            }, platform.animateDelayMs);
+            platform.onRootMount?.();
+        });
+
+        const gapSizePx = () => layoutModel.gapSizePx();
+        const animationTimeS = () => layoutModel.animationTimeS();
+
+        const tileStyle = createMemo(
+            () =>
+                ({
+                    "--gap-size-px": `${gapSizePx()}px`,
+                    "--animation-time-s": `${animationTimeS()}s`,
+                }) as JSX.CSSProperties
+        );
+
+        // Handle drag-over for bounds checking to clear pending action when cursor leaves container.
+        const checkForCursorBounds = debounce(100, (x: number, y: number) => {
+            if (platform.boundsCheckRequiresTileDrag && !dragState.nodeId) return;
+            if (layoutModel.displayContainerRef?.current) {
+                const displayContainerRect = layoutModel.displayContainerRef.current.getBoundingClientRect();
+                const normalizedX = x - displayContainerRect.x;
+                const normalizedY = y - displayContainerRect.y;
+                if (
+                    normalizedX <= 0 ||
+                    normalizedX >= displayContainerRect.width ||
+                    normalizedY <= 0 ||
+                    normalizedY >= displayContainerRect.height
+                ) {
+                    layoutModel.treeReducer({ type: LayoutTreeActionType.ClearPendingAction });
+                }
+            }
+        });
+
+        // Global dragover handler to detect when cursor leaves tile layout
+        const onWindowDragOver = (e: DragEvent) => {
+            checkForCursorBounds(e.clientX, e.clientY);
+        };
+
+        onMount(() => {
+            window.addEventListener("dragover", onWindowDragOver);
+        });
+        onCleanup(() => {
+            window.removeEventListener("dragover", onWindowDragOver);
+        });
+
+        return (
+            <div
+                class={clsx("tile-layout", props.contents.className, { animate: animate() && !isResizing() })}
+                style={tileStyle()}
+            >
+                <div
+                    ref={(el) => {
+                        (layoutModel.displayContainerRef as any).current = el;
+                    }}
+                    class="display-container"
+                >
+                    <ResizeHandleWrapper layoutModel={layoutModel} />
+                    <DisplayNodesWrapper layoutModel={layoutModel} DisplayNode={DisplayNode} />
+                </div>
+
+                {/* Magnify layer — outside display-container to avoid stacking context issues */}
+                <NodeBackdrops layoutModel={layoutModel} />
+                <MagnifiedPaneOverlay layoutModel={layoutModel} />
+
+                <Placeholder layoutModel={layoutModel} style={{ top: "10000px", ...effectiveOverlayTransform() }} />
+                <OverlayNodeWrapper layoutModel={layoutModel} effectiveOverlayTransform={effectiveOverlayTransform} />
+            </div>
+        );
+    }
+
+    /**
+     * The draggable and displayable portion of a leaf node in a layout tree.
+     */
+    const DisplayNode = (props: DisplayNodeProps) => {
+        const nodeModel = useNodeModel(props.layoutModel, props.node);
+        let tileNodeRef: HTMLDivElement | undefined;
+        let previewRef: HTMLDivElement | undefined;
+        let leafRef: HTMLDivElement | undefined;
+        const addlProps = () => nodeModel.additionalProps();
+
+        // Ping the platform's settle signal whenever this node's geometry
+        // changes outside the first-paint reveal gate and a resize drag. (The
+        // CSS reflow animation this once tracked was removed; DOM panes just
+        // take the new rect directly.) Only win32 supplies the hook — see
+        // `TileLayoutPlatform.onLeafGeometryChange`.
+        if (platform.onLeafGeometryChange) {
+            const notify = platform.onLeafGeometryChange;
+            let prevGeomKey: string | undefined;
+            createEffect(() => {
+                const t = addlProps()?.transform as JSX.CSSProperties | undefined;
+                const key = t ? `${t.transform ?? ""}|${t.width ?? ""}|${t.height ?? ""}` : "";
+                const animating = props.layoutModel.ready() === true && !props.layoutModel.isResizing();
+                if (prevGeomKey !== undefined && key !== prevGeomKey && animating) {
+                    notify();
+                }
+                prevGeomKey = key;
+            });
+        }
+
+        const isEphemeral = () => nodeModel.isEphemeral();
+        const isMagnified = () => nodeModel.isMagnified();
+        // True when any pane is magnified. Every tile node is then hidden
+        // (display:none) so nothing inside AgentMux — DOM panes or native browser
+        // panes — shows behind the magnified pane. The magnified pane itself is
+        // reparented into the magnify overlay, outside the tile nodes.
+        const magnifyActive = () => !!props.layoutModel.magnifiedNodeIdAtom();
+        const [isDragging, setIsDragging] = createSignal(false);
+
+        // Clear isDragging when activeDrag goes false without onDrop having
+        // fired — see `TileLayoutPlatform.clearDraggingWhenInactive`.
+        if (platform.clearDraggingWhenInactive) {
+            createEffect(() => {
+                if (!props.layoutModel.activeDrag() && isDragging()) {
+                    setIsDragging(false);
+                }
+            });
+        }
+
+        // Drag preview image state
+        // The rasterised ghost, stored WITH the size it was rendered at. Keeping
+        // them together is deliberate: the cursor grab-offset must be derived from
+        // the size the image actually has, and a separate nominal constant is
+        // exactly how the two drift and the ghost detaches from the cursor.
+        const [previewImage, setPreviewImage] = createSignal<{ img: HTMLImageElement; size: DragPreviewSize } | null>(
+            null
+        );
+        // Drives the hidden .tile-preview element. Starts at the historical fixed
+        // square and is replaced with the pane-shaped size on first hover.
+        const [previewSize, setPreviewSize] = createSignal<DragPreviewSize>(DRAG_PREVIEW_FALLBACK);
+        const [previewElementGeneration, setPreviewElementGeneration] = createSignal(0);
+        const [previewImageGeneration, setPreviewImageGeneration] = createSignal(0);
+
+        // Monotonic token for in-flight rasterisations. `toPng` is async and a
+        // pane can be resized between two hovers, so two requests can be pending
+        // at once; without this the OLDER one resolving last overwrites the
+        // correctly-sized image, and the next drag uses that stale aspect ratio
+        // with no further pointerenter to repair it.
+        let previewRequestSeq = 0;
+
+        const devicePixelRatio = () => window.devicePixelRatio ?? 1;
+
+        const generatePreviewImage = () => {
+            // Size the ghost from the pane being dragged, so its shape matches what
+            // you are holding — a wide terminal reads wide, a tall pane reads tall.
+            // Capped and ratio-preserving; see drag-preview-size.ts for why NOT the
+            // pane's literal size.
+            const measured = computeDragPreviewSize(tileNodeRef?.getBoundingClientRect());
+            setPreviewSize(measured);
+            // Applied to the element directly as well as through the signal: toPng
+            // reads the LIVE DOM, and Solid has not necessarily flushed the signal
+            // into the style by the time we rasterise below. Writing both keeps the
+            // declarative binding honest without racing it.
+            if (previewRef) {
+                previewRef.style.width = `${measured.width}px`;
+                previewRef.style.height = `${measured.height}px`;
+            }
+            const cached = previewImage();
+            const prevElGen = previewElementGeneration();
+            const prevImgGen = previewImageGeneration();
+            // A cached image is only reusable if it was rasterised at the size we
+            // would render NOW. Without this, resizing a pane and then dragging it
+            // hands you the pre-resize ghost shape: the generation counters track
+            // CONTENT changes and know nothing about geometry.
+            const sizeMatches =
+                cached !== null && cached.size.width === measured.width && cached.size.height === measured.height;
+            if (cached !== null && prevElGen === prevImgGen && sizeMatches) {
+                // already up-to-date preview image; used on next dragstart
+            } else if (previewRef) {
+                setPreviewImageGeneration(prevElGen);
+                const seq = ++previewRequestSeq;
+                toPng(previewRef).then((url) => {
+                    // A newer rasterisation was requested while this one was in
+                    // flight — it measured the pane more recently, so drop this
+                    // result rather than clobbering it.
+                    if (seq !== previewRequestSeq) return;
+                    const newImg = new Image();
+                    newImg.src = url;
+                    setPreviewImage({ img: newImg, size: measured });
+                });
+            }
+        };
+
+        // Register pragmatic-dnd draggable on the HEADER element directly.
+        // pragmatic-dnd wraps HTML5 DnD and fires onDragStart AFTER the browser
+        // commits the drag, so SolidJS reactive state updates won't cause
+        // mid-event DOM mutations. See the file header for why the header and
+        // not the tile root (WebView2 / WebKitGTK / WKWebView all break on
+        // pragmatic-dnd's dragHandle option).
+        //
+        // The header ref may not be available at mount time (block content loads
+        // async behind a Show gate). Poll briefly until the ref is set.
+        // SolidJS's <Show> gate destroys/recreates the header element during block
+        // data loading. We must re-register whenever dragHandleRef.current changes
+        // or the element leaves the DOM. A persistent poll (cleared on unmount)
+        // handles all cases without needing to observe SolidJS internals.
+        onMount(() => {
+            if (!tileNodeRef) return;
+            let cleanupFn: (() => void) | null = null;
+            let registeredHandle: HTMLElement | null = null;
+
+            // Query the actual live header from the DOM rather than relying on dragHandleRef.
+            // dragHandleRef is written by two BlockFrame_Header instances (primary + ErrorBoundary
+            // fallback), and the fallback (never inserted into the DOM) always overwrites the
+            // primary one last, so the ref always points to a detached element.
+            // querySelector from tileNodeRef finds the header that is ACTUALLY in the DOM.
+            const findHandle = (): HTMLElement | null =>
+                tileNodeRef?.querySelector<HTMLElement>('[data-role="block-header"]') ?? null;
+
+            const register = () => {
+                const handle = findHandle();
+
+                // Nothing changed
+                if (handle === registeredHandle) return;
+
+                // NEVER tear down while a drag is in progress. If we call cleanupFn()
+                // mid-drag, pragmatic-dnd removes its onDrop listener and activeDrag
+                // never resets to false — leaving pointer-events:none permanently on
+                // all pane bodies ("widgets broken").
+                if (props.layoutModel.activeDrag()) return;
+
+                // Handle changed or left DOM — tear down old registration
+                cleanupFn?.();
+                cleanupFn = null;
+                registeredHandle = null;
+
+                if (!handle) return;
+
+                // New live handle — register draggable on it
+                registeredHandle = handle;
+                cleanupFn = draggable({
+                    element: handle,
+                    canDrag: ({ input }) => {
+                        if (isEphemeral() || isMagnified()) return false;
+                        return !platform.rejectDragAt?.(props.layoutModel, input);
+                    },
+                    getInitialData: () => ({ nodeId: props.node.id, type: tileItemType }),
+                    onGenerateDragPreview: ({ nativeSetDragImage }) => {
+                        const preview = previewImage();
+                        if (preview && nativeSetDragImage) {
+                            const dpr =
+                                typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;
+                            // Offsets from the size THIS image was rasterised at,
+                            // never a nominal constant — see the previewImage
+                            // signal's comment.
+                            const offset = dragPreviewCursorOffset(preview.size, dpr);
+                            nativeSetDragImage(preview.img, offset.x, offset.y);
+                        }
+                    },
+                    onDragStart: () => {
+                        platform.beforeDragStart?.();
+                        dragState.nodeId = props.node.id;
+                        dragState.layoutModel = props.layoutModel;
+                        dragState.node = props.node;
+                        setTileDragInFlight(true);
+                        clearCrossTabDrop();
+                        props.layoutModel.activeDrag._set(true);
+                        setIsDragging(true);
+                        setCurrentDragPayload({
+                            kind: "tile",
+                            node: props.node,
+                            sourceTabId: props.layoutModel.tabAtom()?.oid,
+                        });
+                        platform.afterDragStart?.();
+                    },
+                    onDrop: () => {
+                        platform.beforeDrop?.();
+                        dragState.nodeId = null;
+                        dragState.layoutModel = null;
+                        dragState.node = null;
+                        setTileDragInFlight(false);
+                        props.layoutModel.activeDrag._set(false);
+                        setIsDragging(false);
+                        platform.afterDrop?.();
+                        // Do NOT clear currentDragPayload here — fires for ALL drops including
+                        // out-of-window. Cleared in dropTargetForElements.onDrop instead.
+                    },
+                });
+            };
+
+            // Poll every 100ms for the lifetime of this tile. Handles initial load
+            // and any SolidJS Show-gate replacements during the tile's lifetime.
+            register();
+            const interval = setInterval(register, 100);
+            onCleanup(() => {
+                clearInterval(interval);
+                cleanupFn?.();
+            });
+        });
+
+        const leafContent = () => (
+            <div class="tile-leaf" ref={leafRef}>
+                {props.layoutModel.renderContent(nodeModel)}
+            </div>
+        );
+
+        // Single-instance magnify: the pane's `.tile-leaf` is rendered exactly
+        // once (below, in the tile node). While this node is magnified, move that
+        // same DOM node into the magnify overlay's mount slot rather than letting
+        // the overlay render a second copy. Moving a DOM subtree does not dispose
+        // its SolidJS component, so the Block, its ViewModel, the block-component
+        // registry entry, and any browser-pane native window all survive the
+        // magnify/restore cycle intact. See
+        // SPEC_MAGNIFY_ZOOM_IMPLEMENTATION_2026-05-21.md.
+        createEffect(() => {
+            const mount = props.layoutModel.magnifyMount();
+            if (!leafRef) return;
+            if (isMagnified() && mount) {
+                if (leafRef.parentElement !== mount) mount.appendChild(leafRef);
+            } else if (tileNodeRef && leafRef.parentElement !== tileNodeRef) {
+                tileNodeRef.insertBefore(leafRef, tileNodeRef.firstChild);
+            }
+        });
+
+        const previewElement = () => {
+            const dpr = typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;
+            return (
+                <div class="tile-preview-container">
+                    <div
+                        class="tile-preview"
+                        ref={previewRef}
+                        style={{
+                            width: `${previewSize().width}px`,
+                            height: `${previewSize().height}px`,
+                            transform: `scale(${1 / dpr})`,
+                        }}
+                    >
+                        {props.layoutModel.renderPreview?.(nodeModel)}
+                    </div>
+                </div>
+            );
+        };
+
+        const tileTransform = () => addlProps()?.transform;
+
+        // SPEC_PANE_BLOCK_STACK_MOUNT_FLICKER_2026_08_22 — hide this leaf while
+        // it's mid-remount (a block-stack push/switch, e.g. "+", Quick Fork,
+        // Agent History all force `<Key>` above to tear down and rebuild this
+        // subtree). Merged into the same style object as `tileTransform()`
+        // rather than a separate wrapper element, so the leaf's own absolute
+        // positioning is untouched. Mirrors `workspace.tsx`'s identical
+        // visibility+opacity treatment for the whole-tab reveal gate.
+        const isRevealGated = () => gatingNodeIds().has(props.node.id);
+        const tileStyle = createMemo<JSX.CSSProperties>(() => ({
+            ...(tileTransform() as JSX.CSSProperties),
+            visibility: isRevealGated() ? "hidden" : undefined,
+            opacity: atoms.prefersReducedMotionAtom() ? undefined : isRevealGated() ? 0 : 1,
+            transition: atoms.prefersReducedMotionAtom() ? undefined : "opacity 120ms ease-out",
+        }));
+
+        return (
+            <div
+                class={clsx("tile-node", { dragging: isDragging(), "tile-hidden": magnifyActive() })}
+                ref={tileNodeRef}
+                id={props.node.id}
+                style={tileStyle()}
+                onPointerEnter={generatePreviewImage}
+                onPointerOver={(event) => event.stopPropagation()}
+            >
+                {leafContent()}
+                {previewElement()}
+            </div>
+        );
+    };
+
+    const ResizeHandleWrapper = (props: ResizeHandleWrapperProps) => {
+        const resizeHandles = () => props.layoutModel.resizeHandles();
+
+        return (
+            <Key each={resizeHandles()} by={(h) => h.id}>
+                {(resizeHandleProps) => (
+                    <platform.ResizeHandle
+                        layoutModel={props.layoutModel}
+                        resizeHandleProps={resizeHandleProps()}
+                    />
+                )}
+            </Key>
+        );
+    };
+
+    return TileLayoutComponent;
+}

--- a/frontend/layout/lib/TileLayout.darwin.tsx
+++ b/frontend/layout/lib/TileLayout.darwin.tsx
@@ -1,468 +1,22 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 //
-// macOS-specific TileLayout.
-// Draggable registered on the header element (querySelector '[data-role="block-header"]').
-// WKWebView doesn't support pragmatic-dnd's dragHandle option (sets draggable="true/false"
-// on child/parent which breaks drag). Registering directly on the header avoids that.
+// macOS-specific TileLayout: the WKWebView hooks for TileLayout.core.tsx.
+//
+// WKWebView doesn't support pragmatic-dnd's dragHandle option (sets
+// draggable="true/false" on child/parent which breaks drag). The core
+// registers draggable() directly on the header element instead
+// (querySelector '[data-role="block-header"]'), which avoids that.
 
-import { atoms } from "@/app/store/global";
-import { gatingNodeIds } from "@/app/store/tab-reveal";
-import { draggable } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { preventUnhandled } from "@atlaskit/pragmatic-drag-and-drop/prevent-unhandled";
 import clsx from "clsx";
-import { toPng } from "html-to-image";
-import { createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js";
+import { createSignal } from "solid-js";
 import type { JSX } from "solid-js";
-import { Key } from "@solid-primitives/keyed";
 import { debounce, throttle } from "throttle-debounce";
-import { LayoutModel } from "./layoutModel";
-import { useNodeModel, useTileLayout } from "./layoutModelHooks";
-import "./tilelayout.scss";
-import { LayoutNode, LayoutTreeActionType, ResizeHandleProps, TileLayoutContents } from "./types";
-import { setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
-import { setTileDragInFlight } from "./dragInFlight";
-import { clearCrossTabDrop } from "./crossTabDrag";
-import { dragState } from "./tilelayout-drag-state";
-import {
-    computeDragPreviewSize,
-    dragPreviewCursorOffset,
-    DRAG_PREVIEW_FALLBACK,
-    type DragPreviewSize,
-} from "./drag-preview-size";
-import {
-    DisplayNodesWrapper,
-    MagnifiedPaneOverlay,
-    NodeBackdrops,
-    OverlayNodeWrapper,
-    Placeholder,
-    tileItemType,
-} from "./tilelayout-shared";
+import { createTileLayout, type ResizeHandleComponentProps, type TileLayoutPlatform } from "./TileLayout.core";
 
-export { tileItemType };
-
-// Data stored in the HTML5 drag event dataTransfer
-const DRAG_DATA_KEY = "application/x-tile-node-id";
-
-export interface TileLayoutProps {
-    /**
-     * The accessor returning the current tab.
-     */
-    tabAtom: () => Tab;
-
-    /**
-     * callbacks and information about the contents (or styling) of the TileLayout or contents
-     */
-    contents: TileLayoutContents;
-
-    /**
-     * A callback for getting the cursor point in reference to the current window.
-     * @returns The cursor position relative to the current window.
-     */
-    getCursorPoint?: () => { x: number; y: number };
-}
-
-
-function TileLayoutComponent(props: TileLayoutProps) {
-    const layoutModel = useTileLayout(props.tabAtom, props.contents);
-    const overlayTransform = () => layoutModel.overlayTransform();
-    const isResizing = () => layoutModel.isResizing();
-
-    // Track animate state
-    const [animate, setAnimate] = createSignal(false);
-    onMount(() => {
-        setTimeout(() => {
-            setAnimate(true);
-            layoutModel.ready._set(true);
-        }, 50);
-    });
-
-    // Issue #836: hold the on-screen overlayTransform for 150ms after
-    // activeDrag flips false, so the Placeholder's inner-div exit fade
-    // (also 150ms) stays visible. Without this, overlayTransform()
-    // recomputes the moment onDrop fires and moves the entire
-    // .placeholder-container off-screen (top = 2*height) before the
-    // .exiting CSS transition can play. We cache the last in-drag
-    // transform and serve it during the hold window, then release.
-    const [heldOverlayTransform, setHeldOverlayTransform] = createSignal<JSX.CSSProperties | undefined>(undefined);
-    const [overlayHold, setOverlayHold] = createSignal(false);
-    let overlayHoldTimer: ReturnType<typeof setTimeout> | null = null;
-    createEffect(() => {
-        const active = layoutModel.activeDrag();
-        const xf = overlayTransform();
-        if (active) {
-            setHeldOverlayTransform(xf as JSX.CSSProperties);
-            if (overlayHoldTimer) { clearTimeout(overlayHoldTimer); overlayHoldTimer = null; }
-            setOverlayHold(false);
-        } else if (heldOverlayTransform()) {
-            if (overlayHoldTimer) clearTimeout(overlayHoldTimer);
-            setOverlayHold(true);
-            overlayHoldTimer = setTimeout(() => {
-                setOverlayHold(false);
-                setHeldOverlayTransform(undefined);
-                overlayHoldTimer = null;
-            }, 150);
-        }
-    });
-    onCleanup(() => { if (overlayHoldTimer) clearTimeout(overlayHoldTimer); });
-    const effectiveOverlayTransform = (): JSX.CSSProperties | undefined =>
-        overlayHold() ? heldOverlayTransform() ?? undefined : (overlayTransform() as JSX.CSSProperties | undefined);
-
-    const gapSizePx = () => layoutModel.gapSizePx();
-    const animationTimeS = () => layoutModel.animationTimeS();
-
-    const tileStyle = createMemo(
-        () =>
-            ({
-                "--gap-size-px": `${gapSizePx()}px`,
-                "--animation-time-s": `${animationTimeS()}s`,
-            }) as JSX.CSSProperties
-    );
-
-    // Handle drag-over for bounds checking to clear pending action when cursor leaves container.
-    const checkForCursorBounds = debounce(100, (x: number, y: number) => {
-        if (layoutModel.displayContainerRef?.current) {
-            const displayContainerRect = layoutModel.displayContainerRef.current.getBoundingClientRect();
-            const normalizedX = x - displayContainerRect.x;
-            const normalizedY = y - displayContainerRect.y;
-            if (
-                normalizedX <= 0 ||
-                normalizedX >= displayContainerRect.width ||
-                normalizedY <= 0 ||
-                normalizedY >= displayContainerRect.height
-            ) {
-                layoutModel.treeReducer({ type: LayoutTreeActionType.ClearPendingAction });
-            }
-        }
-    });
-
-    // Global dragover handler to detect when cursor leaves tile layout
-    const onWindowDragOver = (e: DragEvent) => {
-        checkForCursorBounds(e.clientX, e.clientY);
-    };
-
-    onMount(() => {
-        window.addEventListener("dragover", onWindowDragOver);
-    });
-    onCleanup(() => {
-        window.removeEventListener("dragover", onWindowDragOver);
-    });
-
-    return (
-        <div
-            class={clsx("tile-layout", props.contents.className, { animate: animate() && !isResizing() })}
-            style={tileStyle()}
-        >
-            <div
-                ref={(el) => {
-                    (layoutModel.displayContainerRef as any).current = el;
-                }}
-                class="display-container"
-            >
-                <ResizeHandleWrapper layoutModel={layoutModel} />
-                <DisplayNodesWrapper layoutModel={layoutModel} DisplayNode={DisplayNode} />
-            </div>
-
-            {/* Magnify layer — outside display-container to avoid stacking context issues */}
-            <NodeBackdrops layoutModel={layoutModel} />
-            <MagnifiedPaneOverlay layoutModel={layoutModel} />
-
-            <Placeholder layoutModel={layoutModel} style={{ top: "10000px", ...effectiveOverlayTransform() }} />
-            <OverlayNodeWrapper layoutModel={layoutModel} effectiveOverlayTransform={effectiveOverlayTransform} />
-        </div>
-    );
-}
-export const TileLayout = TileLayoutComponent;
-
-interface DisplayNodeProps {
-    layoutModel: LayoutModel;
-    node: LayoutNode;
-}
-
-/**
- * The draggable and displayable portion of a leaf node in a layout tree.
- */
-const DisplayNode = (props: DisplayNodeProps) => {
-    const nodeModel = useNodeModel(props.layoutModel, props.node);
-    let tileNodeRef: HTMLDivElement | undefined;
-    let previewRef: HTMLDivElement | undefined;
-    let leafRef: HTMLDivElement | undefined;
-    const addlProps = () => nodeModel.additionalProps();
-    const isEphemeral = () => nodeModel.isEphemeral();
-    const isMagnified = () => nodeModel.isMagnified();
-    // True when any pane is magnified. Every tile node is then hidden
-    // (display:none) so nothing inside AgentMux — DOM panes or native browser
-    // panes — shows behind the magnified pane. The magnified pane itself is
-    // reparented into the magnify overlay, outside the tile nodes.
-    const magnifyActive = () => !!props.layoutModel.magnifiedNodeIdAtom();
-    const [isDragging, setIsDragging] = createSignal(false);
-
-
-    // Drag preview image state
-    // The rasterised ghost, stored WITH the size it was rendered at. Keeping
-    // them together is deliberate: the cursor grab-offset must be derived from
-    // the size the image actually has, and a separate nominal constant is
-    // exactly how the two drift and the ghost detaches from the cursor.
-    const [previewImage, setPreviewImage] = createSignal<{ img: HTMLImageElement; size: DragPreviewSize } | null>(
-        null
-    );
-    // Drives the hidden .tile-preview element. Starts at the historical fixed
-    // square and is replaced with the pane-shaped size on first hover.
-    const [previewSize, setPreviewSize] = createSignal<DragPreviewSize>(DRAG_PREVIEW_FALLBACK);
-    const [previewElementGeneration, setPreviewElementGeneration] = createSignal(0);
-    const [previewImageGeneration, setPreviewImageGeneration] = createSignal(0);
-
-    // Monotonic token for in-flight rasterisations. `toPng` is async and a
-    // pane can be resized between two hovers, so two requests can be pending
-    // at once; without this the OLDER one resolving last overwrites the
-    // correctly-sized image, and the next drag uses that stale aspect ratio
-    // with no further pointerenter to repair it.
-    let previewRequestSeq = 0;
-
-    const devicePixelRatio = () => window.devicePixelRatio ?? 1;
-
-    const generatePreviewImage = () => {
-        // Size the ghost from the pane being dragged, so its shape matches what
-        // you are holding — a wide terminal reads wide, a tall pane reads tall.
-        // Capped and ratio-preserving; see drag-preview-size.ts for why NOT the
-        // pane's literal size.
-        const measured = computeDragPreviewSize(tileNodeRef?.getBoundingClientRect());
-        setPreviewSize(measured);
-        // Applied to the element directly as well as through the signal: toPng
-        // reads the LIVE DOM, and Solid has not necessarily flushed the signal
-        // into the style by the time we rasterise below. Writing both keeps the
-        // declarative binding honest without racing it.
-        if (previewRef) {
-            previewRef.style.width = `${measured.width}px`;
-            previewRef.style.height = `${measured.height}px`;
-        }
-        const cached = previewImage();
-        const prevElGen = previewElementGeneration();
-        const prevImgGen = previewImageGeneration();
-        // A cached image is only reusable if it was rasterised at the size we
-        // would render NOW. Without this, resizing a pane and then dragging it
-        // hands you the pre-resize ghost shape: the generation counters track
-        // CONTENT changes and know nothing about geometry.
-        const sizeMatches =
-            cached !== null && cached.size.width === measured.width && cached.size.height === measured.height;
-        if (cached !== null && prevElGen === prevImgGen && sizeMatches) {
-            // already up-to-date preview image; used on next dragstart
-        } else if (previewRef) {
-            setPreviewImageGeneration(prevElGen);
-            const seq = ++previewRequestSeq;
-            toPng(previewRef).then((url) => {
-                // A newer rasterisation was requested while this one was in
-                // flight — it measured the pane more recently, so drop this
-                // result rather than clobbering it.
-                if (seq !== previewRequestSeq) return;
-                const newImg = new Image();
-                newImg.src = url;
-                setPreviewImage({ img: newImg, size: measured });
-            });
-        }
-    };
-
-    // Register pragmatic-dnd draggable on the HEADER element directly.
-    // pragmatic-dnd wraps HTML5 DnD and fires onDragStart AFTER the browser
-    // commits the drag, so SolidJS reactive state updates won't cause
-    // mid-event DOM mutations.
-    //
-    // macOS/WKWebView: cannot use dragHandle option — pragmatic-dnd sets
-    // draggable="true" on the handle AND draggable="false" on the tile,
-    // which breaks drag entirely in WKWebView. By registering directly on the
-    // header element, only the header gets draggable="true". The tile-node is
-    // untouched so text selection and widget interaction in pane bodies work.
-    //
-    // dragHandleRef is NOT used because BlockFrame_Default_Component creates
-    // two BlockFrame_Header instances (primary + ErrorBoundary fallback), and
-    // the fallback (never inserted into the DOM) always writes last — so the
-    // ref always points to a detached element. querySelector finds the live
-    // in-DOM header instead.
-    onMount(() => {
-        if (!tileNodeRef) return;
-        let cleanupFn: (() => void) | null = null;
-        let registeredHandle: HTMLElement | null = null;
-
-        const findHandle = (): HTMLElement | null =>
-            tileNodeRef?.querySelector<HTMLElement>('[data-role="block-header"]') ?? null;
-
-        const register = () => {
-            const handle = findHandle();
-
-            if (handle === registeredHandle) return;
-
-            // Never tear down during an active drag — would leave activeDrag=true
-            // permanently, making all pane bodies pointer-events:none ("frozen").
-            if (props.layoutModel.activeDrag()) return;
-
-            cleanupFn?.();
-            cleanupFn = null;
-            registeredHandle = null;
-
-            if (!handle) return;
-
-            registeredHandle = handle;
-            cleanupFn = draggable({
-                element: handle,
-                canDrag: () => !isEphemeral() && !isMagnified(),
-                getInitialData: () => ({ nodeId: props.node.id, type: tileItemType }),
-                onGenerateDragPreview: ({ nativeSetDragImage }) => {
-                    const preview = previewImage();
-                    if (preview && nativeSetDragImage) {
-                        const dpr =
-                            typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;
-                        // Offsets from the size THIS image was rasterised at,
-                        // never a nominal constant — see the previewImage
-                        // signal's comment.
-                        const offset = dragPreviewCursorOffset(preview.size, dpr);
-                        nativeSetDragImage(preview.img, offset.x, offset.y);
-                    }
-                },
-                onDragStart: () => {
-                    // Suppress WebKit's "drop rejected" snapback: a pane
-                    // tear-off releases the drag OUTSIDE any pragmatic-dnd
-                    // drop target (the floater is created on `dragend`), so
-                    // the browser would otherwise animate the drag preview
-                    // back into the source window ("it doesn't want to go").
-                    // preventUnhandled makes every element a drop target in
-                    // the browser's eyes, so the drop is "handled" and there's
-                    // no snapback — the preview just vanishes on release.
-                    // In-window rearrange still works via pragmatic-dnd's own
-                    // drop targets. Stopped in onDrop.
-                    preventUnhandled.start();
-                    dragState.nodeId = props.node.id;
-                    dragState.layoutModel = props.layoutModel;
-                    dragState.node = props.node;
-                    setTileDragInFlight(true);
-                    clearCrossTabDrop();
-                    props.layoutModel.activeDrag._set(true);
-                    setIsDragging(true);
-                    setCurrentDragPayload({
-                        kind: "tile",
-                        node: props.node,
-                        sourceTabId: props.layoutModel.tabAtom()?.oid,
-                    });
-                },
-                onDrop: () => {
-                    preventUnhandled.stop();
-                    dragState.nodeId = null;
-                    dragState.layoutModel = null;
-                    dragState.node = null;
-                    setTileDragInFlight(false);
-                    props.layoutModel.activeDrag._set(false);
-                    setIsDragging(false);
-                    // Do NOT clear currentDragPayload here — fires for ALL drops.
-                    // Cleared in dropTargetForElements.onDrop instead.
-                },
-            });
-        };
-
-        register();
-        const interval = setInterval(register, 100);
-        onCleanup(() => {
-            clearInterval(interval);
-            cleanupFn?.();
-        });
-    });
-
-    const leafContent = () => (
-        <div class="tile-leaf" ref={leafRef}>
-            {props.layoutModel.renderContent(nodeModel)}
-        </div>
-    );
-
-    // Single-instance magnify: the pane's `.tile-leaf` is rendered exactly
-    // once (below, in the tile node). While this node is magnified, move that
-    // same DOM node into the magnify overlay's mount slot rather than letting
-    // the overlay render a second copy. Moving a DOM subtree does not dispose
-    // its SolidJS component, so the Block, its ViewModel, the block-component
-    // registry entry, and any browser-pane native window all survive the
-    // magnify/restore cycle intact. See
-    // SPEC_MAGNIFY_ZOOM_IMPLEMENTATION_2026-05-21.md.
-    createEffect(() => {
-        const mount = props.layoutModel.magnifyMount();
-        if (!leafRef) return;
-        if (isMagnified() && mount) {
-            if (leafRef.parentElement !== mount) mount.appendChild(leafRef);
-        } else if (tileNodeRef && leafRef.parentElement !== tileNodeRef) {
-            tileNodeRef.insertBefore(leafRef, tileNodeRef.firstChild);
-        }
-    });
-
-    const previewElement = () => {
-        const dpr = typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;
-        return (
-            <div class="tile-preview-container">
-                <div
-                    class="tile-preview"
-                    ref={previewRef}
-                    style={{
-                        width: `${previewSize().width}px`,
-                        height: `${previewSize().height}px`,
-                        transform: `scale(${1 / dpr})`,
-                    }}
-                >
-                    {props.layoutModel.renderPreview?.(nodeModel)}
-                </div>
-            </div>
-        );
-    };
-
-    const tileTransform = () => addlProps()?.transform;
-
-    // SPEC_PANE_BLOCK_STACK_MOUNT_FLICKER_2026_08_22 — hide this leaf while
-    // it's mid-remount (a block-stack push/switch, e.g. "+", Quick Fork,
-    // Agent History all force `<Key>` above to tear down and rebuild this
-    // subtree). Merged into the same style object as `tileTransform()`
-    // rather than a separate wrapper element, so the leaf's own absolute
-    // positioning is untouched. Mirrors `workspace.tsx`'s identical
-    // visibility+opacity treatment for the whole-tab reveal gate.
-    const isRevealGated = () => gatingNodeIds().has(props.node.id);
-    const tileStyle = createMemo<JSX.CSSProperties>(() => ({
-        ...(tileTransform() as JSX.CSSProperties),
-        visibility: isRevealGated() ? "hidden" : undefined,
-        opacity: atoms.prefersReducedMotionAtom() ? undefined : isRevealGated() ? 0 : 1,
-        transition: atoms.prefersReducedMotionAtom() ? undefined : "opacity 120ms ease-out",
-    }));
-
-    return (
-        <div
-            class={clsx("tile-node", { dragging: isDragging(), "tile-hidden": magnifyActive() })}
-            ref={tileNodeRef}
-            id={props.node.id}
-            style={tileStyle()}
-            onPointerEnter={generatePreviewImage}
-            onPointerOver={(event) => event.stopPropagation()}
-        >
-            {leafContent()}
-            {previewElement()}
-        </div>
-    );
-};
-
-interface ResizeHandleWrapperProps {
-    layoutModel: LayoutModel;
-}
-
-const ResizeHandleWrapper = (props: ResizeHandleWrapperProps) => {
-    const resizeHandles = () => props.layoutModel.resizeHandles();
-
-    return (
-        <Key each={resizeHandles()} by={(h) => h.id}>
-            {(resizeHandleProps) => (
-                <ResizeHandle
-                    layoutModel={props.layoutModel}
-                    resizeHandleProps={resizeHandleProps()}
-                />
-            )}
-        </Key>
-    );
-};
-
-interface ResizeHandleComponentProps {
-    resizeHandleProps: ResizeHandleProps;
-    layoutModel: LayoutModel;
-}
+export { tileItemType } from "./TileLayout.core";
+export type { TileLayoutProps } from "./TileLayout.core";
 
 const ResizeHandle = (props: ResizeHandleComponentProps) => {
     let resizeHandleRef: HTMLDivElement | undefined;
@@ -518,3 +72,29 @@ const ResizeHandle = (props: ResizeHandleComponentProps) => {
     );
 };
 
+const darwin: TileLayoutPlatform = {
+    animateDelayMs: 50,
+    boundsCheckRequiresTileDrag: false,
+    clearDraggingWhenInactive: false,
+
+    beforeDragStart: () => {
+        // Suppress WebKit's "drop rejected" snapback: a pane
+        // tear-off releases the drag OUTSIDE any pragmatic-dnd
+        // drop target (the floater is created on `dragend`), so
+        // the browser would otherwise animate the drag preview
+        // back into the source window ("it doesn't want to go").
+        // preventUnhandled makes every element a drop target in
+        // the browser's eyes, so the drop is "handled" and there's
+        // no snapback — the preview just vanishes on release.
+        // In-window rearrange still works via pragmatic-dnd's own
+        // drop targets. Stopped in onDrop.
+        preventUnhandled.start();
+    },
+    beforeDrop: () => {
+        preventUnhandled.stop();
+    },
+
+    ResizeHandle,
+};
+
+export const TileLayout = createTileLayout(darwin);

--- a/frontend/layout/lib/TileLayout.linux.tsx
+++ b/frontend/layout/lib/TileLayout.linux.tsx
@@ -1,466 +1,27 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Linux-specific TileLayout.
+// Linux-specific TileLayout: the WebKitGTK / CEF-on-Wayland hooks for
+// TileLayout.core.tsx.
 //
 // WebKitGTK does not support HTML5 DnD from draggable="true" child inside an
 // explicit draggable="false" parent — pragmatic-dnd's dragHandle option sets
 // exactly that, so we cannot use it. The fix (same as win32) is to register
-// draggable() directly on the header element. Only the header gets
-// draggable="true"; the tile root receives no draggable attribute (implicitly
-// non-draggable). No explicit draggable="false" on any parent → no WebKitGTK
-// breakage, and drag is correctly restricted to the header.
+// draggable() directly on the header element, which the core does. Only the
+// header gets draggable="true"; the tile root receives no draggable attribute
+// (implicitly non-draggable). No explicit draggable="false" on any parent →
+// no WebKitGTK breakage, and drag is correctly restricted to the header.
 
-import { atoms, getApi } from "@/app/store/global";
-import { gatingNodeIds } from "@/app/store/tab-reveal";
-import { draggable } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { getApi } from "@/app/store/global";
 import { preventUnhandled } from "@atlaskit/pragmatic-drag-and-drop/prevent-unhandled";
 import clsx from "clsx";
-import { toPng } from "html-to-image";
-import { createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js";
+import { onCleanup } from "solid-js";
 import type { JSX } from "solid-js";
-import { Key } from "@solid-primitives/keyed";
-import { debounce, throttle } from "throttle-debounce";
-import { LayoutModel } from "./layoutModel";
-import { useNodeModel, useTileLayout } from "./layoutModelHooks";
-import "./tilelayout.scss";
-import { LayoutNode, LayoutTreeActionType, ResizeHandleProps, TileLayoutContents } from "./types";
-import { setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
-import { setTileDragInFlight } from "./dragInFlight";
-import { clearCrossTabDrop } from "./crossTabDrag";
-import { dragState } from "./tilelayout-drag-state";
-import {
-    computeDragPreviewSize,
-    dragPreviewCursorOffset,
-    DRAG_PREVIEW_FALLBACK,
-    type DragPreviewSize,
-} from "./drag-preview-size";
-import {
-    DisplayNodesWrapper,
-    MagnifiedPaneOverlay,
-    NodeBackdrops,
-    OverlayNodeWrapper,
-    Placeholder,
-    tileItemType,
-} from "./tilelayout-shared";
+import { throttle } from "throttle-debounce";
+import { createTileLayout, type ResizeHandleComponentProps, type TileLayoutPlatform } from "./TileLayout.core";
 
-export { tileItemType };
-
-// Data stored in the HTML5 drag event dataTransfer
-const DRAG_DATA_KEY = "application/x-tile-node-id";
-
-export interface TileLayoutProps {
-    /**
-     * The accessor returning the current tab.
-     */
-    tabAtom: () => Tab;
-
-    /**
-     * callbacks and information about the contents (or styling) of the TileLayout or contents
-     */
-    contents: TileLayoutContents;
-
-    /**
-     * A callback for getting the cursor point in reference to the current window.
-     * @returns The cursor position relative to the current window.
-     */
-    getCursorPoint?: () => { x: number; y: number };
-}
-
-
-function TileLayoutComponent(props: TileLayoutProps) {
-    const layoutModel = useTileLayout(props.tabAtom, props.contents);
-    const overlayTransform = () => layoutModel.overlayTransform();
-    const isResizing = () => layoutModel.isResizing();
-
-    // Track animate state
-    const [animate, setAnimate] = createSignal(false);
-    onMount(() => {
-        setTimeout(() => {
-            setAnimate(true);
-            layoutModel.ready._set(true);
-        }, 50);
-    });
-
-    // Issue #836: hold the on-screen overlayTransform for 150ms after
-    // activeDrag flips false, so the Placeholder's inner-div exit fade
-    // (also 150ms) stays visible. Without this, overlayTransform()
-    // recomputes the moment onDrop fires and moves the entire
-    // .placeholder-container off-screen (top = 2*height) before the
-    // .exiting CSS transition can play. We cache the last in-drag
-    // transform and serve it during the hold window, then release.
-    const [heldOverlayTransform, setHeldOverlayTransform] = createSignal<JSX.CSSProperties | undefined>(undefined);
-    const [overlayHold, setOverlayHold] = createSignal(false);
-    let overlayHoldTimer: ReturnType<typeof setTimeout> | null = null;
-    createEffect(() => {
-        const active = layoutModel.activeDrag();
-        const xf = overlayTransform();
-        if (active) {
-            setHeldOverlayTransform(xf as JSX.CSSProperties);
-            if (overlayHoldTimer) { clearTimeout(overlayHoldTimer); overlayHoldTimer = null; }
-            setOverlayHold(false);
-        } else if (heldOverlayTransform()) {
-            if (overlayHoldTimer) clearTimeout(overlayHoldTimer);
-            setOverlayHold(true);
-            overlayHoldTimer = setTimeout(() => {
-                setOverlayHold(false);
-                setHeldOverlayTransform(undefined);
-                overlayHoldTimer = null;
-            }, 150);
-        }
-    });
-    onCleanup(() => { if (overlayHoldTimer) clearTimeout(overlayHoldTimer); });
-    const effectiveOverlayTransform = (): JSX.CSSProperties | undefined =>
-        overlayHold() ? heldOverlayTransform() ?? undefined : (overlayTransform() as JSX.CSSProperties | undefined);
-
-    const gapSizePx = () => layoutModel.gapSizePx();
-    const animationTimeS = () => layoutModel.animationTimeS();
-
-    const tileStyle = createMemo(
-        () =>
-            ({
-                "--gap-size-px": `${gapSizePx()}px`,
-                "--animation-time-s": `${animationTimeS()}s`,
-            }) as JSX.CSSProperties
-    );
-
-    // Handle drag-over for bounds checking to clear pending action when cursor leaves container.
-    // Guard: only fire during an active tile drag (dragState.nodeId set). Tab DnD must not
-    // trigger persistToBackend via treeReducer, which caused a crash on Linux (see drag.rs notes).
-    const checkForCursorBounds = debounce(100, (x: number, y: number) => {
-        if (!dragState.nodeId) return;
-        if (layoutModel.displayContainerRef?.current) {
-            const displayContainerRect = layoutModel.displayContainerRef.current.getBoundingClientRect();
-            const normalizedX = x - displayContainerRect.x;
-            const normalizedY = y - displayContainerRect.y;
-            if (
-                normalizedX <= 0 ||
-                normalizedX >= displayContainerRect.width ||
-                normalizedY <= 0 ||
-                normalizedY >= displayContainerRect.height
-            ) {
-                layoutModel.treeReducer({ type: LayoutTreeActionType.ClearPendingAction });
-            }
-        }
-    });
-
-    // Global dragover handler to detect when cursor leaves tile layout
-    const onWindowDragOver = (e: DragEvent) => {
-        checkForCursorBounds(e.clientX, e.clientY);
-    };
-
-    onMount(() => {
-        window.addEventListener("dragover", onWindowDragOver);
-    });
-    onCleanup(() => {
-        window.removeEventListener("dragover", onWindowDragOver);
-    });
-
-    return (
-        <div
-            class={clsx("tile-layout", props.contents.className, { animate: animate() && !isResizing() })}
-            style={tileStyle()}
-        >
-            <div
-                ref={(el) => {
-                    (layoutModel.displayContainerRef as any).current = el;
-                }}
-                class="display-container"
-            >
-                <ResizeHandleWrapper layoutModel={layoutModel} />
-                <DisplayNodesWrapper layoutModel={layoutModel} DisplayNode={DisplayNode} />
-            </div>
-
-            {/* Magnify layer — outside display-container to avoid stacking context issues */}
-            <NodeBackdrops layoutModel={layoutModel} />
-            <MagnifiedPaneOverlay layoutModel={layoutModel} />
-
-            <Placeholder layoutModel={layoutModel} style={{ top: "10000px", ...effectiveOverlayTransform() }} />
-            <OverlayNodeWrapper layoutModel={layoutModel} effectiveOverlayTransform={effectiveOverlayTransform} />
-        </div>
-    );
-}
-export const TileLayout = TileLayoutComponent;
-
-interface DisplayNodeProps {
-    layoutModel: LayoutModel;
-    node: LayoutNode;
-}
-
-/**
- * The draggable and displayable portion of a leaf node in a layout tree.
- */
-const DisplayNode = (props: DisplayNodeProps) => {
-    const nodeModel = useNodeModel(props.layoutModel, props.node);
-    let tileNodeRef: HTMLDivElement | undefined;
-    let previewRef: HTMLDivElement | undefined;
-    let leafRef: HTMLDivElement | undefined;
-    const addlProps = () => nodeModel.additionalProps();
-    const isEphemeral = () => nodeModel.isEphemeral();
-    const isMagnified = () => nodeModel.isMagnified();
-    // True when any pane is magnified. Every tile node is then hidden
-    // (display:none) so nothing inside AgentMux — DOM panes or native browser
-    // panes — shows behind the magnified pane. The magnified pane itself is
-    // reparented into the magnify overlay, outside the tile nodes.
-    const magnifyActive = () => !!props.layoutModel.magnifiedNodeIdAtom();
-    const [isDragging, setIsDragging] = createSignal(false);
-
-
-    // Drag preview image state
-    // The rasterised ghost, stored WITH the size it was rendered at. Keeping
-    // them together is deliberate: the cursor grab-offset must be derived from
-    // the size the image actually has, and a separate nominal constant is
-    // exactly how the two drift and the ghost detaches from the cursor.
-    const [previewImage, setPreviewImage] = createSignal<{ img: HTMLImageElement; size: DragPreviewSize } | null>(
-        null
-    );
-    // Drives the hidden .tile-preview element. Starts at the historical fixed
-    // square and is replaced with the pane-shaped size on first hover.
-    const [previewSize, setPreviewSize] = createSignal<DragPreviewSize>(DRAG_PREVIEW_FALLBACK);
-    const [previewElementGeneration, setPreviewElementGeneration] = createSignal(0);
-    const [previewImageGeneration, setPreviewImageGeneration] = createSignal(0);
-
-    // Monotonic token for in-flight rasterisations. `toPng` is async and a
-    // pane can be resized between two hovers, so two requests can be pending
-    // at once; without this the OLDER one resolving last overwrites the
-    // correctly-sized image, and the next drag uses that stale aspect ratio
-    // with no further pointerenter to repair it.
-    let previewRequestSeq = 0;
-
-    const devicePixelRatio = () => window.devicePixelRatio ?? 1;
-
-    const generatePreviewImage = () => {
-        // Size the ghost from the pane being dragged, so its shape matches what
-        // you are holding — a wide terminal reads wide, a tall pane reads tall.
-        // Capped and ratio-preserving; see drag-preview-size.ts for why NOT the
-        // pane's literal size.
-        const measured = computeDragPreviewSize(tileNodeRef?.getBoundingClientRect());
-        setPreviewSize(measured);
-        // Applied to the element directly as well as through the signal: toPng
-        // reads the LIVE DOM, and Solid has not necessarily flushed the signal
-        // into the style by the time we rasterise below. Writing both keeps the
-        // declarative binding honest without racing it.
-        if (previewRef) {
-            previewRef.style.width = `${measured.width}px`;
-            previewRef.style.height = `${measured.height}px`;
-        }
-        const cached = previewImage();
-        const prevElGen = previewElementGeneration();
-        const prevImgGen = previewImageGeneration();
-        // A cached image is only reusable if it was rasterised at the size we
-        // would render NOW. Without this, resizing a pane and then dragging it
-        // hands you the pre-resize ghost shape: the generation counters track
-        // CONTENT changes and know nothing about geometry.
-        const sizeMatches =
-            cached !== null && cached.size.width === measured.width && cached.size.height === measured.height;
-        if (cached !== null && prevElGen === prevImgGen && sizeMatches) {
-            // already up-to-date preview image; used on next dragstart
-        } else if (previewRef) {
-            setPreviewImageGeneration(prevElGen);
-            const seq = ++previewRequestSeq;
-            toPng(previewRef).then((url) => {
-                // A newer rasterisation was requested while this one was in
-                // flight — it measured the pane more recently, so drop this
-                // result rather than clobbering it.
-                if (seq !== previewRequestSeq) return;
-                const newImg = new Image();
-                newImg.src = url;
-                setPreviewImage({ img: newImg, size: measured });
-            });
-        }
-    };
-
-    // Register pragmatic-dnd draggable on the live header element. Registering
-    // on the header (not the tile) means only the header gets draggable="true";
-    // the tile root stays attribute-free. This avoids the WebKitGTK constraint
-    // (see file header) while still restricting drag — and tear-off — to the
-    // header strip only.
-    //
-    // The header is not in the DOM at tile mount time (block content loads
-    // async behind a Show gate). Poll until it appears, then re-register if
-    // SolidJS ever swaps the element (ErrorBoundary Show-gate replacement).
-    // Never re-register while a drag is active — that would remove pragmatic-dnd's
-    // onDrop listener mid-drag and leave activeDrag stuck true ("widgets broken").
-    onMount(() => {
-        if (!tileNodeRef) return;
-        let cleanupFn: (() => void) | null = null;
-        let registeredHandle: HTMLElement | null = null;
-
-        const findHandle = (): HTMLElement | null =>
-            tileNodeRef?.querySelector<HTMLElement>('[data-role="block-header"]') ?? null;
-
-        const register = () => {
-            const handle = findHandle();
-            if (handle === registeredHandle) return;
-            if (props.layoutModel.activeDrag()) return;
-
-            cleanupFn?.();
-            cleanupFn = null;
-            registeredHandle = null;
-
-            if (!handle) return;
-
-            registeredHandle = handle;
-            cleanupFn = draggable({
-                element: handle,
-                canDrag: () => !isEphemeral() && !isMagnified(),
-                getInitialData: () => ({ nodeId: props.node.id, type: tileItemType }),
-                onGenerateDragPreview: ({ nativeSetDragImage }) => {
-                    const preview = previewImage();
-                    if (preview && nativeSetDragImage) {
-                        const dpr =
-                            typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;
-                        // Offsets from the size THIS image was rasterised at,
-                        // never a nominal constant — see the previewImage
-                        // signal's comment.
-                        const offset = dragPreviewCursorOffset(preview.size, dpr);
-                        nativeSetDragImage(preview.img, offset.x, offset.y);
-                    }
-                },
-                onDragStart: () => {
-                    // Suppress WebKitGTK's "drop rejected" snapback — a pane
-                    // tear-off releases outside any pragmatic-dnd drop target
-                    // (floater created on dragend), so the browser would
-                    // otherwise animate the drag preview back into the source
-                    // window. preventUnhandled makes the drop "handled" so the
-                    // preview just vanishes on release. In-window rearrange
-                    // still works via pragmatic-dnd's own drop targets.
-                    preventUnhandled.start();
-                    dragState.nodeId = props.node.id;
-                    dragState.layoutModel = props.layoutModel;
-                    dragState.node = props.node;
-                    setTileDragInFlight(true);
-                    clearCrossTabDrop();
-                    props.layoutModel.activeDrag._set(true);
-                    setIsDragging(true);
-                    setCurrentDragPayload({
-                        kind: "tile",
-                        node: props.node,
-                        sourceTabId: props.layoutModel.tabAtom()?.oid,
-                    });
-                    getApi().setJsDragActive(true).catch(() => {});
-                },
-                onDrop: () => {
-                    preventUnhandled.stop();
-                    dragState.nodeId = null;
-                    dragState.layoutModel = null;
-                    dragState.node = null;
-                    setTileDragInFlight(false);
-                    props.layoutModel.activeDrag._set(false);
-                    setIsDragging(false);
-                    getApi().setJsDragActive(false).catch(() => {});
-                    // Do NOT clear currentDragPayload here — fires for ALL drops.
-                    // Cleared in dropTargetForElements.onDrop instead.
-                },
-            });
-        };
-
-        register();
-        const interval = setInterval(register, 100);
-        onCleanup(() => {
-            clearInterval(interval);
-            cleanupFn?.();
-        });
-    });
-
-    const leafContent = () => (
-        <div class="tile-leaf" ref={leafRef}>
-            {props.layoutModel.renderContent(nodeModel)}
-        </div>
-    );
-
-    // Single-instance magnify: the pane's `.tile-leaf` is rendered exactly
-    // once (below, in the tile node). While this node is magnified, move that
-    // same DOM node into the magnify overlay's mount slot rather than letting
-    // the overlay render a second copy. Moving a DOM subtree does not dispose
-    // its SolidJS component, so the Block, its ViewModel, the block-component
-    // registry entry, and any browser-pane native window all survive the
-    // magnify/restore cycle intact. See
-    // SPEC_MAGNIFY_ZOOM_IMPLEMENTATION_2026-05-21.md.
-    createEffect(() => {
-        const mount = props.layoutModel.magnifyMount();
-        if (!leafRef) return;
-        if (isMagnified() && mount) {
-            if (leafRef.parentElement !== mount) mount.appendChild(leafRef);
-        } else if (tileNodeRef && leafRef.parentElement !== tileNodeRef) {
-            tileNodeRef.insertBefore(leafRef, tileNodeRef.firstChild);
-        }
-    });
-
-    const previewElement = () => {
-        const dpr = typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;
-        return (
-            <div class="tile-preview-container">
-                <div
-                    class="tile-preview"
-                    ref={previewRef}
-                    style={{
-                        width: `${previewSize().width}px`,
-                        height: `${previewSize().height}px`,
-                        transform: `scale(${1 / dpr})`,
-                    }}
-                >
-                    {props.layoutModel.renderPreview?.(nodeModel)}
-                </div>
-            </div>
-        );
-    };
-
-    const tileTransform = () => addlProps()?.transform;
-
-    // SPEC_PANE_BLOCK_STACK_MOUNT_FLICKER_2026_08_22 — hide this leaf while
-    // it's mid-remount (a block-stack push/switch, e.g. "+", Quick Fork,
-    // Agent History all force `<Key>` above to tear down and rebuild this
-    // subtree). Merged into the same style object as `tileTransform()`
-    // rather than a separate wrapper element, so the leaf's own absolute
-    // positioning is untouched. Mirrors `workspace.tsx`'s identical
-    // visibility+opacity treatment for the whole-tab reveal gate.
-    const isRevealGated = () => gatingNodeIds().has(props.node.id);
-    const tileStyle = createMemo<JSX.CSSProperties>(() => ({
-        ...(tileTransform() as JSX.CSSProperties),
-        visibility: isRevealGated() ? "hidden" : undefined,
-        opacity: atoms.prefersReducedMotionAtom() ? undefined : isRevealGated() ? 0 : 1,
-        transition: atoms.prefersReducedMotionAtom() ? undefined : "opacity 120ms ease-out",
-    }));
-
-    return (
-        <div
-            class={clsx("tile-node", { dragging: isDragging(), "tile-hidden": magnifyActive() })}
-            ref={tileNodeRef}
-            id={props.node.id}
-            style={tileStyle()}
-            onPointerEnter={generatePreviewImage}
-            onPointerOver={(event) => event.stopPropagation()}
-        >
-            {leafContent()}
-            {previewElement()}
-        </div>
-    );
-};
-
-interface ResizeHandleWrapperProps {
-    layoutModel: LayoutModel;
-}
-
-const ResizeHandleWrapper = (props: ResizeHandleWrapperProps) => {
-    const resizeHandles = () => props.layoutModel.resizeHandles();
-
-    return (
-        <Key each={resizeHandles()} by={(h) => h.id}>
-            {(resizeHandleProps) => (
-                <ResizeHandle
-                    layoutModel={props.layoutModel}
-                    resizeHandleProps={resizeHandleProps()}
-                />
-            )}
-        </Key>
-    );
-};
-
-interface ResizeHandleComponentProps {
-    resizeHandleProps: ResizeHandleProps;
-    layoutModel: LayoutModel;
-}
+export { tileItemType } from "./TileLayout.core";
+export type { TileLayoutProps } from "./TileLayout.core";
 
 const ResizeHandle = (props: ResizeHandleComponentProps) => {
     let resizeHandleRef: HTMLDivElement | undefined;
@@ -533,3 +94,36 @@ const ResizeHandle = (props: ResizeHandleComponentProps) => {
     );
 };
 
+const linux: TileLayoutPlatform = {
+    animateDelayMs: 50,
+
+    // Guard: only fire during an active tile drag (dragState.nodeId set). Tab DnD must not
+    // trigger persistToBackend via treeReducer, which caused a crash on Linux (see drag.rs notes).
+    boundsCheckRequiresTileDrag: true,
+
+    clearDraggingWhenInactive: false,
+
+    beforeDragStart: () => {
+        // Suppress WebKitGTK's "drop rejected" snapback — a pane
+        // tear-off releases outside any pragmatic-dnd drop target
+        // (floater created on dragend), so the browser would
+        // otherwise animate the drag preview back into the source
+        // window. preventUnhandled makes the drop "handled" so the
+        // preview just vanishes on release. In-window rearrange
+        // still works via pragmatic-dnd's own drop targets.
+        preventUnhandled.start();
+    },
+    afterDragStart: () => {
+        getApi().setJsDragActive(true).catch(() => {});
+    },
+    beforeDrop: () => {
+        preventUnhandled.stop();
+    },
+    afterDrop: () => {
+        getApi().setJsDragActive(false).catch(() => {});
+    },
+
+    ResizeHandle,
+};
+
+export const TileLayout = createTileLayout(linux);

--- a/frontend/layout/lib/TileLayout.win32.tsx
+++ b/frontend/layout/lib/TileLayout.win32.tsx
@@ -1,555 +1,26 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Windows-specific TileLayout.
-// dragHandle: undefined — whole-tile drag (pragmatic-dnd dragHandle breaks WebView2).
+// Windows-specific TileLayout: the WebView2 hooks for TileLayout.core.tsx.
+//
+// dragHandle: undefined — whole-tile drag (pragmatic-dnd dragHandle breaks
+// WebView2: it sets draggable="true" on the handle AND draggable="false" on
+// the tile, and WebView2 does not fire dragstart from a draggable="true"
+// child inside a draggable="false" parent — breaking pane DnD entirely on
+// Windows). The core registers draggable() directly on the header instead.
 
 import { notifyPaneReflow } from "@/app/platform/pane-anim";
-import { atoms } from "@/app/store/global";
-import { gatingNodeIds } from "@/app/store/tab-reveal";
-import { draggable } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import clsx from "clsx";
-import { toPng } from "html-to-image";
-import { createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js";
+import { createSignal, onCleanup } from "solid-js";
 import type { JSX } from "solid-js";
-import { Key } from "@solid-primitives/keyed";
 import { debounce, throttle } from "throttle-debounce";
-import { LayoutModel } from "./layoutModel";
-import { useNodeModel, useTileLayout } from "./layoutModelHooks";
-import "./tilelayout.scss";
-import { FlexDirection, LayoutNode, LayoutTreeActionType, ResizeHandleProps, TileLayoutContents } from "./types";
-import { setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
 import { setTileDragInFlight } from "./dragInFlight";
-import { clearCrossTabDrop } from "./crossTabDrag";
 import { dragState } from "./tilelayout-drag-state";
-import {
-    computeDragPreviewSize,
-    dragPreviewCursorOffset,
-    DRAG_PREVIEW_FALLBACK,
-    type DragPreviewSize,
-} from "./drag-preview-size";
-import {
-    DisplayNodesWrapper,
-    MagnifiedPaneOverlay,
-    NodeBackdrops,
-    OverlayNodeWrapper,
-    Placeholder,
-    tileItemType,
-} from "./tilelayout-shared";
+import { FlexDirection } from "./types";
+import { createTileLayout, type ResizeHandleComponentProps, type TileLayoutPlatform } from "./TileLayout.core";
 
-export { tileItemType };
-
-// Data stored in the HTML5 drag event dataTransfer
-const DRAG_DATA_KEY = "application/x-tile-node-id";
-
-export interface TileLayoutProps {
-    /**
-     * The accessor returning the current tab.
-     */
-    tabAtom: () => Tab;
-
-    /**
-     * callbacks and information about the contents (or styling) of the TileLayout or contents
-     */
-    contents: TileLayoutContents;
-
-    /**
-     * A callback for getting the cursor point in reference to the current window.
-     * @returns The cursor position relative to the current window.
-     */
-    getCursorPoint?: () => { x: number; y: number };
-}
-
-
-function TileLayoutComponent(props: TileLayoutProps) {
-    const layoutModel = useTileLayout(props.tabAtom, props.contents);
-    const overlayTransform = () => layoutModel.overlayTransform();
-    const isResizing = () => layoutModel.isResizing();
-
-    // Issue #836: hold the on-screen overlayTransform for 150ms after
-    // activeDrag flips false, so the Placeholder's inner-div exit fade
-    // (also 150ms) stays visible. Without this, overlayTransform()
-    // recomputes the moment onDrop fires and moves the entire
-    // .placeholder-container off-screen (top = 2*height) before the
-    // .exiting CSS transition can play. We cache the last in-drag
-    // transform and serve it during the hold window, then release.
-    const [heldOverlayTransform, setHeldOverlayTransform] = createSignal<JSX.CSSProperties | undefined>(undefined);
-    const [overlayHold, setOverlayHold] = createSignal(false);
-    let overlayHoldTimer: ReturnType<typeof setTimeout> | null = null;
-    createEffect(() => {
-        const active = layoutModel.activeDrag();
-        const xf = overlayTransform();
-        if (active) {
-            // Drag in progress: cache the live transform and clear any pending release.
-            setHeldOverlayTransform(xf as JSX.CSSProperties);
-            if (overlayHoldTimer) { clearTimeout(overlayHoldTimer); overlayHoldTimer = null; }
-            setOverlayHold(false);
-        } else if (heldOverlayTransform()) {
-            // Drag just ended (or page initial state with no cached value, skip).
-            // Hold the last in-drag transform for 150ms to match the Placeholder
-            // exit-fade duration, then release. A new drag during the hold window
-            // resets cleanly via the active branch above.
-            if (overlayHoldTimer) clearTimeout(overlayHoldTimer);
-            setOverlayHold(true);
-            overlayHoldTimer = setTimeout(() => {
-                setOverlayHold(false);
-                setHeldOverlayTransform(undefined);
-                overlayHoldTimer = null;
-            }, 150);
-        }
-    });
-    onCleanup(() => { if (overlayHoldTimer) clearTimeout(overlayHoldTimer); });
-    // Effective transform for overlay-positioned surfaces: hold the last
-    // in-drag transform during the exit window, otherwise use the live one.
-    const effectiveOverlayTransform = (): JSX.CSSProperties | undefined =>
-        overlayHold() ? heldOverlayTransform() ?? undefined : (overlayTransform() as JSX.CSSProperties | undefined);
-
-    // Track animate state.
-    //
-    // Issue #774 / SPEC_TAB_CONTENT_REVEAL_GATE: the prior 50 ms was
-    // too short. Block measurements (block.tsx `getBoundingClientRect`,
-    // virtual-list `measureElement`) haven't completed at the 50 ms
-    // mark, so transitions enable mid-settle and panes snap-then-
-    // animate. Bumped to 150 ms — gives the post-paint measurement
-    // wave time to complete before transitions kick in. Combined with
-    // the reveal gate at the workspace level, the user sees neither
-    // the snap nor the partial paint.
-    const [animate, setAnimate] = createSignal(false);
-    onMount(() => {
-        setTimeout(() => {
-            setAnimate(true);
-            layoutModel.ready._set(true);
-        }, 150);
-
-        // Windows 11 safety net: the browser's dragend event can be swallowed
-        // when snap-layouts or Alt+Tab interrupts a drag, preventing pragmatic-dnd's
-        // onDrop from firing and leaving activeDrag=true permanently (all pane bodies
-        // frozen with pointer-events:none). Listen on window so we catch it even when
-        // it fires on the draggable element after bubbling.
-        // Reset the same state onDrop resets so subsequent drags are not corrupted.
-        const resetDragState = () => {
-            if (dragState.layoutModel?.activeDrag()) {
-                dragState.nodeId = null;
-                dragState.node = null;
-                setTileDragInFlight(false);
-                dragState.layoutModel.activeDrag._set(false);
-                dragState.layoutModel = null;
-            }
-        };
-        window.addEventListener("dragend", resetDragState);
-        onCleanup(() => window.removeEventListener("dragend", resetDragState));
-    });
-
-    const gapSizePx = () => layoutModel.gapSizePx();
-    const animationTimeS = () => layoutModel.animationTimeS();
-
-    const tileStyle = createMemo(
-        () =>
-            ({
-                "--gap-size-px": `${gapSizePx()}px`,
-                "--animation-time-s": `${animationTimeS()}s`,
-            }) as JSX.CSSProperties
-    );
-
-    // Handle drag-over for bounds checking to clear pending action when cursor leaves container.
-    const checkForCursorBounds = debounce(100, (x: number, y: number) => {
-        if (layoutModel.displayContainerRef?.current) {
-            const displayContainerRect = layoutModel.displayContainerRef.current.getBoundingClientRect();
-            const normalizedX = x - displayContainerRect.x;
-            const normalizedY = y - displayContainerRect.y;
-            if (
-                normalizedX <= 0 ||
-                normalizedX >= displayContainerRect.width ||
-                normalizedY <= 0 ||
-                normalizedY >= displayContainerRect.height
-            ) {
-                layoutModel.treeReducer({ type: LayoutTreeActionType.ClearPendingAction });
-            }
-        }
-    });
-
-    // Global dragover handler to detect when cursor leaves tile layout
-    const onWindowDragOver = (e: DragEvent) => {
-        checkForCursorBounds(e.clientX, e.clientY);
-    };
-
-    onMount(() => {
-        window.addEventListener("dragover", onWindowDragOver);
-    });
-    onCleanup(() => {
-        window.removeEventListener("dragover", onWindowDragOver);
-    });
-
-    return (
-        <div
-            class={clsx("tile-layout", props.contents.className, { animate: animate() && !isResizing() })}
-            style={tileStyle()}
-        >
-            <div
-                ref={(el) => {
-                    (layoutModel.displayContainerRef as any).current = el;
-                }}
-                class="display-container"
-            >
-                <ResizeHandleWrapper layoutModel={layoutModel} />
-                <DisplayNodesWrapper layoutModel={layoutModel} DisplayNode={DisplayNode} />
-            </div>
-
-            {/* Magnify layer — outside display-container to avoid stacking context issues */}
-            <NodeBackdrops layoutModel={layoutModel} />
-            <MagnifiedPaneOverlay layoutModel={layoutModel} />
-
-            <Placeholder layoutModel={layoutModel} style={{ top: "10000px", ...effectiveOverlayTransform() }} />
-            <OverlayNodeWrapper layoutModel={layoutModel} effectiveOverlayTransform={effectiveOverlayTransform} />
-        </div>
-    );
-}
-export const TileLayout = TileLayoutComponent;
-
-interface DisplayNodeProps {
-    layoutModel: LayoutModel;
-    node: LayoutNode;
-}
-
-/**
- * The draggable and displayable portion of a leaf node in a layout tree.
- */
-const DisplayNode = (props: DisplayNodeProps) => {
-    const nodeModel = useNodeModel(props.layoutModel, props.node);
-    let tileNodeRef: HTMLDivElement | undefined;
-    let previewRef: HTMLDivElement | undefined;
-    let leafRef: HTMLDivElement | undefined;
-    const addlProps = () => nodeModel.additionalProps();
-
-    // Ping the shared settle signal whenever this node's geometry changes
-    // outside the first-paint reveal gate and a resize drag. Native browser
-    // panes read the signal to re-sample + SetWindowPos their HWND onto the new
-    // rect. (The CSS reflow animation this once tracked was removed; DOM panes
-    // just take the new rect directly.) See SPEC_PANE_REFLOW_ANIMATION_2026_05_29.md.
-    let prevGeomKey: string | undefined;
-    createEffect(() => {
-        const t = addlProps()?.transform as JSX.CSSProperties | undefined;
-        const key = t ? `${t.transform ?? ""}|${t.width ?? ""}|${t.height ?? ""}` : "";
-        const animating = props.layoutModel.ready() === true && !props.layoutModel.isResizing();
-        if (prevGeomKey !== undefined && key !== prevGeomKey && animating) {
-            notifyPaneReflow();
-        }
-        prevGeomKey = key;
-    });
-
-    const isEphemeral = () => nodeModel.isEphemeral();
-    const isMagnified = () => nodeModel.isMagnified();
-    // True when any pane is magnified. Every tile node is then hidden
-    // (display:none) so nothing inside AgentMux — DOM panes or native browser
-    // panes — shows behind the magnified pane. The magnified pane itself is
-    // reparented into the magnify overlay, outside the tile nodes.
-    const magnifyActive = () => !!props.layoutModel.magnifiedNodeIdAtom();
-    const [isDragging, setIsDragging] = createSignal(false);
-
-    // Clear isDragging when activeDrag goes false (handles the Win11 safety-net
-    // path where onDrop never fires and setIsDragging(false) is never called
-    // directly, leaving the tile stuck with the .dragging CSS class).
-    createEffect(() => {
-        if (!props.layoutModel.activeDrag() && isDragging()) {
-            setIsDragging(false);
-        }
-    });
-
-    // Drag preview image state
-    // The rasterised ghost, stored WITH the size it was rendered at. Keeping
-    // them together is deliberate: the cursor grab-offset must be derived from
-    // the size the image actually has, and a separate nominal constant is
-    // exactly how the two drift and the ghost detaches from the cursor.
-    const [previewImage, setPreviewImage] = createSignal<{ img: HTMLImageElement; size: DragPreviewSize } | null>(
-        null
-    );
-    // Drives the hidden .tile-preview element. Starts at the historical fixed
-    // square and is replaced with the pane-shaped size on first hover.
-    const [previewSize, setPreviewSize] = createSignal<DragPreviewSize>(DRAG_PREVIEW_FALLBACK);
-    const [previewElementGeneration, setPreviewElementGeneration] = createSignal(0);
-    const [previewImageGeneration, setPreviewImageGeneration] = createSignal(0);
-
-    // Monotonic token for in-flight rasterisations. `toPng` is async and a
-    // pane can be resized between two hovers, so two requests can be pending
-    // at once; without this the OLDER one resolving last overwrites the
-    // correctly-sized image, and the next drag uses that stale aspect ratio
-    // with no further pointerenter to repair it.
-    let previewRequestSeq = 0;
-
-    const devicePixelRatio = () => window.devicePixelRatio ?? 1;
-
-    const generatePreviewImage = () => {
-        // Size the ghost from the pane being dragged, so its shape matches what
-        // you are holding — a wide terminal reads wide, a tall pane reads tall.
-        // Capped and ratio-preserving; see drag-preview-size.ts for why NOT the
-        // pane's literal size.
-        const measured = computeDragPreviewSize(tileNodeRef?.getBoundingClientRect());
-        setPreviewSize(measured);
-        // Applied to the element directly as well as through the signal: toPng
-        // reads the LIVE DOM, and Solid has not necessarily flushed the signal
-        // into the style by the time we rasterise below. Writing both keeps the
-        // declarative binding honest without racing it.
-        if (previewRef) {
-            previewRef.style.width = `${measured.width}px`;
-            previewRef.style.height = `${measured.height}px`;
-        }
-        const cached = previewImage();
-        const prevElGen = previewElementGeneration();
-        const prevImgGen = previewImageGeneration();
-        // A cached image is only reusable if it was rasterised at the size we
-        // would render NOW. Without this, resizing a pane and then dragging it
-        // hands you the pre-resize ghost shape: the generation counters track
-        // CONTENT changes and know nothing about geometry.
-        const sizeMatches =
-            cached !== null && cached.size.width === measured.width && cached.size.height === measured.height;
-        if (cached !== null && prevElGen === prevImgGen && sizeMatches) {
-            // already up-to-date preview image; used on next dragstart
-        } else if (previewRef) {
-            setPreviewImageGeneration(prevElGen);
-            const seq = ++previewRequestSeq;
-            toPng(previewRef).then((url) => {
-                // A newer rasterisation was requested while this one was in
-                // flight — it measured the pane more recently, so drop this
-                // result rather than clobbering it.
-                if (seq !== previewRequestSeq) return;
-                const newImg = new Image();
-                newImg.src = url;
-                setPreviewImage({ img: newImg, size: measured });
-            });
-        }
-    };
-
-    // Register pragmatic-dnd draggable on the HEADER element directly.
-    // pragmatic-dnd wraps HTML5 DnD and fires onDragStart AFTER the browser
-    // commits the drag, so SolidJS reactive state updates won't cause
-    // mid-event DOM mutations.
-    //
-    // We register on the header (dragHandleRef) rather than on tileNodeRef
-    // for a critical WebView2 reason: pragmatic-dnd's dragHandle option sets
-    // draggable="true" on the handle AND draggable="false" on the element.
-    // WebView2 does not fire dragstart from a draggable="true" child inside
-    // a draggable="false" parent — breaking pane DnD entirely on Windows.
-    //
-    // By registering directly on the header element, only the header gets
-    // draggable="true". The tile-node is untouched (no draggable attr) so it
-    // defaults to non-draggable. The body and all pane content have no drag
-    // attribute, meaning clicks, text selection, and widget interaction all
-    // work normally. No canDrag() tricks, no preventDefault() on dragstart.
-    //
-    // The header ref may not be available at mount time (block content loads
-    // async behind a Show gate). Poll briefly until the ref is set.
-    // SolidJS's <Show> gate destroys/recreates the header element during block
-    // data loading. We must re-register whenever dragHandleRef.current changes
-    // or the element leaves the DOM. A persistent poll (cleared on unmount)
-    // handles all cases without needing to observe SolidJS internals.
-    onMount(() => {
-        if (!tileNodeRef) return;
-        let cleanupFn: (() => void) | null = null;
-        let registeredHandle: HTMLElement | null = null;
-
-        // Query the actual live header from the DOM rather than relying on dragHandleRef.
-        // dragHandleRef is written by two BlockFrame_Header instances (primary + ErrorBoundary
-        // fallback), and the fallback (never inserted into the DOM) always overwrites the
-        // primary one last, so the ref always points to a detached element.
-        // querySelector from tileNodeRef finds the header that is ACTUALLY in the DOM.
-        const findHandle = (): HTMLElement | null =>
-            tileNodeRef?.querySelector<HTMLElement>('[data-role="block-header"]') ?? null;
-
-        const register = () => {
-            const handle = findHandle();
-
-            // Nothing changed
-            if (handle === registeredHandle) return;
-
-            // NEVER tear down while a drag is in progress. If we call cleanupFn()
-            // mid-drag, pragmatic-dnd removes its onDrop listener and activeDrag
-            // never resets to false — leaving pointer-events:none permanently on
-            // all pane bodies ("widgets broken").
-            if (props.layoutModel.activeDrag()) return;
-
-            // Handle changed or left DOM — tear down old registration
-            cleanupFn?.();
-            cleanupFn = null;
-            registeredHandle = null;
-
-            if (!handle) return;
-
-            // New live handle — register draggable on it
-            registeredHandle = handle;
-            cleanupFn = draggable({
-                element: handle,
-                canDrag: ({ input }) => {
-                    if (isEphemeral() || isMagnified()) return false;
-                    // Reject drags that originate inside a resize-handle zone.
-                    // The resize handle overlaps slightly with the adjacent
-                    // header; this guard ensures a near-border mousedown never
-                    // turns into a tear-off even if the pointer just missed the
-                    // handle element.
-                    const containerEl = props.layoutModel.displayContainerRef?.current;
-                    if (containerEl) {
-                        const containerRect = containerEl.getBoundingClientRect();
-                        const localX = input.clientX - containerRect.left;
-                        const localY = input.clientY - containerRect.top;
-                        const halfSize = props.layoutModel.resizeHandleSizePx() / 2;
-                        for (const rh of props.layoutModel.resizeHandles()) {
-                            if (rh.flexDirection === FlexDirection.Row &&
-                                Math.abs(localX - rh.centerPx) <= halfSize &&
-                                localY >= rh.perpMinPx && localY <= rh.perpMaxPx) return false;
-                            if (rh.flexDirection === FlexDirection.Column &&
-                                Math.abs(localY - rh.centerPx) <= halfSize &&
-                                localX >= rh.perpMinPx && localX <= rh.perpMaxPx) return false;
-                        }
-                    }
-                    return true;
-                },
-                getInitialData: () => ({ nodeId: props.node.id, type: tileItemType }),
-                onGenerateDragPreview: ({ nativeSetDragImage }) => {
-                    const preview = previewImage();
-                    if (preview && nativeSetDragImage) {
-                        const dpr =
-                            typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;
-                        // Offsets from the size THIS image was rasterised at,
-                        // never a nominal constant — see the previewImage
-                        // signal's comment.
-                        const offset = dragPreviewCursorOffset(preview.size, dpr);
-                        nativeSetDragImage(preview.img, offset.x, offset.y);
-                    }
-                },
-                onDragStart: () => {
-                    dragState.nodeId = props.node.id;
-                    dragState.layoutModel = props.layoutModel;
-                    dragState.node = props.node;
-                    setTileDragInFlight(true);
-                    clearCrossTabDrop();
-                    props.layoutModel.activeDrag._set(true);
-                    setIsDragging(true);
-                    setCurrentDragPayload({
-                        kind: "tile",
-                        node: props.node,
-                        sourceTabId: props.layoutModel.tabAtom()?.oid,
-                    });
-                },
-                onDrop: () => {
-                    dragState.nodeId = null;
-                    dragState.layoutModel = null;
-                    dragState.node = null;
-                    setTileDragInFlight(false);
-                    props.layoutModel.activeDrag._set(false);
-                    setIsDragging(false);
-                    // Do NOT clear currentDragPayload here — fires for ALL drops including
-                    // out-of-window. Cleared in dropTargetForElements.onDrop instead.
-                },
-            });
-        };
-
-        // Poll every 100ms for the lifetime of this tile. Handles initial load
-        // and any SolidJS Show-gate replacements during the tile's lifetime.
-        register();
-        const interval = setInterval(register, 100);
-        onCleanup(() => {
-            clearInterval(interval);
-            cleanupFn?.();
-        });
-    });
-
-    const leafContent = () => (
-        <div class="tile-leaf" ref={leafRef}>
-            {props.layoutModel.renderContent(nodeModel)}
-        </div>
-    );
-
-    // Single-instance magnify: the pane's `.tile-leaf` is rendered exactly
-    // once (below, in the tile node). While this node is magnified, move that
-    // same DOM node into the magnify overlay's mount slot rather than letting
-    // the overlay render a second copy. Moving a DOM subtree does not dispose
-    // its SolidJS component, so the Block, its ViewModel, the block-component
-    // registry entry, and any browser-pane native window all survive the
-    // magnify/restore cycle intact. See
-    // SPEC_MAGNIFY_ZOOM_IMPLEMENTATION_2026-05-21.md.
-    createEffect(() => {
-        const mount = props.layoutModel.magnifyMount();
-        if (!leafRef) return;
-        if (isMagnified() && mount) {
-            if (leafRef.parentElement !== mount) mount.appendChild(leafRef);
-        } else if (tileNodeRef && leafRef.parentElement !== tileNodeRef) {
-            tileNodeRef.insertBefore(leafRef, tileNodeRef.firstChild);
-        }
-    });
-
-    const previewElement = () => {
-        const dpr = typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;
-        return (
-            <div class="tile-preview-container">
-                <div
-                    class="tile-preview"
-                    ref={previewRef}
-                    style={{
-                        width: `${previewSize().width}px`,
-                        height: `${previewSize().height}px`,
-                        transform: `scale(${1 / dpr})`,
-                    }}
-                >
-                    {props.layoutModel.renderPreview?.(nodeModel)}
-                </div>
-            </div>
-        );
-    };
-
-    const tileTransform = () => addlProps()?.transform;
-
-    // SPEC_PANE_BLOCK_STACK_MOUNT_FLICKER_2026_08_22 — hide this leaf while
-    // it's mid-remount (a block-stack push/switch, e.g. "+", Quick Fork,
-    // Agent History all force `<Key>` above to tear down and rebuild this
-    // subtree). Merged into the same style object as `tileTransform()`
-    // rather than a separate wrapper element, so the leaf's own absolute
-    // positioning is untouched. Mirrors `workspace.tsx`'s identical
-    // visibility+opacity treatment for the whole-tab reveal gate.
-    const isRevealGated = () => gatingNodeIds().has(props.node.id);
-    const tileStyle = createMemo<JSX.CSSProperties>(() => ({
-        ...(tileTransform() as JSX.CSSProperties),
-        visibility: isRevealGated() ? "hidden" : undefined,
-        opacity: atoms.prefersReducedMotionAtom() ? undefined : isRevealGated() ? 0 : 1,
-        transition: atoms.prefersReducedMotionAtom() ? undefined : "opacity 120ms ease-out",
-    }));
-
-    return (
-        <div
-            class={clsx("tile-node", { dragging: isDragging(), "tile-hidden": magnifyActive() })}
-            ref={tileNodeRef}
-            id={props.node.id}
-            style={tileStyle()}
-            onPointerEnter={generatePreviewImage}
-            onPointerOver={(event) => event.stopPropagation()}
-        >
-            {leafContent()}
-            {previewElement()}
-        </div>
-    );
-};
-
-interface ResizeHandleWrapperProps {
-    layoutModel: LayoutModel;
-}
-
-const ResizeHandleWrapper = (props: ResizeHandleWrapperProps) => {
-    const resizeHandles = () => props.layoutModel.resizeHandles();
-
-    return (
-        <Key each={resizeHandles()} by={(h) => h.id}>
-            {(resizeHandleProps) => (
-                <ResizeHandle
-                    layoutModel={props.layoutModel}
-                    resizeHandleProps={resizeHandleProps()}
-                />
-            )}
-        </Key>
-    );
-};
-
-interface ResizeHandleComponentProps {
-    resizeHandleProps: ResizeHandleProps;
-    layoutModel: LayoutModel;
-}
+export { tileItemType } from "./TileLayout.core";
+export type { TileLayoutProps } from "./TileLayout.core";
 
 const ResizeHandle = (props: ResizeHandleComponentProps) => {
     let resizeHandleRef: HTMLDivElement | undefined;
@@ -595,3 +66,71 @@ const ResizeHandle = (props: ResizeHandleComponentProps) => {
     );
 };
 
+const win32: TileLayoutPlatform = {
+    // Issue #774 / SPEC_TAB_CONTENT_REVEAL_GATE: the prior 50 ms was
+    // too short. Block measurements (block.tsx `getBoundingClientRect`,
+    // virtual-list `measureElement`) haven't completed at the 50 ms
+    // mark, so transitions enable mid-settle and panes snap-then-
+    // animate. Bumped to 150 ms — gives the post-paint measurement
+    // wave time to complete before transitions kick in. Combined with
+    // the reveal gate at the workspace level, the user sees neither
+    // the snap nor the partial paint.
+    animateDelayMs: 150,
+
+    onRootMount: () => {
+        // Windows 11 safety net: the browser's dragend event can be swallowed
+        // when snap-layouts or Alt+Tab interrupts a drag, preventing pragmatic-dnd's
+        // onDrop from firing and leaving activeDrag=true permanently (all pane bodies
+        // frozen with pointer-events:none). Listen on window so we catch it even when
+        // it fires on the draggable element after bubbling.
+        // Reset the same state onDrop resets so subsequent drags are not corrupted.
+        const resetDragState = () => {
+            if (dragState.layoutModel?.activeDrag()) {
+                dragState.nodeId = null;
+                dragState.node = null;
+                setTileDragInFlight(false);
+                dragState.layoutModel.activeDrag._set(false);
+                dragState.layoutModel = null;
+            }
+        };
+        window.addEventListener("dragend", resetDragState);
+        onCleanup(() => window.removeEventListener("dragend", resetDragState));
+    },
+
+    boundsCheckRequiresTileDrag: false,
+
+    // Native browser panes read the settle signal to re-sample + SetWindowPos
+    // their HWND onto the new rect. See SPEC_PANE_REFLOW_ANIMATION_2026_05_29.md.
+    onLeafGeometryChange: notifyPaneReflow,
+
+    // Handles the Win11 safety-net path above, where onDrop never fires and
+    // setIsDragging(false) is never called directly.
+    clearDraggingWhenInactive: true,
+
+    rejectDragAt: (layoutModel, input) => {
+        // Reject drags that originate inside a resize-handle zone.
+        // The resize handle overlaps slightly with the adjacent
+        // header; this guard ensures a near-border mousedown never
+        // turns into a tear-off even if the pointer just missed the
+        // handle element.
+        const containerEl = layoutModel.displayContainerRef?.current;
+        if (!containerEl) return false;
+        const containerRect = containerEl.getBoundingClientRect();
+        const localX = input.clientX - containerRect.left;
+        const localY = input.clientY - containerRect.top;
+        const halfSize = layoutModel.resizeHandleSizePx() / 2;
+        for (const rh of layoutModel.resizeHandles()) {
+            if (rh.flexDirection === FlexDirection.Row &&
+                Math.abs(localX - rh.centerPx) <= halfSize &&
+                localY >= rh.perpMinPx && localY <= rh.perpMaxPx) return true;
+            if (rh.flexDirection === FlexDirection.Column &&
+                Math.abs(localY - rh.centerPx) <= halfSize &&
+                localX >= rh.perpMinPx && localX <= rh.perpMaxPx) return true;
+        }
+        return false;
+    },
+
+    ResizeHandle,
+};
+
+export const TileLayout = createTileLayout(win32);

--- a/frontend/layout/lib/tilelayout-shared.tsx
+++ b/frontend/layout/lib/tilelayout-shared.tsx
@@ -1,17 +1,16 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Components shared byte-for-byte across all three platform TileLayout
-// implementations (TileLayout.{win32,linux,darwin}.tsx). None of these have
-// platform-conditional logic — the genuinely platform-specific pieces
-// (TileLayoutComponent, DisplayNode's drag REGISTRATION, ResizeHandle's
-// pointer-capture handling) stay local to each platform file and must NOT be
-// merged here.
+// Components shared by the three platform TileLayout builds. The rest of the
+// shared body — TileLayoutComponent, DisplayNode (including its drag
+// REGISTRATION) and ResizeHandleWrapper — lives in TileLayout.core.tsx; each
+// TileLayout.{win32,linux,darwin}.tsx supplies only a `TileLayoutPlatform`
+// object (animate delay, drag-lifecycle side effects, its ResizeHandle).
+// Nothing here has platform-conditional logic.
 //
-// `DisplayNode` itself is platform-specific and stays in each TileLayout.*.tsx
-// (different WebView2/WebKitGTK/WKWebView drag-registration quirks), so
-// `DisplayNodesWrapper` takes it as a prop and renders it via `<Dynamic>`
-// rather than importing a single implementation.
+// `DisplayNodesWrapper` still takes `DisplayNode` as a prop and renders it via
+// `<Dynamic>`: the core builds DisplayNode per platform object inside
+// createTileLayout(), so there is no single importable implementation.
 
 import { getSettingsKeyAtom } from "@/app/store/global";
 import { setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
@@ -158,10 +157,9 @@ export const MagnifiedPaneOverlay = (props: { layoutModel: LayoutModel }) => {
 export interface DisplayNodesWrapperProps {
     layoutModel: LayoutModel;
     /**
-     * The platform-specific `DisplayNode` component (drag REGISTRATION
-     * differs per WebView2/WebKitGTK/WKWebView — see the local `DisplayNode`
-     * in each TileLayout.{win32,linux,darwin}.tsx). Rendered via `<Dynamic>`
-     * since this wrapper itself has no platform-specific logic.
+     * The `DisplayNode` built by `createTileLayout()` for the current
+     * platform object (TileLayout.core.tsx). Rendered via `<Dynamic>` since
+     * this wrapper itself has no platform-specific logic.
      */
     DisplayNode: (props: { layoutModel: LayoutModel; node: LayoutNode }) => JSX.Element;
 }


### PR DESCRIPTION
## Summary

Phase 3 step 11 of `docs/reports/REPORT_DRY_AND_MODULARITY_AUDIT_2026_09_06.md`: `TileLayout.{win32,linux,darwin}.tsx` were three copies of the same component — **437 of 598 lines byte-identical across all three** — and the largest duplication cluster in the frontend. The shared body now lives once in `TileLayout.core.tsx` as `createTileLayout(platform)`; each platform file keeps only a `TileLayoutPlatform` object and its own `ResizeHandle`. **Zero behavior change per platform**; 1,652 → 957 lines (−695).

## What each platform still owns

Every member of `TileLayoutPlatform` is exactly one thing that differed between the old copies, and it is called exactly where that code was:

| Hook | win32 | linux | darwin |
|---|---|---|---|
| `animateDelayMs` | 150 (Issue #774 / reveal gate) | 50 | 50 |
| `onRootMount` | Win11 `dragend` safety net | — | — |
| `boundsCheckRequiresTileDrag` | — | ✓ (tab DnD crashed `persistToBackend`) | — |
| `onLeafGeometryChange` | `notifyPaneReflow` (native panes re-`SetWindowPos`) | — | — |
| `clearDraggingWhenInactive` | ✓ (after the safety net) | — | — |
| `rejectDragAt` | resize-handle-zone guard | — | — |
| `beforeDragStart` / `beforeDrop` | — | `preventUnhandled.start()` / `.stop()` | same as linux |
| `afterDragStart` / `afterDrop` | — | `setJsDragActive(true)` / `(false)` | — |
| `ResizeHandle` | pointer capture | `window` listeners (pointerId is unstable on CEF/Wayland) | capture + `body.cursor` workaround |

The drag **registration** (`draggable()` on the live header found by `querySelector`, 100 ms re-register poll, never torn down mid-drag) was already identical on all three engines — the three header comments each explained the same `dragHandle` breakage for WebView2 / WebKitGTK / WKWebView — so it moves to the core as is, with one comment covering all three.

## How I checked equivalence

- The split was designed from the three pairwise `diff`s, not from memory: every hunk in win32↔linux and linux↔darwin maps to one row above or to a comment-only difference. The mapping is in the commit message.
- Hook call sites preserve order: `beforeDragStart` is the first statement of `onDragStart` and `afterDragStart` the last, matching where linux/darwin had `preventUnhandled.start()` and `setJsDragActive(true)`; likewise for `onDrop`.
- Optional hooks default to "off", which is what the platforms that lacked the code had (`rejectDragAt` absent ⇒ `canDrag` is the old `!isEphemeral() && !isMagnified()`).
- The two conditional effects (geometry → `notifyPaneReflow`, clear-`.dragging`) are created only when the platform sets them, so linux/darwin get no new effects.
- Each platform's `ResizeHandle` is its original code verbatim; they genuinely differ (three pointer models) and stay separate.

## Verification

- `tsc --noEmit -p tsconfig.json` — clean (all three platform files are type-checked; the `.platform` stub is unchanged)
- `vitest run` — **253 files, 3,808 tests passed** (2 files / 3 tests skipped, pre-existing)
- **Not exercised here:** Linux and macOS builds — this machine is Windows. The equivalence argument above is structural; a Linux/macOS smoke test of pane drag and divider resize before the next release would be the belt to these braces.

Follow-up to #3031 (the audit); same family as #3033, #3034, #3036, #3039.

<!-- agentmux:agent_id=manoz -->
