### PR TITLE
fix(ci): generate the specs index from tracked files, not a filesystem glob

### DIFF
--- a/.changesets/1788785889-fix-ci-generate-the-specs-index-from-tracked-files-not-a-fil-kc4u.md
+++ b/.changesets/1788785889-fix-ci-generate-the-specs-index-from-tracked-files-not-a-fil-kc4u.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(ci): generate the specs index from tracked files, not a filesystem glob

--- a/scripts/gen-docs-index.sh
+++ b/scripts/gen-docs-index.sh
@@ -161,10 +161,54 @@ fi
 # per status word — 730 files x 8 statuses, ~5,800 process spawns — which took
 # over two minutes on Windows. Now each file is read once into a status->rows
 # map, which is ~730 spawns and seconds.
+# ── Which files ARE the spec tree ───────────────────────────────────────────
+#
+# Tracked files, not a filesystem glob. The index describes the COMMITTED
+# spec tree, and a bare `docs/specs/*.md` glob does not: it also picks up
+# work-in-progress specs that are not in the repo yet.
+#
+# That is not a cosmetic difference. Regenerating with an untracked spec
+# present writes a row for it into INDEX.md, and committing that INDEX.md
+# without the spec leaves a link to a file nobody else has — the index
+# asserting the existence of something that does not exist. It also made
+# `--check` report STALE for a perfectly clean checkout, so the honest
+# response to the gate ("run the generator") was the thing that introduced
+# the bad row.
+#
+# `git ls-files` reads the INDEX, not HEAD, so a `git add`ed spec counts
+# immediately — the normal "write the spec, add it, regenerate, commit both"
+# flow works without a commit-then-regenerate dance.
+#
+# Deleted-but-still-tracked paths are filtered by the -f test: `git rm`'d in
+# the working tree but not yet staged, the file is gone and must not get a
+# row built from a failed read.
+#
+# CI is unaffected: a checkout has no untracked files, so tracked and
+# on-disk are the same set there and the generated output is byte-identical.
+# Outside a git repo (a tarball, say) it falls back to the glob rather than
+# emitting an empty index.
+spec_files() {
+    if git rev-parse --git-dir >/dev/null 2>&1; then
+        # Depth-1 only. A git pathspec's `*` matches `/` as well (fnmatch
+        # without FNM_PATHNAME), so `docs/specs/*.md` also pulls in
+        # `docs/specs/archive/*.md` — the one subtree this index excludes on
+        # purpose. Caught by asserting the regenerated file was byte-identical
+        # on a clean checkout: it grew 76 archive rows. The grep, not the
+        # pathspec, is what bounds the depth.
+        git ls-files -- docs/specs | grep -E '^docs/specs/[^/]+\.md$' | while IFS= read -r f; do
+            [ -f "$f" ] && printf '%s\n' "$f"
+        done
+    else
+        for f in docs/specs/*.md; do
+            [ -f "$f" ] && printf '%s\n' "$f"
+        done
+    fi
+}
+
 build() {
     declare -A ROWS
     local total=0 shown=0
-    for f in docs/specs/*.md; do
+    while IFS= read -r f; do
         b=$(basename "$f")
         case "$b" in INDEX.md|README.md) continue ;; esac
         total=$((total + 1))
@@ -182,7 +226,7 @@ build() {
 
         ROWS["$w"]="${ROWS[$w]:-}| [\`${b%.md}\`](${b}) | ${title} |
 "
-    done
+    done < <(spec_files)
 
     printf '%s
 ' "$BEGIN"

--- a/scripts/gen-docs-index.sh
+++ b/scripts/gen-docs-index.sh
@@ -195,14 +195,41 @@ spec_files() {
         # purpose. Caught by asserting the regenerated file was byte-identical
         # on a clean checkout: it grew 76 archive rows. The grep, not the
         # pathspec, is what bounds the depth.
-        git ls-files -- docs/specs | grep -E '^docs/specs/[^/]+\.md$' | while IFS= read -r f; do
-            [ -f "$f" ] && printf '%s\n' "$f"
-        done
-    else
-        for f in docs/specs/*.md; do
-            [ -f "$f" ] && printf '%s\n' "$f"
-        done
+        #
+        # `awk '!seen[$0]++'` deduplicates while preserving ls-files' sorted
+        # order (Codex P2, PR #3073). During an unresolved merge conflict
+        # `git ls-files` emits a conflicted path once PER INDEX STAGE, which
+        # would render three identical rows — and the completeness assertion
+        # below could not catch it, since both of its totals come from this
+        # same tripled list. That is not a hypothetical: this script's own
+        # header documents regenerating DURING a conflict as the way to
+        # resolve one, so it is a normal thing to be mid-merge here. Not
+        # `git ls-files --deduplicate`, which needs git >= 2.31; awk is
+        # portable and this script is run by contributors, not just CI.
+        tracked=$(git ls-files -- docs/specs 2>/dev/null \
+            | grep -E '^docs/specs/[^/]+\.md$' \
+            | awk '!seen[$0]++')
+        # An EMPTY result means this tree is not the one that git found
+        # (Codex P2, PR #3073): unpack a source tarball inside an unrelated
+        # checkout and `git rev-parse` happily resolves the ancestor repo,
+        # which tracks none of these files. Taking the git answer there would
+        # silently overwrite INDEX.md with an empty generated section — and
+        # again the completeness assertion cannot object, because 0 == 0.
+        # Falling through to the glob covers that and the plain
+        # not-a-repo case with one condition.
+        if [ -n "$tracked" ]; then
+            printf '%s\n' "$tracked" | while IFS= read -r f; do
+                # Tracked but deleted in the working tree (`rm` without
+                # `git rm`): no file to read, so no row built from a failed
+                # read.
+                [ -f "$f" ] && printf '%s\n' "$f"
+            done
+            return
+        fi
     fi
+    for f in docs/specs/*.md; do
+        [ -f "$f" ] && printf '%s\n' "$f"
+    done
 }
 
 build() {


### PR DESCRIPTION
Follow-up to #3069. The generator globbed `docs/specs/*.md` off disk, so an **uncommitted** spec in the working tree counted as part of the spec tree.

## Why this is more than a local annoyance

Regenerating with an untracked spec present **writes a row for it into `INDEX.md`**. Commit that `INDEX.md` without the spec and the index asserts a file nobody else has — a link that resolves for exactly one person.

It also made `--check` report `STALE` on an otherwise clean checkout, which means the gate's own advice — *"Run: bash scripts/gen-docs-index.sh"* — was the thing that introduced the bad row.

I hit this repeatedly while working on the tray PRs and worked around it by `mv`-ing the file aside before every regeneration. That only works while someone remembers to do it.

## The change

Enumerate via `git ls-files` rather than a glob:

- Reads the **index**, not HEAD, so a `git add`ed spec counts immediately — the ordinary "write it, add it, regenerate, commit both" flow needs no commit-then-regenerate dance.
- Deleted-but-still-tracked paths are filtered out, so a failed read can't become a row.
- Outside a git repo (a tarball) it falls back to the glob rather than emitting an empty index.

## One trap worth naming

A git pathspec's `*` matches `/` as well (fnmatch without `FNM_PATHNAME`), so `git ls-files -- 'docs/specs/*.md'` **also matches `docs/specs/archive/*.md`** — the one subtree this index excludes on purpose. My first attempt did exactly that and grew the index by **76 archive rows**.

What caught it was asserting the regenerated file was *byte-identical* on a clean checkout, rather than just eyeballing that it ran. Depth is now bounded by a `grep -E '^docs/specs/[^/]+\.md$'`, not by the pathspec, with the reason in a comment.

## Verification

Scratch clone throughout:

| Case | Expected | Result |
|---|---|---|
| Clean checkout | byte-identical output (CI unaffected) | ✅ identical |
| Untracked spec present | not in index; `--check` not stale | ✅ 0 rows, `INDEX.md is current` |
| Same spec after `git add` | appears | ✅ 1 row |
| Archive subtree | never in the generated section | ✅ 0 rows |

The clean-checkout case is the load-bearing one: in CI tracked and on-disk are the same set, so this must not change what CI sees — and it doesn't.

Also confirmed against a real working tree holding an uncommitted spec: `--check-all` now reports `INDEX.md is current` where it previously reported `STALE`.

<!-- agentmux:agent_id=agento -->