### PR TITLE
Korp@claudius: refactor(agent-pane): route agent-view's 11 raw dispatches through AgentPaneModel (A9 of #1549)

### DIFF
--- a/.changesets/1788752197-refactor-agent-pane-route-agent-view-s-11-raw-store-dispatch-xkvo.md
+++ b/.changesets/1788752197-refactor-agent-pane-route-agent-view-s-11-raw-store-dispatch-xkvo.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(agent-pane): route agent-view's 11 raw store dispatches through its AgentPaneModel handle (A9 of #1549) — post-unmount dispatches now drop safely instead of throwing, and all pane commands hit the crash-trail

--- a/docs/analysis/TRACKING_ARCHITECTURE_REFACTOR_A1_A15_2026_06_18.md
+++ b/docs/analysis/TRACKING_ARCHITECTURE_REFACTOR_A1_A15_2026_06_18.md
@@ -27,7 +27,7 @@ Value/Effort/Risk are from the audit. "Gate" = which trees the PR touches (colli
 | A6 | Collapse agent-pane's 4 parallel state systems / kill the mirror | ★★★★ | High | Med-High | 🔴 **blocked** | — | Collides with **#1555** (agent-pane). Wait for it to merge. |
 | A7 | Shared `ToolCorrelator` for translator tool-call/result | ★★★ | Low | Low | ✅ **done** | #1545 | `providers/tool-correlation.ts`. |
 | A8 | Split `websocket.rs` by command family | ★★★ | Med | Low | ✅ **done** | #1554 | Backend `server/`. |
-| A9 | De-dup agent-pane "is busy?" selector (17×); route via `paneModel` | ★★★ | Low | Low | 🔴 **blocked** | — | Same gate as A6 (#1555). |
+| A9 | De-dup agent-pane "is busy?" selector (17×); route via `paneModel` | ★★★ | Low | Low | ✅ **done** | #3044 | Busy predicate was already unified by the state-machine work (`isWorking`/`workingFromPhase`, 1 use left); #3044 routed the 11 raw dispatches + added a grep-shaped guard test. |
 | A10 | Consolidate data-dir resolution onto `DataPaths` | ★★★ | Med | Med | 🟢 ready | — | Backend; touches where live data lives — migration care. |
 | A11 | Real `BlockRegistry` + registry-driven `ModalLayer` | ★★★ | Low-Med | Low | ✅ **done** | #1562 | Frontend `block/`, `element/`. |
 | A12 | Dead-code sweep (watchdog family; dead RPC constants) | ★★ | Low-Med | Low | ✅ **done** | #1542, #1565 | StreamStalled removed; watchdogs NOT dead (skip); 65 dead COMMAND_* consts removed. |
@@ -153,12 +153,13 @@ Each item: **entry points** (where to start), **approach**, **acceptance criteri
   `cargo check` green; the A1 contract test still green (registered command set unchanged).
 - **Gotcha:** registrations use string-literal command names here (see A1 lesson #1) — keep names byte-identical or the A1 test catches you (that's the point).
 
-### A9 — De-dup "is busy?" + route via `paneModel` 🔴
+### A9 — De-dup "is busy?" + route via `paneModel` ✅
 - **Entry points:** `status.isLoading() || workingFromPhase(turnPhaseAtom())` duplicated **17×** across
   the agent view; 11 raw `dispatch*` calls in `agent-view.tsx` bypass `paneModel`.
 - **Approach:** one `isPaneBusy()` selector; route the 11 raw dispatches through `paneModel`.
 - **Acceptance:** one definition of "busy"; no raw `dispatch*` in `agent-view.tsx`.
 - **Gotcha / blocker:** same gate as A6 (#1543).
+- **Status (2026-09-06):** ✅ done in #3044. By then the busy-selector half had already been resolved elsewhere — `isWorking`/`workingFromPhase` in `agent-pane-state/types.ts` is the single predicate since the state-machine PR G, and agent-view had one use left, not 17. The 11 raw `dispatch*` calls were still all there (7 hard `dispatchPane`, 2 `dispatchPaneIfRegistered`, 2 `dispatchDocIfRegistered`) and are now routed through `paneModel`; `agent-view-dispatch-via-pane-model.test.ts` pins the acceptance criterion. Blocker #1543 had merged long before.
 
 ### A10 — Consolidate data-dir resolution onto `DataPaths` 🟢
 - **Entry points:** canonical `agentmux-common/src/data_paths.rs:4-7` ("single source of truth") is
@@ -277,7 +278,7 @@ Each item: **entry points** (where to start), **approach**, **acceptance criteri
 | `agentmux-srv/src/backend/blockcontroller/shell.rs` | 2358 | A5 |
 | `frontend/types/gotypes.d.ts` | 2297 | A1 (hand-maintained) |
 | `frontend/app/store/rpc-api.ts` | 1568 | A1 (hand-maintained) |
-| `frontend/app/view/agent/agent-view.tsx` | 1282 | A6/A9 |
+| `frontend/app/view/agent/agent-view.tsx` | 1282 → **2730** (2026-09-06) | A6 |
 | `frontend/app/store/global.ts` | (87 exports / 95 importers) | A3 |
 
 **Healthy patterns to copy** (audit §7): the agent-pane `update()` reducer + `EventSink` fan-out; the

--- a/frontend/app/view/agent/agent-view-dispatch-via-pane-model.test.ts
+++ b/frontend/app/view/agent/agent-view-dispatch-via-pane-model.test.ts
@@ -1,0 +1,58 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pins A9 of the architecture-refactor program (issue #1549,
+ * `docs/analysis/TRACKING_ARCHITECTURE_REFACTOR_A1_A15_2026_06_18.md`):
+ * `agent-view.tsx` must dispatch against the agent-pane stores ONLY through
+ * its `AgentPaneModel` handle, never via the module-level `dispatch` /
+ * `dispatchIfRegistered` exports.
+ *
+ * Why it matters: the model is the one place that (a) drops dispatches after
+ * `unregisterPane` instead of throwing — the hard `dispatch` throws on an
+ * unregistered pane, which is exactly the post-unmount race a view-level
+ * async callback hits — and (b) writes the `agent:dispatchPane` render-trail
+ * point the crash boundary dumps. A raw call bypasses both. The audit found
+ * 11 such bypasses in this file; routing them was the fix.
+ *
+ * Grep-shaped, same as `flows/run-cli-login-single-caller.test.ts`: a future
+ * direct import of the store dispatchers into this file fails a test, not a
+ * user's pane.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const AGENT_VIEW = join(__dirname, "agent-view.tsx");
+
+describe("agent-view.tsx dispatches only through its AgentPaneModel (A9)", () => {
+    const text = readFileSync(AGENT_VIEW, "utf8");
+
+    it("does not import the store-level dispatch helpers", () => {
+        // Both stores export `dispatch` and `dispatchIfRegistered`; agent-view
+        // used to alias them as dispatchPane / dispatchPaneIfRegistered /
+        // dispatchDocIfRegistered. Any of those names appearing in an import
+        // means the bypass is back.
+        const importBlocks = text.match(/^import[\s\S]*?from\s+"[^"]+";/gm) ?? [];
+        const offending = importBlocks.filter((block) =>
+            /\bdispatch(?:IfRegistered)?\b(?!Doc\b)/.test(block) &&
+            /agent-(?:pane-state|document)-store/.test(block),
+        );
+        expect(offending).toEqual([]);
+    });
+
+    it("has no raw dispatch* call sites — every dispatch goes via paneModel.", () => {
+        // A raw call is `dispatchPane(` / `dispatchDoc(` / the *IfRegistered
+        // forms NOT preceded by `paneModel.` (or any other member access).
+        const raw = text.match(/(?<![.\w])dispatch(?:Pane|Doc)(?:IfRegistered)?\(/g) ?? [];
+        expect(raw).toEqual([]);
+    });
+
+    it("still dispatches — the routing did not silently delete call sites", () => {
+        // Guard against the trivial way to satisfy the test above. The audit
+        // counted 11; the number may legitimately move, but it must not be 0.
+        const routed = text.match(/\bpaneModel\.dispatch(?:Pane|Doc)\(/g) ?? [];
+        expect(routed.length).toBeGreaterThan(0);
+    });
+});

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -5,7 +5,6 @@ import { BrainSpinner } from "@/app/element/BrainSpinner";
 import { DragOverlay } from "@/app/element/dragoverlay";
 import { PaneTabRenameInput } from "@/app/element/PaneTabRenameInput";
 import { PaneTabStrip } from "@/app/element/PaneTabStrip";
-import { dispatchIfRegistered as dispatchDocIfRegistered } from "@/app/store/agent-document-store";
 import {
     snapshot as layoutSnapshot,
     registerPane as registerLayoutPane,
@@ -17,11 +16,7 @@ import {
     unregisterPane as unregisterAgentPane,
     type AgentPaneModel,
 } from "@/app/store/agent-pane-registration";
-import {
-    dispatch as dispatchPane,
-    dispatchIfRegistered as dispatchPaneIfRegistered,
-    snapshot as paneSnapshot,
-} from "@/app/store/agent-pane-state-store";
+import { snapshot as paneSnapshot } from "@/app/store/agent-pane-state-store";
 import { workingFromPhase, type PaneFailure } from "@/app/store/agent-pane-state/types";
 import {
     registerActivity as registerAgentActivity,
@@ -1126,7 +1121,7 @@ const AgentPresentationView = ({
     // controllerstatus event. Does NOT touch turnJustEndedAtom — see
     // trackTurnJustEnded for why that's kept separate.
     function reconcileTurnActive(active: boolean): void {
-        dispatchPaneIfRegistered(model.blockId, { type: "ReconcileTurnActive", at: Date.now(), active }, "system");
+        paneModel.dispatchPane({ type: "ReconcileTurnActive", at: Date.now(), active }, "system");
     }
 
     // Feeds the turnJustEndedAtom edge-detector. Deliberately called ONLY
@@ -1184,7 +1179,7 @@ const AgentPresentationView = ({
             if (n === 0) return;
             const timer = setTimeout(() => {
                 if (workingFromPhase(agentAtoms().turnPhaseAtom[0]())) return;
-                dispatchDocIfRegistered(model.blockId, {
+                paneModel.dispatchDoc({
                     type: "ScrubOrphanedInProgress",
                     at: Date.now(),
                     scope: "tools-only",
@@ -1206,7 +1201,7 @@ const AgentPresentationView = ({
             id: `system_notification_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
             content: `${prefix}${text}`,
         } as import("./types").MarkdownNode;
-        dispatchDocIfRegistered(model.blockId, {
+        paneModel.dispatchDoc({
             type: "StreamFlush",
             newNodes: [node],
             updatedNodes: [],
@@ -1276,7 +1271,7 @@ const AgentPresentationView = ({
             // relogin always did, decided at click time from the row's own
             // turnAttempted, and calls onReady() instead of this on its
             // no-retry path. So every caller that reaches here wants a retry.
-            dispatchPane(model.blockId, { type: "FailureCleared" }, "system");
+            paneModel.dispatchPane({ type: "FailureCleared" }, "system");
             retryLastTurn();
         },
         getInitialTermSize: () => computeTermSizeFromEl(rootRef),
@@ -1691,8 +1686,7 @@ const AgentPresentationView = ({
                 : (transcriptStartMs ?? registryStartMs);
         const current = agentAtoms().attachedTaskAtom[0]() != null;
         if ((startMs != null) !== current) {
-            dispatchPaneIfRegistered(
-                model.blockId,
+            paneModel.dispatchPane(
                 startMs != null ? { type: "AttachedTaskObserved", at: startMs } : { type: "AttachedTaskCleared" },
                 "system"
             );
@@ -1800,7 +1794,7 @@ const AgentPresentationView = ({
         // turn; the queue-drain (agent-message-accepted) re-enters Submitting
         // if needed.
         if (!wasAlreadyWorking) {
-            dispatchPane(model.blockId, { type: "TurnStart", at: Date.now(), content: message }, "user");
+            paneModel.dispatchPane({ type: "TurnStart", at: Date.now(), content: message }, "user");
         }
         return commands.sendMessage(message, wasAlreadyWorking, authFailureToPreserve);
     };
@@ -1866,8 +1860,7 @@ const AgentPresentationView = ({
         prevFailure = untrack(() => agentAtoms().failureAtom[0]());
         syntheticDismissed = decision.syntheticDismissed;
         if (decision.action === "raise") {
-            dispatchPane(
-                model.blockId,
+            paneModel.dispatchPane(
                 {
                     type: "FailureObserved",
                     at: Date.now(),
@@ -1888,7 +1881,7 @@ const AgentPresentationView = ({
             // "a row just appeared from nowhere".
             prevFailure = untrack(() => agentAtoms().failureAtom[0]());
         } else if (decision.action === "retract") {
-            dispatchPane(model.blockId, { type: "FailureCleared" }, "system");
+            paneModel.dispatchPane({ type: "FailureCleared" }, "system");
             prevFailure = null;
         }
     });
@@ -1965,7 +1958,7 @@ const AgentPresentationView = ({
     const declareAuthHealthy = () => {
         status.notifyControllerHealthy();
         if (paneSnapshot(model.blockId)?.failure?.data.code === "auth") {
-            dispatchPane(model.blockId, { type: "FailureCleared" }, "system");
+            paneModel.dispatchPane({ type: "FailureCleared" }, "system");
         }
     };
 
@@ -2517,7 +2510,7 @@ const AgentPresentationView = ({
                     // click, the second subscribe is harmless — the
                     // reducer's Disconnected→Idle transition is the
                     // same regardless of who calls it.
-                    dispatchPane(model.blockId, { type: "StreamSubscribe", at: Date.now() }, "user");
+                    paneModel.dispatchPane({ type: "StreamSubscribe", at: Date.now() }, "user");
                 }}
             />
             {/* Non-Claude quick-fork fallback note — SPEC_AGENT_QUICK_FORK_NEW_TAB_2026_08_21.md
@@ -2594,7 +2587,7 @@ const AgentPresentationView = ({
                     createBlock({ meta: { view: "swarm" } });
                 }}
                 logOpen={agentAtoms().detailsOpenAtom[0]()}
-                onToggleLog={() => dispatchPane(model.blockId, { type: "DetailsToggle" }, "user")}
+                onToggleLog={() => paneModel.dispatchPane({ type: "DetailsToggle" }, "user")}
                 contextTokens={agentAtoms().contextTokensAtom[0]()}
                 contextWindow={agentAtoms().contextWindowAtom[0]() ?? provider()?.contextWindow}
                 authStatus={loginStatus()}


### PR DESCRIPTION
## Summary

**A9** of the architecture-refactor program (#1549). Filed 2026-06-18, blocked then on #1543 (long since merged), untouched since. Still exactly **11 raw store dispatches** in `agent-view.tsx` today — a file that has grown from 1,282 to 2,730 lines in the meantime (`REPORT_LARGE_MIGRATIONS_COMPLETION_AUDIT_2026_09_06.md` §3.1).

## Why it matters

`AgentPaneModel` (per its own contract in `agent-pane-model.ts`) is the one place that:
- **drops** a dispatch after `unregisterPane` instead of throwing — the hard `dispatch` throws on an unregistered pane, which is exactly the post-unmount race a view-level async callback hits
- emits the `agent:dispatchPane` **render-trail** point the crash boundary dumps

All 11 raw calls bypassed both.

## Change

Mechanical, one file:

| Before | After |
|---|---|
| `dispatchPane(model.blockId, cmd, src)` ×7 | `paneModel.dispatchPane(cmd, src)` |
| `dispatchPaneIfRegistered(model.blockId, …)` ×2 | `paneModel.dispatchPane(…)` |
| `dispatchDocIfRegistered(model.blockId, …)` ×2 | `paneModel.dispatchDoc(…)` |

`paneModel` is assigned synchronously in the component body ahead of every site; return values preserved. Three now-unused imports removed.

**The other half of A9** ("one `isPaneBusy()` selector; the `isLoading() || workingFromPhase()` combo duplicated 17×") was already resolved by the state-machine work — `isWorking`/`workingFromPhase` in `agent-pane-state/types.ts` is the single predicate ("since PR G") and agent-view has one remaining use. Nothing left to do there.

## Test

`agent-view-dispatch-via-pane-model.test.ts` pins the acceptance criterion grep-shaped (same pattern as `flows/run-cli-login-single-caller.test.ts`): no store-dispatch imports, no raw `dispatch*(` call, **and** a non-zero `paneModel.dispatch*(` count so the first two can't be satisfied by deleting call sites.

## Verification
- `tsc --noEmit`: **0 errors** (baseline on `main` is also 0 — the board's "~31 pre-existing" note is stale)
- vitest: **135 files / 1,822 tests** green across `frontend/app/view/agent` + agent-pane store suites
- ESLint: could not run — fails on config load (`TypeError: Unexpected array`) for *any* file on this checkout, including untouched ones. Pre-existing.

Board + #1549 checkbox will be updated with this PR number in a follow-up commit on this branch.

<!-- agentmux:agent_id=korp -->