### PR TITLE
Korp@claudius: chore: retire the misleading Tauri-era comments and log labels outside the CEF crate

### DIFF
--- a/.changesets/1788784010-chore-retire-the-misleading-tauri-era-comments-and-log-label-l944.md
+++ b/.changesets/1788784010-chore-retire-the-misleading-tauri-era-comments-and-log-label-l944.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+chore: retire the misleading Tauri-era comments and log labels outside the CEF crate (Tauri->CEF migration residue)

--- a/agentmux-srv/src/backend/config_watcher_fs.rs
+++ b/agentmux-srv/src/backend/config_watcher_fs.rs
@@ -24,7 +24,7 @@ use super::wconfig::{self, ConfigState, SettingsType};
 /// Resolve the directory containing settings.json.
 ///
 /// Priority:
-/// 1. `AGENTMUX_SETTINGS_DIR` env var (set by Tauri host to app_config_dir)
+/// 1. `AGENTMUX_SETTINGS_DIR` env var (set by the host app to its config dir)
 /// 2. If [`agentmux_common::isolated_settings_enabled`] — the default for
 ///    every channel except `stable`, see
 ///    `docs/specs/SPEC_SETTINGS_ISOLATED_BY_CHANNEL_2026_08_19.md` —

--- a/agentmux-srv/src/backend/userinput.rs
+++ b/agentmux-srv/src/backend/userinput.rs
@@ -10,7 +10,7 @@
 //! - Confirmation dialogs
 //! - Checkbox-bearing dialogs
 //!
-//! The actual display is handled by the frontend (Tauri webview);
+//! The actual display is handled by the frontend (the CEF renderer);
 //! this module defines the wire format and a registry for pending requests.
 
 

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -402,7 +402,7 @@ async function initHostWave(): Promise<void> {
         t = performance.now();
         await initWaveWrap(initOpts);
         tlog("initWaveWrap", t);
-        tlog("TOTAL initTauriWave", t0);
+        tlog("TOTAL initCefWave", t0);
 
         // Apply dev window title — task dev TITLE="agentx: PR #1780"
         // Only runs in Vite dev mode; VITE_DEV_TITLE is empty string in prod builds.
@@ -449,7 +449,7 @@ async function initHostNewWindow(): Promise<void> {
     };
 
     try {
-        getApi().sendLog("[initTauriNewWindow] Creating new backend objects");
+        getApi().sendLog("[initCefNewWindow] Creating new backend objects");
 
         // Get client data (reuse existing client)
         let t = performance.now();
@@ -461,7 +461,7 @@ async function initHostNewWindow(): Promise<void> {
         // instead of creating a blank one.
         const tearOffWsId = new URLSearchParams(window.location.search).get("workspaceId") ?? "";
         if (tearOffWsId) {
-            getApi().sendLog(`[initTauriNewWindow] tear-off workspaceId=${tearOffWsId}`);
+            getApi().sendLog(`[initCefNewWindow] tear-off workspaceId=${tearOffWsId}`);
         }
 
         t = performance.now();
@@ -518,7 +518,7 @@ async function initHostNewWindow(): Promise<void> {
         t = performance.now();
         await initWaveWrap(initOpts);
         tlog("initWaveWrap", t);
-        tlog("TOTAL initTauriNewWindow", t0);
+        tlog("TOTAL initCefNewWindow", t0);
 
         // Initialize instance tracking (must come after initWaveWrap so global state is ready)
         await initInstanceTracking();
@@ -612,7 +612,7 @@ async function initAppInner() {
     document.body.style.opacity = "0";
     document.body.classList.add("is-transparent");
 
-    // Check if we're in a host app (Tauri or CEF) that owns the backend sidecar.
+    // Check if we're in the host app (CEF) that owns the backend sidecar.
     // Host apps query the backend for client/window/tab state.
     // Non-host mode waits for an agentmux-init event from the host.
     const hostApp = isHostApp();
@@ -737,7 +737,7 @@ async function initAppInner() {
 
 // bootstrap.ts calls initApp() directly (static import).
 // This self-start path is kept only for dev environments where the
-// bootstrap entry point is not used. Skip if running in Tauri or CEF
+// bootstrap entry point is not used. Skip if running in the CEF host
 // since the bootstrap handles setup (window.api) before calling initApp().
 if (!isHostApp()) {
     if (document.readyState === "loading") {

--- a/frontend/app/app.tsx
+++ b/frontend/app/app.tsx
@@ -99,21 +99,21 @@ function AppSettingsUpdater() {
         } else {
             document.body.style.removeProperty("--main-bg-color");
         }
-        // Apply Tauri-level window transparency and platform blur effects.
+        // Apply host-level window transparency and platform blur effects.
         // The IPC call can throw early in startup if window.api hasn't been
         // wired yet (visible as "[getApi] called before window.api exists" in
         // the console). Without try/catch the throw aborts this effect and
         // SolidJS never re-runs it on the next settings tick — leaving the
         // CSS classes set above untouched, and the body opaque. The CEF host
         // also reads CefSettings.background_color directly at init time, so
-        // the IPC is only the "Tauri-side window.transparent" mirror; we can
+        // the IPC is only a best-effort mirror of that host setting; we can
         // safely skip it when the API isn't ready.
         const isBlur = windowSettings?.["window:blur"] ?? false;
         try {
             getApi().setWindowTransparency(isTransparentOrBlur, isBlur, opacity);
         } catch (e) {
             // Swallow — the CSS path above is what actually drives visual
-            // transparency on Linux/Wayland under CEF. The Tauri-era IPC
+            // transparency on Linux/Wayland under CEF. The IPC
             // mirror is best-effort.
         }
 

--- a/frontend/app/drag/DragOverlay.tsx
+++ b/frontend/app/drag/DragOverlay.tsx
@@ -7,7 +7,7 @@
  * Renders a full-window overlay when a cross-window drag is hovering
  * over this window. Shows a visual indicator that a drop will be accepted.
  *
- * Listens for "cross-drag-update" and "cross-drag-end" Tauri events.
+ * Listens for "cross-drag-update" and "cross-drag-end" host events.
  * Only visible when this window is the target of an active cross-drag.
  */
 

--- a/frontend/app/statusbar/HostPopover.tsx
+++ b/frontend/app/statusbar/HostPopover.tsx
@@ -411,7 +411,7 @@ const HostPopover = (): JSX.Element => {
             const info = await invokeCommand<HostInfo>("get_host_info", {});
             setHostInfo(info);
         } catch {
-            // Fallback for Tauri (doesn't have get_host_info yet)
+            // Fallback for a host build without get_host_info
             setHostInfo(null);
         }
         void muxbus.refresh();

--- a/frontend/app/store/app-api.ts
+++ b/frontend/app/store/app-api.ts
@@ -1,7 +1,7 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Accessor for the host API bridge (window.api / Tauri IPC).
+// Accessor for the host API bridge (window.api / host IPC).
 // Extracted here so it can be imported by modules below the store layer
 // (e.g. util/logger.ts, store/wos.ts) without creating a cycle through global.ts.
 

--- a/frontend/app/store/backendStatus.ts
+++ b/frontend/app/store/backendStatus.ts
@@ -33,7 +33,7 @@ interface BackendStatusApi {
     getBackendInfo: () => Promise<{ pid?: number; started_at?: string; web_endpoint?: string; version: string; pending_migrations?: number }>;
 }
 
-/// Wire up the Tauri event listeners that drive backendStatusAtom.
+/// Wire up the host event listeners that drive backendStatusAtom.
 ///
 /// Call once during app init (from initGlobalSignals).
 /// The api and reconnectWS parameters are injected so tests can pass mocks
@@ -71,7 +71,7 @@ export function initBackendStatusListeners(
     });
 
     // The backend-ready event may have already fired before this listener was
-    // registered (when initTauriApi resolved via invoke rather than waiting for
+    // registered (when the host API bootstrap resolved via invoke rather than waiting for
     // the event). Catch up by checking whether the backend is already up.
     api.getBackendInfo().then(() => {
         if (backendStatusAtom() === "connecting") {

--- a/frontend/app/store/rpc-util.ts
+++ b/frontend/app/store/rpc-util.ts
@@ -19,7 +19,7 @@ function initWshrpc(tabId: string): WSControl {
         DefaultRouter.recvRpcMessage(event.data);
     };
 
-    // For Tauri: Get auth key from API and pass it to WebSocket
+    // Host app: get the auth key from the API and pass it to WebSocket
     // Browser WebSocket doesn't support custom headers, so wsutil.ts will
     // append it as a query parameter: ws://endpoint?authkey=xxx
     const authKey = getApi().getAuthKey();

--- a/frontend/app/view/helpview/helpview.tsx
+++ b/frontend/app/view/helpview/helpview.tsx
@@ -78,7 +78,7 @@ function HelpView({ model }: { model: HelpViewModel }): JSX.Element {
         >
             {/* CSS zoom (not font-size) is intentional: scales the full layout box so
                 @container breakpoints respond and the grid reflows responsively.
-                Tauri/WebKit handles zoom correctly; font-size only scales text. */}
+                Chromium handles CSS zoom correctly; font-size only scales text. */}
             <div style={{ zoom: zoom(), padding: "10px 5px" }}>
                 <QuickTips />
             </div>

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -781,7 +781,7 @@ declare global {
 
     // Window extensions — eliminates (window as any) casts throughout the codebase
     interface Window {
-        // Platform API (set by CEF/Tauri bootstrap)
+        // Platform API (set by the CEF bootstrap)
         api: AppApi;
         globalAtoms: any; // GlobalAtomsType has a pre-existing type mismatch — fix separately
 

--- a/frontend/util/cef-api.ts
+++ b/frontend/util/cef-api.ts
@@ -4,7 +4,7 @@
 // CEF API shim — provides the same window.api (AppApi) interface
 // using the platform-agnostic invokeCommand()/listenEvent() from ipc.ts.
 //
-// This is the CEF equivalent of tauri-api.ts. Must be loaded before
+// The CEF host API bridge (successor of the old tauri-api.ts). Must be loaded before
 // the React app bootstraps.
 
 import { invokeCommand, listenEvent } from "@/app/platform/ipc";

--- a/frontend/util/endpoints.ts
+++ b/frontend/util/endpoints.ts
@@ -6,7 +6,7 @@ import { getEnv } from "./getenv";
 const WebServerEndpointVarName = "WAVE_SERVER_WEB_ENDPOINT";
 const WSServerEndpointVarName = "WAVE_SERVER_WS_ENDPOINT";
 
-// Not memoized: endpoints are set asynchronously after module load (by setupTauriApi),
+// Not memoized: endpoints are set asynchronously after module load (by the CEF bootstrap),
 // so lazy() would cache "http://null" if called too early.
 export const getWebServerEndpoint = () => `http://${getEnv(WebServerEndpointVarName)}`;
 

--- a/frontend/util/fetchutil.ts
+++ b/frontend/util/fetchutil.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Utility to abstract the fetch function.
-// Uses standard fetch API. CORS handled via tauri.conf.json security settings.
+// Uses the standard fetch API.
 
 export function fetch(input: string | Request | URL, init?: RequestInit): Promise<Response> {
     // Always use globalThis.fetch (standard Web API)
-    // Tauri provides fetch API in the webview
+    // Chromium provides the fetch API in the renderer
     return globalThis.fetch(input, init);
 }

--- a/frontend/util/getenv.ts
+++ b/frontend/util/getenv.ts
@@ -21,7 +21,7 @@ function getApi(): AppApi {
 export function getEnv(paramName: string): string {
     const win = getWindow();
 
-    // In Tauri, check window globals first (set by initTauriApi)
+    // In the host app, check window globals first (set by the CEF bootstrap)
     if (win != null) {
         const windowGlobalName = `__${paramName}__`;
         if ((win as any)[windowGlobalName] !== undefined) {

--- a/frontend/util/logger.ts
+++ b/frontend/util/logger.ts
@@ -13,7 +13,7 @@ function log(level: string, module: string, message: string, data?: LogData) {
     try {
         getApi().sendLogStructured(level, module, message, data ?? null);
     } catch {
-        // Silently ignore if Tauri bridge not ready
+        // Silently ignore if the host bridge is not ready
     }
 }
 

--- a/frontend/util/startup-bench.ts
+++ b/frontend/util/startup-bench.ts
@@ -3,7 +3,7 @@
 //
 // Startup performance benchmark utility.
 // Records named milestones with high-resolution timestamps relative to
-// performance.timeOrigin so all phases (tauri-api, bootstrap, wave) share
+// performance.timeOrigin so all phases (host api, bootstrap, wave) share
 // the same epoch.
 //
 // Usage:


### PR DESCRIPTION
## Summary

Closes the "comment-only residue" on the Tauri → CEF row of `docs/reports/REPORT_LARGE_MIGRATIONS_COMPLETION_AUDIT_2026_09_06.md` (scoreboard row 1).

- 17 comments in `agentmux-srv` and `frontend/` that still described the host as Tauri (its webview, its IPC, `tauri.conf.json`, `initTauriApi`/`setupTauriApi` — functions that no longer exist) now name the CEF host or the host bridge generically.
- The startup perf/log labels `initTauriWave` / `initTauriNewWindow` in `frontend/app-init.ts` become `initCefWave` / `initCefNewWindow`, exactly as `REPORT_REPO_HEALTH_AUDIT_2026_07_20.md` recommended (an engineer reading a `muxlog` trace should not wonder whether Tauri code still runs).
- The "ported from `src-tauri/...`" provenance notes inside `agentmux-cef` are accurate history and are deliberately left alone.

Comments and two string labels only; no behaviour change. `npx tsc --noEmit` → 0 errors.

<!-- agentmux:agent_id=korp -->