### PR TITLE
Korp@claudius: fix(srv): failed data migration is fatal and surfaced — migration hardening Phase 1a

### DIFF
--- a/.changesets/1788751693-fix-srv-a-failed-data-migration-is-now-fatal-srv-emits-agent-ttg2.md
+++ b/.changesets/1788751693-fix-srv-a-failed-data-migration-is-now-fatal-srv-emits-agent-ttg2.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(srv): a failed data migration is now fatal — srv emits AGENTMUXSRV-MIGRATION-FAILED and exits 1 before ESTART instead of booting against a half-migrated store; launcher and CEF host surface the reason immediately (migration hardening Phase 1a)

--- a/agentmux-cef/src/sidecar.rs
+++ b/agentmux-cef/src/sidecar.rs
@@ -366,6 +366,10 @@ pub async fn spawn_backend(state: &Arc<AppState>) -> Result<BackendSpawnResult, 
     // running (same pattern as agentmux-launcher/src/srv_spawner.rs).
     let (tx, mut rx) = tokio::sync::mpsc::channel::<BackendSpawnResult>(1);
     let (migration_tx, mut migration_rx) = tokio::sync::mpsc::channel::<()>(4);
+    // Third channel: a fatal migration failure. srv reports it on stderr and
+    // exits 1 without ESTART (SPEC_MIGRATION_SYSTEM_HARDENING Phase 1); the
+    // waiter fails immediately with the reason instead of after the timeout.
+    let (failure_tx, mut failure_rx) = tokio::sync::mpsc::channel::<String>(1);
     let state_for_monitor = state.clone();
 
     std::thread::spawn(move || {
@@ -385,6 +389,11 @@ pub async fn spawn_backend(state: &Arc<AppState>) -> Result<BackendSpawnResult, 
                         );
                         estart_received = true;
                         let _ = tx.blocking_send(result);
+                    } else if let Some(reason) =
+                        agentmux_common::srv_stderr::parse_migration_failed_line(&l)
+                    {
+                        tracing::error!("[agentmux-srv] MIGRATION FAILED: {}", reason);
+                        let _ = failure_tx.blocking_send(reason);
                     } else if l.starts_with("AGENTMUXSRV-MIGRATING") {
                         tracing::info!("[agentmux-srv] {}", l);
                         let _ = migration_tx.blocking_send(());
@@ -448,10 +457,13 @@ pub async fn spawn_backend(state: &Arc<AppState>) -> Result<BackendSpawnResult, 
     let mut sleep = tokio::time::sleep_until(deadline);
     tokio::pin!(sleep);
 
-    let recv: Result<Option<BackendSpawnResult>, ()> = loop {
+    let recv: Result<Option<BackendSpawnResult>, String> = loop {
         tokio::select! {
             result = rx.recv() => break Ok(result),
-            _ = &mut sleep => break Err(()),
+            _ = &mut sleep => break Err("Timeout waiting for agentmux-srv to start (30s)".to_string()),
+            Some(reason) = failure_rx.recv() => {
+                break Err(format!("agentmux-srv database migration failed: {}", reason));
+            }
             Some(()) = migration_rx.recv() => {
                 let new_deadline = tokio::time::Instant::now() + migration_timeout;
                 if new_deadline > deadline {
@@ -462,8 +474,7 @@ pub async fn spawn_backend(state: &Arc<AppState>) -> Result<BackendSpawnResult, 
             }
         }
     };
-    let result = recv
-        .map_err(|()| "Timeout waiting for agentmux-srv to start (30s)".to_string())?
+    let result = recv?
         .ok_or_else(|| "agentmux-srv channel closed before sending endpoints".to_string())?;
 
     tracing::info!(

--- a/agentmux-common/src/lib.rs
+++ b/agentmux-common/src/lib.rs
@@ -14,6 +14,7 @@ pub mod layout_types;
 pub mod pagefile;
 pub mod process;
 pub mod runtime_mode;
+pub mod srv_stderr;
 pub mod time;
 pub mod toolchain_path;
 pub mod transcript_request;

--- a/agentmux-common/src/srv_stderr.rs
+++ b/agentmux-common/src/srv_stderr.rs
@@ -1,0 +1,105 @@
+//! The stderr line protocol `agentmux-srv` uses to talk to whichever process
+//! supervises it — the launcher in packaged builds and `task dev`
+//! (`agentmux-launcher/src/srv_spawner.rs`), or the CEF host in
+//! `task dev:standalone` (`agentmux-cef/src/sidecar.rs`).
+//!
+//! srv formats these lines; both supervisors parse them. Putting the
+//! vocabulary here means one definition instead of three string literals that
+//! have to stay byte-identical by convention (the "keep in sync" pattern
+//! `docs/reports/REPORT_DRY_AND_MODULARITY_AUDIT_2026_09_06.md` §2 counts 334
+//! instances of).
+//!
+//! Every line is single-line and prefix-tagged. In startup order:
+//!
+//! - `AGENTMUXSRV-MIGRATING migrations:<n>` — in-process migrations are about
+//!   to run; supervisors extend their ESTART deadline. (Still emitted and
+//!   parsed with inline literals at the three sites above — not migrated to
+//!   this module yet; only the new line below lives here.)
+//! - `AGENTMUXSRV-MIGRATION-FAILED error:<text>` — a migration failed and srv
+//!   is about to exit 1 **without** emitting ESTART. Added by Phase 1 of
+//!   `docs/specs/SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03.md`; before it,
+//!   a failed migration was a `warn!` and srv booted anyway against a store in
+//!   an unknown state.
+//! - `AGENTMUXSRV-ESTART ...` — ready. Parsed separately by each supervisor;
+//!   unchanged.
+
+/// Prefix of the line srv writes to stderr immediately before exiting 1
+/// because `run_pending_migrations` failed. Supervisors match on this to fail
+/// fast with the real reason instead of waiting out the ESTART timeout.
+pub const MIGRATION_FAILED_PREFIX: &str = "AGENTMUXSRV-MIGRATION-FAILED";
+
+/// Format the failure line srv emits. The error text is flattened to a single
+/// line (the protocol is line-delimited; a multi-line SQLite error would
+/// otherwise split into one tagged line and several untagged ones).
+pub fn migration_failed_line(err: &str) -> String {
+    format!("{} error:{}", MIGRATION_FAILED_PREFIX, one_line(err))
+}
+
+/// Parse a stderr line. Returns the error message if this is a
+/// `MIGRATION_FAILED_PREFIX` line, `None` for any other line. Tolerates a
+/// missing `error:` field and never returns an empty message, so callers can
+/// put the result straight into a user-facing dialog.
+pub fn parse_migration_failed_line(line: &str) -> Option<String> {
+    let rest = line.strip_prefix(MIGRATION_FAILED_PREFIX)?;
+    let rest = rest.trim_start();
+    let msg = rest.strip_prefix("error:").unwrap_or(rest).trim();
+    Some(if msg.is_empty() { "unknown error".to_string() } else { msg.to_string() })
+}
+
+fn one_line(s: &str) -> String {
+    s.split(['\n', '\r'])
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join(" | ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn line_is_prefixed_and_single_line() {
+        let line = migration_failed_line("migration 0007 failed:\r\n  FOREIGN KEY constraint failed\n");
+        assert_eq!(
+            line,
+            "AGENTMUXSRV-MIGRATION-FAILED error:migration 0007 failed: | FOREIGN KEY constraint failed"
+        );
+        assert!(!line.contains('\n'));
+    }
+
+    #[test]
+    fn round_trips_through_parse() {
+        let msg = "run_pending_migrations: open shared store: disk I/O error";
+        assert_eq!(parse_migration_failed_line(&migration_failed_line(msg)).as_deref(), Some(msg));
+    }
+
+    #[test]
+    fn parse_tolerates_missing_error_field() {
+        assert_eq!(
+            parse_migration_failed_line("AGENTMUXSRV-MIGRATION-FAILED something broke").as_deref(),
+            Some("something broke")
+        );
+    }
+
+    #[test]
+    fn parse_never_returns_empty_message() {
+        assert_eq!(parse_migration_failed_line("AGENTMUXSRV-MIGRATION-FAILED").as_deref(), Some("unknown error"));
+        assert_eq!(parse_migration_failed_line("AGENTMUXSRV-MIGRATION-FAILED error:").as_deref(), Some("unknown error"));
+    }
+
+    #[test]
+    fn parse_ignores_other_protocol_lines() {
+        assert_eq!(parse_migration_failed_line("AGENTMUXSRV-MIGRATING migrations:3"), None);
+        assert_eq!(parse_migration_failed_line("AGENTMUXSRV-ESTART ws:127.0.0.1:1 web:127.0.0.1:2"), None);
+        assert_eq!(parse_migration_failed_line("plain stderr noise"), None);
+    }
+
+    #[test]
+    fn migrating_prefix_is_not_a_prefix_of_failed() {
+        // Both start with "AGENTMUXSRV-MIGRATI"; the supervisors check
+        // `starts_with` for each, so neither may be a prefix of the other.
+        assert!(!MIGRATION_FAILED_PREFIX.starts_with("AGENTMUXSRV-MIGRATING"));
+        assert!(!"AGENTMUXSRV-MIGRATING".starts_with(MIGRATION_FAILED_PREFIX));
+    }
+}

--- a/agentmux-launcher/src/srv_spawner.rs
+++ b/agentmux-launcher/src/srv_spawner.rs
@@ -111,16 +111,32 @@ impl std::fmt::Display for SrvSpawnError {
 pub const MIGRATION_FAILED_DIALOG_TITLE: &str = "AgentMux — database migration failed";
 
 /// Body for that dialog. Kept here (not in each supervisor) so Windows and
-/// Unix show the same words. Restart-to-retry is accurate: srv re-runs every
-/// unapplied migration on the next launch, and a pre-migration snapshot of the
-/// store was written before the attempt (bootstrap.rs `maybe_snapshot_pre_migration`).
+/// Unix show the same words.
+///
+/// Every sentence is something the launcher actually knows:
+/// - Restart-to-retry: srv re-runs every unapplied migration on the next
+///   launch (`run_pending_migrations` filters on `migration_is_applied`).
+/// - The backup ordering: `runner.rs::run_pending_migrations` calls
+///   `backup_stores` (→ `~/.agentmux/shared/backups/pre-migration-<ver>-<ts>/`)
+///   BEFORE applying anything, and returns `Err("... backup failed: ...")`
+///   without running a migration if that copy fails. So the reason text
+///   itself tells the user which case they are in; we state the ordering
+///   and let it do so, rather than asserting a backup exists.
+///
+/// We deliberately do NOT claim "your data has not been changed" or "a
+/// snapshot was taken": the backup step is one of the things that can be
+/// the failure, and bootstrap.rs's separate `maybe_snapshot_pre_migration`
+/// is best-effort (non-fatal on error, `Ok(None)` when it decides none is
+/// needed). An earlier revision of this text made that claim
+/// unconditionally — reagent P1 on PR #3043.
 pub fn migration_failed_dialog_body(reason: &str) -> String {
     format!(
         "AgentMux could not update its data store and will not start.\n\n\
          {}\n\n\
-         Your data has not been changed: a snapshot was taken before the \
-         attempt. Restart AgentMux to retry. If this keeps happening, run \
-         `muxlog srv` and report the error above.",
+         Restart AgentMux to retry. Migrations only run after a copy of the \
+         store is written to ~/.agentmux/shared/backups/pre-migration-*/ — \
+         if the error above is about writing that copy, nothing was changed. \
+         Run `muxlog srv` for the full log.",
         reason
     )
 }
@@ -741,7 +757,20 @@ mod migration_failed_tests {
         let body = migration_failed_dialog_body("open shared store: database is locked");
         assert!(body.contains("open shared store: database is locked"));
         assert!(body.contains("Restart AgentMux to retry"));
-        assert!(body.contains("snapshot"), "must tell the user their data is intact");
+        assert!(body.contains("shared/backups/pre-migration-"), "must say where the pre-run copy lives");
+    }
+
+    #[test]
+    fn dialog_body_never_asserts_a_backup_exists() {
+        // reagent P1 on #3043: `backup_stores` failing is itself one of the
+        // error paths, so the body must not promise a snapshot/backup was
+        // taken. The wording states the ordering (copy first, then migrate)
+        // and lets the reason text — which names the backup step when that
+        // is what failed — carry the rest.
+        let body = migration_failed_dialog_body("run_pending_migrations: backup failed: disk full");
+        assert!(!body.contains("has not been changed:"), "unconditional data-safety claim");
+        assert!(!body.contains("a snapshot was taken"), "unconditional snapshot claim");
+        assert!(body.contains("if the error above is about writing that copy, nothing was changed"));
     }
 
     #[test]

--- a/agentmux-launcher/src/srv_spawner.rs
+++ b/agentmux-launcher/src/srv_spawner.rs
@@ -57,7 +57,12 @@ pub struct SrvSpawnResult {
     /// see `SrvSpawnResult`'s own doc comment above).
     pub host_reg_secret: String,
     /// Number of data migrations still pending after the in-process startup run.
-    /// Non-zero means run_pending_migrations failed; status-bar shows a retry message.
+    /// Counted by srv at ESTART time (`count_pending_migrations`). Since
+    /// SPEC_MIGRATION_SYSTEM_HARDENING Phase 1 a migration *failure* never
+    /// reaches ESTART at all (srv exits 1 with `MigrationFailed`), so a
+    /// non-zero value here means the count and the run disagree — e.g. the
+    /// fresh-install ordering case runner.rs documents — and the status-bar
+    /// shows its retry message for that.
     pub pending_migrations: usize,
     /// RFC3339 timestamp captured when ESTART arrived. Carried on the
     /// result for `--diag` / debug observability; not currently
@@ -78,6 +83,12 @@ pub enum SrvSpawnError {
     ResumeFailed(String),
     EstartTimeout,
     EstartChannelClosed,
+    /// srv reported `AGENTMUXSRV-MIGRATION-FAILED` and exited 1 before ESTART
+    /// (SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03 Phase 1). Carries the
+    /// reason srv gave. Distinct from `EstartTimeout` so the supervisor can
+    /// show the user a real message instead of "timeout (30s)" — and so it
+    /// can do it immediately rather than 30s later.
+    MigrationFailed(String),
 }
 
 impl std::fmt::Display for SrvSpawnError {
@@ -91,8 +102,27 @@ impl std::fmt::Display for SrvSpawnError {
             Self::EstartChannelClosed => {
                 write!(f, "ESTART channel closed before srv signalled ready")
             }
+            Self::MigrationFailed(s) => write!(f, "database migration failed: {}", s),
         }
     }
+}
+
+/// Title for the fatal dialog both supervisors show on `MigrationFailed`.
+pub const MIGRATION_FAILED_DIALOG_TITLE: &str = "AgentMux — database migration failed";
+
+/// Body for that dialog. Kept here (not in each supervisor) so Windows and
+/// Unix show the same words. Restart-to-retry is accurate: srv re-runs every
+/// unapplied migration on the next launch, and a pre-migration snapshot of the
+/// store was written before the attempt (bootstrap.rs `maybe_snapshot_pre_migration`).
+pub fn migration_failed_dialog_body(reason: &str) -> String {
+    format!(
+        "AgentMux could not update its data store and will not start.\n\n\
+         {}\n\n\
+         Your data has not been changed: a snapshot was taken before the \
+         attempt. Restart AgentMux to retry. If this keeps happening, run \
+         `muxlog srv` and report the error above.",
+        reason
+    )
 }
 
 /// Run `agentmux-srv migrate` synchronously before spawning the daemon.
@@ -442,6 +472,10 @@ pub async fn spawn_srv(
     // large-dataset migration that takes longer than the normal 30s boot window
     // doesn't cause the launcher to kill srv prematurely.
     let (migration_tx, mut migration_rx) = mpsc::channel::<()>(4);
+    // Third channel: srv reports a fatal migration failure on stderr and exits
+    // 1 without ESTART. Without this the waiter would only notice via the 30s
+    // timeout, and the user would see "timeout" instead of the actual error.
+    let (failure_tx, mut failure_rx) = mpsc::channel::<String>(1);
     let auth_key_for_estart = auth_key.clone();
     let host_reg_secret_for_estart = host_reg_secret.clone();
     let started_at_for_estart = started_at.clone();
@@ -469,6 +503,11 @@ pub async fn spawn_srv(
                 ));
                 let _ = tx.send(result).await;
                 estart_sent = true;
+            } else if let Some(reason) =
+                agentmux_common::srv_stderr::parse_migration_failed_line(&line)
+            {
+                crate::log(&format!("[srv {} MIGRATION FAILED] {}", pid_for_log, reason));
+                let _ = failure_tx.send(reason).await;
             } else if line.starts_with("AGENTMUXSRV-MIGRATING") {
                 crate::log(&format!("[srv {} migrating] {}", pid_for_log, line));
                 let _ = migration_tx.send(()).await;
@@ -501,10 +540,16 @@ pub async fn spawn_srv(
     let mut sleep = tokio::time::sleep_until(deadline);
     tokio::pin!(sleep);
 
-    let recv: Result<Option<SrvSpawnResult>, ()> = loop {
+    enum EstartWait {
+        Ready(Option<SrvSpawnResult>),
+        Timeout,
+        MigrationFailed(String),
+    }
+    let recv = loop {
         tokio::select! {
-            result = rx.recv() => break Ok(result),
-            _ = &mut sleep => break Err(()),
+            result = rx.recv() => break EstartWait::Ready(result),
+            _ = &mut sleep => break EstartWait::Timeout,
+            Some(reason) = failure_rx.recv() => break EstartWait::MigrationFailed(reason),
             Some(()) = migration_rx.recv() => {
                 // Migrations are running — extend the deadline generously.
                 let new_deadline = tokio::time::Instant::now() + migration_timeout;
@@ -517,7 +562,7 @@ pub async fn spawn_srv(
         }
     };
     match recv {
-        Err(()) => {
+        EstartWait::Timeout => {
             let _ = child.start_kill();
             sink.stage_end(
                 "backend",
@@ -527,7 +572,20 @@ pub async fn spawn_srv(
             );
             Err(SrvSpawnError::EstartTimeout)
         }
-        Ok(None) => {
+        EstartWait::MigrationFailed(reason) => {
+            // srv exits itself right after the line; start_kill on an
+            // already-exited child is a harmless no-op and keeps this arm in
+            // the same shape as the other two failure paths.
+            let _ = child.start_kill();
+            sink.stage_end(
+                "backend",
+                srv_t.elapsed().as_millis() as u64,
+                crate::startup_events::StartupStatus::Error,
+                Some("migration failed".into()),
+            );
+            Err(SrvSpawnError::MigrationFailed(reason))
+        }
+        EstartWait::Ready(None) => {
             let _ = child.start_kill();
             sink.stage_end(
                 "backend",
@@ -537,7 +595,7 @@ pub async fn spawn_srv(
             );
             Err(SrvSpawnError::EstartChannelClosed)
         }
-        Ok(Some(result)) => {
+        EstartWait::Ready(Some(result)) => {
             sink.stage_end(
                 "backend",
                 srv_t.elapsed().as_millis() as u64,
@@ -665,5 +723,34 @@ pub fn assign_pid_to_job(
             ));
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod migration_failed_tests {
+    use super::*;
+
+    #[test]
+    fn display_names_the_migration_and_carries_srv_reason() {
+        let e = SrvSpawnError::MigrationFailed("migration 0007 failed: disk I/O error".into());
+        assert_eq!(e.to_string(), "database migration failed: migration 0007 failed: disk I/O error");
+    }
+
+    #[test]
+    fn dialog_body_includes_reason_and_restart_guidance() {
+        let body = migration_failed_dialog_body("open shared store: database is locked");
+        assert!(body.contains("open shared store: database is locked"));
+        assert!(body.contains("Restart AgentMux to retry"));
+        assert!(body.contains("snapshot"), "must tell the user their data is intact");
+    }
+
+    #[test]
+    fn stderr_line_from_srv_parses_into_the_reason_the_dialog_shows() {
+        // End-to-end over the shared protocol: what srv writes is what the
+        // launcher reads, without either side owning the literal.
+        let line = agentmux_common::srv_stderr::migration_failed_line("mark applied 0011: readonly db");
+        let reason = agentmux_common::srv_stderr::parse_migration_failed_line(&line).expect("tagged line");
+        assert_eq!(reason, "mark applied 0011: readonly db");
+        assert!(!line.starts_with("AGENTMUXSRV-MIGRATING"), "must not be swallowed by the MIGRATING branch");
     }
 }

--- a/agentmux-launcher/src/supervisor/unix.rs
+++ b/agentmux-launcher/src/supervisor/unix.rs
@@ -347,9 +347,11 @@ pub(crate) async fn run_unix(
             log(&format!("FATAL: srv spawn failed: {}", e));
             eprintln!("Failed to start backend: {}", e);
             if let srv_spawner::SrvSpawnError::MigrationFailed(reason) = &e {
-                // The launcher has the `windows` subsystem in release, so the
-                // eprintln above goes nowhere there; this is the only thing the
-                // user sees. Same helper the OOM give-up path uses.
+                // On Unix `show_fatal_dialog` is itself an eprintln (no native
+                // dialog yet — see main.rs), so today this repeats the line
+                // above. Kept so both supervisors call the same helper with the
+                // same words: when a native macOS/Linux dialog lands in
+                // show_fatal_dialog, this path gets it for free.
                 crate::show_fatal_dialog(
                     srv_spawner::MIGRATION_FAILED_DIALOG_TITLE,
                     &srv_spawner::migration_failed_dialog_body(reason),

--- a/agentmux-launcher/src/supervisor/unix.rs
+++ b/agentmux-launcher/src/supervisor/unix.rs
@@ -346,6 +346,15 @@ pub(crate) async fn run_unix(
         Err(e) => {
             log(&format!("FATAL: srv spawn failed: {}", e));
             eprintln!("Failed to start backend: {}", e);
+            if let srv_spawner::SrvSpawnError::MigrationFailed(reason) = &e {
+                // The launcher has the `windows` subsystem in release, so the
+                // eprintln above goes nowhere there; this is the only thing the
+                // user sees. Same helper the OOM give-up path uses.
+                crate::show_fatal_dialog(
+                    srv_spawner::MIGRATION_FAILED_DIALOG_TITLE,
+                    &srv_spawner::migration_failed_dialog_body(reason),
+                );
+            }
             std::process::exit(1);
         }
     };

--- a/agentmux-launcher/src/supervisor/windows.rs
+++ b/agentmux-launcher/src/supervisor/windows.rs
@@ -429,6 +429,15 @@ pub(crate) async fn run_windows(
         Err(e) => {
             log(&format!("FATAL: srv spawn failed: {}", e));
             eprintln!("Failed to start backend: {}", e);
+            if let srv_spawner::SrvSpawnError::MigrationFailed(reason) = &e {
+                // The launcher has the `windows` subsystem in release, so the
+                // eprintln above goes nowhere there; this is the only thing the
+                // user sees. Same helper the OOM give-up path uses.
+                crate::show_fatal_dialog(
+                    srv_spawner::MIGRATION_FAILED_DIALOG_TITLE,
+                    &srv_spawner::migration_failed_dialog_body(reason),
+                );
+            }
             drop(job);
             std::process::exit(1);
         }

--- a/agentmux-srv/src/bootstrap.rs
+++ b/agentmux-srv/src/bootstrap.rs
@@ -565,7 +565,22 @@ pub fn open_stores_and_migrate(config: &config::Config, version: &str, build_tim
     match migrations::run_pending_migrations(&wave_data_dir) {
         Ok(0) => {}
         Ok(n) => tracing::info!(applied = n, "startup: applied pending migrations"),
-        Err(e) => tracing::warn!("startup: migration error (continuing): {}", e),
+        Err(e) => {
+            // SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03 Phase 1 (F4): a failed
+            // migration is fatal. This used to be a `warn!` and the server
+            // booted anyway against a store in an unknown state, which turned
+            // any migration bug into a silent one. Note the asymmetry it left:
+            // failing to OPEN the store (just below) always exited 1; failing
+            // to MIGRATE it did not.
+            //
+            // The tagged stderr line lets the launcher / CEF host fail fast
+            // with the real reason instead of timing out on ESTART 30s later
+            // (agentmux-common/src/srv_stderr.rs). Exit code 1 is what
+            // docs/exe-return-codes.md already documented for this case.
+            tracing::error!("startup: migration failed — refusing to start: {}", e);
+            eprintln!("{}", agentmux_common::srv_stderr::migration_failed_line(&e));
+            std::process::exit(1);
+        }
     }
 
     let wstore_raw = Store::open(&db_dir.join("objects.db")).unwrap_or_else(|e| {

--- a/docs/exe-return-codes.md
+++ b/docs/exe-return-codes.md
@@ -29,6 +29,8 @@ This table is not a small fixed enum — on Windows, `supervisor/windows.rs` can
 | **0** | Clean shutdown — server exited normally. This includes: version/help flag requested, signal-based shutdown (SIGTERM/SIGINT), lock file indicates another instance is running, or graceful stop via internal command |
 | **1** | Fatal startup error — server failed to start. Causes include: lock file creation failure, database migration failure, HTTP/WebSocket server bind failure, or other unrecoverable initialization error |
 
+A failed data migration exits 1 **without** emitting `AGENTMUXSRV-ESTART`; srv first writes a single `AGENTMUXSRV-MIGRATION-FAILED error:<reason>` line to stderr so the launcher / CEF host can surface the reason immediately (`agentmux-common/src/srv_stderr.rs`). Before 2026-09-06 a migration failure was logged as a warning and the server started anyway — `docs/specs/SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03.md` Phase 1.
+
 ## Windows Installer (Inno Setup)
 
 The Windows installer moved from NSIS to **Inno Setup** (`packaging/windows/agentmux.iss`, driven by `scripts/package-installer.ps1`). It uses Inno Setup's own standard `Setup.exe` exit codes (not the NSIS table this doc previously listed) — see the [Inno Setup documentation](https://jrsoftware.org/ishelp/index.php?topic=setupexitcodes) for the authoritative list, since no custom exit-code handling is defined in `agentmux.iss`. Standard silent-install flags apply: `/SILENT`, `/VERYSILENT`.

--- a/docs/specs/SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03.md
+++ b/docs/specs/SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03.md
@@ -1,6 +1,6 @@
 # Migration System Audit & Hardening Plan
 **Date:** 2026-08-03
-**Status:** active — Phase 0 shipped in PR #2394; Phases 1-6 not started (migration failure is still non-fatal at bootstrap.rs). Verified 2026-08-10.
+**Status:** active — Phase 0 shipped in PR #2394. Phase 1a (failure is fatal: srv emits `AGENTMUXSRV-MIGRATION-FAILED` and exits 1 before ESTART; launcher and CEF host fail fast with the reason instead of a 30s timeout; launcher shows the fatal dialog) shipped 2026-09-06 — see `agentmux-common/src/srv_stderr.rs`. Phase 1b (`--verify` / doctor pass, muxspect wiring) and Phases 2-6 not started. Verified 2026-09-06.
 **Scope:** agentmux-srv, agentmux-launcher, agentmux-cef
 **Related:** [`docs/specs/SPEC_DOCS_LIFECYCLE_HARDENING_2026_08_03.md`](./SPEC_DOCS_LIFECYCLE_HARDENING_2026_08_03.md) — written the same day, deliberately the same shape. Both audits found the identical underlying pattern: a marker that claims a state (a migration flag / a doc's `Status:` field) is trusted without ever being checked against ground truth, and nothing re-verifies it once written.
 **Trigger:** Live incident — a launched agent ("Agent1", channel `local-main-b28b7a-9172ff88`, srv v0.54.9 / commit `1899c5ed`) failed to start, and a `FOREIGN KEY constraint failed` warning on `linkagentidentity` appeared in the logs around the same time.


### PR DESCRIPTION
## Summary

`SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03` **Phase 1a** (failure mode F4). Closes the gap `REPORT_LARGE_MIGRATIONS_COMPLETION_AUDIT_2026_09_06.md` §3.2 verified was still live: `bootstrap.rs` ran startup migrations behind a `warn!` and booted anyway against a store in an unknown state. Failing to *open* the store always exited 1; failing to *migrate* it did not.

## What changes

| Layer | Before | After |
|---|---|---|
| **srv** `bootstrap.rs` | `Err(e) => warn!(... continuing)` | error log → `AGENTMUXSRV-MIGRATION-FAILED error:<reason>` on stderr → `exit(1)` before ESTART |
| **common** (new `srv_stderr.rs`) | — | prefix + formatter (flattens multi-line errors) + parser (never empty). One definition instead of a literal per crate. |
| **launcher** `srv_spawner.rs` | srv exit before ESTART → 30 s silence → `EstartTimeout` | third channel; waiter breaks **immediately** on the line → `SrvSpawnError::MigrationFailed(reason)`; splash stage ends "migration failed" |
| **launcher** supervisors (win + unix) | `eprintln!` + `exit(1)` (invisible on Windows — `windows` subsystem) | additionally `show_fatal_dialog` with the reason and restart guidance |
| **CEF host** `sidecar.rs` (`task dev:standalone`) | same 30 s timeout | `"agentmux-srv database migration failed: <reason>"` immediately |
| `docs/exe-return-codes.md` | already claimed srv exits 1 on migration failure | now true; line protocol documented |

Restart-to-retry guidance in the dialog is accurate: srv re-runs every unapplied migration next launch, and `maybe_snapshot_pre_migration` already wrote a snapshot before the attempt.

## Tests
- **common:** 6 new — format strips newlines, round-trip, tolerant parse (missing `error:`), non-empty guarantee, other protocol lines → `None`, and an explicit check that `MIGRATION-FAILED` isn't a `starts_with` prefix of `MIGRATING` (both consumers branch on `starts_with`).
- **launcher:** 3 new — `Display`, dialog body content, end-to-end srv-format → launcher-parse over the shared module.
- **srv:** `migrations::` slice 64/64.
- `cargo check` clean: common, srv, launcher, cef.

## Not in this PR
Phase 1b (`agentmux-srv migrate --verify` / doctor pass, muxspect wiring) and Phases 2–6. The spec's Status line now says exactly that.

<!-- agentmux:agent_id=korp -->