### PR TITLE
feat(settings): toggle to disable the startup splash screen

### DIFF
--- a/.changesets/1788753709-feat-settings-toggle-to-disable-the-startup-splash-screen-xoi3.md
+++ b/.changesets/1788753709-feat-settings-toggle-to-disable-the-startup-splash-screen-xoi3.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(settings): toggle to disable the startup splash screen

--- a/frontend/app/view/settings/sections/appearance-section.test.tsx
+++ b/frontend/app/view/settings/sections/appearance-section.test.tsx
@@ -1,0 +1,77 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for the startup-splash toggle in the Appearance section.
+ *
+ * This row is the one control in Settings whose stored value is INVERTED
+ * relative to its label: the key is `splash:disabled` (false by default)
+ * because `agentmux-launcher` reads settings.json directly, before the
+ * frontend exists, and "disabled" is the form that fail-safe read wants —
+ * an unreadable or absent value must mean "show the splash"
+ * (`agentmux-launcher/src/splash_config.rs`). A polarity slip here would
+ * silently hide the splash for every user who ever opened Settings, so the
+ * mapping is pinned in both directions.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const setConfig = vi.fn();
+let settings: Record<string, unknown> = {};
+
+vi.mock("@/app/store/rpc-api", () => ({
+    RpcApi: {
+        SetConfigCommand: (...args: unknown[]) => setConfig(...args),
+    },
+}));
+vi.mock("@/app/store/rpc-util", () => ({ TabRpcClient: {} }));
+vi.mock("@/app/store/global", () => ({
+    settingsAtom: () => settings,
+}));
+vi.mock("@/app/menu/base-menus", () => ({ THEME_OPTIONS: [] }));
+
+import { AppearanceSection } from "./appearance-section";
+
+describe("Appearance — startup splash toggle", () => {
+    beforeEach(() => {
+        setConfig.mockReset();
+        settings = {};
+    });
+    afterEach(() => {
+        cleanup();
+    });
+
+    function splashToggle(): HTMLElement {
+        render(() => <AppearanceSection />);
+        // The row's label is positive ("show the splash"), so find the switch
+        // by that row rather than by index — adding a row above must not
+        // silently retarget this test.
+        const row = screen.getByText("Startup splash screen").closest(".setting-row");
+        expect(row).not.toBeNull();
+        const toggle = row!.querySelector('[role="switch"]');
+        expect(toggle).not.toBeNull();
+        return toggle as HTMLElement;
+    }
+
+    it("shows as ON when the setting is absent, because the splash defaults to visible", () => {
+        expect(splashToggle().getAttribute("aria-checked")).toBe("true");
+    });
+
+    it("shows as OFF when splash:disabled is true", () => {
+        settings = { "splash:disabled": true };
+        expect(splashToggle().getAttribute("aria-checked")).toBe("false");
+    });
+
+    it("writes splash:disabled=true when the user turns the splash OFF", () => {
+        fireEvent.click(splashToggle());
+        expect(setConfig).toHaveBeenCalledTimes(1);
+        expect(setConfig.mock.calls[0][1]).toEqual({ "splash:disabled": true });
+    });
+
+    it("writes splash:disabled=false when the user turns the splash back ON", () => {
+        settings = { "splash:disabled": true };
+        fireEvent.click(splashToggle());
+        expect(setConfig.mock.calls[0][1]).toEqual({ "splash:disabled": false });
+    });
+});

--- a/frontend/app/view/settings/sections/appearance-section.tsx
+++ b/frontend/app/view/settings/sections/appearance-section.tsx
@@ -31,6 +31,20 @@ export function AppearanceSection(): JSX.Element {
                 }
             />
             <SettingRow
+                label="Startup splash screen"
+                description="Show the AgentMux splash while the app starts. Applies at the next launch — the launcher reads this before the app itself is running."
+                control={
+                    <ToggleControl
+                        // Stored inverted (`splash:disabled`, false by default) because
+                        // the launcher reads the raw file before any of this code runs;
+                        // the label stays positive so the toggle reads the way the
+                        // splash behaves.
+                        checked={!(s()["splash:disabled"] as boolean)}
+                        onChange={(v) => set("splash:disabled", !v)}
+                    />
+                }
+            />
+            <SettingRow
                 label="Window transparency"
                 description="Enable background transparency and blur"
                 control={

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1739,6 +1739,7 @@ declare global {
         "preview:showhiddenfiles"?: boolean;
         "tab:preset"?: string;
         "tab:skipcloseconfirm"?: boolean;
+        "splash:disabled"?: boolean;
         "widget:*"?: boolean;
         "widget:showhelp"?: boolean;
         "widget:icononly"?: boolean;

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -316,6 +316,11 @@
           "default": true,
           "description": "Insert a file-reference token into the composer on drop (in addition to attaching the file). Default true."
         },
+        "splash:disabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Suppress the startup splash screen entirely (no window is created). Read by agentmux-launcher BEFORE the host and backend exist, so a change applies at the NEXT launch, not the current one. Env AGENTMUX_SPLASH=0 / AGENTMUX_NO_SPLASH=1 override this for a single run. See docs/specs/SPEC_SPLASH_USERINFO_AND_DISABLE_2026_06_21.md §6."
+        },
         "agent:askquestiontimeoutms": {
           "type": "integer",
           "minimum": 1000,

--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -42,6 +42,11 @@
     // "window:maxtabcachesize":   10,
     // "window:disablehardwareacceleration": false,
 
+    // -- Startup --
+    // Suppress the splash screen. Applies at the NEXT launch: the launcher
+    // reads this before the app itself is running.
+    // "splash:disabled":          false,
+
     // -- App --
     // "app:globalhotkey":         "",
     // "app:defaultnewblock":      "",


### PR DESCRIPTION
Adds the Settings toggle the user asked for. **Default is unchanged: the splash still shows.**

## The setting already half-existed

`agentmux-launcher` has read `"splash:disabled"` from `settings.json` since `SPEC_SPLASH_USERINFO_AND_DISABLE_2026_06_21.md` §6 (`splash_config.rs`). What was missing is everything that makes it *findable* — the key appeared in **no** schema, template, type or UI:

| Place | Before |
|---|---|
| `schema/settings.json` | absent — and `SettingsType` is `additionalProperties: false`, so the key was undeclared against its own schema |
| `settings-template.jsonc` | absent |
| `frontend/types/gotypes.d.ts` | absent |
| Settings pane | absent |

So the only way to turn the splash off was to already know the key existed and hand-edit the file. This declares it in all four.

## The one subtle bit: inverted polarity

The row reads positively — **"Startup splash screen"**, on = splash shows — while the stored key stays negative (`splash:disabled`, default `false`).

That is deliberate, not an oversight. The launcher reads the raw file *before* the host, the backend, or any of this code exists, and its read is fail-safe by design: a missing key, an unreadable file or a parse error must all resolve to **show the splash**. `disabled` is the form that gets that for free; a positive `splash:enabled` would make "file unreadable" mean "hide the splash".

Inverting in one place is cheap; getting it backwards would silently hide the splash for everyone who ever opened Settings. So `appearance-section.test.tsx` (new) pins the mapping in both directions — absent → ON, `disabled:true` → OFF, turning it off writes `true`, turning it back on writes `false`. **I mutation-checked it**: dropping the inversion fails 2 of the 4.

## Applies at the next launch

The launcher resolves this before startup, so toggling it does not affect the running app. The row's description says so. `AGENTMUX_SPLASH=0` / `AGENTMUX_NO_SPLASH=1` still override it for a single run.

## Verification

- `npx vitest run frontend/app/view/settings` — 17 passed (3 files), including the 4 new.
- `npx tsc --noEmit` — clean.
- `schema/settings.json` re-parsed as valid JSON.
- **Not verified:** the toggle was not clicked in a running app, and no splash was observed appearing/disappearing across a relaunch — this shell has no screen access on this Mac. The logic is unit-tested and the launcher side is pre-existing, unchanged code.

## Related

Came out of the §7.5.1 work in #3037: background-service mode with the splash disabled is exactly the configuration this toggle makes reachable without hand-editing.

<!-- agentmux:agent_id=agento -->