### PR TITLE
Manoz@Area54: refactor(srv): record each RPC command's request/response types at registration (Phase 2 step 1)

### DIFF
--- a/.changesets/1788786183-refactor-srv-record-each-rpc-command-s-request-response-type-88z4.md
+++ b/.changesets/1788786183-refactor-srv-record-each-rpc-command-s-request-response-type-88z4.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(srv): record each RPC command's request/response types at registration (RpcSchema + register_typed) — the mapping a bindings generator needs, which did not previously exist as data

--- a/agentmux-srv/src/backend/rpc/engine.rs
+++ b/agentmux-srv/src/backend/rpc/engine.rs
@@ -16,6 +16,7 @@ use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use super::super::rpc_types::{RpcContext, RpcMessage, RpcOpts, COMMAND_EVENT_RECV};
+use super::schema::RpcSchema;
 
 // ---- Constants (match Go) ----
 
@@ -180,6 +181,10 @@ struct EngineInner {
     #[allow(dead_code)]
     auth_token: String,
     rpc_context: Option<RpcContext>,
+    /// Request/response types of every command registered through
+    /// [`WshRpcEngine::register_typed`]. Lives beside `handlers` so the
+    /// mapping is a side effect of registration and cannot drift from it.
+    schema: RpcSchema,
 }
 
 /// Core RPC engine: handles incoming RPC requests, dispatches to registered
@@ -211,6 +216,7 @@ impl WshRpcEngine {
                 active_handlers: HashMap::new(),
                 auth_token: String::new(),
                 rpc_context: None,
+                schema: RpcSchema::new(),
             }),
             output_tx,
         });
@@ -223,6 +229,76 @@ impl WshRpcEngine {
         inner
             .handlers
             .insert(command.to_string(), Handler::Call(handler));
+    }
+
+    /// Register a call handler from typed request/response values, and
+    /// record the pair in this engine's [`RpcSchema`].
+    ///
+    /// Behaviourally identical to [`Self::register_handler`]: the closure is
+    /// wrapped in exactly the deserialize → run → serialize steps every
+    /// hand-written handler already performs, so migrating one is not
+    /// supposed to change what goes over the wire. What it adds is that the
+    /// `Req`/`Resp` pairing becomes *data* the process can dump, which is
+    /// the prerequisite for generating the frontend's bindings instead of
+    /// hand-maintaining them — see `schema.rs` and
+    /// `docs/specs/SPEC_RPC_BINDINGS_CODEGEN_2026_09_07.md`.
+    ///
+    /// Two deliberate differences from the untyped path, both matching what
+    /// the existing handlers do anyway:
+    ///
+    /// - **Deserialization failure is reported as `Err`**, with the command
+    ///   name and serde's message — the same `format!("{cmd}: {e}")` shape
+    ///   the hand-written handlers use.
+    /// - **A response is always sent** (`Ok(Some(..))`). Handlers that must
+    ///   answer with nothing at all keep using `register_handler`; `Resp =
+    ///   ()` serializes to `null`, which is a response, not silence.
+    ///
+    /// Serialization failure is also an `Err` rather than a panic: a
+    /// response type whose `Serialize` fails is a bug, but it is not worth
+    /// taking the connection down for.
+    pub fn register_typed<Req, Resp, F, Fut>(&self, command: &'static str, handler: F)
+    where
+        Req: serde::de::DeserializeOwned + Send + 'static,
+        Resp: serde::Serialize + Send + 'static,
+        F: Fn(Req, RpcContext) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Result<Resp, String>> + Send + 'static,
+    {
+        {
+            let mut inner = self.lock_inner();
+            inner.schema.record(
+                command,
+                std::any::type_name::<Req>(),
+                std::any::type_name::<Resp>(),
+            );
+        }
+
+        let handler = std::sync::Arc::new(handler);
+        self.register_handler(
+            command,
+            Box::new(move |data, ctx| {
+                let handler = handler.clone();
+                Box::pin(async move {
+                    let req: Req = serde_json::from_value(data)
+                        .map_err(|e| format!("{command}: {e}"))?;
+                    let resp = handler(req, ctx).await?;
+                    let value = serde_json::to_value(&resp)
+                        .map_err(|e| format!("{command}: response is not serializable: {e}"))?;
+                    Ok(Some(value))
+                })
+            }),
+        );
+    }
+
+    /// Snapshot of every typed command's request/response pair, in command
+    /// order. Handlers registered through the untyped [`Self::register_handler`]
+    /// are absent — that is what lets the migration proceed one at a time.
+    pub fn schema_json(&self) -> serde_json::Value {
+        self.lock_inner().schema.to_json()
+    }
+
+    /// Number of commands registered through the typed path.
+    pub fn typed_command_count(&self) -> usize {
+        self.lock_inner().schema.len()
     }
 
     /// Register a streaming handler (single request → stream of responses).

--- a/agentmux-srv/src/backend/rpc/engine.rs
+++ b/agentmux-srv/src/backend/rpc/engine.rs
@@ -223,12 +223,27 @@ impl WshRpcEngine {
         (engine, output_rx)
     }
 
-    /// Register a call handler (single request → single response).
-    pub fn register_handler(&self, command: &str, handler: CommandHandler) {
+    /// Install a call handler without touching the schema.
+    ///
+    /// The one path that must not evict: [`Self::register_typed`] records a
+    /// binding and then installs its wrapper, so going through the public
+    /// [`Self::register_handler`] would delete the entry it had just written.
+    fn install_call_handler(&self, command: &str, handler: CommandHandler) {
         let mut inner = self.lock_inner();
         inner
             .handlers
             .insert(command.to_string(), Handler::Call(handler));
+    }
+
+    /// Register a call handler (single request → single response).
+    ///
+    /// Drops any typed binding previously recorded for `command`: the last
+    /// registration wins for the handler map, so it must win for the schema
+    /// too, or `schema_json()` would advertise a request/response pair the
+    /// live handler no longer implements.
+    pub fn register_handler(&self, command: &str, handler: CommandHandler) {
+        self.lock_inner().schema.remove(command);
+        self.install_call_handler(command, handler);
     }
 
     /// Register a call handler from typed request/response values, and
@@ -273,7 +288,9 @@ impl WshRpcEngine {
         }
 
         let handler = std::sync::Arc::new(handler);
-        self.register_handler(
+        // install_call_handler, not register_handler: the latter evicts the
+        // schema entry recorded just above.
+        self.install_call_handler(
             command,
             Box::new(move |data, ctx| {
                 let handler = handler.clone();
@@ -305,6 +322,9 @@ impl WshRpcEngine {
     #[allow(dead_code)]
     pub fn register_stream_handler(&self, command: &str, handler: StreamHandler) {
         let mut inner = self.lock_inner();
+        // Same eviction as register_handler — a streaming command has no
+        // single typed response to describe.
+        inner.schema.remove(command);
         inner
             .handlers
             .insert(command.to_string(), Handler::Stream(handler));
@@ -632,6 +652,99 @@ impl WshRpcEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Replacing a typed command through an untyped path clears its schema
+    /// entry (codex P2 on #3074).
+    ///
+    /// The handler map's last-registration-wins rule has to hold for the
+    /// schema too. If it did not, `schema_json()` would keep advertising the
+    /// old request/response pair for a command whose live handler no longer
+    /// accepts it — and a generator reading that would emit a client stub
+    /// that fails at runtime. A stale binding is worse than a missing one.
+    #[tokio::test]
+    async fn replacing_a_typed_command_through_an_untyped_path_clears_its_schema_entry() {
+        #[derive(serde::Deserialize)]
+        struct Req {
+            #[allow(dead_code)]
+            v: i32,
+        }
+        #[derive(serde::Serialize)]
+        struct Resp {
+            ok: bool,
+        }
+
+        let (engine, _rx) = WshRpcEngine::new();
+        engine.register_typed("typed-then-untyped", |_r: Req, _ctx| async move {
+            Ok(Resp { ok: true })
+        });
+        assert_eq!(engine.typed_command_count(), 1, "typed registration should be recorded");
+
+        // Same command, now an untyped handler.
+        engine.register_handler(
+            "typed-then-untyped",
+            Box::new(|_data, _ctx| Box::pin(async move { Ok(Some(serde_json::json!("plain"))) })),
+        );
+        assert_eq!(
+            engine.typed_command_count(),
+            0,
+            "an untyped re-registration must drop the stale typed pair",
+        );
+
+        // And the same via the streaming path, which has no single response
+        // type to describe at all.
+        engine.register_typed("typed-then-stream", |_r: Req, _ctx| async move {
+            Ok(Resp { ok: true })
+        });
+        assert_eq!(engine.typed_command_count(), 1);
+        engine.register_stream_handler(
+            "typed-then-stream",
+            Box::new(|_data, _ctx| {
+                Box::pin(async move {
+                    let (_tx, rx) = mpsc::channel(1);
+                    Ok(rx)
+                })
+            }),
+        );
+        assert_eq!(
+            engine.typed_command_count(),
+            0,
+            "a streaming re-registration must drop the stale typed pair too",
+        );
+    }
+
+    #[tokio::test]
+    async fn register_typed_still_records_after_the_wrapper_is_installed() {
+        // Guards the ordering inside register_typed: it records the binding
+        // and then installs the wrapper. Routing that install through the
+        // public evicting path would delete the entry it had just written,
+        // and this assertion is what catches that.
+        //
+        // NB: keep either registration function's name away from an
+        // immediately-following parenthesised word in prose here.
+        // test/contract/rpc-contract.test.ts scans this file with a regex
+        // that does not skip comments, so such a phrase reads to it as a
+        // real registration whose command it cannot resolve, and fails the
+        // contract extractor. (This comment is deliberately phrased to
+        // describe the trap without containing it.)
+        #[derive(serde::Deserialize)]
+        struct Req {
+            #[allow(dead_code)]
+            v: i32,
+        }
+        #[derive(serde::Serialize)]
+        struct Resp {
+            ok: bool,
+        }
+
+        let (engine, _rx) = WshRpcEngine::new();
+        engine.register_typed("stays-recorded", |_r: Req, _ctx| async move {
+            Ok(Resp { ok: true })
+        });
+        let schema = engine.schema_json();
+        let rows = schema.as_array().unwrap();
+        assert_eq!(rows.len(), 1, "register_typed must not evict its own entry");
+        assert_eq!(rows[0]["command"], "stays-recorded");
+    }
 
     #[tokio::test]
     async fn test_register_and_call_handler() {

--- a/agentmux-srv/src/backend/rpc/mod.rs
+++ b/agentmux-srv/src/backend/rpc/mod.rs
@@ -5,3 +5,4 @@
 //! Port of Go's pkg/wshutil/wshrouter.go and pkg/wshutil/wshrpc.go.
 
 pub mod engine;
+pub mod schema;

--- a/agentmux-srv/src/backend/rpc/schema.rs
+++ b/agentmux-srv/src/backend/rpc/schema.rs
@@ -107,6 +107,16 @@ impl RpcSchema {
         self.bindings.values().collect()
     }
 
+    /// Forget `command`'s binding, if it had one.
+    ///
+    /// Called when a command is (re-)registered through an untyped path, so
+    /// the schema always describes the handler that is actually installed. A
+    /// stale typed pair would be worse than no pair at all: it would generate
+    /// a client stub with types the live handler does not accept.
+    pub fn remove(&mut self, command: &str) {
+        self.bindings.remove(command);
+    }
+
     pub fn len(&self) -> usize {
         self.bindings.len()
     }
@@ -173,6 +183,19 @@ mod tests {
         s.record("dup", "a::Second", "a::SecondR");
         assert_eq!(s.len(), 1);
         assert_eq!(s.get("dup").unwrap().request, "a::Second");
+    }
+
+    #[test]
+    fn remove_forgets_a_binding_so_a_replaced_command_stops_advertising_stale_types() {
+        let mut s = RpcSchema::new();
+        s.record("foo", "a::Req", "a::Resp");
+        s.remove("foo");
+        assert!(s.get("foo").is_none());
+        assert!(s.is_empty());
+        // Removing something that was never recorded is a no-op, not a panic:
+        // every untyped registration calls this, and most commands were never
+        // typed in the first place.
+        s.remove("never-registered");
     }
 
     #[test]

--- a/agentmux-srv/src/backend/rpc/schema.rs
+++ b/agentmux-srv/src/backend/rpc/schema.rs
@@ -1,0 +1,189 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Which request and response type each RPC command carries.
+//!
+//! # Why this exists
+//!
+//! The frontend talks to srv through 284 hand-written command stubs
+//! (`frontend/app/store/rpc-api/*.ts`) and a 2,819-line hand-maintained
+//! `frontend/types/gotypes.d.ts`, every one of them headed "keep in sync
+//! with the agentmux-srv RPC". `docs/reports/REPORT_DRY_AND_MODULARITY_AUDIT_2026_09_06.md`
+//! §2.1 counted 334 such comments and one live drift found by hand.
+//!
+//! The obvious fix — derive the TypeScript types from the Rust ones — does
+//! not work on its own, and `docs/specs/SPEC_RPC_BINDINGS_CODEGEN_2026_09_07.md`
+//! §2 explains why: **which command takes which request and returns which
+//! response is not data anywhere in srv.** Each handler picks its request
+//! type inline (`serde_json::from_value::<CommandXData>(data)`) and builds
+//! its response ad hoc (`serde_json::to_value(&x)`, `json!({"ok": true})`).
+//! A type generator can emit every struct and still not know how to pair
+//! them into a callable stub.
+//!
+//! This module is that missing mapping, recorded as a side effect of
+//! registration itself (`RpcEngine::register_typed`) rather than written
+//! down a second time — so it cannot drift from the handlers the way a
+//! hand-maintained list would. It is deliberately just the mapping: no
+//! TypeScript is emitted here, and adding a code generator on top is a
+//! separate change against an already-proven registry (spec §3.4 step 1).
+//!
+//! # What a binding is
+//!
+//! One row per command registered through the typed path, holding the fully
+//! qualified Rust type names of its request and response. Handlers still on
+//! the untyped `register_handler` contribute nothing — they are simply
+//! absent, which is what makes an incremental migration possible.
+
+use std::collections::BTreeMap;
+
+/// The request/response pair for one command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RpcBinding {
+    /// Wire command name, e.g. `agentdefhide`.
+    pub command: String,
+    /// Fully qualified request type, from [`std::any::type_name`].
+    pub request: &'static str,
+    /// Fully qualified response type.
+    pub response: &'static str,
+}
+
+impl RpcBinding {
+    /// Last path segment of `request` — the name a generator would emit.
+    ///
+    /// Kept alongside the full path rather than replacing it: the short name
+    /// is what a binding is called in TypeScript, but two modules can hold
+    /// same-named types, so the full path stays authoritative.
+    pub fn request_name(&self) -> &str {
+        short_name(self.request)
+    }
+
+    /// Last path segment of `response`.
+    pub fn response_name(&self) -> &str {
+        short_name(self.response)
+    }
+}
+
+/// `a::b::Foo` -> `Foo`; also strips a generic tail so `Vec<a::B>` reads as
+/// `Vec<a::B>` rather than being truncated at a `::` inside the parameter.
+fn short_name(path: &str) -> &str {
+    match path.find('<') {
+        // Generic: leave it whole. Truncating `Vec<crate::x::Y>` at the last
+        // `::` would produce `Y>`, which names nothing.
+        Some(_) => path,
+        None => path.rsplit("::").next().unwrap_or(path),
+    }
+}
+
+/// Every typed command registered on one engine.
+///
+/// Keyed by command so a duplicate registration overwrites rather than
+/// silently recording the command twice — that mirrors the handler map in
+/// `engine.rs`, where the second `register_*` for a command wins.
+#[derive(Debug, Default)]
+pub struct RpcSchema {
+    bindings: BTreeMap<String, RpcBinding>,
+}
+
+impl RpcSchema {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record (or replace) the binding for `command`.
+    pub fn record(&mut self, command: &str, request: &'static str, response: &'static str) {
+        self.bindings.insert(
+            command.to_string(),
+            RpcBinding {
+                command: command.to_string(),
+                request,
+                response,
+            },
+        );
+    }
+
+    /// Bindings in command order. `BTreeMap` makes this stable across runs,
+    /// which is what lets a generated artifact be diffed in CI.
+    pub fn bindings(&self) -> Vec<&RpcBinding> {
+        self.bindings.values().collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.bindings.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.bindings.is_empty()
+    }
+
+    pub fn get(&self, command: &str) -> Option<&RpcBinding> {
+        self.bindings.get(command)
+    }
+
+    /// Stable JSON, sorted by command, for the dump + CI gate.
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::Value::Array(
+            self.bindings
+                .values()
+                .map(|b| {
+                    serde_json::json!({
+                        "command": b.command,
+                        "request": b.request,
+                        "requestName": b.request_name(),
+                        "response": b.response,
+                        "responseName": b.response_name(),
+                    })
+                })
+                .collect(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_name_takes_the_last_segment() {
+        assert_eq!(short_name("agentmux_srv::rpc_types::CommandFooData"), "CommandFooData");
+        assert_eq!(short_name("Foo"), "Foo");
+    }
+
+    #[test]
+    fn short_name_leaves_generics_whole_rather_than_truncating_mid_parameter() {
+        // `rsplit("::")` on this would yield `AgentDefinition>` — a name that
+        // does not exist. Better to hand back something a generator can
+        // reject loudly than something that looks valid and is not.
+        let generic = "alloc::vec::Vec<agentmux_srv::storage::AgentDefinition>";
+        assert_eq!(short_name(generic), generic);
+    }
+
+    #[test]
+    fn bindings_come_back_in_command_order_regardless_of_insertion_order() {
+        let mut s = RpcSchema::new();
+        s.record("zebra", "a::Z", "a::ZR");
+        s.record("alpha", "a::A", "a::AR");
+        let got: Vec<&str> = s.bindings().iter().map(|b| b.command.as_str()).collect();
+        assert_eq!(got, vec!["alpha", "zebra"], "order must not depend on registration order");
+    }
+
+    #[test]
+    fn re_registering_a_command_replaces_it_the_way_the_handler_map_does() {
+        let mut s = RpcSchema::new();
+        s.record("dup", "a::First", "a::FirstR");
+        s.record("dup", "a::Second", "a::SecondR");
+        assert_eq!(s.len(), 1);
+        assert_eq!(s.get("dup").unwrap().request, "a::Second");
+    }
+
+    #[test]
+    fn json_is_stable_and_carries_both_the_full_path_and_the_short_name() {
+        let mut s = RpcSchema::new();
+        s.record("agentdefhide", "crate::rpc_types::CommandAgentDefHideData", "crate::rpc_types::AgentDefHideResult");
+        let v = s.to_json();
+        assert_eq!(v[0]["command"], "agentdefhide");
+        assert_eq!(v[0]["request"], "crate::rpc_types::CommandAgentDefHideData");
+        assert_eq!(v[0]["requestName"], "CommandAgentDefHideData");
+        assert_eq!(v[0]["responseName"], "AgentDefHideResult");
+        assert_eq!(s.to_json(), v, "same input must serialize identically every time");
+    }
+}

--- a/agentmux-srv/src/server/agent_handlers/mod.rs
+++ b/agentmux-srv/src/server/agent_handlers/mod.rs
@@ -1136,6 +1136,81 @@ mod recent_sessions_tests {
         assert_eq!(tpl.user_hidden, 1);
     }
 
+    /// The typed registration path records what it registers.
+    ///
+    /// This is the property the whole codegen plan rests on
+    /// (`docs/specs/SPEC_RPC_BINDINGS_CODEGEN_2026_09_07.md`): the command →
+    /// request/response mapping has to be data the process can hand out, and
+    /// it has to come from registration itself rather than a second list
+    /// someone maintains by hand. Asserting the exact type names means a
+    /// rename that silently changes the generated bindings fails here.
+    #[tokio::test]
+    async fn register_typed_records_each_command_request_and_response_type() {
+        let (_state, engine, _rx) = build_state_with_template_seed();
+        let schema = engine.schema_json();
+        let rows = schema.as_array().expect("schema is an array");
+
+        let find = |cmd: &str| {
+            rows.iter()
+                .find(|r| r["command"] == cmd)
+                .unwrap_or_else(|| panic!("{cmd} missing from the schema — was it registered with register_handler instead of register_typed?"))
+        };
+
+        for cmd in [
+            crate::backend::rpc_types::COMMAND_AGENT_DEF_HIDE,
+            crate::backend::rpc_types::COMMAND_AGENT_DEF_UNHIDE,
+        ] {
+            let row = find(cmd);
+            assert_eq!(row["requestName"], "CommandAgentDefHideData", "{cmd} request type");
+            assert_eq!(row["responseName"], "AgentDefHideResult", "{cmd} response type");
+            // The full path is what disambiguates two same-named types in
+            // different modules, so it must be a path, not a bare name.
+            assert!(
+                row["request"].as_str().unwrap().contains("::"),
+                "{cmd} request should be fully qualified, got {:?}",
+                row["request"]
+            );
+        }
+
+        // Commands still on register_handler are absent rather than recorded
+        // wrong — that absence is what makes migrating one at a time safe.
+        assert!(
+            rows.iter().all(|r| r["command"] != crate::backend::rpc_types::COMMAND_LIST_AGENTS),
+            "listagents is not migrated yet and must not appear in the schema",
+        );
+    }
+
+    /// A migrated handler answers exactly as it did before, including the
+    /// error shape for a malformed request.
+    #[tokio::test]
+    async fn register_typed_preserves_the_wire_behaviour_of_a_migrated_handler() {
+        let (_state, engine, mut rx) = build_state_with_template_seed();
+
+        // Happy path: unchanged response body.
+        let resp: crate::backend::rpc_types::AgentDefHideResult = call_rpc(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_AGENT_DEF_HIDE,
+            serde_json::json!({ "definition_id": "tpl-claude" }),
+        )
+        .await;
+        assert!(resp.ok);
+
+        // Malformed request: still an RPC error, still prefixed with the
+        // command name the hand-written body used.
+        let err = call_rpc_expect_error(
+            &engine,
+            &mut rx,
+            crate::backend::rpc_types::COMMAND_AGENT_DEF_HIDE,
+            serde_json::json!({ "definition_id": 42 }),
+        )
+        .await;
+        assert!(
+            err.starts_with("agentdefhide:"),
+            "error should keep the command prefix, got {err:?}",
+        );
+    }
+
     #[tokio::test]
     async fn hide_then_unhide_round_trip() {
         let (_state, engine, mut rx) = build_state_with_template_seed();

--- a/agentmux-srv/src/server/agent_handlers/template.rs
+++ b/agentmux-srv/src/server/agent_handlers/template.rs
@@ -282,14 +282,18 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     // disappears (existing list query already excludes hidden by default).
     let wstore_hide = state.wstore.clone();
     let broker_hide = state.broker.clone();
-    engine.register_handler(
+    // Registered through `register_typed` (rather than `register_handler`)
+    // so this command's request/response pair lands in the engine's
+    // `RpcSchema` — the mapping the frontend's bindings will be generated
+    // from. See `backend/rpc/schema.rs`. Behaviour is unchanged: the
+    // deserialize-in / serialize-out steps this body used to perform are
+    // exactly what the wrapper now does.
+    engine.register_typed(
         COMMAND_AGENT_DEF_HIDE,
-        Box::new(move |data, _ctx| {
+        move |cmd: CommandAgentDefHideData, _ctx| {
             let wstore = wstore_hide.clone();
             let broker = broker_hide.clone();
-            Box::pin(async move {
-                let cmd: CommandAgentDefHideData = serde_json::from_value(data)
-                    .map_err(|e| format!("agentdefhide: {e}"))?;
+            async move {
                 let ok = wstore
                     .agent_def_set_hidden(&cmd.definition_id, true)
                     .map_err(|e| format!("agentdefhide: {e}"))?;
@@ -306,10 +310,9 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         "agentdefhide: hid template"
                     );
                 }
-                let resp = AgentDefHideResult { ok };
-                Ok(Some(serde_json::to_value(&resp).unwrap_or_default()))
-            })
-        }),
+                Ok(AgentDefHideResult { ok })
+            }
+        },
     );
 
     // agentdefunhide → set user_hidden = 0 on a seeded template,
@@ -317,14 +320,12 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     // agentdefhide. Phase 2 of the two-tier picker spec.
     let wstore_unhide = state.wstore.clone();
     let broker_unhide = state.broker.clone();
-    engine.register_handler(
+    engine.register_typed(
         COMMAND_AGENT_DEF_UNHIDE,
-        Box::new(move |data, _ctx| {
+        move |cmd: CommandAgentDefHideData, _ctx| {
             let wstore = wstore_unhide.clone();
             let broker = broker_unhide.clone();
-            Box::pin(async move {
-                let cmd: CommandAgentDefHideData = serde_json::from_value(data)
-                    .map_err(|e| format!("agentdefunhide: {e}"))?;
+            async move {
                 let ok = wstore
                     .agent_def_set_hidden(&cmd.definition_id, false)
                     .map_err(|e| format!("agentdefunhide: {e}"))?;
@@ -341,10 +342,9 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         "agentdefunhide: unhid template"
                     );
                 }
-                let resp = AgentDefHideResult { ok };
-                Ok(Some(serde_json::to_value(&resp).unwrap_or_default()))
-            })
-        }),
+                Ok(AgentDefHideResult { ok })
+            }
+        },
     );
 
     // agentdeflisthiddentemplates → templates the user has hidden

--- a/test/contract/rpc-contract.test.ts
+++ b/test/contract/rpc-contract.test.ts
@@ -82,7 +82,13 @@ interface Contract {
 }
 
 function deriveContract(root: string): Contract {
-    // ── Backend: resolve `register_handler(NAME, …)` to command names.
+    // ── Backend: resolve `register_handler(NAME, …)` and
+    // `register_typed(NAME, …)` to command names. Both are real
+    // registrations — `register_typed` additionally records the command's
+    // request/response types in the engine's `RpcSchema`
+    // (SPEC_RPC_BINDINGS_CODEGEN_2026_09_07.md). Missing it here would let
+    // a command silently drop out of this contract the moment it is
+    // migrated, which is the opposite of what this test is for.
     // NAME is a string literal or a `pub const … &str = "…"`. Both forms
     // appear; consts are resolved against every const defined in the
     // crate (not just COMMAND_*-prefixed ones).
@@ -97,7 +103,20 @@ function deriveContract(root: string): Contract {
 
     const registered = new Set<string>();
     const unresolved: string[] = [];
-    const regRe = /register_handler\s*\(\s*(?:"([^"]+)"|([A-Za-z_][A-Za-z0-9_:]*))/g;
+    const regRe = /register_(?:handler|typed)\s*\(\s*(?:"([^"]+)"|([A-Za-z_][A-Za-z0-9_:]*))/g;
+    // `register_typed` forwards to `register_handler(command, …)`, where
+    // `command` is its own parameter — unresolvable by construction and not a
+    // registration. Skip exactly that one call: the engine file AND the
+    // identifier `command`.
+    //
+    // Not a whole-file exclusion — engine.rs also carries `#[cfg(test)]`
+    // registrations ("echo", "failme", "checkctx") that are string literals
+    // and legitimately belong in `registered`; dropping the file removed them
+    // and silently shrank the backend surface this test compares against.
+    // Not a bare identifier allow-list either — a real handler elsewhere that
+    // used `command` as a local would then be skipped in silence. Both
+    // conditions together are what keep the loud-failure guarantee intact.
+    const enginePath = path.join("backend", "rpc", "engine.rs");
     for (const f of rsFiles) {
         const src = fs.readFileSync(f, "utf8");
         let m: RegExpExecArray | null;
@@ -108,14 +127,19 @@ function deriveContract(root: string): Contract {
             }
             const ident = m[2].split("::").pop() as string;
             const val = constMap.get(ident);
-            if (val !== undefined) registered.add(val);
-            else unresolved.push(ident);
+            if (val !== undefined) {
+                registered.add(val);
+            } else if (f.endsWith(enginePath) && ident === "command") {
+                // register_typed's forwarding call — see above.
+            } else {
+                unresolved.push(ident);
+            }
         }
     }
     // A register_handler arg we can't resolve means the extractor is
     // blind to part of the contract — fail loudly rather than pass with
     // an incomplete `registered` set.
-    expect(unresolved, `unresolved register_handler args: ${unresolved.join(", ")}`).toEqual([]);
+    expect(unresolved, `unresolved register_handler/register_typed args: ${unresolved.join(", ")}`).toEqual([]);
 
     // ── Frontend: declared bindings (method → command) in rpc-api.ts.
     // Each binding is `Method(client: RpcClient, …): Ret { return
@@ -315,6 +339,12 @@ const KNOWN_REGISTERED_UNDECLARED = [
     "memory.write",
     "pane.open",
     "slow",
+    // engine.rs #[cfg(test)] registrations for the typed-registry eviction
+    // tests, same category as echo/failme/checkctx above: real
+    // register_* calls in test code, never a frontend-facing command.
+    "stays-recorded",
+    "typed-then-stream",
+    "typed-then-untyped",
 ];
 
 describe("RPC frontend↔backend contract (A1)", () => {

--- a/test/contract/rpc-contract.test.ts
+++ b/test/contract/rpc-contract.test.ts
@@ -104,19 +104,12 @@ function deriveContract(root: string): Contract {
     const registered = new Set<string>();
     const unresolved: string[] = [];
     const regRe = /register_(?:handler|typed)\s*\(\s*(?:"([^"]+)"|([A-Za-z_][A-Za-z0-9_:]*))/g;
-    // `register_typed` forwards to `register_handler(command, …)`, where
-    // `command` is its own parameter — unresolvable by construction and not a
-    // registration. Skip exactly that one call: the engine file AND the
-    // identifier `command`.
-    //
-    // Not a whole-file exclusion — engine.rs also carries `#[cfg(test)]`
-    // registrations ("echo", "failme", "checkctx") that are string literals
-    // and legitimately belong in `registered`; dropping the file removed them
-    // and silently shrank the backend surface this test compares against.
-    // Not a bare identifier allow-list either — a real handler elsewhere that
-    // used `command` as a local would then be skipped in silence. Both
-    // conditions together are what keep the loud-failure guarantee intact.
-    const enginePath = path.join("backend", "rpc", "engine.rs");
+    // Every match must resolve to a command name. `register_typed` installs
+    // its wrapper through a private `install_call_handler`, which this regex
+    // deliberately does not match, so the engine's own plumbing contributes
+    // nothing here and needs no special case — only real registrations in the
+    // handler modules (and engine.rs's own `#[cfg(test)]` stubs, which use
+    // string literals) are seen.
     for (const f of rsFiles) {
         const src = fs.readFileSync(f, "utf8");
         let m: RegExpExecArray | null;
@@ -129,8 +122,6 @@ function deriveContract(root: string): Contract {
             const val = constMap.get(ident);
             if (val !== undefined) {
                 registered.add(val);
-            } else if (f.endsWith(enginePath) && ident === "command") {
-                // register_typed's forwarding call — see above.
             } else {
                 unresolved.push(ident);
             }


### PR DESCRIPTION
## Summary

Phase 2 step 1 of `docs/reports/REPORT_DRY_AND_MODULARITY_AUDIT_2026_09_06.md`, per the design in `docs/specs/SPEC_RPC_BINDINGS_CODEGEN_2026_09_07.md` §3.4: **make the command → request/response mapping exist as data.** No generator, no new dependency, no behavior change.

## Why this comes first

The audit's headline number is 334 "keep in sync with the agentmux-srv RPC" comments across 284 hand-written stubs and a 2,819-line hand-maintained `gotypes.d.ts`. The obvious fix is to derive the TypeScript from the Rust — and the spec's §2 finding is that **that alone cannot work**:

> which command takes which request struct and returns which response is not data anywhere in srv

Each handler picks its request type inline (`serde_json::from_value::<CommandXData>(data)`) and builds its response ad hoc (`serde_json::to_value(&x)`, `json!({"ok": true})`). A type generator can emit all 190 structs and still not know how to pair them into a callable stub. So the pairing has to exist before any generator is worth writing.

## What's here

- **`backend/rpc/schema.rs`** — `RpcSchema` / `RpcBinding`: one row per typed command, holding the fully qualified request and response type names, keyed and returned in command order so the output is byte-stable across runs (what a future CI gate diffs).
- **`RpcEngine::register_typed<Req, Resp>`** — registers a handler *and* records the pair. It wraps the closure in exactly the deserialize → run → serialize steps every hand-written handler already performs, so migrating one is not supposed to change the wire at all.
- **Two handlers migrated as proof** — `agentdefhide` and `agentdefunhide` (`CommandAgentDefHideData` → `AgentDefHideResult`). Their bodies are unchanged apart from dropping the two lines `register_typed` now does for them.

Handlers still on `register_handler` contribute nothing to the schema and are simply absent. That absence is deliberate and is what makes a 284-stub migration possible one command at a time.

## Verification

- `cargo test -p agentmux-srv register_typed` — **2 passed**, both asserting properties rather than smoke:
  - the schema records the exact request/response type names for both commands, and the paths are fully qualified (a rename that would silently change generated bindings fails here); and `listagents`, still untyped, is asserted *absent*.
  - a migrated handler's wire behaviour is unchanged — same success body, and a malformed request still errors with the same `agentdefhide:` prefix the hand-written body used.
- `cargo test --workspace -- --test-threads=1` — **4,092 passed, 0 failed**
- No new dependency; `cargo check -p agentmux-srv` clean.

## What is deliberately NOT here

**The dump mode and CI gate** (spec §3.2/§3.3). Building them surfaced the exact risk the spec flagged in §5:

> The dump mode must register every handler without a live `AppState`. If registration turns out to need one, the registry moves to a `const` table next to `commands.rs` — less elegant, same gate.

Handler registration does need a live `AppState` (stores, broker, network). A CLI `--dump-rpc-schema` would have to stand up a throwaway data dir to emit anything, and the alternative — exporting from a test, the way `ts-rs` itself does — is a different enough shape to deserve its own review. Rather than pick one in passing at the end of this change, the registry lands first and proves it works; the dump and the gate follow against something already exercised.

**The TypeScript generator and `ts-rs`.** Adding a proc-macro dependency to `agentmux-srv` is its own decision with its own build-time cost, and the spec asks for that cost to be measured. It belongs on top of a registry that already exists, not bundled with the change that creates it.

So this PR does not yet remove a single sync comment. It makes removing them possible, which is the part the spec identified as load-bearing.

<!-- agentmux:agent_id=manoz -->
