### PR TITLE
docs: regenerate the stale specs index (again — concurrent-PR merge artifact)

### DIFF
--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -339,7 +339,7 @@ partial list.
 | [`SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04`](SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md) | Spec: optional system-tray + persistent background service, cross-platform |
 | [`SPEC_WINDOW_NAME_API_HARDENING_2026_08_08`](SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md) | SPEC: Window-name App API hardening (phantom-id success + status codes) |
 
-### proposed (95)
+### proposed (96)
 
 | Spec | Title |
 |---|---|


### PR DESCRIPTION
**One line, unblocks every open PR again.** Same symptom as #3050 two hours ago, different and more interesting cause.

```
gen-docs-index: INDEX.md is STALE.
    342c342
    < ### proposed (95)
    ---
    > ### proposed (96)
```

## Why it came back

`INDEX.md` is a **generated** file that is **tracked in git**. Two PRs editing it concurrently merge textually without a conflict and land on a number neither of them computed:

1. **#3050** regenerated `96 → 95` (a spec had moved out of `proposed`).
2. **#3046** added a new `proposed` spec, `SPEC_RPC_BINDINGS_CODEGEN_2026_09_07.md`, and included an `INDEX.md` regenerated against **pre-#3050** main — correct for the main it branched from.
3. Git merged both edits cleanly. Committed count stayed `95`; the true count is `96`.

**#3046 did nothing wrong.** This is exactly the failure the gate's own header warns about — *"CI tests the PR MERGE commit, not your branch head"* — and it will keep recurring for as long as a generated artifact is tracked and hand-merged. Every occurrence blocks whichever unrelated PR happens to run next; it caught mine (#3055) this time.

This PR is just the generator's output, unedited: one line, `95` → `96`.

## Worth a follow-up, not in this PR

The repeat is the signal. Options, roughly in order of how invasive they are:

- Have CI **regenerate and commit** `INDEX.md` on merge to main instead of asserting freshness on every PR — the file has no reviewable content, so a bot owning it costs nothing.
- Or add a `merge=union`-style `.gitattributes` entry / a merge driver that re-runs the generator on conflict.
- Or drop the counts from the section headers, which are the only part that goes stale from a concurrent add; the row lists themselves merge cleanly.

Happy to do whichever the docs owner prefers — flagging rather than choosing, since it's their gate.

<!-- agentmux:agent_id=agento -->