### PR TITLE
Korp@claudius: feat(storage): db_agents carries the latest launch state — schema v29 + m0025 backfill (agent consolidation Phase 3b, PR 1 of 4)

### DIFF
--- a/.changesets/1788786719-feat-storage-db-agents-carries-the-latest-launch-state-sessi-5yo1.md
+++ b/.changesets/1788786719-feat-storage-db-agents-carries-the-latest-launch-state-sessi-5yo1.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(storage): db_agents carries the latest launch state (session/status/started/ended) — schema v29 + backfill from db_agent_instances (agent consolidation Phase 3b, PR 1)

--- a/agentmux-srv/src/backend/storage/dual_write.rs
+++ b/agentmux-srv/src/backend/storage/dual_write.rs
@@ -302,7 +302,11 @@ impl Store {
                     instance_name = ?7,
                     updated_at = ?8,
                     user_hidden = ?9,
-                    last_block_id = ?10
+                    last_block_id = ?10,
+                    session_id = ?11,
+                    status = ?12,
+                    started_at = ?13,
+                    ended_at = ?14
                  WHERE id = ?1",
                 params![
                     def.id,
@@ -315,6 +319,10 @@ impl Store {
                     now_ms,
                     if inst.display_hidden { 1_i64 } else { 0_i64 },
                     inst.block_id,
+                    inst.session_id,
+                    inst.status,
+                    inst.started_at,
+                    inst.ended_at,
                 ],
             )
         } else if is_continuation {
@@ -345,7 +353,11 @@ impl Store {
                     instance_name = ?7,
                     updated_at = ?8,
                     user_hidden = ?9,
-                    last_block_id = ?10
+                    last_block_id = ?10,
+                    session_id = ?11,
+                    status = ?12,
+                    started_at = ?13,
+                    ended_at = ?14
                  WHERE id = ?1 AND is_template = 0",
                 params![
                     root_id,
@@ -358,6 +370,10 @@ impl Store {
                     now_ms,
                     if inst.display_hidden { 1_i64 } else { 0_i64 },
                     inst.block_id,
+                    inst.session_id,
+                    inst.status,
+                    inst.started_at,
+                    inst.ended_at,
                 ],
             )
         } else {
@@ -375,7 +391,8 @@ impl Store {
                     created_at, updated_at, is_seeded, user_hidden,
                     last_block_id,
                     container_image, container_volumes, container_name,
-                    use_ambient_login
+                    use_ambient_login,
+                    session_id, status, started_at, ended_at
                  ) VALUES (
                     ?1, ?2, ?3, ?4,
                     0, ?5,
@@ -388,7 +405,8 @@ impl Store {
                     ?23, ?24, 0, ?25,
                     ?26,
                     ?27, ?28, ?29,
-                    ?30
+                    ?30,
+                    ?31, ?32, ?33, ?34
                  )
                  ON CONFLICT(id) DO UPDATE SET
                     name = excluded.name,
@@ -399,7 +417,11 @@ impl Store {
                     instance_name = excluded.instance_name,
                     updated_at = excluded.updated_at,
                     user_hidden = excluded.user_hidden,
-                    last_block_id = excluded.last_block_id",
+                    last_block_id = excluded.last_block_id,
+                    session_id = excluded.session_id,
+                    status = excluded.status,
+                    started_at = excluded.started_at,
+                    ended_at = excluded.ended_at",
                 params![
                     inst.id,
                     name,
@@ -431,6 +453,10 @@ impl Store {
                     def.container_volumes,
                     def.container_name,
                     def.use_ambient_login,
+                    inst.session_id,
+                    inst.status,
+                    inst.started_at,
+                    inst.ended_at,
                 ],
             )
         };
@@ -466,16 +492,20 @@ impl Store {
             Some((k, _)) => k,
             None => return Ok(()),
         };
-        // `instance_update` only touches block_id/session_id/status/
-        // github_context/ended_at. Of those, only `github_context` lands
-        // on db_agents (block/session/status/ended_at are not modelled
-        // on the consolidated row — they're block/session-machine
-        // concerns the consolidation deliberately drops). We DO refresh
-        // updated_at so a Phase-3b reader can sort by recency. Apply
-        // the same monotonic-floor trick as the fold branch in
-        // `agents_dual_write_instance_create` — wall clock alone
-        // collides under millisecond resolution on fast successive
-        // mutations.
+        // `instance_update` touches block_id/session_id/status/
+        // github_context/ended_at. As of schema v29 every one of them is
+        // modelled on the consolidated row (the launch-state columns —
+        // see OBJECT_SCHEMA_VERSION's v29 entry), so mirror the whole
+        // post-update row: `inst` is the reloaded legacy row, i.e. the
+        // authoritative current values, and a continuation's update lands
+        // on the chain head via the projection key above, which is exactly
+        // "the agent's latest launch state". `last_block_id` only moves
+        // when the row actually has a block — an empty block_id must not
+        // erase the pointer My Agents uses to find the snapshot. We also
+        // refresh updated_at so a Phase-3b reader can sort by recency,
+        // with the same monotonic-floor trick as the fold branch in
+        // `agents_dual_write_instance_create` — wall clock alone collides
+        // under millisecond resolution on fast successive mutations.
         let global_prior: i64 = conn
             .query_row(
                 "SELECT COALESCE(MAX(updated_at), 0) FROM db_agents",
@@ -487,9 +517,21 @@ impl Store {
         conn.execute(
             "UPDATE db_agents SET
                 github_context = ?1,
-                updated_at = ?2
+                updated_at = ?2,
+                session_id = ?4,
+                status = ?5,
+                ended_at = ?6,
+                last_block_id = CASE WHEN ?7 = '' THEN last_block_id ELSE ?7 END
              WHERE id = ?3 AND is_template = 0",
-            params![inst.github_context, now_monotonic, key],
+            params![
+                inst.github_context,
+                now_monotonic,
+                key,
+                inst.session_id,
+                inst.status,
+                inst.ended_at,
+                inst.block_id,
+            ],
         )?;
         Ok(())
     }

--- a/agentmux-srv/src/backend/storage/dual_write.rs
+++ b/agentmux-srv/src/backend/storage/dual_write.rs
@@ -488,24 +488,31 @@ impl Store {
         // instance was folded at create. The previous version keyed by
         // `inst.id` always and silently no-op'd on every folded
         // instance's lifecycle event.
-        let key = match Self::agents_projection_key_for_inst(&conn, &inst.id) {
-            Some((k, _)) => k,
+        let (key, is_folded) = match Self::agents_projection_key_for_inst(&conn, &inst.id) {
+            Some(k) => k,
             None => return Ok(()),
         };
         // `instance_update` touches block_id/session_id/status/
         // github_context/ended_at. As of schema v29 every one of them is
         // modelled on the consolidated row (the launch-state columns —
-        // see OBJECT_SCHEMA_VERSION's v29 entry), so mirror the whole
-        // post-update row: `inst` is the reloaded legacy row, i.e. the
-        // authoritative current values, and a continuation's update lands
-        // on the chain head via the projection key above, which is exactly
-        // "the agent's latest launch state". `last_block_id` only moves
-        // when the row actually has a block — an empty block_id must not
-        // erase the pointer My Agents uses to find the snapshot. We also
-        // refresh updated_at so a Phase-3b reader can sort by recency,
-        // with the same monotonic-floor trick as the fold branch in
-        // `agents_dual_write_instance_create` — wall clock alone collides
-        // under millisecond resolution on fast successive mutations.
+        // see OBJECT_SCHEMA_VERSION's v29 entry). The row holds the agent's
+        // LATEST launch state, so the launch-state fields are taken from
+        // the newest instance in the chain, not from `inst`: an older
+        // chain member can still receive a late write (a delayed
+        // session/status capture from its old pane) after a continuation
+        // has superseded it, and mirroring that write would swap the
+        // continuation's session for the old one — resuming the wrong
+        // conversation (codex P1 on #3075). `github_context` is not launch
+        // state and mirrors from `inst` as before. `last_block_id` only
+        // moves when the newest launch actually has a block — an empty
+        // block_id must not erase the pointer My Agents uses to find the
+        // snapshot. We also refresh updated_at so a Phase-3b reader can
+        // sort by recency, with the same monotonic-floor trick as the fold
+        // branch in `agents_dual_write_instance_create` — wall clock alone
+        // collides under millisecond resolution on fast successive
+        // mutations.
+        let latest = Self::latest_launch_state_for_key(&conn, &key, is_folded)?
+            .unwrap_or_else(|| (inst.block_id.clone(), inst.session_id.clone(), inst.status.clone(), inst.ended_at));
         let global_prior: i64 = conn
             .query_row(
                 "SELECT COALESCE(MAX(updated_at), 0) FROM db_agents",
@@ -523,17 +530,47 @@ impl Store {
                 ended_at = ?6,
                 last_block_id = CASE WHEN ?7 = '' THEN last_block_id ELSE ?7 END
              WHERE id = ?3 AND is_template = 0",
-            params![
-                inst.github_context,
-                now_monotonic,
-                key,
-                inst.session_id,
-                inst.status,
-                inst.ended_at,
-                inst.block_id,
-            ],
+            params![inst.github_context, now_monotonic, key, latest.1, latest.2, latest.3, latest.0],
         )?;
         Ok(())
+    }
+
+    /// The `(block_id, session_id, status, ended_at)` of the NEWEST legacy
+    /// instance in the chain a projection key stands for — the state the
+    /// consolidated row must show. A folded key (`is_folded`) is a
+    /// user-clone definition id, whose launches and continuations all carry
+    /// that `definition_id`; a template-launch key is the chain head's own
+    /// id, whose descendants are found by walking `parent_instance_id`
+    /// downward. Newest by `created_at`, then id, so the choice is
+    /// deterministic on equal timestamps. `None` when no instance is found
+    /// (the caller falls back to the row it was handed).
+    fn latest_launch_state_for_key(
+        conn: &Connection,
+        key: &str,
+        is_folded: bool,
+    ) -> Result<Option<(String, String, String, i64)>, StoreError> {
+        let sql = if is_folded {
+            "SELECT block_id, session_id, status, ended_at
+             FROM db_agent_instances
+             WHERE definition_id = ?1
+             ORDER BY created_at DESC, id DESC
+             LIMIT 1"
+        } else {
+            "WITH RECURSIVE chain(id) AS (
+                SELECT id FROM db_agent_instances WHERE id = ?1
+                UNION ALL
+                SELECT c.id FROM db_agent_instances c JOIN chain ON c.parent_instance_id = chain.id
+             )
+             SELECT i.block_id, i.session_id, i.status, i.ended_at
+             FROM db_agent_instances i JOIN chain ON i.id = chain.id
+             ORDER BY i.created_at DESC, i.id DESC
+             LIMIT 1"
+        };
+        match conn.query_row(sql, params![key], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))) {
+            Ok(v) => Ok(Some(v)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
     }
 
     /// Mirror `instance_set_hidden` into `db_agents.user_hidden`.

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -581,12 +581,11 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             github_context       TEXT NOT NULL DEFAULT '',
             instance_name        TEXT NOT NULL DEFAULT '',
 
-            -- Latest launch's block (Phase 3c): pointer to the most-recent
-            -- session's block so the consolidated read can locate the
-            -- conversation snapshot without joining db_agent_instances. The
-            -- only transient per-launch field db_agents retains; the rest
-            -- (status/session_id/started_at/ended_at) live on the block and
-            -- retire with db_agent_instances.
+            -- Latest launch's block: pointer to the most-recent session's
+            -- block so the consolidated read can locate the conversation
+            -- snapshot without joining db_agent_instances. Was the only
+            -- per-launch field db_agents retained until v29 added the
+            -- four launch-state columns right below it.
             last_block_id        TEXT NOT NULL DEFAULT '',
 
             -- Latest launch's state (v29, consolidation Phase 3b/3c). The

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -267,7 +267,23 @@ pub const SHARED_STORE_SCHEMA_VERSION: i64 = 9;
 ///        column (same collision class as this file's own v20→v22 and
 ///        v24→v25 history, see those entries above). See
 ///        docs/reports/REPORT_AGENT_PICKER_FIELD_ORDER_SORT_AND_DATA_GAPS_AUDIT_2026_08_24.md §5a.
-pub const OBJECT_SCHEMA_VERSION: i64 = 28;
+///   v29 — db_agents.session_id / status / started_at / ended_at: the
+///        agent's LATEST launch state, the four `db_agent_instances`
+///        columns the consolidated row never got (Phase 3a deliberately
+///        left them "on the block", but the recent-sessions picker, the
+///        pane close/reopen continuity write-back and the status-filtered
+///        instance list all kept reading them from the legacy table — the
+///        reason it could not be dropped). One row per agent ⇒ one launch
+///        state per agent; a continuation moves it to the new block/session.
+///        Backfilled from the legacy rows by
+///        `m0025_agents_launch_state_backfill` (latest instance per
+///        projection key), kept current by the instance dual-write, and
+///        the read flip in `SPEC_AGENT_ARCHITECTURE_2026_05_27.md` Phase
+///        3b retires the legacy reads on top of it. No unique index on
+///        `db_agents(slug)` is added: template-launch projections copy
+///        their template's slug, so uniqueness stays a definition-level
+///        rule enforced by the slug collision scan in `agent_def_insert`.
+pub const OBJECT_SCHEMA_VERSION: i64 = 29;
 /// `user_version` value stamped into `filestore.db`.
 pub const FILESTORE_SCHEMA_VERSION: i64 = 1;
 /// `user_version` value stamped into `sagas.db`.
@@ -572,6 +588,20 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             -- (status/session_id/started_at/ended_at) live on the block and
             -- retire with db_agent_instances.
             last_block_id        TEXT NOT NULL DEFAULT '',
+
+            -- Latest launch's state (v29, consolidation Phase 3b/3c). The
+            -- original 3a design left status/session_id/started_at/ended_at
+            -- to the block; in practice the recent-sessions picker, the
+            -- pane close/reopen continuity guarantee
+            -- (SPEC_PANE_CLOSE_REOPEN_CONTINUITY_GUARANTEE_2026_07_27.md §4.1)
+            -- and the status-filtered instance list all still read them from
+            -- db_agent_instances, which is what kept that table alive. One
+            -- row per agent means one launch state per agent: a continuation
+            -- moves these to the new block/session rather than adding a row.
+            session_id           TEXT NOT NULL DEFAULT '',
+            status               TEXT NOT NULL DEFAULT '',
+            started_at           INTEGER NOT NULL DEFAULT 0,
+            ended_at             INTEGER NOT NULL DEFAULT 0,
 
             -- Provenance
             created_at           INTEGER NOT NULL DEFAULT 0,
@@ -982,6 +1012,16 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
         // v27: AgentMux-controlled, highest-priority Global Memory tier —
         // see OBJECT_SCHEMA_VERSION's v27 doc comment above.
         "ALTER TABLE db_bundles ADD COLUMN is_system INTEGER NOT NULL DEFAULT 0",
+        // v29: the agent's latest launch state on db_agents — the four
+        // db_agent_instances columns the consolidated row still lacked. See
+        // OBJECT_SCHEMA_VERSION's v29 doc comment above and the column doc in
+        // db_agents' CREATE TABLE. Backfilled from db_agent_instances by
+        // m0025_agents_launch_state_backfill; kept current by the instance
+        // dual-write until the legacy table is dropped.
+        "ALTER TABLE db_agents ADD COLUMN session_id TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE db_agents ADD COLUMN status TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE db_agents ADD COLUMN started_at INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE db_agents ADD COLUMN ended_at INTEGER NOT NULL DEFAULT 0",
     ] {
         if let Err(e) = conn.execute_batch(stmt) {
             let msg = e.to_string();

--- a/agentmux-srv/src/backend/storage/store/tests.rs
+++ b/agentmux-srv/src/backend/storage/store/tests.rs
@@ -3104,6 +3104,126 @@
         assert_eq!(count_agents(&store, "id = 'inst-cont'"), 0);
     }
 
+    /// Schema v29 (agent consolidation Phase 3b, PR 1): the consolidated
+    /// row carries the agent's LATEST launch state, and every instance
+    /// write path keeps it current — create (template launch = own row),
+    /// partial update (session capture, status change, block move), and a
+    /// continuation (which moves the chain head's state to the new launch
+    /// rather than adding a row). This is what lets the Phase 3b readers
+    /// stop joining `db_agent_instances`.
+    #[test]
+    fn dual_write_instance_lifecycle_keeps_launch_state_current_on_db_agents() {
+        let store = make_store();
+        let mut tpl = AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
+            id: "tpl-ls".to_string(),
+            slug: String::new(),
+            name: "Coder".to_string(),
+            icon: String::new(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: "bash".to_string(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 1000,
+            agent_type: "standalone".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 1,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+            updated_at: 1000,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+            auto_continue_enabled: 0,
+            model_vendor_base_url: String::new(),
+            memory_id: String::new(),
+        };
+        store.agent_def_insert(&mut tpl).unwrap();
+        let launch_state = |id: &str| {
+            let conn = store.conn.lock().unwrap();
+            conn.query_row(
+                "SELECT session_id, status, started_at, ended_at, last_block_id FROM db_agents WHERE id = ?1",
+                [id],
+                |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?, r.get::<_, i64>(2)?, r.get::<_, i64>(3)?, r.get::<_, String>(4)?)),
+            )
+            .unwrap()
+        };
+
+        // Create: a template launch is its own row, launch state copied.
+        let head = AgentInstance {
+            id: "inst-ls".to_string(),
+            definition_id: "tpl-ls".to_string(),
+            parent_instance_id: String::new(),
+            block_id: "blk-1".to_string(),
+            session_id: String::new(),
+            status: "running".to_string(),
+            github_context: String::new(),
+            started_at: 2000,
+            ended_at: 0,
+            created_at: 2000,
+            identity_id: String::new(),
+            memory_id: String::new(),
+            instance_name: "Maks".to_string(),
+            working_directory: String::new(),
+            display_hidden: false,
+        };
+        store.instance_create(&head).unwrap();
+        assert_eq!(launch_state("inst-ls"), (String::new(), "running".into(), 2000, 0, "blk-1".into()));
+
+        // Partial update: a session capture lands on the row; an update
+        // that carries no block leaves last_block_id alone.
+        store
+            .instance_update_partial(
+                "inst-ls",
+                &crate::backend::storage::InstanceUpdate { session_id: Some("sess-1".into()), ..Default::default() },
+            )
+            .unwrap();
+        assert_eq!(launch_state("inst-ls"), ("sess-1".into(), "running".into(), 2000, 0, "blk-1".into()));
+        store
+            .instance_update_partial(
+                "inst-ls",
+                &crate::backend::storage::InstanceUpdate {
+                    status: Some("stopped".into()),
+                    ended_at: Some(2500),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(launch_state("inst-ls"), ("sess-1".into(), "stopped".into(), 2000, 2500, "blk-1".into()));
+
+        // Continuation: no new row; the head's state moves to the new launch.
+        let cont = AgentInstance {
+            id: "inst-ls-2".to_string(),
+            parent_instance_id: "inst-ls".to_string(),
+            block_id: "blk-2".to_string(),
+            session_id: String::new(),
+            status: "running".to_string(),
+            started_at: 3000,
+            created_at: 3000,
+            ended_at: 0,
+            ..head.clone()
+        };
+        store.instance_create(&cont).unwrap();
+        assert_eq!(count_agents(&store, "id = 'inst-ls-2'"), 0);
+        assert_eq!(launch_state("inst-ls"), (String::new(), "running".into(), 3000, 0, "blk-2".into()));
+        // ...and a session captured on the continuation reaches the head too.
+        store
+            .instance_update_partial(
+                "inst-ls-2",
+                &crate::backend::storage::InstanceUpdate { session_id: Some("sess-2".into()), ..Default::default() },
+            )
+            .unwrap();
+        assert_eq!(launch_state("inst-ls").0, "sess-2");
+    }
+
     /// Reagent P1 + P2 on #1013 round 2 — pins the user-cloned-def
     /// branch of `agents_dual_write_instance_create` so it matches
     /// the backfill rule (`agents_consolidate.rs::backfill_instances`

--- a/agentmux-srv/src/backend/storage/store/tests.rs
+++ b/agentmux-srv/src/backend/storage/store/tests.rs
@@ -3222,6 +3222,23 @@
             )
             .unwrap();
         assert_eq!(launch_state("inst-ls").0, "sess-2");
+
+        // A late write from the SUPERSEDED launch (its old pane finally
+        // reporting) must not swap the continuation's state back — the row
+        // shows the newest launch's state, not the writer's (codex P1 on
+        // #3075).
+        store
+            .instance_update_partial(
+                "inst-ls",
+                &crate::backend::storage::InstanceUpdate {
+                    session_id: Some("sess-stale".into()),
+                    status: Some("stopped".into()),
+                    ended_at: Some(3500),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(launch_state("inst-ls"), ("sess-2".into(), "running".into(), 3000, 0, "blk-2".into()));
     }
 
     /// Reagent P1 + P2 on #1013 round 2 — pins the user-cloned-def

--- a/agentmux-srv/src/migrations/m0025_agents_launch_state_backfill.rs
+++ b/agentmux-srv/src/migrations/m0025_agents_launch_state_backfill.rs
@@ -82,8 +82,77 @@ fn projection_key(
     }
 }
 
-/// The backfill proper, on an open connection. `Ok(n)` = rows updated.
-pub(super) fn backfill_launch_state(conn: &Connection) -> Result<usize, String> {
+/// What the backfill did. `projected` counts template-launch chains whose
+/// consolidated row was missing and had to be created first; `updated`
+/// counts rows that received launch state.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(super) struct BackfillStats {
+    pub definitions_repaired: usize,
+    pub projected: usize,
+    pub updated: usize,
+    pub missing_definition: usize,
+}
+
+/// Create the consolidated row for a template-launch chain whose head has
+/// no `db_agents` row yet — the "Phase 3a stamped, db_agents partially
+/// populated" upgrade shape (codex P1 on #3075). Without this the UPDATE
+/// below affects zero rows, the migration is still recorded applied, and
+/// the chain's session/status is unreachable once readers flip. Frozen
+/// copy of the consolidate pass-3 / dual-write head-INSERT column mapping
+/// as of v29, `INSERT OR IGNORE` so it can never clobber a row that
+/// appeared in between. `Ok(false)` when the definition itself is gone —
+/// nothing to project against (the legacy FK cascade would have removed
+/// such an instance; if it survived it is an orphan).
+fn project_template_launch_row(conn: &Connection, root: &LegacyInstance) -> Result<bool, String> {
+    let n = conn
+        .execute(
+            "INSERT OR IGNORE INTO db_agents (
+                id, name, icon, description,
+                is_template, parent_template_id,
+                provider, provider_flags, shell, environment,
+                agent_type, agent_bus_id, accounts,
+                auto_start, restart_on_crash, idle_timeout_minutes,
+                slug, branch_label,
+                identity_id, memory_id, working_directory, github_context,
+                instance_name,
+                created_at, updated_at, is_seeded, user_hidden,
+                container_image, container_volumes, container_name,
+                use_ambient_login, model_vendor_base_url, auto_continue_enabled,
+                conversation_visibility
+             )
+             SELECT i.id,
+                    CASE WHEN i.instance_name = '' THEN d.name ELSE i.instance_name END,
+                    d.icon, d.description,
+                    0, d.id,
+                    d.provider, d.provider_flags, d.shell, d.environment,
+                    d.agent_type, d.agent_bus_id, d.accounts,
+                    d.auto_start, d.restart_on_crash, d.idle_timeout_minutes,
+                    d.slug, d.branch_label,
+                    i.identity_id, i.memory_id, d.working_directory, i.github_context,
+                    i.instance_name,
+                    i.created_at, i.created_at, 0, i.display_hidden,
+                    d.container_image, d.container_volumes, d.container_name,
+                    d.use_ambient_login, d.model_vendor_base_url, d.auto_continue_enabled,
+                    d.conversation_visibility
+             FROM db_agent_instances i
+             JOIN db_agent_definitions d ON d.id = i.definition_id
+             WHERE i.id = ?1",
+            params![root.id],
+        )
+        .map_err(|e| format!("project template launch {}: {e}", root.id))?;
+    Ok(n > 0)
+}
+
+/// The backfill proper, on an open connection.
+///
+/// Order matters: first every definition missing from `db_agents` is
+/// repaired (the same `repair_def_gaps` bootstrap runs, but bootstrap runs
+/// it AFTER migrations — too late for this one), then every
+/// template-launch chain head missing its projection row is projected,
+/// and only then is launch state copied. Otherwise a missing row would be
+/// skipped here, created later with default launch state, and never
+/// revisited (codex P1 on #3075).
+pub(super) fn backfill_launch_state(conn: &mut Connection) -> Result<BackfillStats, String> {
     let has_legacy: bool = conn
         .query_row(
             "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'db_agent_instances')",
@@ -92,8 +161,13 @@ pub(super) fn backfill_launch_state(conn: &Connection) -> Result<usize, String> 
         )
         .map_err(|e| format!("probe db_agent_instances: {e}"))?;
     if !has_legacy {
-        return Ok(0);
+        return Ok(BackfillStats::default());
     }
+    let mut stats = BackfillStats {
+        definitions_repaired: crate::backend::storage::agents_consolidate::repair_def_gaps(conn)
+            .map_err(|e| format!("repair definition gaps: {e}"))?,
+        ..Default::default()
+    };
 
     let mut stmt = conn
         .prepare(
@@ -118,8 +192,9 @@ pub(super) fn backfill_launch_state(conn: &Connection) -> Result<usize, String> 
         })
         .and_then(|rows| rows.collect::<Result<Vec<_>, _>>())
         .map_err(|e| format!("read db_agent_instances: {e}"))?;
+    drop(stmt);
     if instances.is_empty() {
-        return Ok(0);
+        return Ok(stats);
     }
 
     let mut seeded_stmt = conn
@@ -129,6 +204,7 @@ pub(super) fn backfill_launch_state(conn: &Connection) -> Result<usize, String> 
         .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)))
         .and_then(|rows| rows.collect::<Result<HashMap<_, _>, _>>())
         .map_err(|e| format!("read db_agent_definitions: {e}"))?;
+    drop(seeded_stmt);
 
     let by_id: HashMap<String, &LegacyInstance> = instances.iter().map(|i| (i.id.clone(), i)).collect();
     // Latest instance per projection key — `created_at`, then id, so the
@@ -145,7 +221,28 @@ pub(super) fn backfill_launch_state(conn: &Connection) -> Result<usize, String> 
         }
     }
 
-    let mut updated = 0usize;
+    // A template-launch key IS the chain head's instance id; if the head has
+    // no consolidated row, project one before the state copy below.
+    for key in latest.keys() {
+        let Some(root) = by_id.get(key) else { continue };
+        let exists: bool = conn
+            .query_row("SELECT EXISTS(SELECT 1 FROM db_agents WHERE id = ?1)", params![key], |r| r.get(0))
+            .map_err(|e| format!("probe db_agents {key}: {e}"))?;
+        if exists {
+            continue;
+        }
+        if project_template_launch_row(conn, root)? {
+            stats.projected += 1;
+        } else {
+            stats.missing_definition += 1;
+            tracing::warn!(
+                instance_id = %root.id,
+                definition_id = %root.definition_id,
+                "m0025_agents_launch_state_backfill: template launch has no definition; cannot project"
+            );
+        }
+    }
+
     for (key, inst) in latest {
         let n = conn
             .execute(
@@ -161,9 +258,9 @@ pub(super) fn backfill_launch_state(conn: &Connection) -> Result<usize, String> 
                 params![key, inst.session_id, inst.status, inst.started_at, inst.ended_at, inst.block_id],
             )
             .map_err(|e| format!("update db_agents {key}: {e}"))?;
-        updated += n;
+        stats.updated += n;
     }
-    Ok(updated)
+    Ok(stats)
 }
 
 impl Migration for M0025AgentsLaunchStateBackfill {
@@ -183,11 +280,17 @@ impl Migration for M0025AgentsLaunchStateBackfill {
             Store::open(&ctx.channel_store_path)
                 .map_err(|e| MigrationError(format!("agents_launch_state_backfill: open wstore: {e}")))?,
         );
-        let conn = Connection::open(&ctx.channel_store_path)
+        let mut conn = Connection::open(&ctx.channel_store_path)
             .map_err(|e| MigrationError(format!("agents_launch_state_backfill: open: {e}")))?;
-        let updated = backfill_launch_state(&conn)
+        let stats = backfill_launch_state(&mut conn)
             .map_err(|e| MigrationError(format!("agents_launch_state_backfill: {e}")))?;
-        tracing::info!(updated, "m0025_agents_launch_state_backfill: complete");
+        tracing::info!(
+            definitions_repaired = stats.definitions_repaired,
+            projected = stats.projected,
+            updated = stats.updated,
+            missing_definition = stats.missing_definition,
+            "m0025_agents_launch_state_backfill: complete"
+        );
         Ok(())
     }
 
@@ -296,8 +399,10 @@ mod tests {
     #[test]
     fn backfills_the_latest_launch_of_each_chain_into_its_projection_row() {
         let (_dir, path) = pre_v29_store();
-        let conn = Connection::open(&path).unwrap();
-        assert_eq!(backfill_launch_state(&conn).unwrap(), 2, "one template chain + one clone");
+        let mut conn = Connection::open(&path).unwrap();
+        let stats = backfill_launch_state(&mut conn).unwrap();
+        assert_eq!(stats.updated, 2, "one template chain + one clone: {stats:?}");
+        assert_eq!((stats.projected, stats.definitions_repaired, stats.missing_definition), (0, 0, 0));
         // The template chain's head row carries the CHILD's (latest) state.
         assert_eq!(launch_state(&conn, "head"), ("s2".into(), "running".into(), 3000, "b2".into()));
         // The clone's own row carries its launch.
@@ -309,12 +414,43 @@ mod tests {
     #[test]
     fn is_idempotent_and_never_overwrites_state_written_since() {
         let (_dir, path) = pre_v29_store();
-        let conn = Connection::open(&path).unwrap();
+        let mut conn = Connection::open(&path).unwrap();
         // Live state already on the head row (the dual-write got there first).
         conn.execute("UPDATE db_agents SET session_id = 'live', status = 'running' WHERE id = 'head'", []).unwrap();
-        assert_eq!(backfill_launch_state(&conn).unwrap(), 1, "only the still-default clone row");
+        assert_eq!(backfill_launch_state(&mut conn).unwrap().updated, 1, "only the still-default clone row");
         assert_eq!(launch_state(&conn, "head").0, "live");
-        assert_eq!(backfill_launch_state(&conn).unwrap(), 0, "second run writes nothing");
+        assert_eq!(backfill_launch_state(&mut conn).unwrap().updated, 0, "second run writes nothing");
+    }
+
+    #[test]
+    fn projects_a_template_launch_whose_consolidated_row_is_missing_before_copying_state() {
+        // The "Phase 3a stamped, db_agents partially populated" upgrade
+        // shape (codex P1 on #3075): the chain head has no db_agents row at
+        // all. Skipping it would record the migration applied while the
+        // chain's session stays unreachable forever.
+        let (_dir, path) = pre_v29_store();
+        let mut conn = Connection::open(&path).unwrap();
+        conn.execute("DELETE FROM db_agents WHERE id = 'head'", []).unwrap();
+        let stats = backfill_launch_state(&mut conn).unwrap();
+        assert_eq!(stats.projected, 1, "{stats:?}");
+        assert_eq!(stats.updated, 2, "{stats:?}");
+        assert_eq!(launch_state(&conn, "head"), ("s2".into(), "running".into(), 3000, "b2".into()));
+        let (is_template, parent, name): (i64, String, String) = conn
+            .query_row("SELECT is_template, parent_template_id, name FROM db_agents WHERE id = 'head'", [], |r| {
+                Ok((r.get(0)?, r.get(1)?, r.get(2)?))
+            })
+            .unwrap();
+        assert_eq!((is_template, parent.as_str(), name.as_str()), (0, "tpl", "head"), "projected as a user agent of its template");
+    }
+
+    #[test]
+    fn repairs_a_definition_missing_from_db_agents_before_copying_state() {
+        let (_dir, path) = pre_v29_store();
+        let mut conn = Connection::open(&path).unwrap();
+        conn.execute("DELETE FROM db_agents WHERE id = 'clone'", []).unwrap();
+        let stats = backfill_launch_state(&mut conn).unwrap();
+        assert_eq!(stats.definitions_repaired, 1, "{stats:?}");
+        assert_eq!(launch_state(&conn, "clone").0, "s3");
     }
 
     #[test]
@@ -322,9 +458,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("objects.db");
         drop(Store::open(&path).unwrap());
-        let conn = Connection::open(&path).unwrap();
+        let mut conn = Connection::open(&path).unwrap();
         conn.execute_batch("DROP TABLE db_agent_instances;").unwrap();
-        assert_eq!(backfill_launch_state(&conn).unwrap(), 0);
+        assert_eq!(backfill_launch_state(&mut conn).unwrap(), BackfillStats::default());
     }
 
     #[test]

--- a/agentmux-srv/src/migrations/m0025_agents_launch_state_backfill.rs
+++ b/agentmux-srv/src/migrations/m0025_agents_launch_state_backfill.rs
@@ -1,0 +1,347 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Backfill `db_agents`' latest-launch state (schema v29:
+//! `session_id`, `status`, `started_at`, `ended_at`, and `last_block_id`
+//! where still empty) from the legacy `db_agent_instances` rows.
+//!
+//! Agent-concept consolidation, Phase 3b
+//! (`SPEC_AGENT_ARCHITECTURE_2026_05_27.md`): these four columns are what
+//! kept the legacy table alive — the recent-sessions picker, the pane
+//! close/reopen continuity write-back and the status-filtered instance
+//! list all read them from `db_agent_instances`. Once every consolidated
+//! row carries its own launch state, those reads can flip and the table
+//! can go.
+//!
+//! Rule: for each projection key (the `db_agents` row an instance chain
+//! maps to — the chain head's own id for a template launch, the user-clone
+//! definition's id for a launch of a user agent) take the most recently
+//! created instance in the chain and copy its launch state, but only into
+//! a row whose launch state is still entirely default. That makes the
+//! migration idempotent and means it never overwrites state the dual-write
+//! has written since v29 shipped. Channel-scoped: each channel's
+//! `objects.db` has its own rows.
+//!
+//! Frozen copy of `dual_write.rs::agents_projection_key_for_inst`'s rule
+//! (as of v29) — deliberately not a call into it, per this module's "freeze
+//! copies of live logic" doc: `dual_write.rs` is deleted when the legacy
+//! table is dropped, and this migration must keep producing the same rows
+//! on every machine it ever runs on.
+//!
+//! Tolerates a store that has already dropped `db_agent_instances`
+//! (Phase 3c): nothing to backfill, `Ok`.
+
+use std::collections::{HashMap, HashSet};
+
+use rusqlite::{params, Connection};
+
+use crate::backend::storage::store::Store;
+
+use super::{Migration, MigrationContext, MigrationError, MigrationScope};
+
+pub struct M0025AgentsLaunchStateBackfill;
+
+/// The legacy instance columns the backfill reads.
+struct LegacyInstance {
+    id: String,
+    parent_instance_id: String,
+    definition_id: String,
+    block_id: String,
+    session_id: String,
+    status: String,
+    started_at: i64,
+    ended_at: i64,
+    created_at: i64,
+}
+
+/// Frozen copy of the v29 projection rule: walk `parent_instance_id` to the
+/// chain root; if the root's definition is a user-clone (`is_seeded = 0`)
+/// the key is that definition's id (the launch was folded into the def's
+/// row), otherwise it is the root instance's own id (a template launch is
+/// its own row). A missing definition counts as seeded, matching the
+/// `COALESCE(d.is_seeded, 1)` in the live helper. A chain whose parent
+/// pointer no longer resolves is rooted at the last instance that does.
+fn projection_key(
+    inst: &LegacyInstance,
+    by_id: &HashMap<String, &LegacyInstance>,
+    is_seeded: &HashMap<String, i64>,
+) -> String {
+    let mut root = inst;
+    let mut seen: HashSet<&str> = HashSet::new();
+    while !root.parent_instance_id.is_empty() && seen.insert(root.id.as_str()) {
+        match by_id.get(&root.parent_instance_id) {
+            Some(parent) => root = parent,
+            None => break,
+        }
+    }
+    let seeded = is_seeded.get(&root.definition_id).copied().unwrap_or(1);
+    if seeded == 0 {
+        root.definition_id.clone()
+    } else {
+        root.id.clone()
+    }
+}
+
+/// The backfill proper, on an open connection. `Ok(n)` = rows updated.
+pub(super) fn backfill_launch_state(conn: &Connection) -> Result<usize, String> {
+    let has_legacy: bool = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'db_agent_instances')",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|e| format!("probe db_agent_instances: {e}"))?;
+    if !has_legacy {
+        return Ok(0);
+    }
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, parent_instance_id, definition_id, block_id, session_id, status,
+                    started_at, ended_at, created_at
+             FROM db_agent_instances",
+        )
+        .map_err(|e| format!("read db_agent_instances: {e}"))?;
+    let instances: Vec<LegacyInstance> = stmt
+        .query_map([], |row| {
+            Ok(LegacyInstance {
+                id: row.get(0)?,
+                parent_instance_id: row.get(1)?,
+                definition_id: row.get(2)?,
+                block_id: row.get(3)?,
+                session_id: row.get(4)?,
+                status: row.get(5)?,
+                started_at: row.get(6)?,
+                ended_at: row.get(7)?,
+                created_at: row.get(8)?,
+            })
+        })
+        .and_then(|rows| rows.collect::<Result<Vec<_>, _>>())
+        .map_err(|e| format!("read db_agent_instances: {e}"))?;
+    if instances.is_empty() {
+        return Ok(0);
+    }
+
+    let mut seeded_stmt = conn
+        .prepare("SELECT id, is_seeded FROM db_agent_definitions")
+        .map_err(|e| format!("read db_agent_definitions: {e}"))?;
+    let is_seeded: HashMap<String, i64> = seeded_stmt
+        .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)))
+        .and_then(|rows| rows.collect::<Result<HashMap<_, _>, _>>())
+        .map_err(|e| format!("read db_agent_definitions: {e}"))?;
+
+    let by_id: HashMap<String, &LegacyInstance> = instances.iter().map(|i| (i.id.clone(), i)).collect();
+    // Latest instance per projection key — `created_at`, then id, so the
+    // choice is deterministic when two rows share a timestamp.
+    let mut latest: HashMap<String, &LegacyInstance> = HashMap::new();
+    for inst in &instances {
+        let key = projection_key(inst, &by_id, &is_seeded);
+        let replace = match latest.get(&key) {
+            None => true,
+            Some(cur) => (inst.created_at, inst.id.as_str()) > (cur.created_at, cur.id.as_str()),
+        };
+        if replace {
+            latest.insert(key, inst);
+        }
+    }
+
+    let mut updated = 0usize;
+    for (key, inst) in latest {
+        let n = conn
+            .execute(
+                "UPDATE db_agents SET
+                    session_id = ?2,
+                    status = ?3,
+                    started_at = ?4,
+                    ended_at = ?5,
+                    last_block_id = CASE WHEN last_block_id = '' THEN ?6 ELSE last_block_id END
+                 WHERE id = ?1
+                   AND is_template = 0
+                   AND session_id = '' AND status = '' AND started_at = 0 AND ended_at = 0",
+                params![key, inst.session_id, inst.status, inst.started_at, inst.ended_at, inst.block_id],
+            )
+            .map_err(|e| format!("update db_agents {key}: {e}"))?;
+        updated += n;
+    }
+    Ok(updated)
+}
+
+impl Migration for M0025AgentsLaunchStateBackfill {
+    fn id(&self) -> &'static str { "0025_agents_launch_state_backfill" }
+    fn scope(&self) -> MigrationScope { MigrationScope::Channel }
+    fn description(&self) -> &'static str {
+        "Backfill db_agents launch state (session/status/started/ended) from db_agent_instances"
+    }
+
+    fn up(&self, ctx: &MigrationContext) -> Result<(), MigrationError> {
+        if !ctx.channel_store_path.exists() {
+            return Ok(());
+        }
+        // Store::open lays down schema v29 (the columns this writes) before
+        // the raw connection below touches the table.
+        drop(
+            Store::open(&ctx.channel_store_path)
+                .map_err(|e| MigrationError(format!("agents_launch_state_backfill: open wstore: {e}")))?,
+        );
+        let conn = Connection::open(&ctx.channel_store_path)
+            .map_err(|e| MigrationError(format!("agents_launch_state_backfill: open: {e}")))?;
+        let updated = backfill_launch_state(&conn)
+            .map_err(|e| MigrationError(format!("agents_launch_state_backfill: {e}")))?;
+        tracing::info!(updated, "m0025_agents_launch_state_backfill: complete");
+        Ok(())
+    }
+
+    // No `verify()`: the post-condition ("every consolidated row whose
+    // legacy chain had launch state now carries it") needs the legacy table
+    // to state, and the legacy table is what Phase 3c removes — a check
+    // that can only run before its own precondition disappears would report
+    // `error` on every post-3c install. `NotVerifiable` is the honest
+    // default here; the dual-write and the Phase 3b readers' own tests are
+    // what pin the live behaviour.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::storage::store::{AgentDefinition, AgentInstance};
+
+    fn def(id: &str, is_seeded: i64, parent_id: &str) -> AgentDefinition {
+        AgentDefinition {
+            conversation_visibility: crate::backend::storage::agents::default_conversation_visibility(),
+            id: id.to_string(),
+            slug: id.to_string(),
+            name: id.to_string(),
+            icon: String::new(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: "bash".to_string(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 1000,
+            agent_type: "standalone".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded,
+            accounts: String::new(),
+            parent_id: parent_id.to_string(),
+            branch_label: String::new(),
+            updated_at: 1000,
+            user_hidden: 0,
+            container_image: String::new(),
+            container_volumes: "[]".to_string(),
+            container_name: String::new(),
+            use_ambient_login: 0,
+            auto_continue_enabled: 0,
+            model_vendor_base_url: String::new(),
+            memory_id: String::new(),
+        }
+    }
+
+    fn inst(id: &str, def_id: &str, parent: &str, block: &str, session: &str, status: &str, created_at: i64) -> AgentInstance {
+        AgentInstance {
+            id: id.to_string(),
+            definition_id: def_id.to_string(),
+            parent_instance_id: parent.to_string(),
+            block_id: block.to_string(),
+            session_id: session.to_string(),
+            status: status.to_string(),
+            github_context: String::new(),
+            started_at: created_at,
+            ended_at: 0,
+            created_at,
+            identity_id: String::new(),
+            memory_id: String::new(),
+            instance_name: id.to_string(),
+            working_directory: String::new(),
+            display_hidden: false,
+        }
+    }
+
+    fn launch_state(conn: &Connection, id: &str) -> (String, String, i64, String) {
+        conn.query_row(
+            "SELECT session_id, status, started_at, last_block_id FROM db_agents WHERE id = ?1",
+            [id],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+        )
+        .unwrap()
+    }
+
+    /// A pre-v29 store: legacy rows in place, db_agents rows present (the
+    /// dual-write wrote them) but with the launch-state columns at their
+    /// defaults — exactly what an upgraded install looks like the first time
+    /// v29's ALTERs run.
+    fn pre_v29_store() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("objects.db");
+        let store = Store::open(&path).unwrap();
+        let mut tpl = def("tpl", 1, "");
+        store.agent_def_insert(&mut tpl).unwrap();
+        let mut clone = def("clone", 0, "tpl");
+        store.agent_def_insert(&mut clone).unwrap();
+        // A template launch with one continuation: head → child.
+        store.instance_create(&inst("head", "tpl", "", "b1", "s1", "stopped", 2000)).unwrap();
+        store.instance_create(&inst("child", "tpl", "head", "b2", "s2", "running", 3000)).unwrap();
+        // A launch of the user clone (folds into the clone's own row).
+        store.instance_create(&inst("clone-run", "clone", "", "b3", "s3", "paused", 2500)).unwrap();
+        drop(store);
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch("UPDATE db_agents SET session_id = '', status = '', started_at = 0, ended_at = 0, last_block_id = '';")
+            .unwrap();
+        (dir, path)
+    }
+
+    #[test]
+    fn backfills_the_latest_launch_of_each_chain_into_its_projection_row() {
+        let (_dir, path) = pre_v29_store();
+        let conn = Connection::open(&path).unwrap();
+        assert_eq!(backfill_launch_state(&conn).unwrap(), 2, "one template chain + one clone");
+        // The template chain's head row carries the CHILD's (latest) state.
+        assert_eq!(launch_state(&conn, "head"), ("s2".into(), "running".into(), 3000, "b2".into()));
+        // The clone's own row carries its launch.
+        assert_eq!(launch_state(&conn, "clone"), ("s3".into(), "paused".into(), 2500, "b3".into()));
+        // The template row itself is untouched.
+        assert_eq!(launch_state(&conn, "tpl"), (String::new(), String::new(), 0, String::new()));
+    }
+
+    #[test]
+    fn is_idempotent_and_never_overwrites_state_written_since() {
+        let (_dir, path) = pre_v29_store();
+        let conn = Connection::open(&path).unwrap();
+        // Live state already on the head row (the dual-write got there first).
+        conn.execute("UPDATE db_agents SET session_id = 'live', status = 'running' WHERE id = 'head'", []).unwrap();
+        assert_eq!(backfill_launch_state(&conn).unwrap(), 1, "only the still-default clone row");
+        assert_eq!(launch_state(&conn, "head").0, "live");
+        assert_eq!(backfill_launch_state(&conn).unwrap(), 0, "second run writes nothing");
+    }
+
+    #[test]
+    fn tolerates_a_store_without_the_legacy_table() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("objects.db");
+        drop(Store::open(&path).unwrap());
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch("DROP TABLE db_agent_instances;").unwrap();
+        assert_eq!(backfill_launch_state(&conn).unwrap(), 0);
+    }
+
+    #[test]
+    fn up_runs_end_to_end_against_a_channel_store_and_skips_a_missing_one() {
+        let (dir, path) = pre_v29_store();
+        let ctx = MigrationContext {
+            home: dir.path().to_path_buf(),
+            data_dir: dir.path().to_path_buf(),
+            shared_store_path: dir.path().join("shared.db"),
+            channel_store_path: path.clone(),
+        };
+        M0025AgentsLaunchStateBackfill.up(&ctx).unwrap();
+        let conn = Connection::open(&path).unwrap();
+        assert_eq!(launch_state(&conn, "clone").0, "s3");
+
+        let missing = MigrationContext { channel_store_path: dir.path().join("nope.db"), ..ctx };
+        M0025AgentsLaunchStateBackfill.up(&missing).unwrap();
+        assert!(!missing.channel_store_path.exists(), "a missing channel store is left missing");
+    }
+}

--- a/agentmux-srv/src/migrations/mod.rs
+++ b/agentmux-srv/src/migrations/mod.rs
@@ -69,6 +69,7 @@ mod m0021_backfill_agent_bundles;
 mod m0022_identity_store_links_backfill;
 mod m0023_native_memory_versions_backfill;
 mod m0024_native_memory_backfill_from_fs;
+mod m0025_agents_launch_state_backfill;
 mod runner;
 #[cfg(test)]
 mod phase5_tests;
@@ -228,4 +229,5 @@ static REGISTRY: &[&(dyn Migration + Sync)] = &[
     &m0022_identity_store_links_backfill::M0022IdentityStoreLinksBackfill,
     &m0023_native_memory_versions_backfill::M0023NativeMemoryVersionsBackfill,
     &m0024_native_memory_backfill_from_fs::M0024NativeMemoryBackfillFromFs,
+    &m0025_agents_launch_state_backfill::M0025AgentsLaunchStateBackfill,
 ];

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -324,6 +324,7 @@ partial list.
 | Spec | Title |
 |---|---|
 | [`PLAN_WINDOWS_CI_SUBPROCESS_IO_FLAKE_FIX_2026_08_13`](PLAN_WINDOWS_CI_SUBPROCESS_IO_FLAKE_FIX_2026_08_13.md) | Plan — fix the recurring `create_no_window_flag_set` flake on Windows nightly CI |
+| [`SPEC_AGENT_ARCHITECTURE_2026_05_27`](SPEC_AGENT_ARCHITECTURE_2026_05_27.md) | SPEC: Agent data-model architecture — consolidation plan & status |
 | [`SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05`](SPEC_AGENT_PANE_HISTORY_ALIGNMENT_2026_08_05.md) | SPEC: Align pane scrollback with actual model context, and make cross-instance opens honest |
 | [`SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09`](SPEC_AGENT_PANE_SESSION_SCOPED_SCROLLBACK_AND_AGENT_HISTORY_VIEW_2026_08_09.md) | SPEC: Session-scoped pane scrollback + a full "Agent History" view |
 | [`SPEC_AGENT_POLLING_AND_WAKEUP_HARDENING_2026_08_04`](SPEC_AGENT_POLLING_AND_WAKEUP_HARDENING_2026_08_04.md) | Agent Recurring-Task / Polling Primitives — Design Hardening |
@@ -1344,12 +1345,6 @@ section above, do not bulk-restamp them.
 | Spec | Title |
 |---|---|
 | [`SPEC_GPU_MEMORY_TRACING_SCAFFOLDING_2026_07_24`](SPEC_GPU_MEMORY_TRACING_SCAFFOLDING_2026_07_24.md) | Spec: GPU Memory Tracing Scaffolding — a real trace, not another process-level guess |
-
-**`tracking`**
-
-| Spec | Title |
-|---|---|
-| [`SPEC_AGENT_ARCHITECTURE_2026_05_27`](SPEC_AGENT_ARCHITECTURE_2026_05_27.md) | SPEC: Agent data-model architecture — consolidation plan & status |
 
 **`updated`**
 

--- a/docs/specs/SPEC_AGENT_ARCHITECTURE_2026_05_27.md
+++ b/docs/specs/SPEC_AGENT_ARCHITECTURE_2026_05_27.md
@@ -7,6 +7,13 @@
 
 > **Staleness note (2026-08-03):** this doc has not been edited since 2026-05-28 (`6584c024`). Phase 3b is only partially shipped and Phase 3c has not happened — `db_agent_definitions`/`db_agent_instances` still exist in the current schema, contradicting this doc's own acceptance criteria. Confirmed stalled, not just unread — see `docs/specs/SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03.md` §1.4 and `SPEC_DOCS_LIFECYCLE_HARDENING_2026_08_03.md` for the audit that found this. Treat the phase table below as historical intent, not current status, until someone either finishes the migration or formally re-scopes it here.
 
+> **Resumed 2026-09-07** (repo-owner decision: finish, not park — `SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03.md` Phase 4 option (a)). Inventory of every remaining legacy read/write, FK and caller is in the PR description of the first PR below; the plan is four PRs, each keeping `db_agents` and the legacy tables in sync until the drop:
+>
+> 1. **Launch state on `db_agents`** (schema v29: `session_id`, `status`, `started_at`, `ended_at`; `m0025` backfill; dual-write keeps them current) — the four columns whose absence kept `db_agent_instances` alive (recent-sessions picker, the pane close/reopen continuity write-back, the status-filtered instance list). Shipped 2026-09-07.
+> 2. **Instance read flip**: `instance_get`, `instance_get_by_block_id`, `instance_list(status)`, `instance_list_named`, the `instance_get_active_for_block` fallback → `db_agents`; instance writes → `db_agents` only; delete the dead `instance_get_by_name`/`user_clone_defs_for_template`.
+> 3. **Definition flip + FK re-point**: the remaining `db_agent_definitions` reads/writes and the six tables whose FK targets it (`db_agent_content`, `_skills`, `_history`, `_identity_links`, `_skills_ref`, `_mcp_ref`) rebuilt against `db_agents(id)`.
+> 4. **Drop** both legacy tables, `dual_write.rs`, `agents_consolidate.rs`, `repair_agent_def_gaps`; retire `0007` and its marker; keep `m0004`/`m0006`/`transcript_backfill` tolerant of `db_agents`-only stores. This doc's phase table is updated in each PR.
+
 ---
 
 ## Why this spec exists

--- a/docs/specs/SPEC_AGENT_ARCHITECTURE_2026_05_27.md
+++ b/docs/specs/SPEC_AGENT_ARCHITECTURE_2026_05_27.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-27
 **Author:** AgentA
-**Status:** Tracking spec — supersedes `SPEC_AGENT_CONCEPT_CONSOLIDATION_2026_05_24.md` for ongoing planning. The 2026-05-24 spec laid out the design; this one is the live status doc with the per-handler matrix and the migration plan.
+**Status:** active — tracking spec (restamped to the closed enum 2026-09-07; Phase 3b resumed, see the note below). Supersedes `SPEC_AGENT_CONCEPT_CONSOLIDATION_2026_05_24.md` for ongoing planning. The 2026-05-24 spec laid out the design; this one is the live status doc with the per-handler matrix and the migration plan.
 **Tracking discussion:** [#1095 — Architecture: agent data-model consolidation — tracking](https://github.com/agentmuxai/agentmux/discussions/1095). All PRs that touch agent data-layer code link there.
 
 > **Staleness note (2026-08-03):** this doc has not been edited since 2026-05-28 (`6584c024`). Phase 3b is only partially shipped and Phase 3c has not happened — `db_agent_definitions`/`db_agent_instances` still exist in the current schema, contradicting this doc's own acceptance criteria. Confirmed stalled, not just unread — see `docs/specs/SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03.md` §1.4 and `SPEC_DOCS_LIFECYCLE_HARDENING_2026_08_03.md` for the audit that found this. Treat the phase table below as historical intent, not current status, until someone either finishes the migration or formally re-scopes it here.


### PR DESCRIPTION
## Summary

PR 1 of 4 finishing the agent-concept consolidation (`docs/specs/SPEC_AGENT_ARCHITECTURE_2026_05_27.md` Phase 3b/3c), per the hardening spec's Phase 4 decision to **finish** rather than park it. The end state is one `db_agents` table; `db_agent_definitions` and `db_agent_instances` go away in PR 4.

### Why this PR comes first

The inventory (every remaining legacy read/write, FK and caller) showed that `db_agents` is a complete mirror of the definitions table but **not** of the instances table: it never got `session_id`, `status`, `started_at`, `ended_at`. Phase 3a left those "on the block", but in practice three things still read them from `db_agent_instances`, and that is exactly what kept the table alive:

- the recent-sessions picker (`instance_list_named`),
- the pane close/reopen continuity write-back (`persist_session_id` → `instance_get_by_block_id` + `instance_update_partial`, `SPEC_PANE_CLOSE_REOPEN_CONTINUITY_GUARANTEE_2026_07_27.md` §4.1),
- the status-filtered `instance_list`.

One row per agent means one launch state per agent; a continuation moves it to the new block/session rather than adding a row (the dual-write already folds continuations that way — only the state was missing).

### What changes

| Piece | Where |
|---|---|
| Schema **v29**: `session_id`, `status`, `started_at`, `ended_at` on `db_agents` (CREATE TABLE + additive ALTERs, doc entry). Deliberately no unique index on `db_agents(slug)` — template-launch projections copy their template's slug. | `backend/storage/migrations.rs` |
| Dual-write keeps them current: instance **create** (fold into a user clone, continuation onto the chain head, template launch as its own row) and instance **update** (session capture, status, ended_at; `last_block_id` moves only when the write carries a block) | `backend/storage/dual_write.rs` |
| `m0025_agents_launch_state_backfill` (channel scope): latest instance per projection key — a frozen copy of the v29 projection rule, per the framework's "freeze copies of live logic" doc — copied into any consolidated row whose launch state is still entirely default. Idempotent, never overwrites state the dual-write wrote since, no-op once the legacy table is gone. | `migrations/m0025_agents_launch_state_backfill.rs` |
| Tracking spec: resumption note + the four-PR plan | `docs/specs/SPEC_AGENT_ARCHITECTURE_2026_05_27.md` |

Nothing reads the new columns yet — that is PR 2. After this PR every consolidated row is a complete mirror of its legacy chain, so PR 2 can flip the instance reads without a data gap.

### Tests

- `m0025` ×4: the template chain's head row takes the **child's** (latest) state and the clone row takes its own; idempotent and never clobbers live state; tolerates a store without `db_agent_instances`; `up()` end to end plus a missing channel store.
- `dual_write_instance_lifecycle_keeps_launch_state_current_on_db_agents`: create → session capture → status/ended → continuation moves the head's state → a capture on the continuation reaches the head.

```
cargo test -p agentmux-srv -- migrations:: storage::   → 489 passed
cargo test -p agentmux-srv (full)                       → see CI
```

### The plan (also in the spec)

1. **This PR** — launch state on `db_agents`.
2. Instance read flip + instance writes to `db_agents` only; delete the dead `instance_get_by_name` / `user_clone_defs_for_template`.
3. Definition flip + re-point the six FKs (`db_agent_content`, `_skills`, `_history`, `_identity_links`, `_skills_ref`, `_mcp_ref`) to `db_agents(id)`.
4. Drop both legacy tables, `dual_write.rs`, `agents_consolidate.rs`, `repair_agent_def_gaps`; retire `0007` and its marker; keep `m0004`/`m0006`/`transcript_backfill` tolerant of `db_agents`-only stores.

<!-- agentmux:agent_id=korp -->
