### PR TITLE
docs: regenerate the stale specs index (unblocks the doc gate on every PR)

### DIFF
--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -339,7 +339,7 @@ partial list.
 | [`SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04`](SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md) | Spec: optional system-tray + persistent background service, cross-platform |
 | [`SPEC_WINDOW_NAME_API_HARDENING_2026_08_08`](SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md) | SPEC: Window-name App API hardening (phantom-id success + status codes) |
 
-### proposed (96)
+### proposed (95)
 
 | Spec | Title |
 |---|---|


### PR DESCRIPTION
**One line. Unblocks CI for every open PR.**

`bash scripts/gen-docs-index.sh --check` currently fails on `main`, so the **doc status + grep gates** leg fails on every PR regardless of its contents — I hit it on #3049, which touches no docs at all.

```
gen-docs-index: INDEX.md is STALE.
    342c342
    < ### proposed (96)
    ---
    > ### proposed (95)
```

## Cause

#3042 moved `SPEC_MIGRATION_FRAMEWORK_2026_06_24` from `proposed` to `implemented`. Its `INDEX.md` edit added the row under **implemented** and bumped that count 134 → 135, but left `### proposed (96)` — the count for the section the spec had just left.

That is the signature of hand-editing `INDEX.md` instead of running the generator, which is the precise failure the `--check` gate exists to catch. (#3040's own regeneration, just before it, was correct: 97 → 96.)

## This change

Output of `bash scripts/gen-docs-index.sh`, unedited: one line, `96` → `95`. `--check` passes after it.

<!-- agentmux:agent_id=agento -->