### PR TITLE
Manoz@Area54: refactor(storage): one ManagedResource implementation behind the skill_* and mcp_server_* store methods

### DIFF
--- a/.changesets/1788751924-storage-one-generic-managedresource-implementation-behind-th-jmrp.md
+++ b/.changesets/1788751924-storage-one-generic-managedresource-implementation-behind-th-jmrp.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+storage: one generic ManagedResource implementation behind the skill_* and mcp_server_* store methods (agent- and bundle-level list/get/bind/unbind/upsert/access checks); public API, messages and tests unchanged

--- a/agentmux-srv/src/backend/session_archive.rs
+++ b/agentmux-srv/src/backend/session_archive.rs
@@ -17,7 +17,6 @@
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::SystemTime;
 
 use flate2::Compression;
 use flate2::read::GzDecoder;

--- a/agentmux-srv/src/backend/storage/managed.rs
+++ b/agentmux-srv/src/backend/storage/managed.rs
@@ -1,0 +1,580 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The "managed primitive" storage shape shared by standalone Skills and MCP
+//! Servers (v1 composable model, SPEC_V1_MCP_SKILLS_PRIMITIVES_2026_06_30.md;
+//! bundle-level refs per SPEC_BUNDLE_AS_CONTAINER_V2_2026_08_17.md).
+//!
+//! Both primitives are the same pattern: one catalog table whose rows are
+//! either global (visible to everyone) or private, an agent-level ref table
+//! binding rows to agents, and a bundle-level ref table binding rows to
+//! bundles. Before this module `skills.rs` and `mcp_servers.rs` each carried
+//! their own copy of the eighteen list / get / delete / bind / unbind /
+//! upsert / access-check methods — identical except for table and column
+//! names and the noun in error messages
+//! (REPORT_DRY_AND_MODULARITY_AUDIT_2026_09_06.md §2.4). The per-primitive
+//! modules keep their public methods, response structs, doc comments and
+//! tests; only the bodies delegate here. Every SQL statement below is the
+//! one the hand-written methods used, with the names substituted.
+//!
+//! SQL is assembled with `format!` from the trait's `const` names only —
+//! never from runtime input — so the generated statements are exactly as
+//! fixed as the literals they replace. Values still go through `?N`
+//! parameters.
+
+use rusqlite::{params, params_from_iter, types::Value, Row};
+
+use super::error::StoreError;
+use super::store::Store;
+
+/// One managed primitive: its catalog row type plus the names that differ
+/// between primitives.
+pub trait ManagedResource: Sized {
+    /// Catalog table, e.g. `db_skills`.
+    const TABLE: &'static str;
+    /// The ref tables' column that points at `TABLE.id`, e.g. `skill_id`.
+    const REF_COL: &'static str;
+    /// Agent-level ref table `(agent_id, REF_COL)`, e.g. `db_agent_skills_ref`.
+    const AGENT_REF_TABLE: &'static str;
+    /// Bundle-level ref table `(bundle_id, REF_COL)`, e.g. `db_bundle_skills_ref`.
+    const BUNDLE_REF_TABLE: &'static str;
+    /// Every column of `TABLE`, in the order `from_row` reads them and
+    /// `values` produces them. Must include `id`, `name`, `is_global`,
+    /// `created_at` and `updated_at`.
+    const COLUMNS: &'static [&'static str];
+    /// Columns rewritten by `ON CONFLICT(id) DO UPDATE` — everything a caller
+    /// may edit; never `id`, `is_global` or `created_at`.
+    const UPDATE_COLUMNS: &'static [&'static str];
+    /// Noun in name-uniqueness errors: "`skill` name 'x' already bound…".
+    const NAME_NOUN: &'static str;
+    /// Noun with article in bundle errors: "cannot bind `an MCP server` to…".
+    const ARTICLE_NOUN: &'static str;
+    /// Noun in the cross-channel bind error: "cross-channel `MCP server` binding…".
+    const KIND: &'static str;
+
+    /// Read one row whose leading columns are `COLUMNS`, in order, from 0.
+    fn from_row(row: &Row<'_>) -> rusqlite::Result<Self>;
+    /// The row's values in `COLUMNS` order (`is_global` as 0/1).
+    fn values(&self) -> Vec<Value>;
+    fn id(&self) -> &str;
+    fn name(&self) -> &str;
+}
+
+/// Which ref table a scoped query is keyed on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Owner {
+    Agent,
+    Bundle,
+}
+
+impl Owner {
+    fn ref_table<R: ManagedResource>(self) -> &'static str {
+        match self {
+            Owner::Agent => R::AGENT_REF_TABLE,
+            Owner::Bundle => R::BUNDLE_REF_TABLE,
+        }
+    }
+    fn key_col(self) -> &'static str {
+        match self {
+            Owner::Agent => "agent_id",
+            Owner::Bundle => "bundle_id",
+        }
+    }
+    fn word(self) -> &'static str {
+        match self {
+            Owner::Agent => "agent",
+            Owner::Bundle => "bundle",
+        }
+    }
+}
+
+fn aliased_cols<R: ManagedResource>(alias: &str) -> String {
+    R::COLUMNS
+        .iter()
+        .map(|c| format!("{alias}.{c}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn placeholders(n: usize) -> String {
+    (1..=n).map(|i| format!("?{i}")).collect::<Vec<_>>().join(", ")
+}
+
+fn update_set<R: ManagedResource>() -> String {
+    R::UPDATE_COLUMNS
+        .iter()
+        .map(|c| format!("{c}=excluded.{c}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// `row.values()` with `is_global` replaced when a method hard-codes it
+/// (the global upsert forces 1, the bundle-scoped upsert forces 0).
+fn values_with_global<R: ManagedResource>(row: &R, force_global: Option<bool>) -> Vec<Value> {
+    let mut v = row.values();
+    if let Some(g) = force_global {
+        let idx = R::COLUMNS
+            .iter()
+            .position(|c| *c == "is_global")
+            .expect("ManagedResource::COLUMNS must contain is_global");
+        v[idx] = Value::Integer(if g { 1 } else { 0 });
+    }
+    v
+}
+
+impl Store {
+    /// Rows visible to `owner_id` — its own referenced rows plus every global
+    /// row — each paired with whether this owner holds the ref. Global rows
+    /// first, newest first.
+    pub(super) fn managed_list<R: ManagedResource>(
+        &self,
+        owner: Owner,
+        owner_id: &str,
+    ) -> Result<Vec<(R, bool)>, StoreError> {
+        let sql = format!(
+            "SELECT {cols},
+                    EXISTS(SELECT 1 FROM {reft} r WHERE r.{refc} = s.id AND r.{key} = ?1) AS bound
+             FROM {table} s
+             WHERE s.is_global = 1
+                OR s.id IN (SELECT {refc} FROM {reft} WHERE {key} = ?1)
+             ORDER BY s.is_global DESC, s.updated_at DESC",
+            cols = aliased_cols::<R>("s"),
+            reft = owner.ref_table::<R>(),
+            refc = R::REF_COL,
+            key = owner.key_col(),
+            table = R::TABLE,
+        );
+        self.managed_rows_with_flag::<R>(&sql, owner_id)
+    }
+
+    /// Global rows only, each paired with whether `agent_id` holds the
+    /// agent-level ref. Newest first. Never returns private rows — the
+    /// caller-supplied `agent_id` is unverified on the catalog RPCs that
+    /// use this (reagentx P0 on PR #2329).
+    pub(super) fn managed_list_global_for_agent<R: ManagedResource>(
+        &self,
+        agent_id: &str,
+    ) -> Result<Vec<(R, bool)>, StoreError> {
+        let sql = format!(
+            "SELECT {cols},
+                    EXISTS(SELECT 1 FROM {reft} r WHERE r.{refc} = s.id AND r.agent_id = ?1) AS bound
+             FROM {table} s
+             WHERE s.is_global = 1
+             ORDER BY s.updated_at DESC",
+            cols = aliased_cols::<R>("s"),
+            reft = R::AGENT_REF_TABLE,
+            refc = R::REF_COL,
+            table = R::TABLE,
+        );
+        self.managed_rows_with_flag::<R>(&sql, agent_id)
+    }
+
+    fn managed_rows_with_flag<R: ManagedResource>(
+        &self,
+        sql: &str,
+        key: &str,
+    ) -> Result<Vec<(R, bool)>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(sql)?;
+        let flag_idx = R::COLUMNS.len();
+        let rows = stmt.query_map(params![key], |row| {
+            Ok((R::from_row(row)?, row.get::<_, i64>(flag_idx)? != 0))
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
+    /// Global rows with how many agents hold an agent-level ref to each —
+    /// the Armory catalog's "used by N agents". Newest first.
+    pub(super) fn managed_list_global<R: ManagedResource>(&self) -> Result<Vec<(R, i64)>, StoreError> {
+        let sql = format!(
+            "SELECT {cols},
+                    (SELECT COUNT(*) FROM {reft} r WHERE r.{refc} = s.id) AS bound_count
+             FROM {table} s
+             WHERE s.is_global = 1
+             ORDER BY s.updated_at DESC",
+            cols = aliased_cols::<R>("s"),
+            reft = R::AGENT_REF_TABLE,
+            refc = R::REF_COL,
+            table = R::TABLE,
+        );
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(&sql)?;
+        let count_idx = R::COLUMNS.len();
+        let rows = stmt.query_map([], |row| Ok((R::from_row(row)?, row.get::<_, i64>(count_idx)?)))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
+    /// One row by id.
+    pub(super) fn managed_get<R: ManagedResource>(&self, id: &str) -> Result<Option<R>, StoreError> {
+        let sql = format!(
+            "SELECT {cols} FROM {table} WHERE id = ?1",
+            cols = R::COLUMNS.join(", "),
+            table = R::TABLE,
+        );
+        let conn = self.conn.lock().unwrap();
+        match conn.query_row(&sql, params![id], |row| R::from_row(row)) {
+            Ok(r) => Ok(Some(r)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(StoreError::Sqlite(e)),
+        }
+    }
+
+    /// Delete a row and purge its agent- and bundle-level refs explicitly
+    /// (FK cascades may be off on some builds). True if a row was deleted.
+    pub(super) fn managed_delete<R: ManagedResource>(&self, id: &str) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            &format!("DELETE FROM {} WHERE {} = ?1", R::AGENT_REF_TABLE, R::REF_COL),
+            params![id],
+        )?;
+        conn.execute(
+            &format!("DELETE FROM {} WHERE {} = ?1", R::BUNDLE_REF_TABLE, R::REF_COL),
+            params![id],
+        )?;
+        let rows = conn.execute(&format!("DELETE FROM {} WHERE id = ?1", R::TABLE), params![id])?;
+        Ok(rows > 0)
+    }
+
+    /// Insert the agent-level ref (idempotent). Errors if `agent_id` is not
+    /// a LOCAL agent definition: the ref table's FK would otherwise swallow
+    /// the `INSERT OR IGNORE` silently for a cross-channel agent, which is
+    /// indistinguishable by row count from "already bound" (reagentx P1 on
+    /// PR #2315; REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md).
+    pub(super) fn managed_bind_agent<R: ManagedResource>(&self, agent_id: &str, id: &str) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let agent_exists: bool = conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM db_agent_definitions WHERE id = ?1)",
+            params![agent_id],
+            |row| row.get(0),
+        )?;
+        if !agent_exists {
+            return Err(StoreError::Other(format!(
+                "agent {agent_id} not found in this channel's local registry — cross-channel {} binding is not supported",
+                R::KIND
+            )));
+        }
+        conn.execute(
+            &format!(
+                "INSERT OR IGNORE INTO {} (agent_id, {}) VALUES (?1, ?2)",
+                R::AGENT_REF_TABLE,
+                R::REF_COL
+            ),
+            params![agent_id, id],
+        )?;
+        Ok(())
+    }
+
+    /// Insert the bundle-level ref (idempotent). Bundle existence is checked
+    /// in `id_store`, not `self` — bundles are authoritatively written through
+    /// the shared store, and `self`'s local `db_bundles` copy is essentially
+    /// always empty in production (reagentx P0 on PR #2639).
+    pub(super) fn managed_bind_bundle<R: ManagedResource>(
+        &self,
+        id_store: &Store,
+        bundle_id: &str,
+        id: &str,
+    ) -> Result<(), StoreError> {
+        if !id_store.bundle_exists(bundle_id)? {
+            return Err(StoreError::Other(format!(
+                "bundle {bundle_id} not found — cannot bind {} to a nonexistent bundle",
+                R::ARTICLE_NOUN
+            )));
+        }
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            &format!(
+                "INSERT OR IGNORE INTO {} (bundle_id, {}) VALUES (?1, ?2)",
+                R::BUNDLE_REF_TABLE,
+                R::REF_COL
+            ),
+            params![bundle_id, id],
+        )?;
+        Ok(())
+    }
+
+    fn bundle_exists(&self, bundle_id: &str) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        Ok(conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM db_bundles WHERE id = ?1)",
+            params![bundle_id],
+            |row| row.get(0),
+        )?)
+    }
+
+    /// Remove the owner-level ref. True if a row was removed.
+    pub(super) fn managed_unbind<R: ManagedResource>(
+        &self,
+        owner: Owner,
+        owner_id: &str,
+        id: &str,
+    ) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute(
+            &format!(
+                "DELETE FROM {} WHERE {} = ?1 AND {} = ?2",
+                owner.ref_table::<R>(),
+                owner.key_col(),
+                R::REF_COL
+            ),
+            params![owner_id, id],
+        )?;
+        Ok(rows > 0)
+    }
+
+    /// Atomically upsert `row` enforcing owner-scoped name uniqueness (no
+    /// other row visible to the owner — bound or global — may share the
+    /// name), and bind it when `bind_new`, in one transaction so concurrent
+    /// upserts of the same name can't both pass the check. `force_global`
+    /// overrides the row's own `is_global` on INSERT: the bundle-scoped
+    /// upsert always creates PRIVATE rows (`Some(false)`), the agent-scoped
+    /// one keeps the row's value (`None`).
+    pub(super) fn managed_upsert_unique<R: ManagedResource>(
+        &self,
+        owner: Owner,
+        owner_id: &str,
+        row: &R,
+        bind_new: bool,
+        force_global: Option<bool>,
+    ) -> Result<(), StoreError> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let dup: i64 = tx.query_row(
+            &format!(
+                "SELECT COUNT(*) FROM {table}
+                 WHERE name = ?1 AND id <> ?2 AND (is_global = 1 OR id IN (
+                   SELECT {refc} FROM {reft} WHERE {key} = ?3
+                 ))",
+                table = R::TABLE,
+                refc = R::REF_COL,
+                reft = owner.ref_table::<R>(),
+                key = owner.key_col(),
+            ),
+            params![row.name(), row.id(), owner_id],
+            |r| r.get(0),
+        )?;
+        if dup > 0 {
+            return Err(StoreError::Other(format!(
+                "{} name '{}' already bound to this {}",
+                R::NAME_NOUN,
+                row.name(),
+                owner.word()
+            )));
+        }
+        tx.execute(&insert_sql::<R>(), params_from_iter(values_with_global(row, force_global)))?;
+        if bind_new {
+            tx.execute(
+                &format!(
+                    "INSERT OR IGNORE INTO {} ({}, {}) VALUES (?1, ?2)",
+                    owner.ref_table::<R>(),
+                    owner.key_col(),
+                    R::REF_COL
+                ),
+                params![owner_id, row.id()],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Bundle-scoped upsert: create a NEW, PRIVATE (never global) row bound
+    /// directly to a bundle, enforcing bundle-scoped name uniqueness. Bundle
+    /// existence is checked in `id_store` (see `managed_bind_bundle`).
+    /// `managed_bind_bundle` may only bind EXISTING global rows — binding an
+    /// existing private row would let one bundle "steal" read access to
+    /// whatever entity that row belongs to — but globals already reach every
+    /// agent, so this is how a bundle gets a genuinely bundle-specific row
+    /// that has never belonged to anyone else (reagentx P1 on PR #2639).
+    pub(super) fn managed_upsert_unique_for_bundle<R: ManagedResource>(
+        &self,
+        id_store: &Store,
+        bundle_id: &str,
+        row: &R,
+        bind_new: bool,
+    ) -> Result<(), StoreError> {
+        if !id_store.bundle_exists(bundle_id)? {
+            return Err(StoreError::Other(format!(
+                "bundle {bundle_id} not found — cannot create {} for a nonexistent bundle",
+                R::ARTICLE_NOUN
+            )));
+        }
+        self.managed_upsert_unique(Owner::Bundle, bundle_id, row, bind_new, Some(false))
+    }
+
+    /// Atomically upsert a GLOBAL row enforcing catalog-wide name uniqueness
+    /// among every global row (not just those visible to one owner). Forces
+    /// `is_global = 1` on INSERT; the caller is expected to have set it too.
+    pub(super) fn managed_upsert_unique_global<R: ManagedResource>(&self, row: &R) -> Result<(), StoreError> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let dup: i64 = tx.query_row(
+            &format!(
+                "SELECT COUNT(*) FROM {} WHERE name = ?1 AND id <> ?2 AND is_global = 1",
+                R::TABLE
+            ),
+            params![row.name(), row.id()],
+            |r| r.get(0),
+        )?;
+        if dup > 0 {
+            return Err(StoreError::Other(format!(
+                "a global {} named '{}' already exists",
+                R::NAME_NOUN,
+                row.name()
+            )));
+        }
+        tx.execute(&insert_sql::<R>(), params_from_iter(values_with_global(row, Some(true))))?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// True when the row is global or the owner holds a ref to it — the
+    /// read/mutation access check.
+    pub(super) fn managed_is_accessible_to<R: ManagedResource>(
+        &self,
+        owner: Owner,
+        owner_id: &str,
+        id: &str,
+    ) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            &format!(
+                "SELECT COUNT(*) FROM {table}
+                 WHERE id = ?1 AND (is_global = 1 OR id IN (
+                   SELECT {refc} FROM {reft} WHERE {key} = ?2
+                 ))",
+                table = R::TABLE,
+                refc = R::REF_COL,
+                reft = owner.ref_table::<R>(),
+                key = owner.key_col(),
+            ),
+            params![id, owner_id],
+            |r| r.get(0),
+        )?;
+        Ok(count > 0)
+    }
+
+    /// True when the owner holds a direct ref to the row (global rows are
+    /// not implied) — the ownership check for edit/delete.
+    pub(super) fn managed_is_bound_to<R: ManagedResource>(
+        &self,
+        owner: Owner,
+        owner_id: &str,
+        id: &str,
+    ) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            &format!(
+                "SELECT COUNT(*) FROM {} WHERE {} = ?1 AND {} = ?2",
+                owner.ref_table::<R>(),
+                owner.key_col(),
+                R::REF_COL
+            ),
+            params![owner_id, id],
+            |r| r.get(0),
+        )?;
+        Ok(count > 0)
+    }
+
+    /// Union the rows referenced by `agent_id`'s bound bundle into
+    /// `visible`, deduped by id (a global row is already in `visible` and
+    /// would otherwise appear twice). Composable model v2 — without this,
+    /// bundle-level refs would be exactly as inert at launch as the bundle's
+    /// old inline JSON columns were (GH issue #2024 item 3). Silent on
+    /// lookup failure, like the two callers it was lifted from.
+    pub(super) fn managed_union_bundle_refs<R: ManagedResource>(&self, agent_id: &str, visible: &mut Vec<R>) {
+        if let Ok(Some(def)) = self.agent_def_get(agent_id) {
+            if !def.memory_id.is_empty() {
+                for (row, _) in self
+                    .managed_list::<R>(Owner::Bundle, &def.memory_id)
+                    .unwrap_or_default()
+                {
+                    if !visible.iter().any(|s| s.id() == row.id()) {
+                        visible.push(row);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn insert_sql<R: ManagedResource>() -> String {
+    format!(
+        "INSERT INTO {table} ({cols})
+         VALUES ({vals})
+         ON CONFLICT(id) DO UPDATE SET {set}",
+        table = R::TABLE,
+        cols = R::COLUMNS.join(", "),
+        vals = placeholders(R::COLUMNS.len()),
+        set = update_set::<R>(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Probe;
+    impl ManagedResource for Probe {
+        const TABLE: &'static str = "db_probe";
+        const REF_COL: &'static str = "probe_id";
+        const AGENT_REF_TABLE: &'static str = "db_agent_probe_ref";
+        const BUNDLE_REF_TABLE: &'static str = "db_bundle_probe_ref";
+        const COLUMNS: &'static [&'static str] = &["id", "name", "is_global", "created_at", "updated_at"];
+        const UPDATE_COLUMNS: &'static [&'static str] = &["name", "updated_at"];
+        const NAME_NOUN: &'static str = "probe";
+        const ARTICLE_NOUN: &'static str = "a probe";
+        const KIND: &'static str = "probe";
+        fn from_row(_row: &Row<'_>) -> rusqlite::Result<Self> {
+            Ok(Probe)
+        }
+        fn values(&self) -> Vec<Value> {
+            vec![
+                Value::Text("id".into()),
+                Value::Text("n".into()),
+                Value::Integer(0),
+                Value::Integer(1),
+                Value::Integer(2),
+            ]
+        }
+        fn id(&self) -> &str {
+            "id"
+        }
+        fn name(&self) -> &str {
+            "n"
+        }
+    }
+
+    #[test]
+    fn insert_sql_lists_every_column_once_and_updates_only_the_editable_ones() {
+        let sql = insert_sql::<Probe>();
+        assert!(sql.contains("INSERT INTO db_probe (id, name, is_global, created_at, updated_at)"));
+        assert!(sql.contains("VALUES (?1, ?2, ?3, ?4, ?5)"));
+        assert!(sql.contains("ON CONFLICT(id) DO UPDATE SET name=excluded.name, updated_at=excluded.updated_at"));
+        assert!(!sql.contains("is_global=excluded"), "is_global must never be rewritten on conflict");
+    }
+
+    #[test]
+    fn force_global_replaces_only_the_is_global_value() {
+        let forced = values_with_global(&Probe, Some(true));
+        assert_eq!(forced[2], Value::Integer(1));
+        assert_eq!(forced[0], Value::Text("id".into()));
+        let cleared = values_with_global(&Probe, Some(false));
+        assert_eq!(cleared[2], Value::Integer(0));
+        assert_eq!(values_with_global(&Probe, None), Probe.values());
+    }
+
+    #[test]
+    fn owner_selects_the_matching_ref_table_and_key() {
+        assert_eq!(Owner::Agent.ref_table::<Probe>(), "db_agent_probe_ref");
+        assert_eq!(Owner::Bundle.ref_table::<Probe>(), "db_bundle_probe_ref");
+        assert_eq!(Owner::Agent.key_col(), "agent_id");
+        assert_eq!(Owner::Bundle.key_col(), "bundle_id");
+    }
+}

--- a/agentmux-srv/src/backend/storage/mcp_servers.rs
+++ b/agentmux-srv/src/backend/storage/mcp_servers.rs
@@ -7,10 +7,10 @@
 //! the full server object JSON (command/args/env for stdio; url/headers for
 //! SSE) that gets merged into `.mcp.json` at agent launch.
 
-use rusqlite::params;
 use serde::{Deserialize, Serialize};
 
 use super::error::StoreError;
+use super::managed::{ManagedResource, Owner};
 use super::store::Store;
 
 /// A standalone MCP Server primitive (v1 composable model).
@@ -23,6 +23,49 @@ pub struct McpServer {
     pub is_global: bool,
     pub created_at: i64,
     pub updated_at: i64,
+}
+
+impl ManagedResource for McpServer {
+    const TABLE: &'static str = "db_mcp_servers";
+    const REF_COL: &'static str = "mcp_id";
+    const AGENT_REF_TABLE: &'static str = "db_agent_mcp_ref";
+    const BUNDLE_REF_TABLE: &'static str = "db_bundle_mcp_ref";
+    const COLUMNS: &'static [&'static str] =
+        &["id", "name", "transport", "config", "is_global", "created_at", "updated_at"];
+    const UPDATE_COLUMNS: &'static [&'static str] = &["name", "transport", "config", "updated_at"];
+    const NAME_NOUN: &'static str = "server";
+    const ARTICLE_NOUN: &'static str = "an MCP server";
+    const KIND: &'static str = "MCP server";
+
+    fn from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Self> {
+        Ok(McpServer {
+            id: row.get(0)?,
+            name: row.get(1)?,
+            transport: row.get(2)?,
+            config: row.get(3)?,
+            is_global: row.get::<_, i64>(4)? != 0,
+            created_at: row.get(5)?,
+            updated_at: row.get(6)?,
+        })
+    }
+    fn values(&self) -> Vec<rusqlite::types::Value> {
+        use rusqlite::types::Value;
+        vec![
+            Value::Text(self.id.clone()),
+            Value::Text(self.name.clone()),
+            Value::Text(self.transport.clone()),
+            Value::Text(self.config.clone()),
+            Value::Integer(if self.is_global { 1 } else { 0 }),
+            Value::Integer(self.created_at),
+            Value::Integer(self.updated_at),
+        ]
+    }
+    fn id(&self) -> &str {
+        &self.id
+    }
+    fn name(&self) -> &str {
+        &self.name
+    }
 }
 
 /// `mcp_server_list`'s response shape: the server plus whether the requesting
@@ -63,34 +106,11 @@ impl Store {
     /// List all MCP servers visible to an agent: own (referenced) + global,
     /// each annotated with whether this specific agent holds the bind ref.
     pub fn mcp_server_list(&self, agent_id: &str) -> Result<Vec<McpServerListItem>, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
-            "SELECT s.id, s.name, s.transport, s.config, s.is_global, s.created_at, s.updated_at,
-                    EXISTS(SELECT 1 FROM db_agent_mcp_ref r WHERE r.mcp_id = s.id AND r.agent_id = ?1) AS bound_to_agent
-             FROM db_mcp_servers s
-             WHERE s.is_global = 1
-                OR s.id IN (SELECT mcp_id FROM db_agent_mcp_ref WHERE agent_id = ?1)
-             ORDER BY s.is_global DESC, s.updated_at DESC",
-        )?;
-        let rows = stmt.query_map(params![agent_id], |row| {
-            Ok(McpServerListItem {
-                server: McpServer {
-                    id: row.get(0)?,
-                    name: row.get(1)?,
-                    transport: row.get(2)?,
-                    config: row.get(3)?,
-                    is_global: row.get::<_, i64>(4)? != 0,
-                    created_at: row.get(5)?,
-                    updated_at: row.get(6)?,
-                },
-                bound_to_agent: row.get::<_, i64>(7)? != 0,
-            })
-        })?;
-        let mut out = Vec::new();
-        for row in rows {
-            out.push(row?);
-        }
-        Ok(out)
+        Ok(self
+            .managed_list::<McpServer>(Owner::Agent, agent_id)?
+            .into_iter()
+            .map(|(server, bound_to_agent)| McpServerListItem { server, bound_to_agent })
+            .collect())
     }
 
     /// Every MCP server visible to an agent for config materialization:
@@ -109,15 +129,7 @@ impl Store {
             .into_iter()
             .map(|item| item.server)
             .collect();
-        if let Ok(Some(def)) = self.agent_def_get(agent_id) {
-            if !def.memory_id.is_empty() {
-                for item in self.bundle_mcp_list(&def.memory_id).unwrap_or_default() {
-                    if !visible.iter().any(|s| s.id == item.server.id) {
-                        visible.push(item.server);
-                    }
-                }
-            }
-        }
+        self.managed_union_bundle_refs(agent_id, &mut visible);
         visible
     }
 
@@ -129,33 +141,11 @@ impl Store {
     /// `db_agent_mcp_ref` to it — per SPEC_V1_MCP_SKILLS_PRIMITIVES_2026_06_30.md
     /// §8 ("used by N agents"), tracked as gap #2 of #1960.
     pub fn mcp_server_list_global(&self) -> Result<Vec<McpServerCatalogItem>, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
-            "SELECT s.id, s.name, s.transport, s.config, s.is_global, s.created_at, s.updated_at,
-                    (SELECT COUNT(*) FROM db_agent_mcp_ref r WHERE r.mcp_id = s.id) AS bound_count
-             FROM db_mcp_servers s
-             WHERE s.is_global = 1
-             ORDER BY s.updated_at DESC",
-        )?;
-        let rows = stmt.query_map([], |row| {
-            Ok(McpServerCatalogItem {
-                server: McpServer {
-                    id: row.get(0)?,
-                    name: row.get(1)?,
-                    transport: row.get(2)?,
-                    config: row.get(3)?,
-                    is_global: row.get::<_, i64>(4)? != 0,
-                    created_at: row.get(5)?,
-                    updated_at: row.get(6)?,
-                },
-                bound_count: row.get(7)?,
-            })
-        })?;
-        let mut out = Vec::new();
-        for row in rows {
-            out.push(row?);
-        }
-        Ok(out)
+        Ok(self
+            .managed_list_global::<McpServer>()?
+            .into_iter()
+            .map(|(server, bound_count)| McpServerCatalogItem { server, bound_count })
+            .collect())
     }
 
     /// Catalog-tier sibling of `mcp_server_list` (above) — same
@@ -172,70 +162,23 @@ impl Store {
     /// alongside a caller-chosen agent's bind status is safe.
     /// reagentx P0 on PR #2329.
     pub fn mcp_server_list_global_for_agent(&self, agent_id: &str) -> Result<Vec<McpServerListItem>, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
-            "SELECT s.id, s.name, s.transport, s.config, s.is_global, s.created_at, s.updated_at,
-                    EXISTS(SELECT 1 FROM db_agent_mcp_ref r WHERE r.mcp_id = s.id AND r.agent_id = ?1) AS bound_to_agent
-             FROM db_mcp_servers s
-             WHERE s.is_global = 1
-             ORDER BY s.updated_at DESC",
-        )?;
-        let rows = stmt.query_map(params![agent_id], |row| {
-            Ok(McpServerListItem {
-                server: McpServer {
-                    id: row.get(0)?,
-                    name: row.get(1)?,
-                    transport: row.get(2)?,
-                    config: row.get(3)?,
-                    is_global: row.get::<_, i64>(4)? != 0,
-                    created_at: row.get(5)?,
-                    updated_at: row.get(6)?,
-                },
-                bound_to_agent: row.get::<_, i64>(7)? != 0,
-            })
-        })?;
-        let mut out = Vec::new();
-        for row in rows {
-            out.push(row?);
-        }
-        Ok(out)
+        Ok(self
+            .managed_list_global_for_agent::<McpServer>(agent_id)?
+            .into_iter()
+            .map(|(server, bound_to_agent)| McpServerListItem { server, bound_to_agent })
+            .collect())
     }
 
     /// Get a standalone MCP server by id.
     pub fn mcp_server_get(&self, id: &str) -> Result<Option<McpServer>, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let result = conn.query_row(
-            "SELECT id, name, transport, config, is_global, created_at, updated_at
-             FROM db_mcp_servers WHERE id = ?1",
-            params![id],
-            |row| {
-                Ok(McpServer {
-                    id: row.get(0)?,
-                    name: row.get(1)?,
-                    transport: row.get(2)?,
-                    config: row.get(3)?,
-                    is_global: row.get::<_, i64>(4)? != 0,
-                    created_at: row.get(5)?,
-                    updated_at: row.get(6)?,
-                })
-            },
-        );
-        match result {
-            Ok(s) => Ok(Some(s)),
-            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-            Err(e) => Err(StoreError::Sqlite(e)),
-        }
+        self.managed_get::<McpServer>(id)
     }
 
     /// Delete a standalone MCP server and purge ref rows (both agent- and
     /// bundle-level — FK cascades may be off on some builds, same reasoning
     /// as `skill_delete`). Returns true if deleted.
     pub fn mcp_server_delete(&self, id: &str) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        conn.execute("DELETE FROM db_agent_mcp_ref WHERE mcp_id = ?1", params![id])?;
-        conn.execute("DELETE FROM db_bundle_mcp_ref WHERE mcp_id = ?1", params![id])?;
-        let rows = conn.execute("DELETE FROM db_mcp_servers WHERE id = ?1", params![id])?;
-        Ok(rows > 0)
+        self.managed_delete::<McpServer>(id)
     }
 
     /// Bind an MCP server to an agent (insert ref row). Idempotent —
@@ -253,32 +196,12 @@ impl Store {
     /// skill_bind — see
     /// docs/reports/REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md.
     pub fn mcp_server_bind(&self, agent_id: &str, mcp_id: &str) -> Result<(), StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let agent_exists: bool = conn.query_row(
-            "SELECT EXISTS(SELECT 1 FROM db_agent_definitions WHERE id = ?1)",
-            params![agent_id],
-            |row| row.get(0),
-        )?;
-        if !agent_exists {
-            return Err(StoreError::Other(format!(
-                "agent {agent_id} not found in this channel's local registry — cross-channel MCP server binding is not supported"
-            )));
-        }
-        conn.execute(
-            "INSERT OR IGNORE INTO db_agent_mcp_ref (agent_id, mcp_id) VALUES (?1, ?2)",
-            params![agent_id, mcp_id],
-        )?;
-        Ok(())
+        self.managed_bind_agent::<McpServer>(agent_id, mcp_id)
     }
 
     /// Unbind an MCP server from an agent. Returns true if a row was removed.
     pub fn mcp_server_unbind(&self, agent_id: &str, mcp_id: &str) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let rows = conn.execute(
-            "DELETE FROM db_agent_mcp_ref WHERE agent_id = ?1 AND mcp_id = ?2",
-            params![agent_id, mcp_id],
-        )?;
-        Ok(rows > 0)
+        self.managed_unbind::<McpServer>(Owner::Agent, agent_id, mcp_id)
     }
 
     /// Atomically upsert an MCP server enforcing per-agent name uniqueness, and
@@ -292,42 +215,7 @@ impl Store {
         server: &McpServer,
         bind_new: bool,
     ) -> Result<(), StoreError> {
-        let mut conn = self.conn.lock().unwrap();
-        let tx = conn.transaction()?;
-        let dup: i64 = tx.query_row(
-            "SELECT COUNT(*) FROM db_mcp_servers
-             WHERE name = ?1 AND id <> ?2 AND (is_global = 1 OR id IN (
-               SELECT mcp_id FROM db_agent_mcp_ref WHERE agent_id = ?3
-             ))",
-            params![server.name, server.id, agent_id],
-            |r| r.get(0),
-        )?;
-        if dup > 0 {
-            return Err(StoreError::Other(format!(
-                "server name '{}' already bound to this agent",
-                server.name
-            )));
-        }
-        tx.execute(
-            "INSERT INTO db_mcp_servers (id, name, transport, config, is_global, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
-             ON CONFLICT(id) DO UPDATE SET
-               name=excluded.name, transport=excluded.transport, config=excluded.config,
-               updated_at=excluded.updated_at",
-            params![
-                server.id, server.name, server.transport, server.config,
-                if server.is_global { 1i64 } else { 0i64 },
-                server.created_at, server.updated_at,
-            ],
-        )?;
-        if bind_new {
-            tx.execute(
-                "INSERT OR IGNORE INTO db_agent_mcp_ref (agent_id, mcp_id) VALUES (?1, ?2)",
-                params![agent_id, server.id],
-            )?;
-        }
-        tx.commit()?;
-        Ok(())
+        self.managed_upsert_unique(Owner::Agent, agent_id, server, bind_new, None)
     }
 
     /// Atomically upsert a GLOBAL MCP server enforcing catalog-wide name
@@ -339,59 +227,19 @@ impl Store {
     /// clobber each other's config for every agent that has either bound.
     /// `server.is_global` must already be `true`; caller's job.
     pub fn mcp_server_upsert_unique_global(&self, server: &McpServer) -> Result<(), StoreError> {
-        let mut conn = self.conn.lock().unwrap();
-        let tx = conn.transaction()?;
-        let dup: i64 = tx.query_row(
-            "SELECT COUNT(*) FROM db_mcp_servers WHERE name = ?1 AND id <> ?2 AND is_global = 1",
-            params![server.name, server.id],
-            |r| r.get(0),
-        )?;
-        if dup > 0 {
-            return Err(StoreError::Other(format!(
-                "a global server named '{}' already exists",
-                server.name
-            )));
-        }
-        tx.execute(
-            "INSERT INTO db_mcp_servers (id, name, transport, config, is_global, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, 1, ?5, ?6)
-             ON CONFLICT(id) DO UPDATE SET
-               name=excluded.name, transport=excluded.transport, config=excluded.config,
-               updated_at=excluded.updated_at",
-            params![
-                server.id, server.name, server.transport, server.config,
-                server.created_at, server.updated_at,
-            ],
-        )?;
-        tx.commit()?;
-        Ok(())
+        self.managed_upsert_unique_global(server)
     }
 
     /// Return true if the given MCP server is accessible to the agent (global or bound).
     /// Used for read and mutation access checks.
     pub fn mcp_server_is_accessible_to(&self, agent_id: &str, mcp_id: &str) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM db_mcp_servers
-             WHERE id = ?1 AND (is_global = 1 OR id IN (
-               SELECT mcp_id FROM db_agent_mcp_ref WHERE agent_id = ?2
-             ))",
-            rusqlite::params![mcp_id, agent_id],
-            |row| row.get(0),
-        )?;
-        Ok(count > 0)
+        self.managed_is_accessible_to::<McpServer>(Owner::Agent, agent_id, mcp_id)
     }
 
     /// Return true if the agent has a direct ref binding to this MCP server.
     /// Used for delete access — an agent may only delete servers it directly bound.
     pub fn mcp_server_is_bound_to(&self, agent_id: &str, mcp_id: &str) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM db_agent_mcp_ref WHERE agent_id = ?1 AND mcp_id = ?2",
-            rusqlite::params![agent_id, mcp_id],
-            |row| row.get(0),
-        )?;
-        Ok(count > 0)
+        self.managed_is_bound_to::<McpServer>(Owner::Agent, agent_id, mcp_id)
     }
 
     // ── Bundle-level references (composable model v2) ──────────────────
@@ -406,34 +254,11 @@ impl Store {
     /// (referenced) + global servers, each annotated with whether this
     /// specific bundle holds the `db_bundle_mcp_ref` row.
     pub fn bundle_mcp_list(&self, bundle_id: &str) -> Result<Vec<McpServerBundleListItem>, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
-            "SELECT s.id, s.name, s.transport, s.config, s.is_global, s.created_at, s.updated_at,
-                    EXISTS(SELECT 1 FROM db_bundle_mcp_ref r WHERE r.mcp_id = s.id AND r.bundle_id = ?1) AS bound_to_bundle
-             FROM db_mcp_servers s
-             WHERE s.is_global = 1
-                OR s.id IN (SELECT mcp_id FROM db_bundle_mcp_ref WHERE bundle_id = ?1)
-             ORDER BY s.is_global DESC, s.updated_at DESC",
-        )?;
-        let rows = stmt.query_map(params![bundle_id], |row| {
-            Ok(McpServerBundleListItem {
-                server: McpServer {
-                    id: row.get(0)?,
-                    name: row.get(1)?,
-                    transport: row.get(2)?,
-                    config: row.get(3)?,
-                    is_global: row.get::<_, i64>(4)? != 0,
-                    created_at: row.get(5)?,
-                    updated_at: row.get(6)?,
-                },
-                bound_to_bundle: row.get::<_, i64>(7)? != 0,
-            })
-        })?;
-        let mut out = Vec::new();
-        for row in rows {
-            out.push(row?);
-        }
-        Ok(out)
+        Ok(self
+            .managed_list::<McpServer>(Owner::Bundle, bundle_id)?
+            .into_iter()
+            .map(|(server, bound_to_bundle)| McpServerBundleListItem { server, bound_to_bundle })
+            .collect())
     }
 
     /// Bind an MCP server to a bundle (insert ref row). Idempotent — binding
@@ -451,25 +276,7 @@ impl Store {
     /// application layer, not via FK" pattern as
     /// `identity::resolver::resolve_account`'s cross-store lookups.
     pub fn bundle_mcp_bind(&self, id_store: &Store, bundle_id: &str, mcp_id: &str) -> Result<(), StoreError> {
-        let bundle_exists: bool = {
-            let conn = id_store.conn.lock().unwrap();
-            conn.query_row(
-                "SELECT EXISTS(SELECT 1 FROM db_bundles WHERE id = ?1)",
-                params![bundle_id],
-                |row| row.get(0),
-            )?
-        };
-        if !bundle_exists {
-            return Err(StoreError::Other(format!(
-                "bundle {bundle_id} not found — cannot bind an MCP server to a nonexistent bundle"
-            )));
-        }
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "INSERT OR IGNORE INTO db_bundle_mcp_ref (bundle_id, mcp_id) VALUES (?1, ?2)",
-            params![bundle_id, mcp_id],
-        )?;
-        Ok(())
+        self.managed_bind_bundle::<McpServer>(id_store, bundle_id, mcp_id)
     }
 
     /// Atomically create a NEW, PRIVATE (never global) MCP server scoped
@@ -494,83 +301,18 @@ impl Store {
         server: &McpServer,
         bind_new: bool,
     ) -> Result<(), StoreError> {
-        let bundle_exists: bool = {
-            let conn = id_store.conn.lock().unwrap();
-            conn.query_row(
-                "SELECT EXISTS(SELECT 1 FROM db_bundles WHERE id = ?1)",
-                params![bundle_id],
-                |row| row.get(0),
-            )?
-        };
-        if !bundle_exists {
-            return Err(StoreError::Other(format!(
-                "bundle {bundle_id} not found — cannot create an MCP server for a nonexistent bundle"
-            )));
-        }
-        let mut conn = self.conn.lock().unwrap();
-        let tx = conn.transaction()?;
-        let dup: i64 = tx.query_row(
-            "SELECT COUNT(*) FROM db_mcp_servers
-             WHERE name = ?1 AND id <> ?2 AND (is_global = 1 OR id IN (
-               SELECT mcp_id FROM db_bundle_mcp_ref WHERE bundle_id = ?3
-             ))",
-            params![server.name, server.id, bundle_id],
-            |r| r.get(0),
-        )?;
-        if dup > 0 {
-            return Err(StoreError::Other(format!(
-                "server name '{}' already bound to this bundle",
-                server.name
-            )));
-        }
-        // is_global hardcoded to 0 — this method's entire purpose is
-        // creating PRIVATE bundle-scoped content (mirrors
-        // mcp_server_upsert_unique_global's opposite hardcode of 1).
-        // Referencing an EXISTING global server is bundle_mcp_bind's job.
-        tx.execute(
-            "INSERT INTO db_mcp_servers (id, name, transport, config, is_global, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, 0, ?5, ?6)
-             ON CONFLICT(id) DO UPDATE SET
-               name=excluded.name, transport=excluded.transport, config=excluded.config,
-               updated_at=excluded.updated_at",
-            params![
-                server.id, server.name, server.transport, server.config,
-                server.created_at, server.updated_at,
-            ],
-        )?;
-        if bind_new {
-            tx.execute(
-                "INSERT OR IGNORE INTO db_bundle_mcp_ref (bundle_id, mcp_id) VALUES (?1, ?2)",
-                params![bundle_id, server.id],
-            )?;
-        }
-        tx.commit()?;
-        Ok(())
+        self.managed_upsert_unique_for_bundle(id_store, bundle_id, server, bind_new)
     }
 
     /// Unbind an MCP server from a bundle. Returns true if a row was removed.
     pub fn bundle_mcp_unbind(&self, bundle_id: &str, mcp_id: &str) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let rows = conn.execute(
-            "DELETE FROM db_bundle_mcp_ref WHERE bundle_id = ?1 AND mcp_id = ?2",
-            params![bundle_id, mcp_id],
-        )?;
-        Ok(rows > 0)
+        self.managed_unbind::<McpServer>(Owner::Bundle, bundle_id, mcp_id)
     }
 
     /// Return true if the given MCP server is accessible to the bundle
     /// (global or bundle-bound). Mirrors `mcp_server_is_accessible_to`.
     pub fn bundle_mcp_is_accessible_to(&self, bundle_id: &str, mcp_id: &str) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM db_mcp_servers
-             WHERE id = ?1 AND (is_global = 1 OR id IN (
-               SELECT mcp_id FROM db_bundle_mcp_ref WHERE bundle_id = ?2
-             ))",
-            rusqlite::params![mcp_id, bundle_id],
-            |row| row.get(0),
-        )?;
-        Ok(count > 0)
+        self.managed_is_accessible_to::<McpServer>(Owner::Bundle, bundle_id, mcp_id)
     }
 
     /// Return true if the bundle has a direct ref binding to this MCP
@@ -578,13 +320,7 @@ impl Store {
     /// for edit/delete-ownership checks, as opposed to
     /// `bundle_mcp_is_accessible_to`'s broader read-access check.
     pub fn bundle_mcp_is_bound_to(&self, bundle_id: &str, mcp_id: &str) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM db_bundle_mcp_ref WHERE bundle_id = ?1 AND mcp_id = ?2",
-            rusqlite::params![bundle_id, mcp_id],
-            |row| row.get(0),
-        )?;
-        Ok(count > 0)
+        self.managed_is_bound_to::<McpServer>(Owner::Bundle, bundle_id, mcp_id)
     }
 }
 

--- a/agentmux-srv/src/backend/storage/mod.rs
+++ b/agentmux-srv/src/backend/storage/mod.rs
@@ -24,6 +24,7 @@ pub mod error;
 pub mod filestore;
 pub mod history;
 pub mod identities;
+pub mod managed;
 pub mod mcp_servers;
 pub mod memory_bundles;
 pub mod migrations;

--- a/agentmux-srv/src/backend/storage/skills.rs
+++ b/agentmux-srv/src/backend/storage/skills.rs
@@ -15,6 +15,7 @@ use rusqlite::params;
 use serde::{Deserialize, Serialize};
 
 use super::error::StoreError;
+use super::managed::{ManagedResource, Owner};
 use super::store::Store;
 
 /// A reusable skill/capability attached to a agent definition.
@@ -218,6 +219,55 @@ pub struct Skill {
     pub updated_at: i64,
 }
 
+impl ManagedResource for Skill {
+    const TABLE: &'static str = "db_skills";
+    const REF_COL: &'static str = "skill_id";
+    const AGENT_REF_TABLE: &'static str = "db_agent_skills_ref";
+    const BUNDLE_REF_TABLE: &'static str = "db_bundle_skills_ref";
+    const COLUMNS: &'static [&'static str] = &[
+        "id", "name", "trigger", "skill_type", "description", "content", "is_global", "created_at", "updated_at",
+    ];
+    const UPDATE_COLUMNS: &'static [&'static str] =
+        &["name", "trigger", "skill_type", "description", "content", "updated_at"];
+    const NAME_NOUN: &'static str = "skill";
+    const ARTICLE_NOUN: &'static str = "a skill";
+    const KIND: &'static str = "skill";
+
+    fn from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Self> {
+        Ok(Skill {
+            id: row.get(0)?,
+            name: row.get(1)?,
+            trigger: row.get(2)?,
+            skill_type: row.get(3)?,
+            description: row.get(4)?,
+            content: row.get(5)?,
+            is_global: row.get::<_, i64>(6)? != 0,
+            created_at: row.get(7)?,
+            updated_at: row.get(8)?,
+        })
+    }
+    fn values(&self) -> Vec<rusqlite::types::Value> {
+        use rusqlite::types::Value;
+        vec![
+            Value::Text(self.id.clone()),
+            Value::Text(self.name.clone()),
+            Value::Text(self.trigger.clone()),
+            Value::Text(self.skill_type.clone()),
+            Value::Text(self.description.clone()),
+            Value::Text(self.content.clone()),
+            Value::Integer(if self.is_global { 1 } else { 0 }),
+            Value::Integer(self.created_at),
+            Value::Integer(self.updated_at),
+        ]
+    }
+    fn id(&self) -> &str {
+        &self.id
+    }
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
 /// `skill_list`'s response shape: the skill plus whether the requesting agent
 /// specifically holds a `db_agent_skills_ref` row for it. Mirrors
 /// `McpServerListItem` — see its doc comment for why `is_global` alone isn't
@@ -254,36 +304,11 @@ impl Store {
     /// List all skills visible to an agent: own (referenced) + global, each
     /// annotated with whether this specific agent holds the bind ref.
     pub fn skill_list(&self, agent_id: &str) -> Result<Vec<SkillListItem>, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
-            "SELECT s.id, s.name, s.trigger, s.skill_type, s.description, s.content, s.is_global, s.created_at, s.updated_at,
-                    EXISTS(SELECT 1 FROM db_agent_skills_ref r WHERE r.skill_id = s.id AND r.agent_id = ?1) AS bound_to_agent
-             FROM db_skills s
-             WHERE s.is_global = 1
-                OR s.id IN (SELECT skill_id FROM db_agent_skills_ref WHERE agent_id = ?1)
-             ORDER BY s.is_global DESC, s.updated_at DESC",
-        )?;
-        let rows = stmt.query_map(params![agent_id], |row| {
-            Ok(SkillListItem {
-                skill: Skill {
-                    id: row.get(0)?,
-                    name: row.get(1)?,
-                    trigger: row.get(2)?,
-                    skill_type: row.get(3)?,
-                    description: row.get(4)?,
-                    content: row.get(5)?,
-                    is_global: row.get::<_, i64>(6)? != 0,
-                    created_at: row.get(7)?,
-                    updated_at: row.get(8)?,
-                },
-                bound_to_agent: row.get::<_, i64>(9)? != 0,
-            })
-        })?;
-        let mut out = Vec::new();
-        for row in rows {
-            out.push(row?);
-        }
-        Ok(out)
+        Ok(self
+            .managed_list::<Skill>(Owner::Agent, agent_id)?
+            .into_iter()
+            .map(|(skill, bound_to_agent)| SkillListItem { skill, bound_to_agent })
+            .collect())
     }
 
     /// Effective skills for an agent at launch/config-materialization time:
@@ -334,15 +359,7 @@ impl Store {
         // `bundle_skill_list` below. Happens AFTER the has_own decision —
         // bundle-referenced skills still appear in the final list, they
         // just never trigger the "discard legacy" path on their own.
-        if let Ok(Some(def)) = self.agent_def_get(agent_id) {
-            if !def.memory_id.is_empty() {
-                for item in self.bundle_skill_list(&def.memory_id).unwrap_or_default() {
-                    if !visible_skills.iter().any(|s| s.id == item.skill.id) {
-                        visible_skills.push(item.skill);
-                    }
-                }
-            }
-        }
+        self.managed_union_bundle_refs(agent_id, &mut visible_skills);
         if has_own_skill_refs {
             crate::backend::agent_config::skills_to_agent_skills(&visible_skills, agent_id)
         } else {
@@ -361,35 +378,11 @@ impl Store {
     /// SPEC_V1_MCP_SKILLS_PRIMITIVES_2026_06_30.md §8 ("used by N agents"),
     /// tracked as gap #2 of #1960.
     pub fn skill_list_global(&self) -> Result<Vec<SkillCatalogItem>, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
-            "SELECT s.id, s.name, s.trigger, s.skill_type, s.description, s.content, s.is_global, s.created_at, s.updated_at,
-                    (SELECT COUNT(*) FROM db_agent_skills_ref r WHERE r.skill_id = s.id) AS bound_count
-             FROM db_skills s
-             WHERE s.is_global = 1
-             ORDER BY s.updated_at DESC",
-        )?;
-        let rows = stmt.query_map([], |row| {
-            Ok(SkillCatalogItem {
-                skill: Skill {
-                    id: row.get(0)?,
-                    name: row.get(1)?,
-                    trigger: row.get(2)?,
-                    skill_type: row.get(3)?,
-                    description: row.get(4)?,
-                    content: row.get(5)?,
-                    is_global: row.get::<_, i64>(6)? != 0,
-                    created_at: row.get(7)?,
-                    updated_at: row.get(8)?,
-                },
-                bound_count: row.get(9)?,
-            })
-        })?;
-        let mut out = Vec::new();
-        for row in rows {
-            out.push(row?);
-        }
-        Ok(out)
+        Ok(self
+            .managed_list_global::<Skill>()?
+            .into_iter()
+            .map(|(skill, bound_count)| SkillCatalogItem { skill, bound_count })
+            .collect())
     }
 
     /// Catalog-tier sibling of `skill_list` (above) — same `bound_to_agent`
@@ -405,74 +398,22 @@ impl Store {
     /// catalog) — so exposing them alongside a caller-chosen agent's bind
     /// status is safe. reagentx P0 on PR #2329.
     pub fn skill_list_global_for_agent(&self, agent_id: &str) -> Result<Vec<SkillListItem>, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
-            "SELECT s.id, s.name, s.trigger, s.skill_type, s.description, s.content, s.is_global, s.created_at, s.updated_at,
-                    EXISTS(SELECT 1 FROM db_agent_skills_ref r WHERE r.skill_id = s.id AND r.agent_id = ?1) AS bound_to_agent
-             FROM db_skills s
-             WHERE s.is_global = 1
-             ORDER BY s.updated_at DESC",
-        )?;
-        let rows = stmt.query_map(params![agent_id], |row| {
-            Ok(SkillListItem {
-                skill: Skill {
-                    id: row.get(0)?,
-                    name: row.get(1)?,
-                    trigger: row.get(2)?,
-                    skill_type: row.get(3)?,
-                    description: row.get(4)?,
-                    content: row.get(5)?,
-                    is_global: row.get::<_, i64>(6)? != 0,
-                    created_at: row.get(7)?,
-                    updated_at: row.get(8)?,
-                },
-                bound_to_agent: row.get::<_, i64>(9)? != 0,
-            })
-        })?;
-        let mut out = Vec::new();
-        for row in rows {
-            out.push(row?);
-        }
-        Ok(out)
+        Ok(self
+            .managed_list_global_for_agent::<Skill>(agent_id)?
+            .into_iter()
+            .map(|(skill, bound_to_agent)| SkillListItem { skill, bound_to_agent })
+            .collect())
     }
 
     /// Get a standalone skill by id.
     pub fn skill_get(&self, id: &str) -> Result<Option<Skill>, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let result = conn.query_row(
-            "SELECT id, name, trigger, skill_type, description, content, is_global, created_at, updated_at
-             FROM db_skills WHERE id = ?1",
-            params![id],
-            |row| {
-                Ok(Skill {
-                    id: row.get(0)?,
-                    name: row.get(1)?,
-                    trigger: row.get(2)?,
-                    skill_type: row.get(3)?,
-                    description: row.get(4)?,
-                    content: row.get(5)?,
-                    is_global: row.get::<_, i64>(6)? != 0,
-                    created_at: row.get(7)?,
-                    updated_at: row.get(8)?,
-                })
-            },
-        );
-        match result {
-            Ok(s) => Ok(Some(s)),
-            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-            Err(e) => Err(StoreError::Sqlite(e)),
-        }
+        self.managed_get::<Skill>(id)
     }
 
     /// Delete a standalone skill and purge its ref rows (both agent- and
     /// bundle-level). Returns true if deleted.
     pub fn skill_delete(&self, id: &str) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        // Purge ref rows explicitly (FK cascades may be off on some builds).
-        conn.execute("DELETE FROM db_agent_skills_ref WHERE skill_id = ?1", params![id])?;
-        conn.execute("DELETE FROM db_bundle_skills_ref WHERE skill_id = ?1", params![id])?;
-        let rows = conn.execute("DELETE FROM db_skills WHERE id = ?1", params![id])?;
-        Ok(rows > 0)
+        self.managed_delete::<Skill>(id)
     }
 
     /// Bind a skill to an agent (insert ref row). Idempotent — binding an
@@ -489,32 +430,12 @@ impl Store {
     /// case — reporting success while creating nothing. reagentx P1, PR
     /// #2315.
     pub fn skill_bind(&self, agent_id: &str, skill_id: &str) -> Result<(), StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let agent_exists: bool = conn.query_row(
-            "SELECT EXISTS(SELECT 1 FROM db_agent_definitions WHERE id = ?1)",
-            params![agent_id],
-            |row| row.get(0),
-        )?;
-        if !agent_exists {
-            return Err(StoreError::Other(format!(
-                "agent {agent_id} not found in this channel's local registry — cross-channel skill binding is not supported"
-            )));
-        }
-        conn.execute(
-            "INSERT OR IGNORE INTO db_agent_skills_ref (agent_id, skill_id) VALUES (?1, ?2)",
-            params![agent_id, skill_id],
-        )?;
-        Ok(())
+        self.managed_bind_agent::<Skill>(agent_id, skill_id)
     }
 
     /// Unbind a skill from an agent. Returns true if a row was removed.
     pub fn skill_unbind(&self, agent_id: &str, skill_id: &str) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let rows = conn.execute(
-            "DELETE FROM db_agent_skills_ref WHERE agent_id = ?1 AND skill_id = ?2",
-            params![agent_id, skill_id],
-        )?;
-        Ok(rows > 0)
+        self.managed_unbind::<Skill>(Owner::Agent, agent_id, skill_id)
     }
 
     /// Atomically upsert a skill enforcing per-agent name uniqueness, and (when
@@ -529,44 +450,7 @@ impl Store {
         skill: &Skill,
         bind_new: bool,
     ) -> Result<(), StoreError> {
-        let mut conn = self.conn.lock().unwrap();
-        let tx = conn.transaction()?;
-        let dup: i64 = tx.query_row(
-            "SELECT COUNT(*) FROM db_skills
-             WHERE name = ?1 AND id <> ?2 AND (is_global = 1 OR id IN (
-               SELECT skill_id FROM db_agent_skills_ref WHERE agent_id = ?3
-             ))",
-            params![skill.name, skill.id, agent_id],
-            |r| r.get(0),
-        )?;
-        if dup > 0 {
-            return Err(StoreError::Other(format!(
-                "skill name '{}' already bound to this agent",
-                skill.name
-            )));
-        }
-        tx.execute(
-            "INSERT INTO db_skills (id, name, trigger, skill_type, description, content, is_global, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
-             ON CONFLICT(id) DO UPDATE SET
-               name=excluded.name, trigger=excluded.trigger, skill_type=excluded.skill_type,
-               description=excluded.description, content=excluded.content,
-               updated_at=excluded.updated_at",
-            params![
-                skill.id, skill.name, skill.trigger, skill.skill_type,
-                skill.description, skill.content,
-                if skill.is_global { 1i64 } else { 0i64 },
-                skill.created_at, skill.updated_at,
-            ],
-        )?;
-        if bind_new {
-            tx.execute(
-                "INSERT OR IGNORE INTO db_agent_skills_ref (agent_id, skill_id) VALUES (?1, ?2)",
-                params![agent_id, skill.id],
-            )?;
-        }
-        tx.commit()?;
-        Ok(())
+        self.managed_upsert_unique(Owner::Agent, agent_id, skill, bind_new, None)
     }
 
     /// Atomically upsert a GLOBAL skill enforcing catalog-wide name
@@ -578,61 +462,19 @@ impl Store {
     /// duplicate bullet in the assembled CLAUDE.md skills index.
     /// `skill.is_global` must already be `true`; caller's job.
     pub fn skill_upsert_unique_global(&self, skill: &Skill) -> Result<(), StoreError> {
-        let mut conn = self.conn.lock().unwrap();
-        let tx = conn.transaction()?;
-        let dup: i64 = tx.query_row(
-            "SELECT COUNT(*) FROM db_skills WHERE name = ?1 AND id <> ?2 AND is_global = 1",
-            params![skill.name, skill.id],
-            |r| r.get(0),
-        )?;
-        if dup > 0 {
-            return Err(StoreError::Other(format!(
-                "a global skill named '{}' already exists",
-                skill.name
-            )));
-        }
-        tx.execute(
-            "INSERT INTO db_skills (id, name, trigger, skill_type, description, content, is_global, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1, ?7, ?8)
-             ON CONFLICT(id) DO UPDATE SET
-               name=excluded.name, trigger=excluded.trigger, skill_type=excluded.skill_type,
-               description=excluded.description, content=excluded.content,
-               updated_at=excluded.updated_at",
-            params![
-                skill.id, skill.name, skill.trigger, skill.skill_type,
-                skill.description, skill.content,
-                skill.created_at, skill.updated_at,
-            ],
-        )?;
-        tx.commit()?;
-        Ok(())
+        self.managed_upsert_unique_global(skill)
     }
 
     /// Return true if the given skill is accessible to the agent (global or bound).
     /// Used for read and delete access checks.
     pub fn skill_is_accessible_to(&self, agent_id: &str, skill_id: &str) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM db_skills
-             WHERE id = ?1 AND (is_global = 1 OR id IN (
-               SELECT skill_id FROM db_agent_skills_ref WHERE agent_id = ?2
-             ))",
-            rusqlite::params![skill_id, agent_id],
-            |row| row.get(0),
-        )?;
-        Ok(count > 0)
+        self.managed_is_accessible_to::<Skill>(Owner::Agent, agent_id, skill_id)
     }
 
     /// Return true if the agent has a direct ref binding to this skill (for delete/mutation).
     /// Global skills are excluded — use the is_global guard separately.
     pub fn skill_is_bound_to(&self, agent_id: &str, skill_id: &str) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM db_agent_skills_ref WHERE agent_id = ?1 AND skill_id = ?2",
-            rusqlite::params![agent_id, skill_id],
-            |row| row.get(0),
-        )?;
-        Ok(count > 0)
+        self.managed_is_bound_to::<Skill>(Owner::Agent, agent_id, skill_id)
     }
 
     // ── Bundle-level references (composable model v2) ──────────────────
@@ -644,36 +486,11 @@ impl Store {
     /// and global skills, each annotated with whether this specific bundle
     /// holds the `db_bundle_skills_ref` row.
     pub fn bundle_skill_list(&self, bundle_id: &str) -> Result<Vec<SkillBundleListItem>, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
-            "SELECT s.id, s.name, s.trigger, s.skill_type, s.description, s.content, s.is_global, s.created_at, s.updated_at,
-                    EXISTS(SELECT 1 FROM db_bundle_skills_ref r WHERE r.skill_id = s.id AND r.bundle_id = ?1) AS bound_to_bundle
-             FROM db_skills s
-             WHERE s.is_global = 1
-                OR s.id IN (SELECT skill_id FROM db_bundle_skills_ref WHERE bundle_id = ?1)
-             ORDER BY s.is_global DESC, s.updated_at DESC",
-        )?;
-        let rows = stmt.query_map(params![bundle_id], |row| {
-            Ok(SkillBundleListItem {
-                skill: Skill {
-                    id: row.get(0)?,
-                    name: row.get(1)?,
-                    trigger: row.get(2)?,
-                    skill_type: row.get(3)?,
-                    description: row.get(4)?,
-                    content: row.get(5)?,
-                    is_global: row.get::<_, i64>(6)? != 0,
-                    created_at: row.get(7)?,
-                    updated_at: row.get(8)?,
-                },
-                bound_to_bundle: row.get::<_, i64>(9)? != 0,
-            })
-        })?;
-        let mut out = Vec::new();
-        for row in rows {
-            out.push(row?);
-        }
-        Ok(out)
+        Ok(self
+            .managed_list::<Skill>(Owner::Bundle, bundle_id)?
+            .into_iter()
+            .map(|(skill, bound_to_bundle)| SkillBundleListItem { skill, bound_to_bundle })
+            .collect())
     }
 
     /// Bind a skill to a bundle (insert ref row). Idempotent.
@@ -682,25 +499,7 @@ impl Store {
     /// `Store::bundle_mcp_bind`'s doc comment (mcp_servers.rs) for the full
     /// reasoning (reagentx P0 review on PR #2639).
     pub fn bundle_skill_bind(&self, id_store: &Store, bundle_id: &str, skill_id: &str) -> Result<(), StoreError> {
-        let bundle_exists: bool = {
-            let conn = id_store.conn.lock().unwrap();
-            conn.query_row(
-                "SELECT EXISTS(SELECT 1 FROM db_bundles WHERE id = ?1)",
-                params![bundle_id],
-                |row| row.get(0),
-            )?
-        };
-        if !bundle_exists {
-            return Err(StoreError::Other(format!(
-                "bundle {bundle_id} not found — cannot bind a skill to a nonexistent bundle"
-            )));
-        }
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "INSERT OR IGNORE INTO db_bundle_skills_ref (bundle_id, skill_id) VALUES (?1, ?2)",
-            params![bundle_id, skill_id],
-        )?;
-        Ok(())
+        self.managed_bind_bundle::<Skill>(id_store, bundle_id, skill_id)
     }
 
     /// Atomically create a NEW, PRIVATE (never global) skill scoped and
@@ -715,83 +514,18 @@ impl Store {
         skill: &Skill,
         bind_new: bool,
     ) -> Result<(), StoreError> {
-        let bundle_exists: bool = {
-            let conn = id_store.conn.lock().unwrap();
-            conn.query_row(
-                "SELECT EXISTS(SELECT 1 FROM db_bundles WHERE id = ?1)",
-                params![bundle_id],
-                |row| row.get(0),
-            )?
-        };
-        if !bundle_exists {
-            return Err(StoreError::Other(format!(
-                "bundle {bundle_id} not found — cannot create a skill for a nonexistent bundle"
-            )));
-        }
-        let mut conn = self.conn.lock().unwrap();
-        let tx = conn.transaction()?;
-        let dup: i64 = tx.query_row(
-            "SELECT COUNT(*) FROM db_skills
-             WHERE name = ?1 AND id <> ?2 AND (is_global = 1 OR id IN (
-               SELECT skill_id FROM db_bundle_skills_ref WHERE bundle_id = ?3
-             ))",
-            params![skill.name, skill.id, bundle_id],
-            |r| r.get(0),
-        )?;
-        if dup > 0 {
-            return Err(StoreError::Other(format!(
-                "skill name '{}' already bound to this bundle",
-                skill.name
-            )));
-        }
-        // is_global hardcoded to 0 — see bundle_mcp_upsert_unique's
-        // identical comment.
-        tx.execute(
-            "INSERT INTO db_skills (id, name, trigger, skill_type, description, content, is_global, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7, ?8)
-             ON CONFLICT(id) DO UPDATE SET
-               name=excluded.name, trigger=excluded.trigger, skill_type=excluded.skill_type,
-               description=excluded.description, content=excluded.content,
-               updated_at=excluded.updated_at",
-            params![
-                skill.id, skill.name, skill.trigger, skill.skill_type,
-                skill.description, skill.content,
-                skill.created_at, skill.updated_at,
-            ],
-        )?;
-        if bind_new {
-            tx.execute(
-                "INSERT OR IGNORE INTO db_bundle_skills_ref (bundle_id, skill_id) VALUES (?1, ?2)",
-                params![bundle_id, skill.id],
-            )?;
-        }
-        tx.commit()?;
-        Ok(())
+        self.managed_upsert_unique_for_bundle(id_store, bundle_id, skill, bind_new)
     }
 
     /// Unbind a skill from a bundle. Returns true if a row was removed.
     pub fn bundle_skill_unbind(&self, bundle_id: &str, skill_id: &str) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let rows = conn.execute(
-            "DELETE FROM db_bundle_skills_ref WHERE bundle_id = ?1 AND skill_id = ?2",
-            params![bundle_id, skill_id],
-        )?;
-        Ok(rows > 0)
+        self.managed_unbind::<Skill>(Owner::Bundle, bundle_id, skill_id)
     }
 
     /// Return true if the given skill is accessible to the bundle (global or
     /// bundle-bound). Mirrors `skill_is_accessible_to`.
     pub fn bundle_skill_is_accessible_to(&self, bundle_id: &str, skill_id: &str) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM db_skills
-             WHERE id = ?1 AND (is_global = 1 OR id IN (
-               SELECT skill_id FROM db_bundle_skills_ref WHERE bundle_id = ?2
-             ))",
-            rusqlite::params![skill_id, bundle_id],
-            |row| row.get(0),
-        )?;
-        Ok(count > 0)
+        self.managed_is_accessible_to::<Skill>(Owner::Bundle, bundle_id, skill_id)
     }
 
     /// Return true if the bundle has a direct ref binding to this skill
@@ -799,13 +533,7 @@ impl Store {
     /// edit/delete-ownership checks, as opposed to
     /// `bundle_skill_is_accessible_to`'s broader read-access check.
     pub fn bundle_skill_is_bound_to(&self, bundle_id: &str, skill_id: &str) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM db_bundle_skills_ref WHERE bundle_id = ?1 AND skill_id = ?2",
-            rusqlite::params![bundle_id, skill_id],
-            |row| row.get(0),
-        )?;
-        Ok(count > 0)
+        self.managed_is_bound_to::<Skill>(Owner::Bundle, bundle_id, skill_id)
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 4 (storage side) of `docs/reports/REPORT_DRY_AND_MODULARITY_AUDIT_2026_09_06.md`: `skills.rs` and `mcp_servers.rs` each carried the same **eighteen** store methods — agent- and bundle-level list / get / delete / bind / unbind / upsert-unique / is-accessible / is-bound plus the two catalog lists — identical except for table and column names and the noun in four error messages (§2.4 measured 58–71% duplication). One generic implementation now lives in `storage/managed.rs` behind a `ManagedResource` trait; `Skill` and `McpServer` implement it in ~45 lines each, and every public method keeps its name, signature, doc comment and response struct and delegates in one line. **No behavior change**; `skills.rs` 1,353 → 1,082 lines, `mcp_servers.rs` 939 → 677, `managed.rs` +~440 including its own tests.

## Shape

```rust
pub trait ManagedResource: Sized {
    const TABLE, REF_COL, AGENT_REF_TABLE, BUNDLE_REF_TABLE: &'static str;
    const COLUMNS, UPDATE_COLUMNS: &'static [&'static str];
    const NAME_NOUN, ARTICLE_NOUN, KIND: &'static str;   // the four error messages' nouns
    fn from_row(&Row) -> rusqlite::Result<Self>;
    fn values(&self) -> Vec<Value>;
    fn id(&self) -> &str;  fn name(&self) -> &str;
}
```

`Store` gains `managed_list / _list_global / _list_global_for_agent / _get / _delete / _bind_agent / _bind_bundle / _unbind / _upsert_unique / _upsert_unique_for_bundle / _upsert_unique_global / _is_accessible_to / _is_bound_to / _union_bundle_refs`, all `pub(super)`, parameterised on `Owner::{Agent, Bundle}` where the original had an agent-level and a bundle-level twin. `effective_skills` / `effective_mcp_servers` share the bundle-union step; the skills-only legacy `db_agent_skills` fallback stays exactly where it was (including the reagentx P1 ordering constraint from #2639 that `has_own_skill_refs` is decided *before* the union — the comment and the code order are untouched).

## Why it is safe

- **Every SQL statement is the hand-written one with names substituted.** The substitutions come from trait `const`s only, never runtime input, so the statements are exactly as fixed as the literals they replace; values still go through `?N` parameters. `is_global` is never in `UPDATE_COLUMNS`, and the two places that hard-coded it (`1` in the global upsert, `0` in the bundle-scoped upsert) are `force_global: Some(true|false)` — unit-tested in `managed.rs`.
- **Error strings are byte-for-byte the originals** (e.g. `cross-channel MCP server binding is not supported`, `skill name 'x' already bound to this bundle`), via the three noun consts. Nothing outside the two modules matches on them (grepped).
- **The rewrite was scripted, not hand-edited:** a table of 18 method names per module, bodies replaced between the signature's `{` and the closing `}`, each name asserted to occur exactly once; doc comments and the test modules were never touched.
- The `id_store`-not-`self` bundle-existence check (reagentx P0 on #2639) and the cross-channel agent check (reagentx P1 on #2315) are preserved in `managed_bind_bundle` / `managed_bind_agent`, with their rationale moved into those docs.

## Verification

- `cargo test -p agentmux-srv storage::` — **396 passed, 0 failed**; specifically `storage::managed` 3, `storage::skills` 17, `storage::mcp_servers` 14 (the 31 pre-existing primitive tests run unchanged against the new implementation — they cover list ordering, bind/unbind idempotency, cross-store bundle checks, name-conflict errors, delete purging both ref tables, and the effective-set union/dedup).
- `cargo test --workspace -- --test-threads=1` (the CI invocation) — **4,005 passed, 0 failed**
- One unused `rusqlite::params` import in `mcp_servers.rs` was removed; no other warnings in the three files.
- Also removes the `use std::time::SystemTime;` in `session_archive.rs` that #3033 left behind — its one use is fully qualified, so the import was dead and warned. A leftover of mine, not of this refactor.

## Not in this PR

The audit's step 13 also names the frontend half (a generic manager pane + agent modal for `McpManager` / `SkillManager`) and the "does memory bundles fit as a third?" test of the abstraction. Storage first: it is the half with an existing test suite to prove equivalence, and the trait is what a third primitive would implement.

Follow-up to #3031 (the audit); same family as #3033, #3034, #3036, #3039, #3041.

<!-- agentmux:agent_id=manoz -->
