### PR TITLE
Camper@claudius: docs: regenerate stale specs INDEX.md (unblocks CI for every open PR)

### DIFF
--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -339,7 +339,7 @@ partial list.
 | [`SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04`](SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md) | Spec: optional system-tray + persistent background service, cross-platform |
 | [`SPEC_WINDOW_NAME_API_HARDENING_2026_08_08`](SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md) | SPEC: Window-name App API hardening (phantom-id success + status codes) |
 
-### proposed (96)
+### proposed (95)
 
 | Spec | Title |
 |---|---|


### PR DESCRIPTION
## Summary

`scripts/gen-docs-index.sh --check` **fails on `main` itself**, so the "doc status + grep gates" CI job is currently red for **every open PR**, not just the one that happens to run it.

The committed index says `### proposed (96)`; regenerating yields `(95)`. A spec's `Status` was changed without regenerating the index.

Confirmed pre-existing rather than caused by any PR: I ran the gate on a clean `main` checkout and it reproduces the identical diff. The gate's own log on my unrelated Rust PR even says `check-doc-status: no docs changed` immediately before failing.

## Changes

One line, pure regeneration — `bash scripts/gen-docs-index.sh`, no hand edits:

```
342c342
< ### proposed (96)
---
> ### proposed (95)
```

## Test plan

- [x] Reproduced the failure on clean `main` (not just on a feature branch)
- [x] `bash scripts/gen-docs-index.sh --check` passes after regeneration
- [x] Diff is exactly the one line the gate reported

No changeset: docs-only regeneration of a generated artifact, no shipped behavior change.

<!-- agentmux:agent_id=camper -->