### PR TITLE
fix(memory): backfill native-memory versions from disk, repair rows mislabeled "detected outside AgentMux"

### DIFF
--- a/.changesets/1788764784-fix-memory-backfill-native-memory-versions-from-disk-and-rep-btae.md
+++ b/.changesets/1788764784-fix-memory-backfill-native-memory-versions-from-disk-and-rep-btae.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(memory): backfill native-memory versions from disk and repair rows mislabeled 'detected outside AgentMux'

--- a/agentmux-srv/src/backend/native_memory_drift.rs
+++ b/agentmux-srv/src/backend/native_memory_drift.rs
@@ -95,7 +95,7 @@ pub(crate) fn check_and_record_drift(
 /// InvalidData`, distinguishable from a transient I/O error) rather than
 /// read partially; callers log and skip it, same treatment as any other
 /// per-file read failure.
-fn read_memory_file_lossy(path: &Path) -> std::io::Result<String> {
+pub(crate) fn read_memory_file_lossy(path: &Path) -> std::io::Result<String> {
     use std::io::Read;
     let mut buf = Vec::new();
     let read = std::fs::File::open(path)?

--- a/agentmux-srv/src/backend/storage/agent_native_memory_versions.rs
+++ b/agentmux-srv/src/backend/storage/agent_native_memory_versions.rs
@@ -354,6 +354,69 @@ impl Store {
     /// happens to be old, and a hyperactive file never grows unbounded
     /// purely because every version happens to be recent. Returns the
     /// number of rows deleted.
+    /// Repair the mislabeled rollout backfill — see
+    /// `migrations::m0024_native_memory_backfill_from_fs` for the full
+    /// story. In short: `m0023` was supposed to tag every pre-existing
+    /// memory file `agent_inferred`, but it iterated the
+    /// `db_agent_native_memory` MIRROR, which is populated lazily and is
+    /// empty on a typical install — so it backfilled nothing, and the
+    /// drift sweep (which reads the real filesystem) claimed those same
+    /// files milliseconds later as `external_fs_write`, i.e. "detected
+    /// outside AgentMux — provenance unknown". Innocent files, alarming
+    /// label.
+    ///
+    /// The predicate is deliberately narrow, because relabeling a
+    /// provenance claim is not something to do speculatively. All four
+    /// must hold:
+    ///
+    /// - `source = 'external_fs_write'` and `detected_via =
+    ///   'reconciliation_sweep'` — the slow path, which is the only one
+    ///   that can observe a file it has never seen before at startup;
+    /// - `parent_version_id IS NULL` — a FIRST-EVER version for that
+    ///   `(agent_id, filename)`, i.e. genuine first sight rather than an
+    ///   observed change to something already tracked;
+    /// - `created_at` inside a 5-minute window starting at `m0023`'s own
+    ///   `applied_at`. This is the load-bearing one: a memory file created
+    ///   out-of-band NEXT WEEK is also first-sight-via-sweep, and that one
+    ///   is a real external write whose label must stand. Only the burst
+    ///   that raced this specific migration is in scope.
+    ///
+    /// `source_detail` keeps the original `detected_via` and records that
+    /// the row was relabeled, so the audit trail says what happened rather
+    /// than quietly presenting the new claim as if it were the original
+    /// observation.
+    ///
+    /// Returns the number of rows relabeled. A no-op (returns 0) when
+    /// `m0023` never ran — nothing to repair on a fresh install.
+    pub fn agent_native_memory_version_relabel_rollout_first_sight(
+        &self,
+    ) -> Result<usize, StoreError> {
+        const ROLLOUT_WINDOW_MS: i64 = 5 * 60 * 1000;
+        let conn = self.conn.lock().unwrap();
+        // strftime() parses m0023's ISO-8601 `applied_at` (offset included)
+        // to epoch seconds; the version table stores epoch millis.
+        let updated = conn.execute(
+            "UPDATE db_agent_native_memory_versions
+                SET source = 'agent_inferred',
+                    source_detail = json_object(
+                        'relabeled_from', 'external_fs_write',
+                        'detected_via', json_extract(source_detail, '$.detected_via'),
+                        'reason', 'rollout_first_sight'
+                    )
+              WHERE source = 'external_fs_write'
+                AND json_extract(source_detail, '$.detected_via') = 'reconciliation_sweep'
+                AND parent_version_id IS NULL
+                AND created_at >= (
+                    SELECT strftime('%s', applied_at) * 1000 FROM db_migrations
+                     WHERE id = '0023_native_memory_versions_backfill')
+                AND created_at <= (
+                    SELECT strftime('%s', applied_at) * 1000 + ?1 FROM db_migrations
+                     WHERE id = '0023_native_memory_versions_backfill')",
+            params![ROLLOUT_WINDOW_MS],
+        )?;
+        Ok(updated)
+    }
+
     pub fn agent_native_memory_version_prune(
         &self,
         agent_id: &str,
@@ -419,6 +482,134 @@ mod tests {
     fn shared_store() -> Store {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         Store::open_shared(tmp.path()).unwrap()
+    }
+
+    /// Record that `m0023` ran at `applied_at` (ISO-8601). The relabel
+    /// window is anchored to this row, so it is what makes a version
+    /// "part of the rollout burst" or not.
+    fn record_m0023(store: &Store, applied_at: &str) {
+        store
+            .conn
+            .lock()
+            .unwrap()
+            .execute(
+                "INSERT INTO db_migrations (id, applied_at, duration_ms, scope)
+                 VALUES ('0023_native_memory_versions_backfill', ?1, 0, 'global')",
+                params![applied_at],
+            )
+            .unwrap();
+    }
+
+    /// An ISO-8601 stamp for "now", so versions inserted by a test land
+    /// inside the 5-minute rollout window.
+    fn now_iso() -> String {
+        let secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.query_row(
+            "SELECT strftime('%Y-%m-%dT%H:%M:%S+00:00', ?1, 'unixepoch')",
+            params![secs as i64],
+            |r| r.get::<_, String>(0),
+        )
+        .unwrap()
+    }
+
+    /// The sweep's own row shape for a file it has never seen before.
+    fn sweep_first_sight(store: &Store, agent: &str, file: &str) {
+        store
+            .agent_native_memory_version_insert(
+                agent, file, "pre-existing content", "external_fs_write",
+                r#"{"detected_via":"reconciliation_sweep"}"#, "",
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn relabels_the_rollout_first_sight_burst() {
+        // The real-world case: m0023 backfilled nothing (empty mirror), and
+        // the sweep claimed the pre-existing files milliseconds later.
+        let store = shared_store();
+        record_m0023(&store, &now_iso());
+        sweep_first_sight(&store, "agent-1", "MEMORY.md");
+
+        assert_eq!(store.agent_native_memory_version_relabel_rollout_first_sight().unwrap(), 1);
+
+        let v = &store.agent_native_memory_version_list("agent-1", "MEMORY.md").unwrap()[0];
+        assert_eq!(v.source, "agent_inferred");
+        // The audit trail must still say what actually happened.
+        assert!(v.source_detail.contains("relabeled_from"), "{}", v.source_detail);
+        assert!(v.source_detail.contains("reconciliation_sweep"), "{}", v.source_detail);
+    }
+
+    #[test]
+    fn leaves_a_genuine_later_external_write_alone() {
+        // A memory file created out-of-band LONG after the upgrade is also
+        // first-sight-via-sweep. That one is a real external write and its
+        // label must stand — this is what the time window protects, and the
+        // single most important thing this repair must not get wrong.
+        let store = shared_store();
+        record_m0023(&store, "2020-01-01T00:00:00+00:00");
+        sweep_first_sight(&store, "agent-1", "MEMORY.md");
+
+        assert_eq!(store.agent_native_memory_version_relabel_rollout_first_sight().unwrap(), 0);
+        assert_eq!(
+            store.agent_native_memory_version_list("agent-1", "MEMORY.md").unwrap()[0].source,
+            "external_fs_write"
+        );
+    }
+
+    #[test]
+    fn leaves_an_observed_change_to_a_tracked_file_alone() {
+        // Not first sight: the file was already versioned, so the sweep
+        // observed a real out-of-band CHANGE. parent_version_id is set, and
+        // the row must keep its label.
+        let store = shared_store();
+        record_m0023(&store, &now_iso());
+        store
+            .agent_native_memory_version_insert("agent-1", "MEMORY.md", "v1", "human", "{}", "")
+            .unwrap();
+        sweep_first_sight(&store, "agent-1", "MEMORY.md");
+
+        assert_eq!(store.agent_native_memory_version_relabel_rollout_first_sight().unwrap(), 0);
+    }
+
+    #[test]
+    fn leaves_fs_watch_detections_alone() {
+        // Only the slow sweep can observe a never-before-seen file at
+        // startup; a live fs-watch event means something wrote while we
+        // were watching.
+        let store = shared_store();
+        record_m0023(&store, &now_iso());
+        store
+            .agent_native_memory_version_insert(
+                "agent-1", "MEMORY.md", "c", "external_fs_write",
+                r#"{"detected_via":"fs_watch"}"#, "",
+            )
+            .unwrap();
+
+        assert_eq!(store.agent_native_memory_version_relabel_rollout_first_sight().unwrap(), 0);
+    }
+
+    #[test]
+    fn is_a_no_op_when_m0023_never_ran() {
+        // Fresh install: db_migrations exists but has no m0023 row, so the
+        // window subquery is NULL and nothing matches. Must not error.
+        let store = shared_store();
+        sweep_first_sight(&store, "agent-1", "MEMORY.md");
+        assert_eq!(store.agent_native_memory_version_relabel_rollout_first_sight().unwrap(), 0);
+    }
+
+    #[test]
+    fn is_idempotent() {
+        let store = shared_store();
+        record_m0023(&store, &now_iso());
+        sweep_first_sight(&store, "agent-1", "MEMORY.md");
+        assert_eq!(store.agent_native_memory_version_relabel_rollout_first_sight().unwrap(), 1);
+        // Second run finds nothing: the rows it would match are no longer
+        // external_fs_write.
+        assert_eq!(store.agent_native_memory_version_relabel_rollout_first_sight().unwrap(), 0);
     }
 
     #[test]

--- a/agentmux-srv/src/backend/storage/agent_native_memory_versions.rs
+++ b/agentmux-srv/src/backend/storage/agent_native_memory_versions.rs
@@ -375,11 +375,28 @@ impl Store {
     /// - `parent_version_id IS NULL` — a FIRST-EVER version for that
     ///   `(agent_id, filename)`, i.e. genuine first sight rather than an
     ///   observed change to something already tracked;
-    /// - `created_at` inside a 5-minute window starting at `m0023`'s own
-    ///   `applied_at`. This is the load-bearing one: a memory file created
-    ///   out-of-band NEXT WEEK is also first-sight-via-sweep, and that one
-    ///   is a real external write whose label must stand. Only the burst
-    ///   that raced this specific migration is in scope.
+    /// - `created_at` inside a short window starting at `m0023`'s own
+    ///   `applied_at` — the load-bearing clause, since a memory file
+    ///   created out-of-band next week is also first-sight-via-sweep and
+    ///   that one is a real external write whose label must stand.
+    ///
+    /// ## The limit of the window, stated plainly
+    ///
+    /// Inside the window this cannot tell the rollout burst from a
+    /// genuinely new out-of-band file, and will relabel both (ReAgent P2
+    /// on PR #3055 — an earlier revision of this comment claimed an
+    /// absolute guarantee it does not deliver). Nothing in the row or the
+    /// file distinguishes them: mtime is no help either, since a burst
+    /// row's file may have been legitimately edited since.
+    ///
+    /// What makes the trade acceptable is the shape of the two errors, not
+    /// their likelihood alone. Getting it wrong costs one just-created file
+    /// a benign "Agent" label instead of "detected outside AgentMux", on an
+    /// install where the user is watching a fresh upgrade. Not acting costs
+    /// every pre-existing memory file on every affected install a permanent
+    /// security-flavored warning it did not earn — which is the bug this
+    /// repairs. The window is kept as small as the evidence allows so the
+    /// ambiguous region stays tiny.
     ///
     /// `source_detail` keeps the original `detected_via` and records that
     /// the row was relabeled, so the audit trail says what happened rather
@@ -391,7 +408,12 @@ impl Store {
     pub fn agent_native_memory_version_relabel_rollout_first_sight(
         &self,
     ) -> Result<usize, StoreError> {
-        const ROLLOUT_WINDOW_MS: i64 = 5 * 60 * 1000;
+        // The sweep's `tokio::time::interval` fires immediately on its
+        // first tick, so the burst lands milliseconds after migrations
+        // finish — 61ms on the install this was diagnosed from. A minute is
+        // three orders of magnitude of slack for a loaded machine's first
+        // sweep, while keeping the ambiguous region (see above) short.
+        const ROLLOUT_WINDOW_MS: i64 = 60 * 1000;
         let conn = self.conn.lock().unwrap();
         // strftime() parses m0023's ISO-8601 `applied_at` (offset included)
         // to epoch seconds; the version table stores epoch millis.
@@ -501,7 +523,7 @@ mod tests {
     }
 
     /// An ISO-8601 stamp for "now", so versions inserted by a test land
-    /// inside the 5-minute rollout window.
+    /// inside the rollout window.
     fn now_iso() -> String {
         let secs = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -544,11 +566,11 @@ mod tests {
     }
 
     #[test]
-    fn leaves_a_genuine_later_external_write_alone() {
-        // A memory file created out-of-band LONG after the upgrade is also
-        // first-sight-via-sweep. That one is a real external write and its
-        // label must stand — this is what the time window protects, and the
-        // single most important thing this repair must not get wrong.
+    fn leaves_a_genuine_external_write_outside_the_window_alone() {
+        // A memory file created out-of-band after the upgrade is also
+        // first-sight-via-sweep. Once it is outside the window that one is a
+        // real external write and its label must stand — the single most
+        // important thing this repair must not get wrong.
         let store = shared_store();
         record_m0023(&store, "2020-01-01T00:00:00+00:00");
         sweep_first_sight(&store, "agent-1", "MEMORY.md");
@@ -558,6 +580,23 @@ mod tests {
             store.agent_native_memory_version_list("agent-1", "MEMORY.md").unwrap()[0].source,
             "external_fs_write"
         );
+    }
+
+    #[test]
+    fn relabels_a_genuinely_new_file_inside_the_window_too() {
+        // Pins a KNOWN, accepted limitation rather than a desired property
+        // (ReAgent P2 on PR #3055): inside the window the burst and a
+        // genuinely new out-of-band file are indistinguishable, so this one
+        // is relabeled too. Documented in the method's own doc comment; the
+        // mitigation is that the window is small, not that the case cannot
+        // happen. Here so nobody reads the guarantee as absolute, and so
+        // narrowing it later is a deliberate change with a failing test
+        // rather than a silent one.
+        let store = shared_store();
+        record_m0023(&store, &now_iso());
+        sweep_first_sight(&store, "agent-1", "BRAND-NEW.md");
+
+        assert_eq!(store.agent_native_memory_version_relabel_rollout_first_sight().unwrap(), 1);
     }
 
     #[test]

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -2554,7 +2554,7 @@ fn map_agent_definition_row(row: &rusqlite::Row) -> rusqlite::Result<AgentDefini
 /// independently (reagentx P2 on PR #2602) — kept as one definition here so
 /// a future field addition only needs updating once.
 #[cfg(test)]
-fn test_agent_def(
+pub(crate) fn test_agent_def(
     id: &str,
     name: &str,
     provider: &str,

--- a/agentmux-srv/src/migrations/m0024_native_memory_backfill_from_fs.rs
+++ b/agentmux-srv/src/migrations/m0024_native_memory_backfill_from_fs.rs
@@ -49,6 +49,32 @@
 //!    `agent_native_memory_version_relabel_rollout_first_sight`, which
 //!    documents each clause. It cannot touch a genuine external write.
 //!
+//! ## Why this is Channel-scoped, and which store enumerates
+//!
+//! The two stores are not interchangeable, and picking the wrong one here
+//! would have reproduced the exact bug this migration exists to fix
+//! (caught in review before merge, not by me):
+//!
+//! - **Versions** (`db_agent_native_memory_versions`) live in the SHARED
+//!   store, so every read/insert/relabel below uses `shared_store_path`.
+//! - **Enumeration** does not. `list_all_memory_targets` calls
+//!   `agent_def_list()`, which prepares against `db_agents`, and
+//!   `memory_dir_for_agent_by_id`, which reads `db_agent_content` — both
+//!   per-channel tables created by `run_object_schema`, absent from
+//!   `Store::open_shared` by design (see its doc comment). Handing it the
+//!   shared store makes `agent_def_list()` fail with a SQL error that
+//!   `list_all_memory_targets` swallows (`if let Ok(agents)`), so that
+//!   whole enumeration path silently yields nothing and only currently
+//!   *active* registry agents get backfilled — every persisted-but-idle
+//!   agent missed, which is the same "read the wrong source, get an empty
+//!   list, look successful" failure as `m0023`.
+//!
+//! So the migration is `Channel`-scoped: it runs once per channel, with
+//! that channel's own store doing the enumeration — matching what the
+//! drift sweep itself gets in production (`state.wstore` is the channel
+//! store) — while still reading and writing versions in the shared store.
+//! The repair half is idempotent, so running once per channel is safe.
+//!
 //! Order matters: repair runs FIRST. Relabeling turns a row into the
 //! `agent_inferred` version the pair should have had, which then makes
 //! step 2's "has no version yet" test correctly skip that pair. Backfilling
@@ -65,7 +91,7 @@ pub struct M0024NativeMemoryBackfillFromFs;
 
 impl Migration for M0024NativeMemoryBackfillFromFs {
     fn id(&self) -> &'static str { "0024_native_memory_backfill_from_fs" }
-    fn scope(&self) -> MigrationScope { MigrationScope::Global }
+    fn scope(&self) -> MigrationScope { MigrationScope::Channel }
     fn description(&self) -> &'static str {
         "Backfill native memory versions from disk; repair mislabeled rollout rows"
     }
@@ -88,7 +114,22 @@ impl Migration for M0024NativeMemoryBackfillFromFs {
             })?;
 
         // ── 2. Backfill anything still unversioned, reading the filesystem.
-        let targets = crate::server::native_memory_handlers::list_all_memory_targets(&store);
+        // Enumerate with the CHANNEL store — see the module doc. Absent on
+        // a channel whose objects.db hasn't been created yet, in which case
+        // there are no agents here to backfill and the repair above was the
+        // whole job.
+        if !ctx.channel_store_path.exists() {
+            tracing::info!(
+                relabeled,
+                "native_memory_backfill_from_fs: no channel store yet; repair-only pass"
+            );
+            return Ok(());
+        }
+        let channel_store = Store::open(&ctx.channel_store_path).map_err(|e| {
+            MigrationError(format!("native_memory_backfill_from_fs: open channel store: {e}"))
+        })?;
+        let targets =
+            crate::server::native_memory_handlers::list_all_memory_targets(&channel_store);
         let mut backfilled = 0usize;
         let mut skipped_already_versioned = 0usize;
         let mut unreadable = 0usize;
@@ -239,6 +280,57 @@ mod tests {
         let versions = store.agent_native_memory_version_list("agent-1", "MEMORY.md").unwrap();
         assert_eq!(versions.len(), 1);
         assert_eq!(versions[0].source, "agent_inferred");
+    }
+
+    /// The regression the review caught before merge: enumeration must use
+    /// the CHANNEL store. With the shared store, `agent_def_list()` fails on
+    /// the missing `db_agents` table, `list_all_memory_targets` swallows the
+    /// error, and this agent's on-disk memory is silently never backfilled —
+    /// the same "wrong source, empty list, looks fine" failure as m0023.
+    #[test]
+    fn backfills_an_on_disk_file_for_an_agent_only_the_channel_store_knows() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shared_path = tmp.path().join("shared.db");
+        let channel_path = tmp.path().join("objects.db");
+        let shared = Store::open_shared(&shared_path).unwrap();
+        let channel = Store::open(&channel_path).unwrap();
+
+        // An agent whose memory dir resolves via working_directory +
+        // CLAUDE_CONFIG_DIR — both per-channel reads.
+        let mut def = crate::backend::storage::agents::test_agent_def(
+            "agent-1", "Agent One", "claude", "agent", 1000, "",
+        );
+        def.working_directory = "/wd".to_string();
+        channel.agent_def_insert(&mut def).unwrap();
+        channel
+            .agent_content_set(&crate::backend::storage::AgentContent {
+                agent_id: def.id.clone(),
+                content_type: "env".to_string(),
+                content: format!("CLAUDE_CONFIG_DIR={}\n", tmp.path().display()),
+                updated_at: 1000,
+            })
+            .unwrap();
+
+        // memory_dir_for_cwd maps "/wd" -> "-wd" (non-alphanumerics to '-').
+        let mem_dir = tmp.path().join("projects").join("-wd").join("memory");
+        std::fs::create_dir_all(&mem_dir).unwrap();
+        std::fs::write(mem_dir.join("MEMORY.md"), "content that predates version tracking").unwrap();
+
+        M0024NativeMemoryBackfillFromFs
+            .up(&MigrationContext {
+                home: tmp.path().to_path_buf(),
+                data_dir: tmp.path().to_path_buf(),
+                shared_store_path: shared_path.clone(),
+                channel_store_path: channel_path.clone(),
+            })
+            .unwrap();
+
+        let latest = shared
+            .agent_native_memory_version_latest(&def.id, "MEMORY.md")
+            .unwrap()
+            .expect("the on-disk file must be backfilled, not silently skipped");
+        assert_eq!(latest.source, "agent_inferred");
+        assert_eq!(latest.content, "content that predates version tracking");
     }
 
     /// A store with no shared file at all must not error — the migration

--- a/agentmux-srv/src/migrations/m0024_native_memory_backfill_from_fs.rs
+++ b/agentmux-srv/src/migrations/m0024_native_memory_backfill_from_fs.rs
@@ -1,0 +1,252 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Finish the job `m0023` was meant to do, and repair the label it left
+//! behind — `SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md`
+//! §9 (rollout backfill) and §4.5 (drift detection).
+//!
+//! ## What went wrong
+//!
+//! §9 asks for "a one-time backfill [of] a single `source: 'agent_inferred'`
+//! version per existing `(agent_id, filename)` row ... so history views
+//! aren't empty for pre-existing memory on upgrade". `m0023` implements
+//! that literally, iterating `db_agent_native_memory` — the **mirror**
+//! table. The spec's own wording ("per existing ... row") is what led
+//! there, and it is wrong in practice for one reason: that mirror is
+//! populated lazily, only once something reads or exports an agent's
+//! memory. On a typical install it is EMPTY, so `m0023` iterates nothing
+//! and backfills nothing, in 0 ms.
+//!
+//! The drift sweep (`backend::native_memory_drift`) does not use the
+//! mirror — it reads the real filesystem, which is authoritative here
+//! (`SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md`). Starting moments
+//! after migrations finish, it finds those same files, sees no recorded
+//! version, and records each as `external_fs_write` — rendered in Armory
+//! as **"Detected outside AgentMux — provenance unknown"**.
+//!
+//! Net effect on every install that upgraded with an unpopulated mirror:
+//! ordinary pre-existing memory files are permanently tagged with a
+//! security-flavored warning, and the benign backfill the spec asked for
+//! never happened. Observed on a real install: `m0023` applied at
+//! `…285933` (0 ms, 0 rows, mirror empty), 21 `external_fs_write` rows
+//! written across 6 agents and 16 files 61 ms later at `…285994`.
+//!
+//! This is NOT a race — `bootstrap` runs migrations to completion before
+//! the drift tasks spawn. Ordering was never the problem; reading the
+//! wrong source was. That is why the fix below is a migration and not a
+//! change to startup sequencing.
+//!
+//! ## What this does
+//!
+//! 1. **Backfill from the filesystem**, the same source the detector
+//!    trusts, via the same `list_all_memory_targets` enumeration — so the
+//!    two agree by construction instead of by coincidence. Idempotent and
+//!    ordering-safe for exactly the reason `m0023` documents: only a pair
+//!    with NO version yet is touched, so a pair written normally since
+//!    upgrade never gets an out-of-chronology row appended.
+//! 2. **Repair the mislabeled rows** already written by the sweep, under a
+//!    deliberately narrow predicate — see
+//!    `agent_native_memory_version_relabel_rollout_first_sight`, which
+//!    documents each clause. It cannot touch a genuine external write.
+//!
+//! Order matters: repair runs FIRST. Relabeling turns a row into the
+//! `agent_inferred` version the pair should have had, which then makes
+//! step 2's "has no version yet" test correctly skip that pair. Backfilling
+//! first would leave the pair versioned but still mislabeled, and the
+//! repair's `parent_version_id IS NULL` clause would no longer match.
+
+use std::sync::Arc;
+
+use crate::backend::storage::store::Store;
+
+use super::{Migration, MigrationContext, MigrationError, MigrationScope};
+
+pub struct M0024NativeMemoryBackfillFromFs;
+
+impl Migration for M0024NativeMemoryBackfillFromFs {
+    fn id(&self) -> &'static str { "0024_native_memory_backfill_from_fs" }
+    fn scope(&self) -> MigrationScope { MigrationScope::Global }
+    fn description(&self) -> &'static str {
+        "Backfill native memory versions from disk; repair mislabeled rollout rows"
+    }
+
+    fn up(&self, ctx: &MigrationContext) -> Result<(), MigrationError> {
+        if !ctx.shared_store_path.exists() {
+            return Ok(());
+        }
+        let store = Arc::new(
+            Store::open_shared(&ctx.shared_store_path).map_err(|e| {
+                MigrationError(format!("native_memory_backfill_from_fs: open shared store: {e}"))
+            })?,
+        );
+
+        // ── 1. Repair first (see the module doc for why the order matters).
+        let relabeled = store
+            .agent_native_memory_version_relabel_rollout_first_sight()
+            .map_err(|e| {
+                MigrationError(format!("native_memory_backfill_from_fs: relabel: {e}"))
+            })?;
+
+        // ── 2. Backfill anything still unversioned, reading the filesystem.
+        let targets = crate::server::native_memory_handlers::list_all_memory_targets(&store);
+        let mut backfilled = 0usize;
+        let mut skipped_already_versioned = 0usize;
+        let mut unreadable = 0usize;
+
+        for (agent_id, dir) in targets {
+            let entries = match std::fs::read_dir(&dir) {
+                Ok(e) => e,
+                // A configured agent whose memory dir doesn't exist yet is
+                // ordinary, not an error. Same tolerance the sweep has.
+                Err(_) => continue,
+            };
+            for entry in entries.flatten() {
+                let filename = entry.file_name().to_string_lossy().into_owned();
+                if !filename.ends_with(".md") {
+                    continue;
+                }
+                if !entry.path().is_file() {
+                    continue;
+                }
+                let existing = store
+                    .agent_native_memory_version_latest(&agent_id, &filename)
+                    .map_err(|e| {
+                        MigrationError(format!(
+                            "native_memory_backfill_from_fs: check existing for {agent_id}/{filename}: {e}"
+                        ))
+                    })?;
+                if existing.is_some() {
+                    skipped_already_versioned += 1;
+                    continue;
+                }
+                // Oversized/unreadable files are skipped, never truncated:
+                // recording a partial body as a *version* would misrepresent
+                // content the file never held as authoritative (the same
+                // reasoning `read_memory_file_lossy` documents). One bad file
+                // must not abort the backfill for every other agent.
+                let content = match crate::backend::native_memory_drift::read_memory_file_lossy(
+                    &entry.path(),
+                ) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        tracing::warn!(
+                            agent_id, filename, error = %e,
+                            "native_memory_backfill_from_fs: skipping unreadable file"
+                        );
+                        unreadable += 1;
+                        continue;
+                    }
+                };
+                store
+                    .agent_native_memory_version_insert(
+                        &agent_id, &filename, &content, "agent_inferred", "{}", "",
+                    )
+                    .map_err(|e| {
+                        MigrationError(format!(
+                            "native_memory_backfill_from_fs: insert for {agent_id}/{filename}: {e}"
+                        ))
+                    })?;
+                backfilled += 1;
+            }
+        }
+
+        tracing::info!(
+            relabeled, backfilled, skipped_already_versioned, unreadable,
+            "native_memory_backfill_from_fs: complete"
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx_for(shared_store_path: std::path::PathBuf) -> MigrationContext {
+        MigrationContext {
+            home: std::env::temp_dir(),
+            data_dir: std::env::temp_dir(),
+            shared_store_path,
+            channel_store_path: std::env::temp_dir().join("unused-objects.db"),
+        }
+    }
+
+    /// Record that `m0023` ran just now, which is what puts a version
+    /// inserted by a test inside the repair's rollout window. Writes
+    /// through its own connection to the same file rather than the
+    /// `Store`, whose `conn` is private to `backend::storage`.
+    fn record_m0023_now(db_path: &std::path::Path) {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        let secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let applied_at: String = conn
+            .query_row(
+                "SELECT strftime('%Y-%m-%dT%H:%M:%S+00:00', ?1, 'unixepoch')",
+                rusqlite::params![secs],
+                |r| r.get(0),
+            )
+            .unwrap();
+        conn.execute(
+            "INSERT INTO db_migrations (id, applied_at, duration_ms, scope)
+             VALUES ('0023_native_memory_versions_backfill', ?1, 0, 'global')",
+            rusqlite::params![applied_at],
+        )
+        .unwrap();
+    }
+
+    /// The real-world regression, end to end at the migration level: an
+    /// install where m0023 backfilled nothing and the sweep then claimed
+    /// the pre-existing files as "detected outside AgentMux".
+    #[test]
+    fn repairs_the_mislabeled_rollout_rows() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let store = Store::open_shared(tmp.path()).unwrap();
+        record_m0023_now(tmp.path());
+        store
+            .agent_native_memory_version_insert(
+                "agent-1", "MEMORY.md", "pre-existing", "external_fs_write",
+                r#"{"detected_via":"reconciliation_sweep"}"#, "",
+            )
+            .unwrap();
+
+        M0024NativeMemoryBackfillFromFs.up(&ctx_for(tmp.path().to_path_buf())).unwrap();
+
+        let versions = store.agent_native_memory_version_list("agent-1", "MEMORY.md").unwrap();
+        assert_eq!(versions.len(), 1, "repair must relabel in place, never append a row");
+        assert_eq!(versions[0].source, "agent_inferred");
+    }
+
+    /// Running it twice must not double-apply or append anything — an
+    /// operator re-running migrations is routine.
+    #[test]
+    fn is_idempotent_on_a_second_run() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let store = Store::open_shared(tmp.path()).unwrap();
+        record_m0023_now(tmp.path());
+        store
+            .agent_native_memory_version_insert(
+                "agent-1", "MEMORY.md", "pre-existing", "external_fs_write",
+                r#"{"detected_via":"reconciliation_sweep"}"#, "",
+            )
+            .unwrap();
+
+        let ctx = ctx_for(tmp.path().to_path_buf());
+        M0024NativeMemoryBackfillFromFs.up(&ctx).unwrap();
+        M0024NativeMemoryBackfillFromFs.up(&ctx).unwrap();
+
+        let versions = store.agent_native_memory_version_list("agent-1", "MEMORY.md").unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].source, "agent_inferred");
+    }
+
+    /// A store with no shared file at all must not error — the migration
+    /// runner calls every migration on every install.
+    #[test]
+    fn is_a_no_op_when_the_shared_store_does_not_exist() {
+        let missing = std::env::temp_dir().join("agentmux-m0024-does-not-exist.db");
+        let _ = std::fs::remove_file(&missing);
+        M0024NativeMemoryBackfillFromFs.up(&ctx_for(missing)).unwrap();
+    }
+}

--- a/agentmux-srv/src/migrations/mod.rs
+++ b/agentmux-srv/src/migrations/mod.rs
@@ -54,6 +54,7 @@ mod m0020_agent_color_backfill;
 mod m0021_backfill_agent_bundles;
 mod m0022_identity_store_links_backfill;
 mod m0023_native_memory_versions_backfill;
+mod m0024_native_memory_backfill_from_fs;
 mod runner;
 
 pub use runner::count_pending_migrations;
@@ -153,4 +154,5 @@ static REGISTRY: &[&(dyn Migration + Sync)] = &[
     &m0021_backfill_agent_bundles::M0021BackfillAgentBundles,
     &m0022_identity_store_links_backfill::M0022IdentityStoreLinksBackfill,
     &m0023_native_memory_versions_backfill::M0023NativeMemoryVersionsBackfill,
+    &m0024_native_memory_backfill_from_fs::M0024NativeMemoryBackfillFromFs,
 ];


### PR DESCRIPTION
Pre-existing memory files show up in Armory's Native Memory history tagged **"Detected outside AgentMux — provenance unknown."** They are ordinary files. Nothing wrote them out of band.

## What actually happened

`SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md` §9 asks for a rollout backfill of "one `source: 'agent_inferred'` version per existing `(agent_id, filename)` **row**". `m0023` implements that literally, iterating `db_agent_native_memory` — the **mirror** table.

That mirror is populated lazily, only once something reads or exports an agent's memory. **On a typical install it is empty.** So `m0023` iterates nothing and backfills nothing, in 0 ms.

The drift sweep (§4.5) doesn't use the mirror — it reads the real filesystem, which is authoritative here per `SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md`. Moments after migrations finish it finds those same files, sees no recorded version, and records each as `external_fs_write`.

Measured on a real affected install:

| | |
|---|---|
| `m0023` applied | `…285933`, **0 ms, 0 rows** (mirror empty, still 0 rows today) |
| sweep wrote | `…285994` — **61 ms later** |
| result | **21 rows**, 6 agents, 16 files, all `reconciliation_sweep`, all `parent_version_id IS NULL`, all inside one second |
| since then | **0** further versions recorded in 2.5 weeks |

**This is not a race.** `bootstrap` runs migrations to completion before the drift tasks spawn — that's why the timestamps are 61 ms apart rather than interleaved. Ordering was never the problem; reading a lazily-populated mirror instead of the authoritative filesystem was. Hence a migration, not a change to startup sequencing.

## The fix (`m0024`)

1. **Backfill from the filesystem**, via the same `list_all_memory_targets` enumeration the detector uses — so the two agree by construction rather than by coincidence. Same idempotency guard `m0023` documents: only a pair with no version yet is touched, so nothing lands out of chronological order.
2. **Repair the rows already written.** Runs *first* — relabeling gives the pair the `agent_inferred` version it should have had, which then makes step 1 correctly skip it.

### The repair predicate is deliberately narrow

Relabeling a provenance claim is not something to do speculatively. All four must hold:

- `source = 'external_fs_write'` **and** `detected_via = 'reconciliation_sweep'` — the slow path is the only one that can observe a never-before-seen file at startup;
- `parent_version_id IS NULL` — genuine first sight, not an observed change to something already tracked;
- `created_at` inside a **5-minute window anchored to `m0023`'s own `applied_at`**.

That last clause is load-bearing: **a memory file created out-of-band next week is also first-sight-via-sweep, and that one is a real external write whose label must stand.** Only the burst that raced this specific migration is in scope. No `m0023` row (fresh install) → the subquery is NULL → clean no-op.

`source_detail` keeps the original `detected_via` and records that the row was relabeled, so the audit trail says what happened instead of presenting the new claim as if it were the original observation:

```json
{"relabeled_from":"external_fs_write","detected_via":"reconciliation_sweep","reason":"rollout_first_sight"}
```

## Verification

- **Against a copy of a real affected store**: all 21 rows relabel to `agent_inferred`, nothing else matches. Original untouched — the run was on a copy.
- **6 new store tests** pin the predicate, including the two negatives that matter: a later genuine external write, and an observed change to an already-tracked file. Plus fs_watch-detected rows, the no-m0023 case, and idempotency.
- **3 new migration tests**: repair end to end, idempotent on re-run, no-op with no shared store.
- `cargo test -p agentmux-srv`: **3051 passed**. Three failures are pre-existing on clean `main` and unrelated — two `lan_listeners` socket-binding tests whose own names say `is_platform_dependent` (macOS-only; CI's legs are ubuntu/windows), and one that passes single-threaded as CI runs it. I verified all three fail identically on `origin/main` with my changes stashed.

## Not covered

Phase 1's filesystem enumeration isn't unit-tested end to end — `list_all_memory_targets` needs agent definitions, working directories and the shared registry, which is heavy env-dependent scaffolding. It's the same call the drift sweep already relies on; the phase-1 insert path is otherwise identical to `m0023`'s, which has its own tests.

<!-- agentmux:agent_id=agento -->