### PR TITLE
fix(agent-pane,statusbar): reclaim the fresh-pane picker gap, restore a LAN signal

### DIFF
--- a/.changesets/1788764361-fix-agent-pane-drop-the-dead-tab-strip-gap-above-my-agents-o-5r6w.md
+++ b/.changesets/1788764361-fix-agent-pane-drop-the-dead-tab-strip-gap-above-my-agents-o-5r6w.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): drop the dead tab-strip gap above My Agents on a fresh pane

--- a/.changesets/1788764363-fix-statusbar-lan-diamond-now-shows-all-three-states-peers-o-ajtk.md
+++ b/.changesets/1788764363-fix-statusbar-lan-diamond-now-shows-all-three-states-peers-o-ajtk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(statusbar): LAN diamond now shows all three states (peers / on-but-idle / off)

--- a/docs/retro/retro-lan-diamond-vanished-after-self-peer-fix-2026-09-06.md
+++ b/docs/retro/retro-lan-diamond-vanished-after-self-peer-fix-2026-09-06.md
@@ -1,0 +1,144 @@
+# Retro: the status-bar LAN diamond vanished — because #3025 fixed the bug that was lighting it
+
+**Date:** 2026-09-06
+**Status:** Root-caused, no code change made yet. The current behavior matches
+the written spec; what changed is the behavior users had actually learned. A
+follow-up UI decision is proposed below but deliberately not implemented in
+this retro.
+**Severity:** Low functionally (LAN discovery is working correctly), Medium for
+trust — the only status-bar signal that discovery is alive silently disappeared
+for every single-instance user, with nothing to distinguish it from "off".
+**Observed by:** repo owner, on a running v0.55.37 portable
+**Related:** PR #3025 (`b904ae00d`, "fix(lan): stop this instance discovering
+itself as a LAN peer"), `docs/specs/hostname-popover.md`
+
+---
+
+## TL;DR
+
+The blue diamond (`◆`) next to the hostname is gated on **how many LAN peers
+were found**, not on whether LAN discovery is **enabled**:
+
+```tsx
+// frontend/app/statusbar/HostPopover.tsx
+const lanCount = () => lanInstances().length;
+...
+<Show when={lanCount() > 0}>
+    <span style={{ color: "var(--accent-color)", "margin-left": "4px" }}>{"◆"}</span>
+</Show>
+```
+
+Until #3025, every instance discovered **itself** as a phantom peer, so that
+count was ≥ 1 whenever discovery was on. The diamond therefore *looked* like an
+"LAN discovery is enabled" lamp, and that is how it was learned. #3025 removed
+the phantom. On a machine with no other live AgentMux instance, the count is now
+genuinely 0, so the diamond correctly hides — and the enabled state lost its only
+status-bar representation.
+
+Nothing is broken. The indicator's real meaning was simply masked by a bug for
+as long as anyone had been looking at it.
+
+---
+
+## What was actually verified
+
+Measured on the reporting instance (v0.55.37, channel `local-main-b28b7a`), not
+inferred:
+
+1. **Discovery is running, with no error.** Its srv log contains exactly two
+   LAN lines and nothing else:
+   ```
+   "LAN discovery started (mDNS)", instance_id: "v0.55.37", port: 59859
+   "LAN discovery enabled via setting"
+   ```
+   No `laninstances:error`, so the panel's "enabled" state is truthful and the
+   mDNS daemon did start (this is *not* the Windows-firewall-blocked path).
+2. **Zero peers, correctly.** No `LAN peer discovered` event has been logged by
+   that instance at all. At the time of the report only two srv processes were
+   alive — v0.55.37 itself and the v0.55.38 `task dev` instance — and the dev
+   instance **never started LAN discovery**, because `settings.json` is now
+   channel-isolated (`SPEC_SETTINGS_ISOLATED_BY_CHANNEL_2026_08_19.md`) and a
+   fresh dev channel defaults `network:lan_discovery` to `false`. So there was
+   genuinely nothing on the LAN to find. `lanCount() === 0` is the correct answer.
+3. **The pre-fix behavior is still observable.** A v0.55.34 instance (older than
+   #3025) that had been running earlier logged the phantom signature the #3025
+   comment describes, verbatim:
+   ```
+   "LAN peer discovered", peer_id: "", address: fe80::142e:c4b3:9f29:8348, port: 55019
+   ```
+   — empty `peer_id`, its *own* port, its *own* link-local addresses, plus a
+   conflict-renamed service (`agentmux-v0 (2).55.34._agentmux._tcp.local.`).
+   That phantom is what used to hold the diamond on.
+4. **The spec agrees with the code, not with the expectation.**
+   `docs/specs/hostname-popover.md`: *"If mDNS is enabled **and peers are
+   found**, the hostname text could show a subtle indicator: `Area54 ◆` … to
+   signal **LAN peers exist**"*. Peer count, explicitly — never enabled-state.
+
+---
+
+## Root cause
+
+Two correct-in-isolation decisions, whose interaction was never considered:
+
+- **The indicator** was specified and built as "peers exist" (`lanCount() > 0`).
+- **#3025** removed a phantom peer that made `lanCount()` ≥ 1 for *any* instance
+  with discovery on, regardless of whether real peers existed.
+
+Because the phantom was universal, the two were indistinguishable in practice
+for the most common setup (one machine, one AgentMux). #3025 was a genuine bug
+fix — the phantom cost a real fan-out request per `find_agent` lookup — and it
+correctly did not touch the UI. But the fix silently changed what a user sees in
+the single-instance case from "always lit when enabled" to "never lit", with no
+release note connecting the two, and no other affordance in the status bar.
+
+This is the recurring shape: **when a long-standing bug is the thing feeding a
+UI signal, fixing the bug is a UI change.** The diff for #3025 contains no
+frontend files, so nothing in review would have surfaced it.
+
+---
+
+## Why "no diamond" is worse than it sounds
+
+The status bar now renders **identically** whether LAN discovery is enabled with
+no peers, or disabled entirely. The only way to tell them apart is to open the
+popover. For a feature whose entire value is passive background presence, losing
+the passive signal removes the reason to trust it is on — which is precisely the
+report that prompted this retro.
+
+---
+
+## Proposed fix (not implemented here)
+
+Make the status bar distinguish the three real states, keeping the spec's
+peers-exist meaning intact rather than overloading the diamond:
+
+| State | Status bar |
+|---|---|
+| Discovery off | nothing (unchanged) |
+| Discovery on, 0 peers | dimmed/outline `◇`, tooltip "LAN discovery on — no peers found" |
+| Discovery on, N peers | current accent-colored `◆`, tooltip "N on LAN" |
+
+`lanDiscoveryEnabled()` already exists in `HostPopover.tsx` immediately below
+`lanCount()`, so this is a small, self-contained change. Deliberately left for a
+separate PR with the repo owner's call on the glyph, since it is a visual-design
+decision, not a defect fix.
+
+An alternative — have the diamond track `lanDiscoveryEnabled()` — is **not**
+recommended: it contradicts the spec, and it would discard the genuinely useful
+"someone else is out there" signal that the diamond is supposed to carry.
+
+---
+
+## Lessons
+
+1. **A bug can be load-bearing for a UI.** Before landing a fix that changes the
+   population of a collection, grep for what reads that collection's `.length`.
+   Here, `lanInstances().length` had exactly one other consumer, and it was a
+   user-visible indicator.
+2. **"Enabled" and "working" deserve separate signals.** Collapsing them is only
+   safe while something guarantees they coincide — and here that guarantee was
+   itself the bug.
+3. **The empirical check was cheap and decisive.** Two greps of the srv log
+   ("did discovery start?", "were any peers ever discovered?") separated
+   "feature broken" from "feature idle" in under a minute, and disproved the
+   firewall-blocked hypothesis without touching the running instance.

--- a/docs/retro/retro-lan-diamond-vanished-after-self-peer-fix-2026-09-06.md
+++ b/docs/retro/retro-lan-diamond-vanished-after-self-peer-fix-2026-09-06.md
@@ -1,10 +1,10 @@
 # Retro: the status-bar LAN diamond vanished — because #3025 fixed the bug that was lighting it
 
 **Date:** 2026-09-06
-**Status:** Root-caused, no code change made yet. The current behavior matches
-the written spec; what changed is the behavior users had actually learned. A
-follow-up UI decision is proposed below but deliberately not implemented in
-this retro.
+**Status:** implemented — root-caused here, and the three-state indicator
+described below shipped in PR #3052 alongside this file. The pre-existing
+behavior matched the written spec; what had changed underneath it was the
+behavior users actually learned.
 **Severity:** Low functionally (LAN discovery is working correctly), Medium for
 trust — the only status-bar signal that discovery is alive silently disappeared
 for every single-instance user, with nothing to distinguish it from "off".
@@ -107,25 +107,40 @@ report that prompted this retro.
 
 ---
 
-## Proposed fix (not implemented here)
+## The fix (shipped in PR #3052)
 
-Make the status bar distinguish the three real states, keeping the spec's
-peers-exist meaning intact rather than overloading the diamond:
+The status bar now distinguishes all three real states, keeping the spec's
+peers-exist meaning intact rather than overloading one glyph. The repo owner
+asked for the off state to be visible too (rather than rendering nothing), so
+the indicator is now always present:
 
-| State | Status bar |
-|---|---|
-| Discovery off | nothing (unchanged) |
-| Discovery on, 0 peers | dimmed/outline `◇`, tooltip "LAN discovery on — no peers found" |
-| Discovery on, N peers | current accent-colored `◆`, tooltip "N on LAN" |
+| State | Glyph | Color | Tooltip |
+|---|---|---|---|
+| Discovery off (the default) | `◇` hollow | `--warning-color` | "LAN discovery off — click to enable" |
+| Discovery on, 0 peers | `◇` hollow | muted `--secondary-text-color` | "LAN discovery on — no peers found" |
+| Discovery on, daemon failed | `◇` hollow | `--error-color` | "LAN discovery failed: ‹reason›" |
+| Discovery on, N peers | `◆` filled | `--accent-color` | "N on LAN" |
 
-`lanDiscoveryEnabled()` already exists in `HostPopover.tsx` immediately below
-`lanCount()`, so this is a small, self-contained change. Deliberately left for a
-separate PR with the repo owner's call on the glyph, since it is a visual-design
-decision, not a defect fix.
+The failure row was added after review (codex P2 on #3052) and is the same
+bug class as the one this retro is about: when `LanDiscovery::start` fails —
+the Windows-firewall-"Block" path — the *setting* stays enabled, so a resolver
+reading only enabled+peer-count renders the muted state whose tooltip says
+nothing is wrong. Ranking is off → peers → error → idle, mirroring the popover,
+whose peer rows are not gated on the error while its "no peers" row is
+(`!lanDiscoveryError()`): reaching a peer is proof discovery works, which makes
+a lingering error stale rather than current.
 
-An alternative — have the diamond track `lanDiscoveryEnabled()` — is **not**
-recommended: it contradicts the spec, and it would discard the genuinely useful
-"someone else is out there" signal that the diamond is supposed to carry.
+Filled-vs-hollow carries the peers/no-peers distinction without relying on
+color, so the two hollow states remain distinguishable from the useful one even
+if their hues are not. Glyph, state class and tooltip all come from a single
+pure `resolveLanIndicator()` (`frontend/app/statusbar/lan-indicator.ts`, tested
+in `lan-indicator.test.ts`), so the label a user reads cannot drift from the
+glyph they see — the failure mode that made this bug invisible in the first
+place was exactly a UI signal quietly meaning something other than it appeared to.
+
+An alternative — have the diamond simply track `lanDiscoveryEnabled()` — was
+**rejected**: it contradicts the spec, and it would discard the genuinely useful
+"someone else is out there" signal the diamond is supposed to carry.
 
 ---
 

--- a/frontend/app/statusbar/HostPopover.tsx
+++ b/frontend/app/statusbar/HostPopover.tsx
@@ -378,7 +378,12 @@ const HostPopover = (): JSX.Element => {
 
     // Glyph + label + state in one place (`lan-indicator.ts`), so the tooltip
     // a user reads can never disagree with the glyph they see.
-    const lanIndicator = () => resolveLanIndicator({ enabled: lanDiscoveryEnabled(), peerCount: lanCount() });
+    const lanIndicator = () =>
+        resolveLanIndicator({
+            enabled: lanDiscoveryEnabled(),
+            peerCount: lanCount(),
+            error: lanDiscoveryError(),
+        });
 
     // Toggle the network:lan_discovery setting. The backend's setconfig handler
     // calls LanDiscoveryController.apply, which starts/stops the mDNS daemon

--- a/frontend/app/statusbar/HostPopover.tsx
+++ b/frontend/app/statusbar/HostPopover.tsx
@@ -7,6 +7,7 @@ import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { Accessor, createEffect, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
+import { resolveLanIndicator } from "./lan-indicator";
 import { autoUpdate } from "@floating-ui/dom";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import { computeMenuPosition } from "@/app/util/menu-position";
@@ -375,6 +376,10 @@ const HostPopover = (): JSX.Element => {
     const lanDiscoveryEnabled = () => !!settingsAtom()?.["network:lan_discovery"];
     const lanDiscoveryError = lanDiscoveryErrorAtom;
 
+    // Glyph + label + state in one place (`lan-indicator.ts`), so the tooltip
+    // a user reads can never disagree with the glyph they see.
+    const lanIndicator = () => resolveLanIndicator({ enabled: lanDiscoveryEnabled(), peerCount: lanCount() });
+
     // Toggle the network:lan_discovery setting. The backend's setconfig handler
     // calls LanDiscoveryController.apply, which starts/stops the mDNS daemon
     // live — no restart. On Windows, the first enable triggers the firewall
@@ -437,9 +442,22 @@ const HostPopover = (): JSX.Element => {
                 <span class="status-hostname">
                     {hostname}
                 </span>
-                <Show when={lanCount() > 0}>
-                    <span style={{ color: "var(--accent-color)", "margin-left": "4px" }}>{"◆"}</span>
-                </Show>
+                {/* Three states, always one of them rendered — see
+                    docs/retro/retro-lan-diamond-vanished-after-self-peer-fix-2026-09-06.md.
+                    Peer-count alone used to drive this, so the indicator
+                    disappeared entirely once #3025 stopped an instance
+                    discovering ITSELF as a phantom peer: a lone instance with
+                    discovery genuinely on then looked identical to one with it
+                    off. Enabled-but-idle and off are distinct facts and each
+                    now has its own glyph. */}
+                <span
+                    class="status-lan-diamond"
+                    classList={{ [`status-lan-diamond--${lanIndicator().state}`]: true }}
+                    data-tip={lanIndicator().label}
+                    aria-label={lanIndicator().label}
+                >
+                    {lanIndicator().glyph}
+                </span>
                 <Show when={muxbus.isConfigured() && muxbus.status() !== null}>
                     <span
                         class="status-muxbus-dot"

--- a/frontend/app/statusbar/StatusBar.scss
+++ b/frontend/app/statusbar/StatusBar.scss
@@ -508,6 +508,41 @@
     }
 }
 
+// ── LAN discovery diamond (next to the hostname) ────────────────────────
+// Three distinct states, because "discovery off" and "discovery on but no
+// peers yet" are different facts the user acts on differently — and until
+// #3025 they were indistinguishable here (every instance discovered itself,
+// so the peer count was never 0 while enabled). See
+// docs/retro/retro-lan-diamond-vanished-after-self-peer-fix-2026-09-06.md.
+//
+//   filled + accent  ◆  peers found        (unchanged from before)
+//   hollow + muted   ◇  on, none found     (working, just nobody out there)
+//   hollow + warning ◇  discovery off      (the default — opt-in feature)
+//
+// Filled-vs-hollow carries the peers/no-peers distinction on its own, so the
+// state is not conveyed by color alone (the two hollow states differ in hue
+// but a user who cannot separate them still sees "not filled = no peers").
+.status-lan-diamond {
+    margin-left: 4px;
+    flex-shrink: 0;
+    line-height: 1;
+
+    &--peers {
+        color: var(--accent-color);
+    }
+
+    // Deliberately dimmer than --off: this is the quiet, healthy steady state
+    // for anyone with a single machine, and should not read as a warning.
+    &--idle {
+        color: var(--secondary-text-color);
+        opacity: 0.65;
+    }
+
+    &--off {
+        color: var(--warning-color);
+    }
+}
+
 // ── MuxBus session dot (on the network pill, next to the LAN diamond) ──────
 // Red = no valid MuxBus session (WAN jekt delivery dead — click the pill and
 // sign in from the panel); green = connected. Deliberately quiet: a dot, not

--- a/frontend/app/statusbar/StatusBar.scss
+++ b/frontend/app/statusbar/StatusBar.scss
@@ -541,6 +541,14 @@
     &--off {
         color: var(--warning-color);
     }
+
+    // Enabled, but the mDNS daemon could not start (Windows firewall "Block"
+    // is the usual cause). Distinct from --idle, which looks identical to the
+    // user otherwise: same hollow glyph, no peers, but nothing wrong. Ranked
+    // below --peers, since reaching a peer proves discovery works [codex P2].
+    &--error {
+        color: var(--error-color);
+    }
 }
 
 // ── MuxBus session dot (on the network pill, next to the LAN diamond) ──────

--- a/frontend/app/statusbar/lan-indicator.test.ts
+++ b/frontend/app/statusbar/lan-indicator.test.ts
@@ -1,0 +1,46 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { resolveLanIndicator } from "./lan-indicator";
+
+describe("resolveLanIndicator", () => {
+    it("shows the accent-filled diamond when real peers exist", () => {
+        const r = resolveLanIndicator({ enabled: true, peerCount: 2 });
+        expect(r.state).toBe("peers");
+        expect(r.glyph).toBe("◆");
+        expect(r.label).toBe("2 on LAN");
+    });
+
+    // The state that had NO representation at all before this change: #3025
+    // stopped the phantom self-peer, so an enabled-but-alone instance fell to
+    // peerCount 0 and rendered nothing — identical to discovery being off.
+    it("distinguishes enabled-but-no-peers from off", () => {
+        const idle = resolveLanIndicator({ enabled: true, peerCount: 0 });
+        const off = resolveLanIndicator({ enabled: false, peerCount: 0 });
+
+        expect(idle.state).toBe("idle");
+        expect(off.state).toBe("off");
+        expect(idle.state).not.toBe(off.state);
+        expect(idle.label).not.toBe(off.label);
+    });
+
+    it("reports off regardless of a stale peer count", () => {
+        // Peers linger in the atom for a tick after the setting is toggled
+        // off; the setting is authoritative, not the leftover list.
+        const r = resolveLanIndicator({ enabled: false, peerCount: 3 });
+        expect(r.state).toBe("off");
+        expect(r.glyph).toBe("◇");
+    });
+
+    it("fills the glyph only when peers exist, so state is not color-only", () => {
+        expect(resolveLanIndicator({ enabled: true, peerCount: 1 }).glyph).toBe("◆");
+        expect(resolveLanIndicator({ enabled: true, peerCount: 0 }).glyph).toBe("◇");
+        expect(resolveLanIndicator({ enabled: false, peerCount: 0 }).glyph).toBe("◇");
+    });
+
+    it("treats a negative count as no peers rather than as peers", () => {
+        const r = resolveLanIndicator({ enabled: true, peerCount: -1 });
+        expect(r.state).toBe("idle");
+    });
+});

--- a/frontend/app/statusbar/lan-indicator.test.ts
+++ b/frontend/app/statusbar/lan-indicator.test.ts
@@ -43,4 +43,36 @@ describe("resolveLanIndicator", () => {
         const r = resolveLanIndicator({ enabled: true, peerCount: -1 });
         expect(r.state).toBe("idle");
     });
+
+    // codex P2: the daemon failing to start leaves the SETTING enabled and
+    // populates the error atom. Reporting that as the muted "idle" state hid a
+    // real failure behind a tooltip documented as healthy.
+    it("surfaces a start-up failure instead of the healthy idle state", () => {
+        const r = resolveLanIndicator({
+            enabled: true,
+            peerCount: 0,
+            error: "mDNS daemon failed to bind",
+        });
+        expect(r.state).toBe("error");
+        expect(r.state).not.toBe("idle");
+        expect(r.label).toContain("mDNS daemon failed to bind");
+    });
+
+    it("still reports off when disabled, even with a stale error", () => {
+        const r = resolveLanIndicator({ enabled: false, peerCount: 0, error: "boom" });
+        expect(r.state).toBe("off");
+    });
+
+    // Mirrors the popover, whose peer rows are not gated on the error while
+    // its "no peers" row is: an actual peer proves discovery works.
+    it("prefers peers over a lingering error", () => {
+        const r = resolveLanIndicator({ enabled: true, peerCount: 2, error: "stale" });
+        expect(r.state).toBe("peers");
+        expect(r.label).toBe("2 on LAN");
+    });
+
+    it("treats null/undefined error as no error", () => {
+        expect(resolveLanIndicator({ enabled: true, peerCount: 0, error: null }).state).toBe("idle");
+        expect(resolveLanIndicator({ enabled: true, peerCount: 0 }).state).toBe("idle");
+    });
 });

--- a/frontend/app/statusbar/lan-indicator.ts
+++ b/frontend/app/statusbar/lan-indicator.ts
@@ -13,19 +13,25 @@
  * genuinely enabled started rendering exactly like one with it switched off.
  * See docs/retro/retro-lan-diamond-vanished-after-self-peer-fix-2026-09-06.md.
  *
- * "Off" and "on but nobody out there" are different facts the user acts on
- * differently, so each gets its own state here.
+ * "Off", "on but nobody out there", and "on but the daemon failed to start"
+ * are different facts the user acts on differently, so each gets its own
+ * state here.
  *
  * Pure so the state table can be tested without mounting the status bar —
  * the same extract-and-test pattern as `tab-strip-visibility.ts`.
  */
-export type LanIndicatorState = "peers" | "idle" | "off";
+export type LanIndicatorState = "peers" | "idle" | "error" | "off";
 
 export interface LanIndicatorInput {
     /** The `network:lan_discovery` setting. */
     enabled: boolean;
     /** Number of DISCOVERED peers — excludes this instance, post-#3025. */
     peerCount: number;
+    /** `lanDiscoveryErrorAtom` — set when the mDNS daemon could not be
+     *  started (the Windows firewall "Block" path is the common one). The
+     *  setting stays enabled in that case, so without this the failure would
+     *  render as the muted, documented-as-healthy idle state [codex P2]. */
+    error?: string | null;
 }
 
 export interface LanIndicator {
@@ -38,18 +44,27 @@ export interface LanIndicator {
 }
 
 export function resolveLanIndicator(input: LanIndicatorInput): LanIndicator {
+    // Off wins outright: the user turned it off, so a stale error from a
+    // previous attempt is not something to nag about.
     if (!input.enabled) {
         return { state: "off", glyph: "◇", label: "LAN discovery off — click to enable" };
     }
-    // Defensive `<= 0`: a negative count is nonsense, but treating it as
-    // "peers found" would be the worse failure — it would claim peers exist
-    // while the popover lists none.
-    if (input.peerCount <= 0) {
-        return { state: "idle", glyph: "◇", label: "LAN discovery on — no peers found" };
+    // Peers outrank an error, mirroring the popover, whose peers rows are NOT
+    // gated on the error while its "no peers" row IS (`!lanDiscoveryError()`).
+    // Reaching a peer is direct proof discovery works, which makes a lingering
+    // error stale rather than current.
+    //
+    // Defensive `> 0`: a negative count is nonsense, but treating it as "peers
+    // found" would be the worse failure — it would claim peers exist while
+    // the popover lists none.
+    if (input.peerCount > 0) {
+        return { state: "peers", glyph: "◆", label: `${input.peerCount} on LAN` };
     }
-    return {
-        state: "peers",
-        glyph: "◆",
-        label: `${input.peerCount} on LAN`,
-    };
+    // Enabled, nothing found, and the daemon reported a failure: the reason
+    // there are no peers is that discovery never started. Must not render as
+    // the healthy idle state [codex P2].
+    if (input.error) {
+        return { state: "error", glyph: "◇", label: `LAN discovery failed: ${input.error}` };
+    }
+    return { state: "idle", glyph: "◇", label: "LAN discovery on — no peers found" };
 }

--- a/frontend/app/statusbar/lan-indicator.ts
+++ b/frontend/app/statusbar/lan-indicator.ts
@@ -1,0 +1,55 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Which LAN indicator to show next to the hostname in the status bar.
+ *
+ * Three states, not two. The indicator used to render only when peers were
+ * found (`lanCount() > 0`), which was correct per
+ * `docs/specs/hostname-popover.md` — but until #3025 every instance discovered
+ * ITSELF as a phantom peer, so the count was never 0 while discovery was on.
+ * The glyph therefore behaved like an "enabled" lamp, and that is how it was
+ * learned. #3025 removed the phantom, and a lone instance with discovery
+ * genuinely enabled started rendering exactly like one with it switched off.
+ * See docs/retro/retro-lan-diamond-vanished-after-self-peer-fix-2026-09-06.md.
+ *
+ * "Off" and "on but nobody out there" are different facts the user acts on
+ * differently, so each gets its own state here.
+ *
+ * Pure so the state table can be tested without mounting the status bar —
+ * the same extract-and-test pattern as `tab-strip-visibility.ts`.
+ */
+export type LanIndicatorState = "peers" | "idle" | "off";
+
+export interface LanIndicatorInput {
+    /** The `network:lan_discovery` setting. */
+    enabled: boolean;
+    /** Number of DISCOVERED peers — excludes this instance, post-#3025. */
+    peerCount: number;
+}
+
+export interface LanIndicator {
+    state: LanIndicatorState;
+    /** Filled only when real peers exist, so the peers/no-peers distinction
+     *  survives without relying on color. */
+    glyph: "◆" | "◇";
+    /** Reused for both the tooltip and the accessible name. */
+    label: string;
+}
+
+export function resolveLanIndicator(input: LanIndicatorInput): LanIndicator {
+    if (!input.enabled) {
+        return { state: "off", glyph: "◇", label: "LAN discovery off — click to enable" };
+    }
+    // Defensive `<= 0`: a negative count is nonsense, but treating it as
+    // "peers found" would be the worse failure — it would claim peers exist
+    // while the popover lists none.
+    if (input.peerCount <= 0) {
+        return { state: "idle", glyph: "◇", label: "LAN discovery on — no peers found" };
+    }
+    return {
+        state: "peers",
+        glyph: "◆",
+        label: `${input.peerCount} on LAN`,
+    };
+}

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -335,6 +335,17 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
     // lone conversation shows just the "+" (no pill for itself). The
     // moment a 2nd tab exists, both (including the first) appear.
     const visibleTabs = createMemo(() => (combinedTabs().length > 1 ? combinedTabs() : []));
+    // Single source of truth for whether the strip renders — read both by
+    // the <Show> that mounts it and by the picker host's strip-clearance
+    // custom property below, so the space reserved for the strip can never
+    // disagree with whether the strip is actually there.
+    const showTabStrip = createMemo(() =>
+        shouldShowTabStrip({
+            visibleTabCount: visibleTabs().length,
+            hasAgent: !!agentId(),
+            isHistoryTab: isHistoryTab(),
+        }),
+    );
     const activeBlockId = createMemo(() => {
         layoutModel.localTreeStateAtom();
         return layoutModel.getNodeByBlockId(model.blockId)?.data?.activeBlockId ?? model.blockId;
@@ -549,13 +560,7 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
                         back the moment the pane is a real conversation; see
                         shouldShowTabStrip for why a 2nd blank tab still keeps
                         the strip up. */}
-                    <Show
-                        when={shouldShowTabStrip({
-                            visibleTabCount: visibleTabs().length,
-                            hasAgent: !!agentId(),
-                            isHistoryTab: isHistoryTab(),
-                        })}
-                    >
+                    <Show when={showTabStrip()}>
                         <PaneTabStrip
                             tabs={visibleTabs()}
                             activeId={activeBlockId()}
@@ -600,6 +605,20 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
                                 <Show when={pickerVisible()}>
                                     <div
                                         class="agent-picker-host"
+                                        // Strip clearance, inherited by
+                                        // `.agent-picker`'s padding-top (see
+                                        // _picker.scss). The strip floats over
+                                        // the content, so the picker pads
+                                        // itself out of the way — but on a
+                                        // fresh pane the strip isn't rendered
+                                        // at all (shouldShowTabStrip), and
+                                        // reserving its height there is pure
+                                        // dead space above "My Agents".
+                                        style={{
+                                            "--pane-tab-strip-reserve": showTabStrip()
+                                                ? "var(--pane-tab-strip-height, 28px)"
+                                                : "0px",
+                                        }}
                                         classList={{
                                             // Applied the instant agentId()
                                             // is set (same render as

--- a/frontend/app/view/agent/styles/_picker.scss
+++ b/frontend/app/view/agent/styles/_picker.scss
@@ -18,14 +18,20 @@
         // Reserves the pane tab strip's rendered height so the picker's own
         // top row (the "My Agents"/"+ New from template" header + first
         // cards) never renders behind it — same overlay problem, same fix,
-        // as .agent-document's padding-top in _document.scss (the strip
-        // renders for a blank/picker tab too, agent-view.tsx: "the strip
-        // stays visible whether the active member is a launched
-        // conversation OR a blank/picker tab"). Unconditional (not gated on
-        // whether the strip actually has >1 tab to show) — same tradeoff
-        // _document.scss makes: a little extra top whitespace when the
-        // strip is empty beats the content staying hidden when it isn't.
-        padding-top: calc(var(--space-4) + var(--pane-tab-strip-height, 28px));
+        // as .agent-document's padding-top in _document.scss.
+        //
+        // The amount is NOT a constant: `--pane-tab-strip-reserve` is set
+        // per-pane on `.agent-picker-host` (agent-view.tsx) from the same
+        // `shouldShowTabStrip` predicate that decides whether the strip
+        // mounts at all, and inherits down to here. It resolves to 0px on a
+        // FRESH pane — picker showing, no agent launched — because #2984
+        // stopped rendering the strip there entirely. This rule used to
+        // reserve the strip's height unconditionally, which was correct
+        // when the strip always rendered (collapsing to a lone 28×28 "+"),
+        // but after #2984 left ~44px of dead space above "My Agents"
+        // reserved for a strip that isn't there. The fallback keeps the old
+        // behavior for any caller that doesn't set the property.
+        padding-top: calc(var(--space-4) + var(--pane-tab-strip-reserve, var(--pane-tab-strip-height, 28px)));
         gap: var(--space-3);
         overflow-y: auto;
         // Min tile width for the My Agents / Templates grids. The grids


### PR DESCRIPTION
Two small UI fixes. Both are downstream of a recent change that silently removed something the UI had been relying on — neither was caught by review, because in both cases the diff that broke them contained no frontend files.

## 1. Dead gap above "My Agents"

`.agent-picker` reserved the pane tab strip's height unconditionally (`space-4 + 28px`). #2984 stopped rendering that strip **at all** on a fresh pane, so the reservation became ~28px of dead space above the header — reported as "an unnatural looking margin at the top."

The clearance is now a `--pane-tab-strip-reserve` custom property set on `.agent-picker-host` from the **same** `shouldShowTabStrip` predicate that decides whether the strip mounts, so the space reserved and the thing it's reserved for can't disagree. `0px` on a fresh pane; unchanged (`28px`) whenever the strip actually renders.

Note the old comment claimed parity with `.agent-document`'s rule while actually using a different base value — that's corrected too.

## 2. LAN diamond had no "on, but no peers" state

The diamond was gated purely on peer count (`lanCount() > 0`), which matches `docs/specs/hostname-popover.md`. But until #3025, every instance discovered **itself** as a phantom peer, so the count was never 0 while discovery was on — the glyph effectively behaved as an "enabled" lamp, and that's how it was learned. #3025 correctly removed the phantom; the consequence is that a lone instance with discovery genuinely enabled now renders **identically** to one with it switched off.

Three states now:

| State | Glyph | Color |
|---|---|---|
| Peers found | `◆` filled | accent |
| On, no peers | `◇` hollow | muted |
| Off (default) | `◇` hollow | warning |

Filled-vs-hollow carries the peers/no-peers distinction on its own, so state isn't conveyed by color alone. Glyph, color-class and tooltip all come from one pure `resolveLanIndicator()` so the label can't drift from what's drawn.

## Verification

- `npx tsc --noEmit` clean.
- New `lan-indicator.test.ts` (6 cases) pins the state table, including the case that had no representation before (`enabled + 0 peers` must differ from `off`) and a stale-peer-count-after-toggle-off case. `tab-strip-visibility.test.ts` still passes — 10 total.
- The LAN behavior was root-caused against the **live** instance's srv log, not inferred: discovery started cleanly (`LAN discovery started (mDNS)`, port 59859), no error, and **zero** `LAN peer discovered` events — while an older pre-#3025 instance on the same machine still logged the phantom signature verbatim (`peer_id:""`, its own port, its own link-local addresses). Written up in `docs/retro/retro-lan-diamond-vanished-after-self-peer-fix-2026-09-06.md`.
- **Not yet visually confirmed in a running build** — a `task dev` instance is being brought up on this branch for that. I'll confirm here once the picker gap and all three diamond states have been eyeballed.

<!-- agentmux:agent_id=agenty -->