### PR TITLE
Camper@claudius: feat(abf): authoring UI for per-provider instruction overrides — closes the last ABF v0.2 gap

### DIFF
--- a/.changesets/1788768360-feat-abf-authoring-ui-for-per-provider-instruction-overrides-ir4m.md
+++ b/.changesets/1788768360-feat-abf-authoring-ui-for-per-provider-instruction-overrides-ir4m.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(abf): authoring UI for per-provider instruction overrides (instructions_by_provider)

--- a/frontend/app/view/memory/BundleProviderInstructionsSection.tsx
+++ b/frontend/app/view/memory/BundleProviderInstructionsSection.tsx
@@ -25,7 +25,7 @@
  * our own last write (switching bundles, a fresh load).
  */
 
-import { createEffect, createMemo, createSignal, For, Show, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, For, Index, Show, type JSX } from "solid-js";
 import { showTextInputContextMenu } from "@/app/store/contextmenu";
 import { PROVIDERS } from "@/app/view/agent/providers/catalog";
 import {
@@ -103,10 +103,17 @@ export const BundleProviderInstructionsSection = (
                     </div>
                 }
             >
-                <For each={rows()}>
+                {/* <Index>, NOT <For>: these rows are index-addressed and every
+                    edit replaces the row object, which <For> keys by identity —
+                    so it would dispose and recreate the row's DOM on every
+                    keystroke, dropping focus after each character and making
+                    the field unusable for normal typing (codex P1, #3063).
+                    <Index> keys by position and hands the item in as an
+                    accessor, so the input element survives edits. */}
+                <Index each={rows()}>
                     {(row, index) => {
-                        const problem = () => providerKeyProblem(row.provider);
-                        const duped = () => dupes().has(row.provider.trim());  // keyed on the raw trimmed key, which is what duplicateProviderKeys reports
+                        const problem = () => providerKeyProblem(row().provider);
+                        const duped = () => dupes().has(row().provider.trim());  // keyed on the raw trimmed key, which is what duplicateProviderKeys reports
                         return (
                             <div class="memory-view-provider-instruction-row">
                                 <div class="memory-view-provider-instruction-head">
@@ -114,16 +121,16 @@ export const BundleProviderInstructionsSection = (
                                         class="memory-view-input"
                                         list="abf-known-providers"
                                         placeholder="Provider (e.g. claude)"
-                                        value={row.provider}
+                                        value={row().provider}
                                         onInput={(e) =>
-                                            updateRow(index(), { provider: e.currentTarget.value })
+                                            updateRow(index, { provider: e.currentTarget.value })
                                         }
                                         onContextMenu={showTextInputContextMenu}
                                     />
                                     <button
                                         type="button"
                                         class="memory-view-provider-instruction-remove"
-                                        onClick={() => removeRow(index())}
+                                        onClick={() => removeRow(index)}
                                         title="Remove this provider override"
                                     >
                                         Remove
@@ -144,7 +151,7 @@ export const BundleProviderInstructionsSection = (
                                           warning, so it vanishes from the .abf. */}
                                     <div class="memory-view-provider-instruction-warn">
                                         {problem()}{" "}
-                                        {row.provider.trim().length === 0
+                                        {row().provider.trim().length === 0
                                             ? "This row will not be saved until you name it."
                                             : "It will still be saved, but skipped when this bundle is exported."}
                                     </div>
@@ -158,9 +165,9 @@ export const BundleProviderInstructionsSection = (
                                 <textarea
                                     class="memory-view-textarea"
                                     rows={5}
-                                    value={row.content}
+                                    value={row().content}
                                     onInput={(e) =>
-                                        updateRow(index(), { content: e.currentTarget.value })
+                                        updateRow(index, { content: e.currentTarget.value })
                                     }
                                     onContextMenu={showTextInputContextMenu}
                                     placeholder="Instructions used only when this bundle runs on this provider."
@@ -168,7 +175,7 @@ export const BundleProviderInstructionsSection = (
                             </div>
                         );
                     }}
-                </For>
+                </Index>
 
                 <datalist id="abf-known-providers">
                     <For each={knownProviders()}>{(p) => <option value={p} />}</For>

--- a/frontend/app/view/memory/BundleProviderInstructionsSection.tsx
+++ b/frontend/app/view/memory/BundleProviderInstructionsSection.tsx
@@ -1,0 +1,170 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * BundleProviderInstructionsSection — authoring UI for ABF v0.2 §2.2's
+ * `instructions_by_provider`: per-provider overrides of the bundle's default
+ * Instructions, applied when the agent runs on that specific CLI/harness.
+ *
+ * Closes the last gap in ABF v0.2. Storage, export (`instructions/<provider>/
+ * AGENTS.md`) and import all shipped in #2521/#2523/#2527; the spec committed
+ * to shipping "the storage shape, the authoring UI, and export/import", and
+ * only the authoring half was missing — an imported bundle's variants
+ * round-tripped through the form untouched but could not be created or edited
+ * in the app at all.
+ *
+ * WHY THIS IS A CONTROLLED/UNCONTROLLED HYBRID, which is the one subtle thing
+ * here: the draft stores this field as a RAW JSON STRING, deliberately (see
+ * `memory-model.ts`'s seam comment — round-tripping the string verbatim is
+ * what fixed reagent P1 on #2523, where editing any field silently wiped an
+ * imported bundle's variants). Deriving the rows from that string on every
+ * keystroke would make a row vanish the moment its provider key went blank,
+ * because a blank key cannot be represented in a JSON object. So rows live in
+ * local state and are serialized OUT to the draft on each edit, while an
+ * effect re-seeds them if the incoming string changes for a reason other than
+ * our own last write (switching bundles, a fresh load).
+ */
+
+import { createEffect, createMemo, createSignal, For, Show, type JSX } from "solid-js";
+import { showTextInputContextMenu } from "@/app/store/contextmenu";
+import { PROVIDERS } from "@/app/view/agent/providers/catalog";
+import {
+    duplicateProviderKeys,
+    parseInstructionsByProvider,
+    providerKeyProblem,
+    serializeInstructionsByProvider,
+    type ProviderInstruction,
+} from "./memory-model";
+
+interface BundleProviderInstructionsSectionProps {
+    /** The draft's raw `instructions_by_provider` JSON string. */
+    value: string;
+    onChange: (nextRaw: string) => void;
+}
+
+export const BundleProviderInstructionsSection = (
+    props: BundleProviderInstructionsSectionProps,
+): JSX.Element => {
+    const parsed = createMemo(() => parseInstructionsByProvider(props.value));
+
+    const [rows, setRows] = createSignal<ProviderInstruction[]>(parsed().entries);
+    // What we last wrote out, so the re-seed effect can tell an external change
+    // (bundle switch) apart from the echo of our own edit.
+    let lastEmitted = props.value;
+
+    createEffect(() => {
+        const incoming = props.value;
+        if (incoming === lastEmitted) return;
+        lastEmitted = incoming;
+        setRows(parseInstructionsByProvider(incoming).entries);
+    });
+
+    const emit = (next: ProviderInstruction[]) => {
+        setRows(next);
+        const raw = serializeInstructionsByProvider(next);
+        lastEmitted = raw;
+        props.onChange(raw);
+    };
+
+    const updateRow = (index: number, patch: Partial<ProviderInstruction>) => {
+        emit(rows().map((r, i) => (i === index ? { ...r, ...patch } : r)));
+    };
+
+    const removeRow = (index: number) => {
+        emit(rows().filter((_, i) => i !== index));
+    };
+
+    const addRow = () => {
+        // Blank key by design: the user names it. It is flagged immediately and
+        // simply does not serialize until named, so an unnamed row can never
+        // reach storage or export.
+        emit([...rows(), { provider: "", content: "" }]);
+    };
+
+    const dupes = createMemo(() => new Set(duplicateProviderKeys(rows())));
+    const knownProviders = createMemo(() => Object.keys(PROVIDERS).sort());
+
+    return (
+        <div class="memory-view-provider-instructions">
+            <Show
+                when={!parsed().malformed}
+                fallback={
+                    // Refusing to edit is the correct behavior, not a cop-out:
+                    // rendering an empty editor here would serialize `{}` over
+                    // the stored value on the next save and destroy variants we
+                    // merely failed to parse. The raw string is preserved
+                    // untouched, so an export/re-import or a manual fix
+                    // recovers it.
+                    <div class="memory-view-provider-instructions-malformed">
+                        This bundle's per-provider instructions are not readable as a JSON
+                        object of provider → text, so they cannot be edited here. The stored
+                        value is preserved exactly as-is and will survive saving this form —
+                        nothing is lost. Export the bundle to inspect or repair it.
+                    </div>
+                }
+            >
+                <For each={rows()}>
+                    {(row, index) => {
+                        const problem = () => providerKeyProblem(row.provider);
+                        const duped = () => dupes().has(row.provider.trim());
+                        return (
+                            <div class="memory-view-provider-instruction-row">
+                                <div class="memory-view-provider-instruction-head">
+                                    <input
+                                        class="memory-view-input"
+                                        list="abf-known-providers"
+                                        placeholder="Provider (e.g. claude)"
+                                        value={row.provider}
+                                        onInput={(e) =>
+                                            updateRow(index(), { provider: e.currentTarget.value })
+                                        }
+                                        onContextMenu={showTextInputContextMenu}
+                                    />
+                                    <button
+                                        type="button"
+                                        class="memory-view-provider-instruction-remove"
+                                        onClick={() => removeRow(index())}
+                                        title="Remove this provider override"
+                                    >
+                                        Remove
+                                    </button>
+                                </div>
+                                <Show when={problem()}>
+                                    <div class="memory-view-provider-instruction-warn">
+                                        {problem()} It will not be saved.
+                                    </div>
+                                </Show>
+                                <Show when={!problem() && duped()}>
+                                    <div class="memory-view-provider-instruction-warn">
+                                        Duplicate provider key — only one of these will survive
+                                        export.
+                                    </div>
+                                </Show>
+                                <textarea
+                                    class="memory-view-textarea"
+                                    rows={5}
+                                    value={row.content}
+                                    onInput={(e) =>
+                                        updateRow(index(), { content: e.currentTarget.value })
+                                    }
+                                    onContextMenu={showTextInputContextMenu}
+                                    placeholder="Instructions used only when this bundle runs on this provider."
+                                />
+                            </div>
+                        );
+                    }}
+                </For>
+
+                <datalist id="abf-known-providers">
+                    <For each={knownProviders()}>{(p) => <option value={p} />}</For>
+                </datalist>
+
+                <button type="button" class="memory-view-provider-instruction-add" onClick={addRow}>
+                    + Add provider override
+                </button>
+            </Show>
+        </div>
+    );
+};
+
+BundleProviderInstructionsSection.displayName = "BundleProviderInstructionsSection";

--- a/frontend/app/view/memory/BundleProviderInstructionsSection.tsx
+++ b/frontend/app/view/memory/BundleProviderInstructionsSection.tsx
@@ -106,7 +106,7 @@ export const BundleProviderInstructionsSection = (
                 <For each={rows()}>
                     {(row, index) => {
                         const problem = () => providerKeyProblem(row.provider);
-                        const duped = () => dupes().has(row.provider.trim());
+                        const duped = () => dupes().has(row.provider.trim());  // keyed on the raw trimmed key, which is what duplicateProviderKeys reports
                         return (
                             <div class="memory-view-provider-instruction-row">
                                 <div class="memory-view-provider-instruction-head">
@@ -130,14 +130,29 @@ export const BundleProviderInstructionsSection = (
                                     </button>
                                 </div>
                                 <Show when={problem()}>
+                                    {/* The consequence differs by case and the
+                                        warning has to match, or it is just a
+                                        different wrong message (reagent P1,
+                                        #3063 said "It will not be saved" for
+                                        every problem, which was false for most
+                                        of them):
+                                        - blank key: genuinely not saved,
+                                          serializeInstructionsByProvider drops
+                                          it;
+                                        - any other rejected key: saved fine,
+                                          but bundle_export.rs skips it with a
+                                          warning, so it vanishes from the .abf. */}
                                     <div class="memory-view-provider-instruction-warn">
-                                        {problem()} It will not be saved.
+                                        {problem()}{" "}
+                                        {row.provider.trim().length === 0
+                                            ? "This row will not be saved until you name it."
+                                            : "It will still be saved, but skipped when this bundle is exported."}
                                     </div>
                                 </Show>
                                 <Show when={!problem() && duped()}>
                                     <div class="memory-view-provider-instruction-warn">
-                                        Duplicate provider key — only one of these will survive
-                                        export.
+                                        Two keys resolve to the same export path — only one of
+                                        them survives export.
                                     </div>
                                 </Show>
                                 <textarea

--- a/frontend/app/view/memory/memory-manager.tsx
+++ b/frontend/app/view/memory/memory-manager.tsx
@@ -26,6 +26,7 @@ import { showTextInputContextMenu } from "@/app/store/contextmenu";
 import { PROVIDERS } from "@/app/view/agent/providers/catalog";
 import { type MemoryDraft, MemoryViewModel } from "./memory-model";
 import { BundleMcpSection } from "./BundleMcpSection";
+import { BundleProviderInstructionsSection } from "./BundleProviderInstructionsSection";
 import { BundleSkillsSection } from "./BundleSkillsSection";
 
 import "./memory-view.scss";
@@ -389,7 +390,7 @@ const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element => {
                             <label class="memory-view-field">
                                 <span class="memory-view-field-label">
                                     Instructions
-                                    <FieldHelp text="The default system prompt injected into the agent's context at launch — provider-agnostic, applies regardless of which CLI/harness the agent uses. ABF v0.2 supports additional per-provider variants (instructions_by_provider) that override this for a specific harness; there's no authoring UI for those yet, but an imported bundle's variants round-trip through this form unchanged." />
+                                    <FieldHelp text="The default system prompt injected into the agent's context at launch — provider-agnostic, applies regardless of which CLI/harness the agent uses. To override it for one specific harness, add a per-provider variant below; the default still applies to every provider without one." />
                                 </span>
                                 <textarea
                                     class="memory-view-textarea"
@@ -400,6 +401,19 @@ const MemoryManagerBody = (props: MemoryManagerBodyProps): JSX.Element => {
                                     }
                                     onContextMenu={showTextInputContextMenu}
                                     placeholder="System prompt. The agent's soul."
+                                />
+                            </label>
+
+                            <label class="memory-view-field">
+                                <span class="memory-view-field-label">
+                                    Per-provider instruction overrides
+                                    <FieldHelp text="ABF v0.2 §2.2. Each entry replaces the Instructions above when this bundle runs on that provider — it is an override, not an addition, and providers without an entry use the default unchanged. On export each becomes instructions/<provider>/AGENTS.md, so a key that is not a usable directory name is skipped; this form flags those before you save." />
+                                </span>
+                                <BundleProviderInstructionsSection
+                                    value={draft().instructions_by_provider}
+                                    onChange={(next) =>
+                                        updateDraft("instructions_by_provider", next)
+                                    }
                                 />
                             </label>
 

--- a/frontend/app/view/memory/memory-model.test.ts
+++ b/frontend/app/view/memory/memory-model.test.ts
@@ -1,8 +1,16 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { beforeEach, describe, expect, test, vi } from "vitest";
-import { draftFromMemory, draftToWire, emptyDraft } from "./memory-model";
+import { beforeEach, describe, expect, it, test, vi } from "vitest";
+import {
+    draftFromMemory,
+    draftToWire,
+    duplicateProviderKeys,
+    emptyDraft,
+    parseInstructionsByProvider,
+    providerKeyProblem,
+    serializeInstructionsByProvider,
+} from "./memory-model";
 
 // reagent P1, PR #2523: instructions_by_provider (ABF v0.2 §2.2) was
 // previously dropped by the edit round-trip. Since this form has no field
@@ -239,5 +247,103 @@ describe("validateDraft", () => {
         // change to the content it described.
         model.setValidation(null);
         expect(model.validationAtom()).toBeNull();
+    });
+});
+
+// -- ABF v0.2 §2.2 per-provider instructions: authoring-UI model layer --
+//
+// The authoring UI edits a parsed list, but the draft still carries the raw
+// JSON string, because that string is what round-trips (see the suite above,
+// which exists because reagent P1 on #2523 caught an edit silently wiping an
+// imported bundle's variants). These functions are the seam between the two,
+// so the wipe-safety property has to hold HERE or the UI reintroduces the bug.
+describe("instructions_by_provider authoring model", () => {
+    it("parses an object into sorted entries", () => {
+        const r = parseInstructionsByProvider('{"codex":"C","claude":"A"}');
+        expect(r.malformed).toBe(false);
+        expect(r.entries).toEqual([
+            { provider: "claude", content: "A" },
+            { provider: "codex", content: "C" },
+        ]);
+    });
+
+    it("treats empty/missing as an empty, editable set (not malformed)", () => {
+        for (const raw of ["", "   ", "{}"]) {
+            const r = parseInstructionsByProvider(raw);
+            expect(r.malformed).toBe(false);
+            expect(r.entries).toEqual([]);
+        }
+    });
+
+    // THE wipe-safety property. Malformed input must be reported as such and
+    // must NOT yield an empty entry list that the UI would then serialize back
+    // over the top of, destroying variants it merely failed to parse.
+    it("flags malformed JSON as malformed rather than as empty", () => {
+        for (const raw of ["not json", "[1,2]", '"a string"', "null", "42"]) {
+            const r = parseInstructionsByProvider(raw);
+            expect(r.malformed).toBe(true);
+            expect(r.entries).toEqual([]);
+        }
+    });
+
+    it("ignores non-string values rather than coercing them", () => {
+        const r = parseInstructionsByProvider('{"claude":"ok","codex":123}');
+        expect(r.malformed).toBe(true);
+        expect(r.entries).toEqual([]);
+    });
+
+    it("serializes entries back to a JSON object", () => {
+        expect(
+            serializeInstructionsByProvider([
+                { provider: "claude", content: "A" },
+                { provider: "codex", content: "C" },
+            ]),
+        ).toBe('{"claude":"A","codex":"C"}');
+    });
+
+    it("drops rows with a blank provider key on serialize", () => {
+        expect(
+            serializeInstructionsByProvider([
+                { provider: "  ", content: "orphaned" },
+                { provider: "claude", content: "A" },
+            ]),
+        ).toBe('{"claude":"A"}');
+    });
+
+    it("trims the provider key but never the content", () => {
+        expect(
+            serializeInstructionsByProvider([{ provider: " claude ", content: "  padded  " }]),
+        ).toBe(JSON.stringify({ claude: "  padded  " }));
+    });
+
+    it("round-trips parse -> serialize without altering content", () => {
+        const raw = JSON.stringify({ claude: ["line1", "line2"].join("\n"), codex: "  padded  " });
+        const { entries } = parseInstructionsByProvider(raw);
+        expect(serializeInstructionsByProvider(entries)).toBe(raw);
+    });
+
+    // Authoring-time mirror of the export-side rule
+    // (bundle_export.rs sanitize_context_relative_path): a key that is not a
+    // safe path segment is SKIPPED on export with a warning, so the variant is
+    // silently lost. Better to say so while the user is typing it.
+    it("rejects provider keys that would not survive export", () => {
+        for (const bad of ["", "   ", "a/b", "a\b", ".", "..", "with space/../esc"]) {
+            expect(providerKeyProblem(bad)).not.toBeNull();
+        }
+    });
+
+    it("accepts ordinary provider keys", () => {
+        for (const ok of ["claude", "codex", "gemini", "my-harness", "my_harness2"]) {
+            expect(providerKeyProblem(ok)).toBeNull();
+        }
+    });
+
+    it("flags duplicate keys, which export resolves by dropping all but one", () => {
+        const entries = [
+            { provider: "claude", content: "A" },
+            { provider: "claude", content: "B" },
+        ];
+        expect(duplicateProviderKeys(entries)).toEqual(["claude"]);
+        expect(duplicateProviderKeys([{ provider: "claude", content: "A" }])).toEqual([]);
     });
 });

--- a/frontend/app/view/memory/memory-model.test.ts
+++ b/frontend/app/view/memory/memory-model.test.ts
@@ -361,6 +361,26 @@ describe("instructions_by_provider authoring model", () => {
         expect(providerKeyProblem("a\bb")).toBeNull();
     });
 
+    // codex P2 on #3063. `out[key] = content` for key "__proto__" hits the
+    // inherited legacy setter instead of creating an own property, so
+    // JSON.stringify omits it — editing ANY row would then silently delete an
+    // imported __proto__ override. Same wipe-class bug the raw-string
+    // round-trip exists to prevent, arriving through a different door.
+    it("serializes a __proto__ key as an own property", () => {
+        expect(
+            serializeInstructionsByProvider([{ provider: "__proto__", content: "P" }]),
+        ).toBe('{"__proto__":"P"}');
+    });
+
+    it("round-trips a __proto__ key without losing it", () => {
+        const raw = '{"__proto__":"P","claude":"A"}';
+        const { entries, malformed } = parseInstructionsByProvider(raw);
+        expect(malformed).toBe(false);
+        expect(entries.map((e) => e.provider).sort()).toEqual(["__proto__", "claude"]);
+        const out = JSON.parse(serializeInstructionsByProvider(entries));
+        expect(Object.keys(out).sort()).toEqual(["__proto__", "claude"]);
+    });
+
     it("sanitizes to the path export will actually write", () => {
         expect(sanitizeProviderKey("claude")).toBe("claude");
         expect(sanitizeProviderKey(String.raw`a\b`)).toBe("a/b");
@@ -385,6 +405,28 @@ describe("instructions_by_provider authoring model", () => {
             ]),
         ).toEqual(["claude"]);
         expect(duplicateProviderKeys([{ provider: "claude", content: "A" }])).toEqual([]);
+    });
+
+    // reagent P1 on #3063. bundle_export.rs sorts RAW keys ascending and keeps
+    // the FIRST of a colliding set. Flagging by array order instead marks
+    // whichever row the UI happens to hold first — which can be the row export
+    // actually KEEPS, warning on the survivor while the row that is really
+    // dropped shows nothing. "a/b" (0x2F) sorts before "a\b" (0x5C), so the
+    // loser here is the backslash row even though it was added first.
+    it("flags the row export drops, not the one it keeps, regardless of UI order", () => {
+        // Built from a char code on purpose: a literal backslash in this
+        // file has been mangled by tooling more than once (it is what
+        // produced codex P2 on this very PR — "a-backslash-b" read as a backspace
+        // escape, so the separator case was never exercised).
+        const backslashKey = "a" + String.fromCharCode(92) + "b";
+        const uiOrder = [
+            { provider: backslashKey, content: "added first" },
+            { provider: "a/b", content: "added second" },
+        ];
+        expect(duplicateProviderKeys(uiOrder)).toEqual([backslashKey]);
+        // Reversing the UI order must not change the verdict — export does not
+        // care what order the form holds them in.
+        expect(duplicateProviderKeys([...uiOrder].reverse())).toEqual([backslashKey]);
     });
 
     it("does not report backend-rejected keys as duplicates", () => {

--- a/frontend/app/view/memory/memory-model.test.ts
+++ b/frontend/app/view/memory/memory-model.test.ts
@@ -9,6 +9,7 @@ import {
     emptyDraft,
     parseInstructionsByProvider,
     providerKeyProblem,
+    sanitizeProviderKey,
     serializeInstructionsByProvider,
 } from "./memory-model";
 
@@ -322,28 +323,78 @@ describe("instructions_by_provider authoring model", () => {
         expect(serializeInstructionsByProvider(entries)).toBe(raw);
     });
 
-    // Authoring-time mirror of the export-side rule
-    // (bundle_export.rs sanitize_context_relative_path): a key that is not a
-    // safe path segment is SKIPPED on export with a warning, so the variant is
-    // silently lost. Better to say so while the user is typing it.
-    it("rejects provider keys that would not survive export", () => {
-        for (const bad of ["", "   ", "a/b", "a\b", ".", "..", "with space/../esc"]) {
-            expect(providerKeyProblem(bad)).not.toBeNull();
-        }
+    // Authoring-time mirror of the export-side rule. These assertions are
+    // pinned to sanitize_context_relative_path (bundle_export.rs) EXACTLY —
+    // reagent P1 on #3063 caught the first version inventing stricter rules
+    // than the backend has, so it warned "It will not be saved" about keys
+    // that in fact export fine. A mirror that disagrees with what it mirrors
+    // is worse than no mirror.
+    it("rejects only the keys the backend actually rejects", () => {
+        // empty / no usable segment
+        expect(providerKeyProblem("")).not.toBeNull();
+        expect(providerKeyProblem("   ")).not.toBeNull();
+        expect(providerKeyProblem(".")).not.toBeNull();
+        expect(providerKeyProblem("./.")).not.toBeNull();
+        expect(providerKeyProblem("/")).not.toBeNull();
+        // leading separator, colon, traversal
+        expect(providerKeyProblem("/abs")).not.toBeNull();
+        expect(providerKeyProblem("C:/x")).not.toBeNull();
+        expect(providerKeyProblem("a:b")).not.toBeNull();
+        expect(providerKeyProblem("..")).not.toBeNull();
+        expect(providerKeyProblem("a/../b")).not.toBeNull();
     });
 
-    it("accepts ordinary provider keys", () => {
-        for (const ok of ["claude", "codex", "gemini", "my-harness", "my_harness2"]) {
+    // The backend normalizes "\" to "/" and splits — nested segments are legal
+    // and export to instructions/a/b/AGENTS.md. Warning about them was the
+    // actual defect in #3063's first cut.
+    it("accepts keys the backend accepts, including nested and odd ones", () => {
+        for (const ok of ["claude", "codex", "my-harness", "my_harness2", "a/b"]) {
             expect(providerKeyProblem(ok)).toBeNull();
         }
+        // Real backslash, via String.raw. The previous version of this test
+        // wrote "a\b", which JS reads as a BACKSPACE control character, so the
+        // separator case was never exercised and passed only by accident
+        // (reagent P2, #3063).
+        expect(providerKeyProblem(String.raw`a\b`)).toBeNull();
+        // Control characters are not rejected by the backend, so we must not
+        // claim they are.
+        expect(providerKeyProblem("a\bb")).toBeNull();
     });
 
-    it("flags duplicate keys, which export resolves by dropping all but one", () => {
-        const entries = [
-            { provider: "claude", content: "A" },
-            { provider: "claude", content: "B" },
-        ];
-        expect(duplicateProviderKeys(entries)).toEqual(["claude"]);
+    it("sanitizes to the path export will actually write", () => {
+        expect(sanitizeProviderKey("claude")).toBe("claude");
+        expect(sanitizeProviderKey(String.raw`a\b`)).toBe("a/b");
+        expect(sanitizeProviderKey("./a//b")).toBe("a/b");
+        expect(sanitizeProviderKey("..")).toBeNull();
+    });
+
+    // Export keys its collision set on the SANITIZED path, so two keys that
+    // differ as strings but normalize identically are a real collision — one
+    // of them is silently dropped from the .abf.
+    it("flags duplicates that collide only after sanitizing", () => {
+        expect(
+            duplicateProviderKeys([
+                { provider: "a/b", content: "A" },
+                { provider: String.raw`a\b`, content: "B" },
+            ]),
+        ).toEqual([String.raw`a\b`]);
+        expect(
+            duplicateProviderKeys([
+                { provider: "claude", content: "A" },
+                { provider: "claude", content: "B" },
+            ]),
+        ).toEqual(["claude"]);
         expect(duplicateProviderKeys([{ provider: "claude", content: "A" }])).toEqual([]);
+    });
+
+    it("does not report backend-rejected keys as duplicates", () => {
+        // They are already flagged by providerKeyProblem; double-warning about
+        // a key that never reaches export is noise.
+        expect(
+            duplicateProviderKeys([
+                { provider: "..", content: "A" },
+                { provider: "..", content: "B" },
+            ]),
+        ).toEqual([]);
     });
 });

--- a/frontend/app/view/memory/memory-model.test.ts
+++ b/frontend/app/view/memory/memory-model.test.ts
@@ -429,6 +429,33 @@ describe("instructions_by_provider authoring model", () => {
         expect(duplicateProviderKeys([...uiOrder].reverse())).toEqual([backslashKey]);
     });
 
+    // reagent P1 (round 3) on #3063. bundle_export.rs skips an entry whose
+    // content is blank BEFORE it reaches the sanitize/collision check
+    // (content.trim().is_empty() -> continue), so an empty-content row never
+    // occupies a collision slot. Ignoring content here re-created the exact
+    // "warning on the wrong row" defect the ordering fix had just removed,
+    // this time via emptiness instead of insertion order.
+    it("ignores blank-content rows when resolving collisions, as export does", () => {
+        const backslashKey = "a" + String.fromCharCode(92) + "b";
+        // "a/b" sorts first but is empty, so export skips it entirely and
+        // exports the backslash row with NO collision at all.
+        const entries = [
+            { provider: "a/b", content: "   " },
+            { provider: backslashKey, content: "real" },
+        ];
+        expect(duplicateProviderKeys(entries)).toEqual([]);
+    });
+
+    it("still flags a real collision when both rows have content", () => {
+        const backslashKey = "a" + String.fromCharCode(92) + "b";
+        expect(
+            duplicateProviderKeys([
+                { provider: "a/b", content: "kept" },
+                { provider: backslashKey, content: "dropped" },
+            ]),
+        ).toEqual([backslashKey]);
+    });
+
     it("does not report backend-rejected keys as duplicates", () => {
         // They are already flagged by providerKeyProblem; double-warning about
         // a key that never reaches export is noise.

--- a/frontend/app/view/memory/memory-model.ts
+++ b/frontend/app/view/memory/memory-model.ts
@@ -485,38 +485,74 @@ export function serializeInstructionsByProvider(entries: ProviderInstruction[]):
     return JSON.stringify(out);
 }
 
+/** Faithful port of `sanitize_context_relative_path` (bundle_export.rs).
+ *
+ *  Returns the sanitized path a key would be exported under, or `null` if the
+ *  backend would reject it (in which case export SKIPS the variant with a
+ *  warning). Kept deliberately mechanical rather than "improved", because its
+ *  only job is to agree with the Rust — a stricter frontend rule warns about
+ *  keys that in fact work, and a looser one stays silent about keys that get
+ *  dropped. Mirrors, in order: empty, `\` normalized to `/`, leading `/`
+ *  rejected, any `:` rejected, `..` segments rejected, `.`/empty segments
+ *  skipped, and "nothing left" rejected.
+ *
+ *  NOTE what this does NOT reject, because the backend does not either:
+ *  nested segments (`a/b` is legal and exports to instructions/a/b/AGENTS.md)
+ *  and control characters. */
+export function sanitizeProviderKey(provider: string): string | null {
+    // The stored key is the trimmed one (see serializeInstructionsByProvider),
+    // so validate what will actually be stored, not what was typed.
+    const key = provider.trim();
+    if (key.length === 0) return null;
+    const normalized = key.split("\\").join("/");
+    if (normalized.startsWith("/") || normalized.includes(":")) return null;
+    const parts: string[] = [];
+    for (const component of normalized.split("/")) {
+        if (component === "" || component === ".") continue;
+        if (component === "..") return null;
+        parts.push(component);
+    }
+    if (parts.length === 0) return null;
+    return parts.join("/");
+}
+
 /** Why a provider key would not survive export, or `null` if it is fine.
  *
- *  Mirrors the export-side rule in `bundle_export.rs`, which runs each key
- *  through `sanitize_context_relative_path` before writing
- *  `instructions/<provider>/AGENTS.md` and SKIPS the variant with a warning if
- *  it is unsafe. Surfacing that while the user is typing beats losing the
- *  variant silently at export time. Advisory — the caller should warn, not
- *  block, matching the Validate button's posture. */
+ *  Advisory. The key IS still saved to the bundle (serialization drops only
+ *  blank keys) — what it loses is the export: `bundle_export.rs` skips any key
+ *  this rejects, with a warning, so the variant silently vanishes from the
+ *  `.abf`. Better to say so while the user is typing than at export time. */
 export function providerKeyProblem(provider: string): string | null {
     const key = provider.trim();
     if (key.length === 0) return "Provider key cannot be empty.";
-    if (key === "." || key === "..") return `"${key}" is not a usable directory name.`;
-    if (key.includes("/") || key.includes("\\")) {
-        return "Provider key cannot contain path separators.";
+    if (sanitizeProviderKey(key) !== null) return null;
+    const normalized = key.split("\\").join("/");
+    if (normalized.startsWith("/")) {
+        return "Provider key cannot start with a path separator.";
     }
-    // eslint-disable-next-line no-control-regex
-    if (/[\x00-\x1f]/.test(key)) return "Provider key cannot contain control characters.";
-    return null;
+    if (normalized.includes(":")) return "Provider key cannot contain a colon.";
+    if (normalized.split("/").some((c) => c === "..")) {
+        return 'Provider key cannot contain a ".." segment.';
+    }
+    return "Provider key has no usable path segment.";
 }
 
-/** Keys that appear more than once after trimming.
+/** Keys that collide once sanitized.
  *
- *  Export keeps exactly one of a colliding pair (sorted-first wins) and warns
- *  about the rest, so duplicates mean silent data loss on export. */
+ *  Compares SANITIZED paths, not raw strings, because that is what collides in
+ *  `bundle_export.rs`: it keys `seen_safe_providers` on the sanitized value and
+ *  keeps only the sorted-first of a colliding set, warning about the rest. So
+ *  `a/b` and `a\b` are the same export path and one of them is silently lost —
+ *  comparing raw strings would miss exactly that case. Keys the backend
+ *  rejects outright are excluded; `providerKeyProblem` already covers those. */
 export function duplicateProviderKeys(entries: ProviderInstruction[]): string[] {
     const seen = new Set<string>();
     const dupes = new Set<string>();
     for (const { provider } of entries) {
-        const key = provider.trim();
-        if (key.length === 0) continue;
-        if (seen.has(key)) dupes.add(key);
-        seen.add(key);
+        const safe = sanitizeProviderKey(provider);
+        if (safe === null) continue;
+        if (seen.has(safe)) dupes.add(provider.trim());
+        seen.add(safe);
     }
     return [...dupes].sort();
 }

--- a/frontend/app/view/memory/memory-model.ts
+++ b/frontend/app/view/memory/memory-model.ts
@@ -565,7 +565,20 @@ export function duplicateProviderKeys(entries: ProviderInstruction[]): string[] 
     // Plain `<`/`>` rather than localeCompare, to match Rust's `String::cmp`
     // (byte order). localeCompare is locale-aware and would disagree — e.g. it
     // ignores punctuation differences that decide this exact comparison.
+    // Blank-CONTENT rows are excluded before collision resolution, because
+    // export excludes them first too: `if content.trim().is_empty() { continue }`
+    // runs BEFORE the sanitize/collision check, so such a row never occupies a
+    // collision slot. Ignoring content here re-created the same wrong-row
+    // warning the sort above removes — with {"a/b": ""} and {"a\b": "real"},
+    // export silently skips the empty "a/b" and writes "a\b" with no collision
+    // at all, while we flagged "a\b" as the casualty (reagent P1 round 3,
+    // #3063).
+    //
+    // Deliberately NOT also warning "this row's empty content will not be
+    // exported": a row the user just added is empty by definition, so that
+    // fires on every new row before they have typed anything.
     const sortedKeys = entries
+        .filter((e) => e.content.trim().length > 0)
         .map((e) => e.provider.trim())
         .filter((key) => key.length > 0)
         .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));

--- a/frontend/app/view/memory/memory-model.ts
+++ b/frontend/app/view/memory/memory-model.ts
@@ -411,3 +411,112 @@ export class MemoryViewModel implements ViewModel {
         this.unsubChanged();
     }
 }
+
+// -- ABF v0.2 §2.2 per-provider instructions: authoring-model seam --------
+//
+// The draft carries `instructions_by_provider` as a RAW JSON string, not a
+// parsed structure, and that is deliberate: reagent P1 on PR #2523 found that
+// editing any field of an imported bundle silently wiped its provider variants,
+// because `bundle_memory_upsert`'s ON CONFLICT UPDATE overwrites the column
+// unconditionally. Round-tripping the raw string is what fixed it.
+//
+// The authoring UI needs a list, so these three functions are the seam. The
+// wipe-safety property has to be enforced here: `parse` reports malformed input
+// as `malformed` WITHOUT yielding an empty list, so the UI can refuse to edit
+// and keep the original string byte-for-byte rather than serializing `{}` over
+// variants it merely failed to understand.
+
+export interface ProviderInstruction {
+    provider: string;
+    content: string;
+}
+
+export interface ParsedInstructionsByProvider {
+    entries: ProviderInstruction[];
+    /** True when the stored value is not a flat object of string values. The
+     *  caller MUST leave the raw string untouched in this case — an empty
+     *  `entries` here means "could not read", never "there is nothing". */
+    malformed: boolean;
+}
+
+/** Parse the stored JSON object into sorted, editable entries.
+ *
+ *  Empty/whitespace/`{}` are a legitimately empty set, not malformed — that is
+ *  the normal state of a bundle nobody has added a variant to. Anything that is
+ *  not an object of strings (array, scalar, null, or an object with a
+ *  non-string value) is malformed. */
+export function parseInstructionsByProvider(raw: string): ParsedInstructionsByProvider {
+    const trimmed = (raw ?? "").trim();
+    if (trimmed.length === 0) return { entries: [], malformed: false };
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(trimmed);
+    } catch {
+        return { entries: [], malformed: true };
+    }
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return { entries: [], malformed: true };
+    }
+    const entries: ProviderInstruction[] = [];
+    for (const [provider, content] of Object.entries(parsed as Record<string, unknown>)) {
+        // Coercing a non-string here would rewrite the user's data on the next
+        // save; refusing to parse leaves it exactly as imported.
+        if (typeof content !== "string") return { entries: [], malformed: true };
+        entries.push({ provider, content });
+    }
+    entries.sort((a, b) => a.provider.localeCompare(b.provider));
+    return { entries, malformed: false };
+}
+
+/** Serialize edited entries back to the stored JSON-object form.
+ *
+ *  Provider keys are trimmed (a stray space would become a distinct variant,
+ *  and on export a distinct directory); content is never trimmed, since leading
+ *  and trailing whitespace in a system prompt is the author's business. Rows
+ *  with a blank key are dropped — they cannot be exported and would serialize
+ *  as a `""` key. */
+export function serializeInstructionsByProvider(entries: ProviderInstruction[]): string {
+    const out: Record<string, string> = {};
+    for (const { provider, content } of entries) {
+        const key = provider.trim();
+        if (key.length === 0) continue;
+        out[key] = content;
+    }
+    return JSON.stringify(out);
+}
+
+/** Why a provider key would not survive export, or `null` if it is fine.
+ *
+ *  Mirrors the export-side rule in `bundle_export.rs`, which runs each key
+ *  through `sanitize_context_relative_path` before writing
+ *  `instructions/<provider>/AGENTS.md` and SKIPS the variant with a warning if
+ *  it is unsafe. Surfacing that while the user is typing beats losing the
+ *  variant silently at export time. Advisory — the caller should warn, not
+ *  block, matching the Validate button's posture. */
+export function providerKeyProblem(provider: string): string | null {
+    const key = provider.trim();
+    if (key.length === 0) return "Provider key cannot be empty.";
+    if (key === "." || key === "..") return `"${key}" is not a usable directory name.`;
+    if (key.includes("/") || key.includes("\\")) {
+        return "Provider key cannot contain path separators.";
+    }
+    // eslint-disable-next-line no-control-regex
+    if (/[\x00-\x1f]/.test(key)) return "Provider key cannot contain control characters.";
+    return null;
+}
+
+/** Keys that appear more than once after trimming.
+ *
+ *  Export keeps exactly one of a colliding pair (sorted-first wins) and warns
+ *  about the rest, so duplicates mean silent data loss on export. */
+export function duplicateProviderKeys(entries: ProviderInstruction[]): string[] {
+    const seen = new Set<string>();
+    const dupes = new Set<string>();
+    for (const { provider } of entries) {
+        const key = provider.trim();
+        if (key.length === 0) continue;
+        if (seen.has(key)) dupes.add(key);
+        seen.add(key);
+    }
+    return [...dupes].sort();
+}

--- a/frontend/app/view/memory/memory-model.ts
+++ b/frontend/app/view/memory/memory-model.ts
@@ -476,7 +476,15 @@ export function parseInstructionsByProvider(raw: string): ParsedInstructionsByPr
  *  with a blank key are dropped — they cannot be exported and would serialize
  *  as a `""` key. */
 export function serializeInstructionsByProvider(entries: ProviderInstruction[]): string {
-    const out: Record<string, string> = {};
+    // Null prototype, deliberately: on a plain `{}`, assigning the key
+    // "__proto__" hits Object.prototype's inherited legacy setter instead of
+    // creating an own property, so JSON.stringify silently omits it. A bundle
+    // that imported a `__proto__` override would lose it the moment the user
+    // edited ANY row — the same wipe class the raw-string round-trip exists to
+    // prevent, arriving through a different door (codex P2, #3063). Provider
+    // keys are free text and can arrive from an untrusted .abf, so this is
+    // reachable, not theoretical.
+    const out: Record<string, string> = Object.create(null);
     for (const { provider, content } of entries) {
         const key = provider.trim();
         if (key.length === 0) continue;
@@ -546,13 +554,29 @@ export function providerKeyProblem(provider: string): string | null {
  *  comparing raw strings would miss exactly that case. Keys the backend
  *  rejects outright are excluded; `providerKeyProblem` already covers those. */
 export function duplicateProviderKeys(entries: ProviderInstruction[]): string[] {
+    // Order is part of the contract, not an implementation detail:
+    // `bundle_export.rs` sorts the RAW keys ascending and keeps the FIRST of
+    // each colliding set, skipping the rest with a warning. Walking the
+    // caller's array order instead marks whichever row the form happens to
+    // hold first — which can be the row export actually KEEPS, so the warning
+    // lands on the survivor while the row that really gets dropped shows
+    // nothing at all (reagent P1, #3063).
+    //
+    // Plain `<`/`>` rather than localeCompare, to match Rust's `String::cmp`
+    // (byte order). localeCompare is locale-aware and would disagree — e.g. it
+    // ignores punctuation differences that decide this exact comparison.
+    const sortedKeys = entries
+        .map((e) => e.provider.trim())
+        .filter((key) => key.length > 0)
+        .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+
     const seen = new Set<string>();
     const dupes = new Set<string>();
-    for (const { provider } of entries) {
-        const safe = sanitizeProviderKey(provider);
+    for (const key of sortedKeys) {
+        const safe = sanitizeProviderKey(key);
         if (safe === null) continue;
-        if (seen.has(safe)) dupes.add(provider.trim());
-        seen.add(safe);
+        if (seen.has(safe)) dupes.add(key);
+        else seen.add(safe);
     }
     return [...dupes].sort();
 }

--- a/frontend/app/view/memory/memory-view.scss
+++ b/frontend/app/view/memory/memory-view.scss
@@ -333,3 +333,67 @@
     margin: 4px 0 0;
     font-style: italic;
 }
+
+/* ABF v0.2 §2.2 per-provider instruction overrides — see
+   BundleProviderInstructionsSection.tsx. Deliberately reuses the existing
+   field/input/textarea vars rather than introducing a parallel palette, so the
+   section reads as part of the same form rather than a bolted-on panel. */
+.memory-view-provider-instructions {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.memory-view-provider-instruction-row {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px;
+    border: 1px solid var(--border-color);
+    border-radius: 0;
+}
+
+.memory-view-provider-instruction-head {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+
+    .memory-view-input {
+        flex: 1;
+    }
+}
+
+.memory-view-provider-instruction-remove,
+.memory-view-provider-instruction-add {
+    padding: 4px 10px;
+    background: transparent;
+    color: var(--secondary-text-color);
+    border: 1px solid var(--border-color);
+    border-radius: 0;
+    font-size: 12px;
+    font-family: inherit;
+    cursor: pointer;
+
+    &:hover {
+        color: var(--main-text-color);
+        border-color: var(--accent-color);
+    }
+}
+
+.memory-view-provider-instruction-add {
+    align-self: flex-start;
+}
+
+/* Advisory, never blocking — matches the Validate button's posture. The user
+   can still save; the key simply will not be exported. */
+.memory-view-provider-instruction-warn,
+.memory-view-provider-instructions-malformed {
+    font-size: 12px;
+    color: var(--warning-color, #d08770);
+    line-height: 1.4;
+}
+
+.memory-view-provider-instructions-malformed {
+    padding: 8px;
+    border: 1px solid var(--warning-color, #d08770);
+}


### PR DESCRIPTION
## Summary

Closes the last open gap in **ABF v0.2**. Storage, export (`instructions/<provider>/AGENTS.md`) and import all shipped in #2521/#2523/#2527, and `SPEC_ABF_V0_2_PROVIDER_AWARE_COMPONENTS_AND_NATIVE_MEMORY_2026_08_10.md` §2.2 committed to shipping *"the storage shape, the authoring UI, and export/import"* — only the authoring half was ever built.

Until now an imported bundle's variants round-tripped through the form untouched but could not be **created or edited in the app at all**. The field's own tooltip admitted it: *"there's no authoring UI for those yet."*

## The one subtle thing: wipe-safety

The draft carries this field as a **raw JSON string**, not a parsed structure. That is deliberate and load-bearing — reagent P1 on #2523 found that editing *any* field of an imported bundle silently wiped its provider variants, because `bundle_memory_upsert`'s `ON CONFLICT UPDATE` overwrites the column unconditionally. Round-tripping the string verbatim is what fixed it.

An authoring UI has to turn that string into a list, which is exactly where that fix could be undone. So the seam enforces it: **malformed input is reported as malformed and yields no entries**, rather than yielding an empty list the UI would then serialize back over the top of. When the stored value is unreadable the editor refuses to edit and says the raw value is preserved, instead of rendering an empty editor that destroys it on the next save.

## Changes

**Model (`memory-model.ts`)** — where the correctness lives, and what the tests target:
- `parseInstructionsByProvider` / `serializeInstructionsByProvider`
- `providerKeyProblem` / `duplicateProviderKeys` — advisory checks mirroring the export-side rules

**UI (`BundleProviderInstructionsSection.tsx`)**, following the existing `BundleMcpSection`/`BundleSkillsSection` split:
- Add/edit/remove `provider → instructions` rows; known providers offered via `datalist`, free text still allowed (import accepts unknown keys, so the editor must too).
- **Flags keys that would not survive export.** `bundle_export.rs` runs each key through `sanitize_context_relative_path` and *skips* unsafe ones with a warning, and keeps only one of a colliding pair. Both are silent data loss at export time, so they are surfaced while the user is typing. Advisory only, never blocking — same posture as the Validate button.
- Controlled/uncontrolled hybrid, reasoned in the file header: rows are local state serialized out per edit, because deriving them from the JSON string on every keystroke would make a row vanish the instant its key went blank (a blank key cannot exist in a JSON object). An effect re-seeds when the incoming string changes for any reason other than our own write.

Also corrects the Instructions tooltip, which still claimed no authoring UI existed, and now states the **override-not-append** semantics.

## Test plan

- [x] 11 new model tests: sorted parse; **empty vs malformed** (the wipe-safety property, including an object with a non-string value, which is rejected rather than coerced); key trimming without content trimming; `parse → serialize` round-trip fidelity; both advisory checks
- [x] Written test-first — confirmed all 11 failed before the implementation existed
- [x] Pre-existing `instructions_by_provider` round-trip suite from #2523 still green
- [x] `npx vitest run` — **3826 passed**, 3 skipped
- [x] `npx tsc --noEmit` — clean
- [x] Changeset added (minor)

## Not covered

No screenshot — this is an editor form section, and I have no way to drive the GUI headlessly here. Manual check of the actual rendering would be worth doing before release.

<!-- agentmux:agent_id=camper -->