### PR TITLE
Korp@claudius: chore(deps): drop the unused react dependency left over from the React→SolidJS migration

### DIFF
--- a/.changesets/1788772081-chore-deps-drop-the-unused-react-dependency-left-over-from-t-lti0.md
+++ b/.changesets/1788772081-chore-deps-drop-the-unused-react-dependency-left-over-from-t-lti0.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+chore(deps): drop the unused react dependency left over from the React→SolidJS migration

--- a/docs/reports/REPORT_LARGE_MIGRATIONS_COMPLETION_AUDIT_2026_09_06.md
+++ b/docs/reports/REPORT_LARGE_MIGRATIONS_COMPLETION_AUDIT_2026_09_06.md
@@ -318,7 +318,7 @@ proposes is done. Restamp `historical`.
 | # | Initiative | State | What remains |
 |---|---|---|---|
 | 1 | Tauri → CEF | ✅ done | comment-only residue |
-| 2 | React → SolidJS | ✅ done | drop the unused `react` dep |
+| 2 | React → SolidJS | ✅ done | — (unused `react` dep dropped 2026-09-07) |
 | 3 | Reducer/saga (E–H) | ✅ done | reconcile two status docs (§5.2) |
 | 4 | Arch refactor A1–A15 | 🟡 12/15 | **A6, A9**, A10 (optional) |
 | 5 | muxspect A/B/C | ✅ done | fix CLAUDE.md (§5.1) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -7692,19 +7692,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -9476,19 +9463,6 @@
       "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
-    },
-    "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,6 @@
         "prettier": "^3.7.4",
         "prettier-plugin-jsdoc": "^1.8.0",
         "prettier-plugin-organize-imports": "^4.3.0",
-        "react": "18.3.1",
         "sass": "1.97.2",
         "stylelint": "^17.9.0",
         "stylelint-config-standard-scss": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "prettier": "^3.7.4",
     "prettier-plugin-jsdoc": "^1.8.0",
     "prettier-plugin-organize-imports": "^4.3.0",
-    "react": "18.3.1",
     "sass": "1.97.2",
     "stylelint": "^17.9.0",
     "stylelint-config-standard-scss": "^17.0.0",


### PR DESCRIPTION
## Summary

Closes the last residue item on the React → SolidJS row of `docs/reports/REPORT_LARGE_MIGRATIONS_COMPLETION_AUDIT_2026_09_06.md` (scoreboard row 2): the `react` package was still a runtime dependency although no source file imports it (390 files import `solid-js`, none import `react`, per the audit's §2.2).

- `package.json`: `react` removed from `dependencies`.
- `package-lock.json`: only the `node_modules/react` and `node_modules/loose-envify` entries (react's sole transitive dep) and the root reference are removed — pruned surgically rather than via `npm uninstall`, because the local npm re-normalised ~50 unrelated `peer`/`devOptional` flags on the way, which would have made a 2-line change read as a 200-line one. A guard in the prune step asserted nothing else in the lock still depends on either package.
- Audit report row 2 marked done.

```
npx tsc --noEmit -p tsconfig.json   → 0 errors
npm ls react                        → (empty)
npm ls --depth=0                    → no invalid / missing / extraneous
```

The other two "done" rows' residue is deliberately not swept here: the Tauri comment residue is 44 mentions across 29 source files and belongs in its own commit; §5.2–5.4's doc restamps already landed in #3042.

<!-- agentmux:agent_id=korp -->
