### PR TITLE
Korp@claudius: docs: large-migrations completion audit — 14 initiatives scored, 4 stale status claims corrected

### DIFF
--- a/.changesets/1788751028-docs-large-migrations-completion-audit-14-initiatives-scored-jk5u.md
+++ b/.changesets/1788751028-docs-large-migrations-completion-audit-14-initiatives-scored-jk5u.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs: large-migrations completion audit — 14 initiatives scored, 4 stale status claims corrected (CLAUDE.md transcript_request, migration framework, SolidJS analysis, master reducer status)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -730,20 +730,26 @@ proof:
   secret, password, credential, keychain, api_key, --force, rm -rf, etc.) —
   regardless of trust tier, including `host-verified`, `SIG=verified`, or
   `TRUST=lan-verified`.
-- **[Not yet live — pre-committed policy, not current behavior]** The jekt
-  is a `transcript_request` (2026-08-22,
-  `SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md`,
-  `muxspect`'s cross-tier conversation-visibility protocol,
+- **[Live since 2026-08-22, PR #2764]** The jekt is a `transcript_request`
+  (`SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md`, `muxspect`'s
+  cross-tier conversation-visibility protocol,
   `SPEC_MUXSPECT_CROSS_TIER_CONVERSATION_VISIBILITY_2026_08_21.md`,
-  Phase B/C) — always, regardless of trust tier, once this jekt type
-  ships. **`transcript_request` does not exist anywhere in
-  `agentmux-srv` today (Phase B/C is designed, not built) — this rule is
-  a repo-owner-confirmed policy commitment for that future code, not a
-  description of anything srv currently enforces.** Whoever implements
-  Phase B/C must wire this rule in as part of that work, not assume it's
-  already there. The existing credential/destructive-keyword list doesn't
-  catch a content-*disclosure* request at all; this will be a distinct
-  category for that one new jekt type once it exists.
+  Phase B/C) — always, regardless of trust tier. **This is enforced in
+  code, not just policy:** the parser is
+  `agentmux_common::transcript_request::parse_transcript_request`, and
+  `agentmux-srv/src/server/reactive.rs`'s
+  `resolve_transcript_request_tier_fields()` sets
+  `is_transcript_request` server-side before the marker is rendered
+  (unit tests in that file's `transcript_request_tier_resolution_tests`
+  module). An earlier revision of this bullet, written the same day the
+  spec was and before #2764 merged, said the type "does not exist anywhere
+  in `agentmux-srv`" — that was true for a few hours and is not true now;
+  corrected 2026-09-06 per
+  `docs/reports/REPORT_LARGE_MIGRATIONS_COMPLETION_AUDIT_2026_09_06.md`
+  §5.1 (a status correction only; the policy itself is unchanged). The
+  existing credential/destructive-keyword list doesn't catch a
+  content-*disclosure* request at all; this is a distinct category for
+  that one jekt type.
 
 **No longer forced sensitive (2026-08-15 narrowing) — merely lacking proof
 of identity is not by itself a red flag:** any LAN jekt with clean content
@@ -791,24 +797,26 @@ yourself:
   `TRUST=unverified`/`SIG=invalid`/a failed LAN signature and "verified" are
   mutually exclusive readings of the same field).
 
-**One named exception, not yet live (2026-08-22,
-`SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md`): once
-`transcript_request` jekts exist (`muxspect` Phase B/C, designed but not
-built), their `ESCALATE=required` must NOT be relaxed to `none` by a
-verified sender — but ONLY when the RECEIVING (responding) agent's own
-`conversation_visibility` setting is `ask`, or is `trusted_peers` and the
-requester isn't on that agent's own allowlist.** This is narrower than a
-blanket rule for every `transcript_request` — do not read it as one. For
-`private` mode, or `trusted_peers` with an allow-listed requester, the
-request is fully auto-resolved (auto-deny / auto-approve) by that
-mode's own design intent regardless of the sender's verification status;
-this exception never applies to those, and the ordinary
-`ESCALATE=none`-for-verified-senders behavior is unaffected for them.
-**This is a pre-committed policy for future code, the same way the bullet
-above it is — `transcript_request` doesn't exist in `agentmux-srv` today,
-so there is nothing to relax or not-relax yet; whoever builds Phase B/C
-must implement this exception, correctly scoped to `ask`/non-allow-listed
-`trusted_peers` only, as part of that work.** No blind spot for the
+**One named exception, live since 2026-08-22 (PR #2764,
+`SPEC_JEKT_TRANSCRIPT_REQUEST_TIER_RULES_2026_08_22.md`): a
+`transcript_request` jekt's (`muxspect` Phase B/C) `ESCALATE=required`
+is NOT relaxed to `none` by a verified sender — but ONLY when the
+RECEIVING (responding) agent's own `conversation_visibility` setting is
+`ask`, or is `trusted_peers` and the requester isn't on that agent's own
+allowlist.** This is narrower than a blanket rule for every
+`transcript_request` — do not read it as one. For `private` mode, or
+`trusted_peers` with an allow-listed requester, the request is fully
+auto-resolved (auto-deny / auto-approve) by that mode's own design intent
+regardless of the sender's verification status; this exception never
+applies to those, and the ordinary `ESCALATE=none`-for-verified-senders
+behavior is unaffected for them. **This is implemented, not pending:**
+`resolve_transcript_request_tier_fields()` in
+`agentmux-srv/src/server/reactive.rs` computes
+`transcript_request_escalate_forced` from exactly that visibility
+setting (`ask` → forced; `trusted_peers` → forced unless the requester is
+in `conversation_trust_grants`; `private` → not forced). An earlier
+revision of this paragraph described it as "a pre-committed policy for
+future code"; corrected 2026-09-06, see the bullet above. No blind spot for the
 receiving agent despite this depending on ITS OWN setting: `ESCALATE` is
 computed server-side against the responding agent's own configuration
 before the marker ever reaches it, the same "authoritative, don't

--- a/docs/reports/REPORT_LARGE_MIGRATIONS_COMPLETION_AUDIT_2026_09_06.md
+++ b/docs/reports/REPORT_LARGE_MIGRATIONS_COMPLETION_AUDIT_2026_09_06.md
@@ -1,0 +1,349 @@
+# Report: large migrations and initiatives — what is done, what is pending
+
+**Status:** proposed
+**Date:** 2026-09-06
+**Author:** Korp
+**Baseline:** `main` @ `fe87e1732` (post-v0.55.37)
+**Ask (repo owner):** *"we were doing a lot of migrations and initiatives, but some never completed. can you take a look through all the docs and code and ID what is done and what is pending as far as our large migrations."*
+
+---
+
+## 0. The short version
+
+Fourteen large initiatives were identified. **Five are genuinely complete**, **six are partially
+done and stalled**, and **three were designed and never started.**
+
+The headline is not the count — it is *which* ones stalled. The two biggest migrations in the
+repo's history (Tauri→CEF and React→SolidJS) both **ran to completion and are done**, quietly,
+without either being tracked to closure in a doc. Meanwhile the initiatives that stalled are
+almost all **hardening and consolidation** work — the unglamorous second half of a migration,
+where the new thing works but the old thing was never removed.
+
+Three findings worth acting on independently of any single initiative:
+
+| # | Finding | Evidence |
+|---|---|---|
+| 1 | **`agent-view.tsx` more than doubled (1,282 → 2,730 lines) while the two items assigned to fix it stayed open for 3 months** | A6/A9 in issue #1549, open since 2026-06-18; `wc -l` today |
+| 2 | **`CLAUDE.md`'s jekt section states `transcript_request` "does not exist anywhere in agentmux-srv today" — it shipped 2026-08-22 in PR #2764** | `agentmux-srv/src/server/reactive.rs:540-606`, `agentmux-common/src/transcript_request.rs` |
+| 3 | **Migration failure is still silently non-fatal at startup**, exactly as `SPEC_MIGRATION_SYSTEM_HARDENING` says — every migration runs behind a `warn!` | `agentmux-srv/src/bootstrap.rs:565-569` |
+
+---
+
+## 1. Method, and how much to trust this
+
+- **Doc sweep:** all 857 specs under `docs/specs/` (+61 archived), 70 reports, 137 analyses,
+  15 status docs, 5 plans. `**Status:**` lines extracted in one pass and tallied.
+- **Status lines are not trusted on their own.** `docs/specs/README.md` says so itself
+  ("statuses rot... spot-verify against current code"), and the numbers back it: of 754 specs
+  with a Status line, only 544 use the closed enum — 210 use non-canonical words and 150 have
+  no Status line at all. Every claim in §2–§4 below is marked **[verified]** (checked against
+  code at this baseline) or **[doc-claim]** (taken from a spec, not independently confirmed).
+- **Code checks:** grep/`wc` against the live tree for the specific artifact each initiative
+  was supposed to create or remove.
+- **Issue checks:** open tracking issues via `gh`.
+
+**What this report does not do:** it does not re-litigate whether each initiative was a good
+idea, and it does not estimate effort. It answers "is it finished, and if not, what is left."
+
+---
+
+## 2. Complete — verified
+
+### 2.1 Tauri → CEF  ✅ **[verified]**
+
+The entire desktop shell moved off Tauri/WebView2 onto embedded CEF. No Tauri dependency
+remains in any `Cargo.toml` or `package.json`. The 29 files matching "tauri" are all
+**comments and historical references** (e.g. `agentmux-cef/src/commands/backend.rs:5`
+"Ported from src-tauri/..."; `ipc.rs:36` "maps to Tauri command names"), not code.
+
+**Residue, cosmetic only:** IPC command names are still described as "Tauri command names" in
+`agentmux-cef/src/ipc.rs`. Harmless; rename if it ever confuses someone.
+
+### 2.2 React → SolidJS  ✅ **[verified]** — and nothing says so
+
+390 frontend files import `solid-js`. **Zero** import `react`.
+`docs/reports/solidjs-migration-analysis.md` (2026-03-11) opens with "Current stack: React 19 +
+Jotai + Vite + Tauri" — three of those four are now false. The analysis doc was the *proposal*;
+no doc anywhere records that the migration happened, let alone finished.
+
+**Residue:** `react: 18.3.1` is still a declared `devDependency` in `package.json:57` with no
+importer. Worth removing — it is a real install cost and a misleading signal to any new reader
+(and to the analysis doc's own future readers).
+
+### 2.3 Reducer / saga architecture (Phases E–H)  ✅ **[doc-claim, partially verified]**
+
+The launcher/host/srv reducer stack and saga coordinator shipped across phases E, E4, E4b, F,
+and H. Saga durability was later deliberately **collapsed** rather than completed:
+`SPEC_PILLAR1_STEP6_SAGA_COLLAPSE_2026_07_16.md` ("Implemented") deletes the durable log,
+recovery walker, retention vacuum and `--diag sagas` offline reader from
+`SPEC_LAUNCHER_SAGA_DURABILITY_2026-05-01.md`, keeping only the live coordinator semantics.
+That is a completed decision, not an abandoned phase.
+
+**Caveat:** `MASTER_REDUCER_STACK_STATUS_2026-05-05.md` claims authority over this subsystem's
+status and carries its own staleness note — it has not been updated since 2026-05-29, and a
+later independent pass (`REPORT_REDUCER_STACK_AUDIT_2026_07_26.md`) covers the same ground
+without updating it. Two "current status" docs disagree about which is current. See §5.2.
+
+### 2.4 Architecture refactor A1–A15 — 12 of 15  ✅ **[verified]**
+
+Issue #1549. Verified by locating the artifacts each item was supposed to produce:
+
+- **A1** — `rpc_types.rs` (2,427 lines) → `agentmux-srv/src/backend/rpc_types/` (directory);
+  `rpc-api.ts` (1,568 lines) → `frontend/app/store/rpc-api/` (directory).
+- **A4** — `service.rs` (2,892 lines, one 2,272-line `match`) → `server/service/` split into
+  `client.rs`, `object.rs`, `credential.rs`, `introspect.rs`, `reducer_helpers.rs`, and more.
+- **A5** — `blockcontroller/shell.rs` (2,358 lines) → `shellexec.rs`, `shellintegration.rs`,
+  `shell_node.rs`, `server/shell_handlers.rs`.
+- **A8** — `websocket.rs` 2,371 → 1,837 lines, split by command family.
+- A2, A3, A7, A11, A12, A13, A14, A15 all closed with cited PRs.
+
+Three remain open — see §3.1.
+
+### 2.5 muxspect cross-tier conversation visibility (Phases A, B, C)  ✅ **[verified]**
+
+Phase A, B, and C all shipped (B/C in PR #2764, 2026-08-22). `transcript_request` parsing,
+per-agent `conversation_visibility` policy, trust-grant storage, and server-side `ESCALATE`
+resolution are live:
+
+- `agentmux-common/src/transcript_request.rs` — the parser
+- `agentmux-srv/src/server/reactive.rs:562` — `resolve_transcript_request_tier_fields()`
+- `agentmux-srv/src/backend/storage/conversation_trust_grants.rs` — the allowlist store
+
+Both phase specs say "Implemented (scoped)" with deferred items listed in their own §2/§3.
+**This is the initiative `CLAUDE.md` still describes as unbuilt** — see §5.1.
+
+---
+
+## 3. Partially complete — the actual backlog
+
+These are the ones the ask was about. Each has a working first phase and a stalled remainder.
+
+### 3.1 Architecture refactor A1–A15 — the 3 that stalled  🟡 **[verified]**
+
+Open since 2026-06-18 (issue #1549 last updated the same day — ~12 weeks untouched):
+
+| Item | What's left | Verified state today |
+|---|---|---|
+| **A6** | Collapse agent-pane's 4 parallel state systems | All four still exist: `agent-document-store.ts`, `agent-pane-layout-store.ts`, `agent-pane-model.ts`, `agent-pane-state-store.ts` |
+| **A9** | De-dup the agent-pane "is busy?" selector (4×); route raw dispatches via `paneModel` | Blocked at filing on PR #1573; that PR has long since resolved |
+| **A10** | Consolidate data-dir resolution onto `DataPaths` | Marked "safe to skip or tackle incrementally" by the board itself |
+
+**This is the item to act on.** The audit named `agent-view.tsx` at **1,282 lines** as the
+A6/A9 hotspot. It is **2,730 lines today** — it has more than doubled while the fix sat open.
+A6 is the only one of the three the board rates "high effort," and it gets more expensive every
+month. A10 is explicitly optional; A9 is small and no longer blocked.
+
+### 3.2 Migration system hardening  🟡 **[verified — the gap is real]**
+
+`SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03.md`: "Phase 0 shipped in PR #2394; Phases 1-6 not
+started (migration failure is still non-fatal at bootstrap.rs)."
+
+**Confirmed true at this baseline.** `agentmux-srv/src/bootstrap.rs:565-569`:
+
+```rust
+match migrations::run_pending_migrations(&wave_data_dir) {
+    Ok(0) => {}
+    Ok(n) => tracing::info!(applied = n, "startup: applied pending migrations"),
+    Err(e) => tracing::warn!("startup: migration error (continuing): {}", e),
+}
+```
+
+A failed schema migration logs a warning and the server starts anyway, against a database in an
+unknown state. Note the asymmetry a few lines below: failing to *open* the store calls
+`process::exit(1)`. Failing to *migrate* it does not.
+
+The underlying framework (`SPEC_MIGRATION_FRAMEWORK_2026_06_24.md`) is fully built and in daily
+use — `agentmux-srv/src/migrations/` with `m0000_bootstrap` through `m0006_definitions_global`
+and beyond — so this is hardening a working system, not finishing a broken one. Phases 1–6 remain.
+
+### 3.3 Docs lifecycle hardening  🟡 **[doc-claim, corroborated]**
+
+`SPEC_DOCS_LIFECYCLE_HARDENING_2026_08_03.md`: Phase 0 (PR #2394) and Phase 1 (closed Status
+vocabulary, 2026-08-10) shipped; **Phases 2, 3, 5 not started**; Phase 4 partially covered by
+the reader guardrail in `docs/specs/README.md`.
+
+Phase 3's generated `INDEX.md` and `scripts/gen-docs-index.sh` **do** exist and run, which
+suggests Phase 3 landed after that Status line was last edited. The enforcement gate
+(`scripts/check-doc-status.sh`) exists and is deliberately scoped to changed files only.
+
+**The measured backlog this leaves:** of 857 specs, **150 have no Status line** and **210 use a
+non-canonical status word** (`ready` ×38, `spec` ×34, `design` ×13, `shipped` ×12, `approved`
+×11, …). The gate stops the backlog growing but by design never reduces it, and nothing
+schedules the cleanup of those ~360 files.
+
+### 3.4 Jekt cross-channel trust  🟡 **[doc-claim]**
+
+`SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md`: "Phase A (D1 key publication + D5 signing
+primitives) shipped in #2959. Phases B (verification), C (enforcement) and D (escalation
+chaining) remain."
+
+Phase A is explicitly additive — it publishes keys, but nothing verifies against them yet, so
+the security benefit arrives in Phase B/C. This is the newest stalled item (4 days old) and is
+plausibly just in-flight rather than abandoned, but it is incomplete at this baseline.
+
+### 3.5 Container / sandbox agents  🟡 **[doc-claim]**
+
+Umbrella issue #2939 (open, "multi-generation"), with Phase 3 integration gaps in issue #1400
+(open since 2026-06). The umbrella's own framing: *"The lifecycle and turn execution have
+worked for months; everything around them did not, and the gaps were found one at a time
+because nothing tracked them together."*
+
+Known open gaps from #1400: the sidecar is not reachable from inside the container
+(`AGENTMUX_LOCAL_URL` is never added to the per-turn `env_vars` map, and `localhost` would
+resolve to the container anyway); MCP servers and PreToolUse/bashwrap hooks are written to the
+agent's *host* working directory, which the container never mounts.
+
+### 3.6 Armory / Stash foundation consolidation  🟡 **[doc-claim]**
+
+`ARCHITECTURE_ARMORY_FOUNDATION_CONSOLIDATION_2026_08_19.md` is explicitly a **north-star
+document**: "proposal — vision/north-star... Not implemented, not meant to land as one PR.
+Intended to be worked incrementally via follow-up `SPEC_` docs, sequenced per §4."
+
+Earlier Armory phases (4: storage rename; 5: consolidation + skill seeding) did ship. The
+consolidation *vision* layered on top of them has not started. This one is correctly labelled
+and is pending-by-design rather than stalled — but it is pending.
+
+---
+
+## 4. Designed, never started
+
+### 4.1 Mandatory ABF rethink  🔴 **[doc-claim]**
+
+`ARCHITECTURE_MANDATORY_ABF_RETHINK_2026_08_14.md`: **"DECISIONS RESOLVED, NOT YET
+IMPLEMENTED."** All open questions closed; extended the same day with the portability idea
+(harness + model as read-only ABF fields, making an ABF the portable unit rather than "the
+agent"). Nothing built. This is the largest fully-designed-but-unbuilt item found.
+
+### 4.2 DRY / modularity slimming plan  🔴 **[doc-claim, 1 of 5 started]**
+
+`docs/reports/REPORT_DRY_AND_MODULARITY_AUDIT_2026_09_06.md` (**written today**, Status:
+proposed). Measured duplication is low (2.8% frontend / 3.2% Rust) but it found **334 "keep in
+sync" comments across 210 source files** — one file in six. Five root causes, in its own payoff
+order:
+
+1. **No Rust↔TypeScript codegen** — 322 hand-maintained RPC stubs + a 2,819-line
+   hand-maintained `gotypes.d.ts`. **[verified]** `frontend/types/gotypes.d.ts` is 2,819 lines
+   and no codegen script exists in `scripts/`. Note this is the *unfinished half of A1*: A1
+   split the god-files and added a contract-enforcement test, but never removed the
+   hand-maintenance the test was guarding.
+2. **`agentmux-common` isn't used as a common** — 8K shared lines vs 300K Rust.
+3. **Whole-file platform forks** — `zoom.{win32,linux,darwin}.ts` differ by 9 comment lines of 186.
+4. **Twin primitives by copy-rename** — `mcp` ↔ `skill` are 58–71% structurally identical.
+5. **Parallel saga+reducer frameworks** in launcher and srv sharing only vocabulary.
+
+**Root cause 2 is already in progress** — PR #3033 (2026-09-06) lifted `CREATE_NO_WINDOW`,
+`now_ms`, `event_log`, process-kill and `WindowKind` into `agentmux-common`, and PR #3036
+consolidated the ten `backend_*` helpers onto one raw-TCP transport. The other four are untouched.
+
+### 4.3 Wave → Mux rename  🔴 **[verified]** — issue #851, open since 2026-05-14
+
+The single largest unfinished cleanup by raw count. Still in the tree:
+
+| Symbol | Occurrences |
+|---|---|
+| `WaveEvent` | 223 |
+| `WaveObjUpdate` | 93 |
+| `WaveObj` | 42 |
+| `WaveKeyboardEvent` | 23 |
+| `WaveFile` | 19 |
+| `WaveWindow` | 16 |
+| `WaveObject` | 11 |
+| others (`WaveInfoData`, `WaveLock`, `WaveBlock`, `WaveNotificationOptions`, …) | ~30 |
+
+**285 source files** contain a `wave` reference of some kind. It also reaches into runtime
+identifiers, not just type names: `bootstrap.rs:427` calls `base::get_wave_data_dir()`, and the
+variable is `wave_data_dir` throughout the migration code quoted in §3.2.
+
+This is pure tech debt with no user-visible payoff, which is presumably why it has sat for ~4
+months. Worth an explicit decision: schedule it, or close #851 and accept `Wave*` as permanent
+internal vocabulary. Leaving it open indefinitely is the worst of the three options — it keeps
+signalling "we are mid-rename" to every new reader.
+
+---
+
+## 5. Stale claims found while verifying
+
+Reported separately because each will actively mislead the next reader, and because the repo's
+own guardrail (`docs/specs/README.md`) asks for exactly this kind of spot-check.
+
+### 5.1 `CLAUDE.md` says `transcript_request` doesn't exist. It does. **[verified]**
+
+The jekt security section states, twice and emphatically:
+
+> "**`transcript_request` does not exist anywhere in `agentmux-srv` today (Phase B/C is
+> designed, not built)** — this rule is a repo-owner-confirmed policy commitment for that
+> future code, not a description of anything srv currently enforces."
+>
+> "Whoever implements Phase B/C must wire this rule in as part of that work, not assume it's
+> already there."
+
+It shipped on 2026-08-22 in PR #2764 — the same day that spec was written.
+`reactive.rs:562`'s `resolve_transcript_request_tier_fields()` computes
+`transcript_request_escalate_forced` from the responding agent's own `conversation_visibility`,
+which is precisely the rule CLAUDE.md describes as unbuilt.
+
+**Why this one matters more than the others:** CLAUDE.md instructs agents to treat that section
+as authoritative and to distrust inline corrections. An agent following it literally would
+either re-implement a live feature or wrongly conclude the escalation rule isn't enforced.
+Correct it in CLAUDE.md directly, citing the PR.
+
+### 5.2 Two competing "current status" docs for the reducer stack **[verified]**
+
+`MASTER_REDUCER_STACK_STATUS_2026-05-05.md` claims "**Authority.** When this file disagrees
+with another spec... this file wins for *current status*", then carries a note admitting it is
+~9 weeks stale and that `REPORT_REDUCER_STACK_AUDIT_2026_07_26.md` covers the same subsystem
+without updating it. Withdraw the authority claim or restamp the file `historical`.
+
+### 5.3 `SPEC_MIGRATION_FRAMEWORK_2026_06_24.md` is marked "Proposed" but shipped **[verified]**
+
+Already caught by the 2026-08-07 audit and annotated inline — but the Status line still reads
+`Proposed`, so the generated `INDEX.md` files a foundational, in-daily-use framework under
+proposals. A one-word fix.
+
+### 5.4 The SolidJS analysis doc describes a stack that no longer exists **[verified]**
+
+`docs/reports/solidjs-migration-analysis.md` still opens "Current stack: React 19 + Jotai +
+Vite + Tauri (WebView2/Chromium)". Every element except Vite is wrong, and the migration it
+proposes is done. Restamp `historical`.
+
+---
+
+## 6. Scoreboard
+
+| # | Initiative | State | What remains |
+|---|---|---|---|
+| 1 | Tauri → CEF | ✅ done | comment-only residue |
+| 2 | React → SolidJS | ✅ done | drop the unused `react` dep |
+| 3 | Reducer/saga (E–H) | ✅ done | reconcile two status docs (§5.2) |
+| 4 | Arch refactor A1–A15 | 🟡 12/15 | **A6, A9**, A10 (optional) |
+| 5 | muxspect A/B/C | ✅ done | fix CLAUDE.md (§5.1) |
+| 6 | Migration system hardening | 🟡 Phase 0 of 6 | Phases 1–6; failure still non-fatal |
+| 7 | Docs lifecycle hardening | 🟡 ~3 of 6 | Phases 2, 5; ~360-file status backlog |
+| 8 | Jekt cross-channel trust | 🟡 Phase A of D | Phases B, C, D |
+| 9 | Container agents | 🟡 multi-generation | #2939 workstreams; #1400 Phase 3 gaps |
+| 10 | Armory foundation consolidation | 🟡 by design | follow-up SPECs per its §4 |
+| 11 | Mandatory ABF rethink | 🔴 not started | everything |
+| 12 | DRY / modularity slimming | 🔴 1 of 5 | causes 1, 3, 4, 5 |
+| 13 | Wave → Mux rename (#851) | 🔴 not started | ~460 symbol uses across 285 files |
+| 14 | Agent working-state unification | 🟡 Phase 1 | `SPEC_AGENT_WORKING_STATE_UNIFICATION_2026_09_04` — overlaps A6 |
+
+---
+
+## 7. Recommendation
+
+If only three things get picked up:
+
+1. **A6/A9** (§3.1) — the only stalled item that is measurably getting worse (`agent-view.tsx`
+   1,282 → 2,730 lines in 12 weeks). A9 is small and no longer blocked; do it first to derisk A6.
+2. **Migration hardening Phase 1** (§3.2) — a small change to make migration failure fatal,
+   guarding a database that seven-plus migrations write to. Highest safety-per-line here.
+3. **Correct CLAUDE.md's jekt section** (§5.1) — costs minutes, and it is the one stale claim
+   that actively instructs every agent in the fleet to believe something false.
+
+Then make a **decision** on #851 rather than leaving it open: schedule it or close it.
+
+One structural note. Items 1, 6, 7, 8 and 12 share a shape — a Phase 0 or Phase A lands, is
+genuinely useful, and the remaining phases never start. Phase 0 is usually the instrumentation
+or the additive half; the phase that *removes the old path* or *enforces the new one* is the
+one that gets skipped. Worth considering whether "Phase 0 shipped" should be allowed to close a
+tracking issue at all, or whether these should stay open against the enforcing phase.

--- a/docs/reports/solidjs-migration-analysis.md
+++ b/docs/reports/solidjs-migration-analysis.md
@@ -1,7 +1,8 @@
 # SolidJS Migration Analysis — Performance & Bundle Size
 
 **Date:** 2026-03-11  
-**Current stack:** React 19 + Jotai + Vite + Tauri (WebView2/Chromium)
+**Status:** historical — the migration this doc proposed is complete: as of 2026-09-06, 390 frontend files import `solid-js` and none import `react`; the desktop shell is CEF, not Tauri (`docs/reports/REPORT_LARGE_MIGRATIONS_COMPLETION_AUDIT_2026_09_06.md` §2.2). The stack line below is the pre-migration baseline, kept as written.
+**Stack at time of writing:** React 19 + Jotai + Vite + Tauri (WebView2/Chromium)
 
 ---
 

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -178,7 +178,7 @@ are doing history". Everything else is here; the completeness
 assertion in the generator fails the build rather than emit a
 partial list.
 
-### implemented (134)
+### implemented (135)
 
 | Spec | Title |
 |---|---|
@@ -256,6 +256,7 @@ partial list.
 | [`SPEC_MEDIA_PANE_2026_07_26`](SPEC_MEDIA_PANE_2026_07_26.md) | Spec: Media pane — live-updating image/video viewer for agent-generated files |
 | [`SPEC_MEDIA_PANE_V4_MCP_OPEN_TOOL_2026_08_03`](SPEC_MEDIA_PANE_V4_MCP_OPEN_TOOL_2026_08_03.md) | Spec: Media pane v4 — agent-facing `OpenMedia` MCP tool |
 | [`SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19`](SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md) | Spec: Native Memory Version Control — Single Source of Truth, Two Views (Stash + Armory) |
+| [`SPEC_MIGRATION_FRAMEWORK_2026_06_24`](SPEC_MIGRATION_FRAMEWORK_2026_06_24.md) | Migration Framework Spec |
 | [`SPEC_MUXLOG_SWARM_DISPATCH_VERDICT_2026_08_22`](SPEC_MUXLOG_SWARM_DISPATCH_VERDICT_2026_08_22.md) | SPEC: `muxlog swarm -d/--dispatch` — a correlated dispatch-lifecycle verdict |
 | [`SPEC_MUXSPECT_CROSS_INSTANCE_FIND_2026_08_22`](SPEC_MUXSPECT_CROSS_INSTANCE_FIND_2026_08_22.md) | SPEC: `muxspect find` — cross-instance block/agent lookup |
 | [`SPEC_MUXSPECT_DOCK_DIAGNOSIS_AND_REMEDIATION_2026_08_06`](SPEC_MUXSPECT_DOCK_DIAGNOSIS_AND_REMEDIATION_2026_08_06.md) | SPEC — `muxspect dock`: diagnose and clear stuck Activity Dock entries |
@@ -337,7 +338,7 @@ partial list.
 | [`SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29`](SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29.md) | Spec: multi-tier discovery + remote API invocation over muxbus |
 | [`SPEC_WINDOW_NAME_API_HARDENING_2026_08_08`](SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md) | SPEC: Window-name App API hardening (phantom-id success + status codes) |
 
-### proposed (97)
+### proposed (96)
 
 | Spec | Title |
 |---|---|
@@ -390,7 +391,6 @@ partial list.
 | [`SPEC_MEMORY_CARRYOVER_LOAD_AND_MANAGE_2026_09_05`](SPEC_MEMORY_CARRYOVER_LOAD_AND_MANAGE_2026_09_05.md) | Memory carry-over: loading and management across the three agent-awareness cases |
 | [`SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16`](SPEC_MEMORY_PRESSURE_SUPERVISION_2026_06_16.md) | Memory-Pressure Supervision & Graceful Degradation (host / instance level) |
 | [`SPEC_MEMORY_RPC_HANDLERS_BLANK_WORKDIR_2026_09_02`](SPEC_MEMORY_RPC_HANDLERS_BLANK_WORKDIR_2026_09_02.md) | Spec: fix agent:memory:{list,read_file,write_file,revert} for a blank working_directory |
-| [`SPEC_MIGRATION_FRAMEWORK_2026_06_24`](SPEC_MIGRATION_FRAMEWORK_2026_06_24.md) | Migration Framework Spec |
 | [`SPEC_MODEL_EFFORT_CAPABILITY_VALIDATION_2026_07_02`](SPEC_MODEL_EFFORT_CAPABILITY_VALIDATION_2026_07_02.md) | SPEC — Per-model effort-capability validation for the composer strip |
 | [`SPEC_MUXBUS_CLOUD_RELAYED_LOGIN_CALLBACK_2026_08_15`](SPEC_MUXBUS_CLOUD_RELAYED_LOGIN_CALLBACK_2026_08_15.md) | SPEC: MuxBus cloud-relayed login callback (no loopback listener) |
 | [`SPEC_MUXSPECT_CROSS_TIER_INSTANCE_INSPECTION_2026_09_02`](SPEC_MUXSPECT_CROSS_TIER_INSTANCE_INSPECTION_2026_09_02.md) | muxspect Phase 2: cross-tier instance inspection (same-host channels + LAN) |
@@ -694,10 +694,11 @@ partial list.
 | [`SPEC_DECISION_PROMPT_DESIGN_2026_04_25`](SPEC_DECISION_PROMPT_DESIGN_2026_04_25.md) | Decision Prompt — Cohesive Design (Step-Back Doc) |
 | [`SPEC_POOL_COVERAGE_AND_ROADMAP_2026_06_20`](SPEC_POOL_COVERAGE_AND_ROADMAP_2026_06_20.md) | Pre-warmed Window Pool — Coverage Map and Implementation Roadmap |
 
-### historical (1)
+### historical (2)
 
 | Spec | Title |
 |---|---|
+| [`MASTER_REDUCER_STACK_STATUS_2026-05-05`](MASTER_REDUCER_STACK_STATUS_2026-05-05.md) | Master Reducer-Stack Status — 2026-05-05 |
 | [`SPEC_ACTIVE_TAB_COLOR_LINE_STOP_AT_TAB_STRIP_2026_07_13`](SPEC_ACTIVE_TAB_COLOR_LINE_STOP_AT_TAB_STRIP_2026_07_13.md) | SPEC — active-tab color line: stop at the tab strip's right edge, not the viewport edge |
 
 ### superseded (3)
@@ -708,7 +709,7 @@ partial list.
 | [`SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06`](SPEC_AGENT_WORKING_ROW_SCROLLBAR_GAP_2026_08_06.md) | Spec: Continuous AgentWorkingRow background through the scrollbar gutter |
 | [`SPEC_COMPOSER_STRIP_LEFT_RIGHT_BALANCE_2026_08_24`](SPEC_COMPOSER_STRIP_LEFT_RIGHT_BALANCE_2026_08_24.md) | SPEC: Composer strip — balance misc elements across left/right zones |
 
-### no status line (150)
+### no status line (149)
 
 Predate the closed vocabulary. Not a backlog to bulk-restamp —
 an unverified restamp turns "unknown" into "confidently wrong".
@@ -722,7 +723,6 @@ Fix one when you touch it and know its real state.
 | [`ANALYSIS_WINDOW_PROCESS_STATE_INVENTORY_2026_04_27`](ANALYSIS_WINDOW_PROCESS_STATE_INVENTORY_2026_04_27.md) | ANALYSIS: AgentMux Window/Process State Inventory |
 | [`BUG_MACOS26_DUAL_DOCK_ICON_2026_06_20`](BUG_MACOS26_DUAL_DOCK_ICON_2026_06_20.md) | BUG: Dual Dock Icon on macOS 26 Tahoe |
 | [`CLEANUP_LEGACY_REMNANTS`](CLEANUP_LEGACY_REMNANTS.md) | Cleanup Spec: Remove Legacy Remnants |
-| [`MASTER_REDUCER_STACK_STATUS_2026-05-05`](MASTER_REDUCER_STACK_STATUS_2026-05-05.md) | Master Reducer-Stack Status — 2026-05-05 |
 | [`OAUTH_FLOW_SMOKE_DIAGNOSTIC_2026_05_14`](OAUTH_FLOW_SMOKE_DIAGNOSTIC_2026_05_14.md) | OAuth Pre-Launch Smoke-Test Diagnostic — 2026-05-14 |
 | [`OAUTH_RESUME_AFTER_REBOOT_2026_05_14`](OAUTH_RESUME_AFTER_REBOOT_2026_05_14.md) | OAuth pre-launch — resume notes after PC reboot (2026-05-14) |
 | [`PHASE_E_SAGAS_EXECUTION_PLAN_2026-04-30`](PHASE_E_SAGAS_EXECUTION_PLAN_2026-04-30.md) | Phase E.5 Sagas — Execution Plan |

--- a/docs/specs/MASTER_REDUCER_STACK_STATUS_2026-05-05.md
+++ b/docs/specs/MASTER_REDUCER_STACK_STATUS_2026-05-05.md
@@ -4,7 +4,9 @@
 
 **Scope.** State, not implementation plans. For active PR sequencing see [`frontend-reducer-implementation-plan-2026-05-03.md`](./frontend-reducer-implementation-plan-2026-05-03.md), [`SPEC_HOST_REDUCER_5PR_PLAN_2026-05-02.md`](./SPEC_HOST_REDUCER_5PR_PLAN_2026-05-02.md), and [`srv-phase-e4b-implementation-plan-2026-05-03.md`](./srv-phase-e4b-implementation-plan-2026-05-03.md).
 
-**Authority.** When this file disagrees with another spec, the source spec wins for *design* and this file wins for *current status*. Update this file when status changes; don't fork the source specs.
+**Status:** historical — point-in-time snapshot, last code-verified 2026-05-29 (§0). Restamped 2026-09-06 per `docs/reports/REPORT_LARGE_MIGRATIONS_COMPLETION_AUDIT_2026_09_06.md` §5.2: the "Authority" claim this line used to carry is withdrawn. For the reducer stack's current shape, read `REPORT_REDUCER_STACK_AUDIT_2026_07_26.md` first, then spot-verify against code.
+
+**Authority (withdrawn 2026-09-06).** This file no longer wins for *current status* — see the Status line above. Source specs still win for *design*.
 
 > **Staleness note (2026-08-03):** this file hasn't been updated since its own 2026-05-29 correction (§0) — now ~9 weeks stale. A later, independently-scoped pass exists — `docs/specs/REPORT_REDUCER_STACK_AUDIT_2026_07_26.md` — covering the same subsystem without referencing or updating this file. Check both before trusting either as "current status"; this file's own "Authority" claim above no longer holds uncontested.
 

--- a/docs/specs/SPEC_MIGRATION_FRAMEWORK_2026_06_24.md
+++ b/docs/specs/SPEC_MIGRATION_FRAMEWORK_2026_06_24.md
@@ -1,6 +1,6 @@
 # Migration Framework Spec
 **Date:** 2026-06-24  
-**Status:** Proposed (implemented — see note below)
+**Status:** implemented — `agentmux-srv/src/migrations/` is the live framework (m0000–m0006+), used at every startup by `bootstrap.rs`; see the 2026-08-07 audit note below. Restamped 2026-09-06 (was "Proposed") per `docs/reports/REPORT_LARGE_MIGRATIONS_COMPLETION_AUDIT_2026_09_06.md` §5.3.
 **Scope:** agentmux-srv, agentmux-launcher
 
 > **2026-08-07 audit note:** Implemented, foundational — `agentmux-srv/src/migrations/`


### PR DESCRIPTION
## Summary

Repo-owner ask: *"we were doing a lot of migrations and initiatives, but some never completed... ID what is done and what is pending."*

**New:** `docs/reports/REPORT_LARGE_MIGRATIONS_COMPLETION_AUDIT_2026_09_06.md` — all 857 specs swept, every claim marked **[verified]** (checked against code at `fe87e1732`) or **[doc-claim]**.

**Scoreboard:** 5 complete · 6 partial/stalled · 3 designed-never-started.

The headline: Tauri→CEF and React→SolidJS both *finished* (390 files import `solid-js`, zero import `react`) without any doc saying so. What stalled is almost entirely the hardening/consolidation second half — Phase 0 lands, the phase that removes the old path or enforces the new one never starts.

Three findings worth acting on independently (§0):
1. `agent-view.tsx` doubled (1,282 → 2,730 lines) while A6/A9 in #1549 sat open 12 weeks
2. Migration failure is still non-fatal at `bootstrap.rs:565-569` — a `warn!`, then boot continues
3. `CLAUDE.md` states `transcript_request` "does not exist anywhere in `agentmux-srv`" — it shipped in #2764

## Stale status claims corrected in this PR (§5 of the report)

- **`CLAUDE.md` jekt section** — the `transcript_request` bullet and the named `ESCALATE` exception rewritten from "not yet live / pre-committed policy for future code" to "live since 2026-08-22, PR #2764", citing `reactive.rs`'s `resolve_transcript_request_tier_fields()`. **Status correction only; the policy text is unchanged.** Flagging this explicitly because the section instructs agents to distrust inline corrections — the evidence is real code + tests (`transcript_request_tier_resolution_tests`), not prose.
- `SPEC_MIGRATION_FRAMEWORK_2026_06_24.md` — `Proposed` → `implemented` (in daily startup use since June; INDEX filed it under proposals)
- `solidjs-migration-analysis.md` — added `Status: historical` (still opened "Current stack: React 19 + Jotai + Vite + Tauri")
- `MASTER_REDUCER_STACK_STATUS_2026-05-05.md` — `Status: historical`, "this file wins for current status" authority claim withdrawn (it already admitted being 9 weeks stale)

`docs/specs/INDEX.md` regenerated; `gen-docs-index.sh --check` and `check-doc-status.sh` both pass.

## Not in this PR
Follow-up code PRs in flight, in the order the report recommends: migration-hardening Phase 1 (make failure fatal + surface it), then A9, then A6.

<!-- agentmux:agent_id=korp -->