### PR TITLE
Korp@claudius: fix(launcher,cef): migration-failure reason can no longer lose the ESTART select! race

### DIFF
--- a/.changesets/1788753142-fix-launcher-cef-migration-failure-reason-can-no-longer-lose-bnj2.md
+++ b/.changesets/1788753142-fix-launcher-cef-migration-failure-reason-can-no-longer-lose-bnj2.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(launcher,cef): migration-failure reason can no longer lose a select! race to the closed ESTART channel — biased poll order plus a post-loop buffered-reason check, so a failed migration always surfaces as MigrationFailed instead of degrading to the generic channel-closed error

--- a/agentmux-cef/src/sidecar.rs
+++ b/agentmux-cef/src/sidecar.rs
@@ -457,13 +457,20 @@ pub async fn spawn_backend(state: &Arc<AppState>) -> Result<BackendSpawnResult, 
     let mut sleep = tokio::time::sleep_until(deadline);
     tokio::pin!(sleep);
 
+    let migration_failed = |reason: String| format!("agentmux-srv database migration failed: {}", reason);
     let recv: Result<Option<BackendSpawnResult>, String> = loop {
         tokio::select! {
+            // `biased;` — failure arm first. The stderr thread sends the
+            // reason then exits (srv exits 1 right after the line), dropping
+            // all senders before this select! is next polled; unbiased,
+            // `rx.recv()` → None could win over the buffered reason and
+            // degrade to the generic "channel closed" error (reagent P1,
+            // post-merge on #3043). Same fix as srv_spawner.rs, which also
+            // re-checks the failure channel after the loop — mirrored below.
+            biased;
+            Some(reason) = failure_rx.recv() => break Err(migration_failed(reason)),
             result = rx.recv() => break Ok(result),
             _ = &mut sleep => break Err("Timeout waiting for agentmux-srv to start (30s)".to_string()),
-            Some(reason) = failure_rx.recv() => {
-                break Err(format!("agentmux-srv database migration failed: {}", reason));
-            }
             Some(()) = migration_rx.recv() => {
                 let new_deadline = tokio::time::Instant::now() + migration_timeout;
                 if new_deadline > deadline {
@@ -473,6 +480,15 @@ pub async fn spawn_backend(state: &Arc<AppState>) -> Result<BackendSpawnResult, 
                 }
             }
         }
+    };
+    // Second guard for the same race: if ESTART's channel closed but a
+    // failure reason is already buffered, the reason is the real outcome.
+    let recv = match recv {
+        Ok(None) => match failure_rx.try_recv() {
+            Ok(reason) => Err(migration_failed(reason)),
+            Err(_) => Ok(None),
+        },
+        other => other,
     };
     let result = recv?
         .ok_or_else(|| "agentmux-srv channel closed before sending endpoints".to_string())?;

--- a/agentmux-launcher/src/srv_spawner.rs
+++ b/agentmux-launcher/src/srv_spawner.rs
@@ -141,6 +141,72 @@ pub fn migration_failed_dialog_body(reason: &str) -> String {
     )
 }
 
+/// Outcome of waiting for srv's readiness signal. Module-level (not local to
+/// `spawn_srv`) so `prefer_buffered_failure` can be unit-tested.
+enum EstartWait {
+    Ready(Option<SrvSpawnResult>),
+    Timeout,
+    MigrationFailed(String),
+}
+
+/// Second guard for the ESTART-vs-failure race (reagent P1, post-merge on
+/// #3043). The stderr reader task sends the migration-failure reason and then
+/// drops every sender as srv exits, so by the time the waiter's `select!`
+/// runs, BOTH "failure buffered" and "ESTART channel closed" are ready.
+/// `biased;` in the select makes the failure arm win when both are seen in
+/// one poll; this covers the remaining shape, where the closed channel was
+/// observed first and the reason is sitting in `failure_rx` unread. Every
+/// other outcome passes through unchanged.
+fn prefer_buffered_failure(recv: EstartWait, failure_rx: &mut mpsc::Receiver<String>) -> EstartWait {
+    match recv {
+        EstartWait::Ready(None) => match failure_rx.try_recv() {
+            Ok(reason) => EstartWait::MigrationFailed(reason),
+            Err(_) => EstartWait::Ready(None),
+        },
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod estart_race_tests {
+    use super::*;
+
+    #[test]
+    fn closed_estart_channel_with_buffered_failure_becomes_migration_failed() {
+        let (tx, mut rx) = mpsc::channel::<String>(1);
+        // Reader task's exact sequence: send the reason, then drop the sender.
+        tx.try_send("migration 0007 failed: disk I/O error".into()).unwrap();
+        drop(tx);
+        match prefer_buffered_failure(EstartWait::Ready(None), &mut rx) {
+            EstartWait::MigrationFailed(r) => assert_eq!(r, "migration 0007 failed: disk I/O error"),
+            _ => panic!("buffered failure reason must win over a closed ESTART channel"),
+        }
+    }
+
+    #[test]
+    fn closed_estart_channel_without_failure_stays_channel_closed() {
+        let (tx, mut rx) = mpsc::channel::<String>(1);
+        drop(tx); // srv died before ESTART for some other reason — no failure line
+        assert!(matches!(
+            prefer_buffered_failure(EstartWait::Ready(None), &mut rx),
+            EstartWait::Ready(None)
+        ));
+    }
+
+    #[test]
+    fn other_outcomes_pass_through_untouched() {
+        let (tx, mut rx) = mpsc::channel::<String>(1);
+        tx.try_send("should not be consumed".into()).unwrap();
+        assert!(matches!(prefer_buffered_failure(EstartWait::Timeout, &mut rx), EstartWait::Timeout));
+        assert!(matches!(
+            prefer_buffered_failure(EstartWait::MigrationFailed("x".into()), &mut rx),
+            EstartWait::MigrationFailed(_)
+        ));
+        // Neither pass-through drained the channel.
+        assert_eq!(rx.try_recv().ok().as_deref(), Some("should not be consumed"));
+    }
+}
+
 /// Run `agentmux-srv migrate` synchronously before spawning the daemon.
 ///
 /// The migration runner exits 0 (success / nothing to do) or 1 (failure).
@@ -556,16 +622,21 @@ pub async fn spawn_srv(
     let mut sleep = tokio::time::sleep_until(deadline);
     tokio::pin!(sleep);
 
-    enum EstartWait {
-        Ready(Option<SrvSpawnResult>),
-        Timeout,
-        MigrationFailed(String),
-    }
     let recv = loop {
         tokio::select! {
+            // `biased;` — poll arms in declaration order, failure first.
+            // The stderr reader sends the failure reason and then hits EOF
+            // (srv exits 1 right after the line), dropping every sender
+            // before this select! is next polled. Unbiased, `rx.recv()`
+            // resolving to None (closed) could win the coin flip over the
+            // already-buffered reason and degrade this to the generic
+            // EstartChannelClosed — invisible on Windows, exactly what the
+            // MigrationFailed path exists to fix (reagent P1, post-merge on
+            // #3043). `prefer_buffered_failure` below is the second guard.
+            biased;
+            Some(reason) = failure_rx.recv() => break EstartWait::MigrationFailed(reason),
             result = rx.recv() => break EstartWait::Ready(result),
             _ = &mut sleep => break EstartWait::Timeout,
-            Some(reason) = failure_rx.recv() => break EstartWait::MigrationFailed(reason),
             Some(()) = migration_rx.recv() => {
                 // Migrations are running — extend the deadline generously.
                 let new_deadline = tokio::time::Instant::now() + migration_timeout;
@@ -577,6 +648,7 @@ pub async fn spawn_srv(
             }
         }
     };
+    let recv = prefer_buffered_failure(recv, &mut failure_rx);
     match recv {
         EstartWait::Timeout => {
             let _ = child.start_kill();


### PR DESCRIPTION
## Summary

Follow-up to #3043, fixing the P1 ReAgent filed on it post-merge. Real bug.

**The race:** the stderr reader sends the migration-failure reason and then hits EOF within microseconds (srv `exit(1)`s right after the line), dropping every sender before the waiter's `tokio::select!` is next polled. Both "failure buffered" and "ESTART channel closed" are then ready. `select!` without `biased;` picks pseudo-randomly, so `rx.recv() → None` could win, degrading the outcome to `EstartChannelClosed` — which the supervisors' fatal-dialog branch doesn't match. On Windows that is precisely the silent failure #3043 was meant to end.

## Fix (identical in launcher and CEF host)

1. **`biased;`** with the failure arm first — when both are visible in one poll, the reason wins.
2. **Post-loop buffered check** — if the outcome is "channel closed", `try_recv` the failure channel and prefer a buffered reason. Covers the ordering `biased;` alone can't: closed channel observed on an earlier poll than the reason's arrival.

Launcher's guard is `prefer_buffered_failure()` on a now-module-level `EstartWait`, unit-tested (3 new tests: buffered+closed → `MigrationFailed`; closed alone stays `Ready(None)`; `Timeout`/`MigrationFailed` pass through without draining). CEF mirrors it inline on its `Result<_, String>`.

## Verification
- launcher: **7/7** `srv_spawner` tests green
- cef: `cargo check` clean

<!-- agentmux:agent_id=korp -->