### PR TITLE
Camper@claudius: chore: release v0.55.39

### DIFF
--- a/.changesets/1788731945-feat-tray-macos-menu-bar-backend-headless-appkit-pump-for-ba-uvjn.md
+++ b/.changesets/1788731945-feat-tray-macos-menu-bar-backend-headless-appkit-pump-for-ba-uvjn.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(tray): macOS menu-bar backend + headless AppKit pump for background-service mode (issue #2977 WS1)

--- a/.changesets/1788750245-dry-contained-cleanups-one-menurows-renderer-in-flyoutmenu-t-plab.md
+++ b/.changesets/1788750245-dry-contained-cleanups-one-menurows-renderer-in-flyoutmenu-t-plab.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-DRY contained cleanups: one MenuRows renderer in flyoutmenu, TreeNode prop pass-through in file-tree, single Connect-CTA arm in PreLaunchAuthPanel, migrations freeze-copy policy, audit report corrections

--- a/.changesets/1788751028-docs-large-migrations-completion-audit-14-initiatives-scored-jk5u.md
+++ b/.changesets/1788751028-docs-large-migrations-completion-audit-14-initiatives-scored-jk5u.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: large-migrations completion audit — 14 initiatives scored, 4 stale status claims corrected (CLAUDE.md transcript_request, migration framework, SolidJS analysis, master reducer status)

--- a/.changesets/1788751173-tilelayout-one-shared-core-createtilelayout-with-per-platfor-jnel.md
+++ b/.changesets/1788751173-tilelayout-one-shared-core-createtilelayout-with-per-platfor-jnel.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-TileLayout: one shared core (createTileLayout) with per-platform hook objects for win32/linux/darwin instead of three near-identical copies; no behavior change

--- a/.changesets/1788751693-fix-srv-a-failed-data-migration-is-now-fatal-srv-emits-agent-ttg2.md
+++ b/.changesets/1788751693-fix-srv-a-failed-data-migration-is-now-fatal-srv-emits-agent-ttg2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(srv): a failed data migration is now fatal — srv emits AGENTMUXSRV-MIGRATION-FAILED and exits 1 before ESTART instead of booting against a half-migrated store; launcher and CEF host surface the reason immediately (migration hardening Phase 1a)

--- a/.changesets/1788751924-storage-one-generic-managedresource-implementation-behind-th-jmrp.md
+++ b/.changesets/1788751924-storage-one-generic-managedresource-implementation-behind-th-jmrp.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-storage: one generic ManagedResource implementation behind the skill_* and mcp_server_* store methods (agent- and bundle-level list/get/bind/unbind/upsert/access checks); public API, messages and tests unchanged

--- a/.changesets/1788752197-refactor-agent-pane-route-agent-view-s-11-raw-store-dispatch-xkvo.md
+++ b/.changesets/1788752197-refactor-agent-pane-route-agent-view-s-11-raw-store-dispatch-xkvo.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(agent-pane): route agent-view's 11 raw store dispatches through its AgentPaneModel handle (A9 of #1549) — post-unmount dispatches now drop safely instead of throwing, and all pane commands hit the crash-trail

--- a/.changesets/1788752674-docs-phase-2-rpc-bindings-codegen-design-spec-and-phase-5-sa-oub6.md
+++ b/.changesets/1788752674-docs-phase-2-rpc-bindings-codegen-design-spec-and-phase-5-sa-oub6.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: Phase 2 RPC-bindings codegen design spec and Phase 5 saga/reducer decision record for the DRY audit; report progress note updated

--- a/.changesets/1788753142-fix-launcher-cef-migration-failure-reason-can-no-longer-lose-bnj2.md
+++ b/.changesets/1788753142-fix-launcher-cef-migration-failure-reason-can-no-longer-lose-bnj2.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(launcher,cef): migration-failure reason can no longer lose a select! race to the closed ESTART channel — biased poll order plus a post-loop buffered-reason check, so a failed migration always surfaces as MigrationFailed instead of degrading to the generic channel-closed error

--- a/.changesets/1788753575-fix-lan-make-the-mdns-instance-label-unique-and-dot-free-so--4y72.md
+++ b/.changesets/1788753575-fix-lan-make-the-mdns-instance-label-unique-and-dot-free-so--4y72.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(lan): make the mDNS instance label unique and dot-free so two hosts on the same version discover each other

--- a/.changesets/1788753709-feat-settings-toggle-to-disable-the-startup-splash-screen-xoi3.md
+++ b/.changesets/1788753709-feat-settings-toggle-to-disable-the-startup-splash-screen-xoi3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(settings): toggle to disable the startup splash screen

--- a/.changesets/1788764233-refactor-agent-pane-drop-the-agentatoms-mirror-the-pane-mode-2ef4.md
+++ b/.changesets/1788764233-refactor-agent-pane-drop-the-agentatoms-mirror-the-pane-mode-2ef4.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-refactor(agent-pane): drop the AgentAtoms mirror — the pane model exposes the reducer state and document nodes reactively (A6 of #1549); adding a reducer field is now a one-place change, and the two detailsOpen writes that bypassed the reducer go through it

--- a/.changesets/1788764361-fix-agent-pane-drop-the-dead-tab-strip-gap-above-my-agents-o-5r6w.md
+++ b/.changesets/1788764361-fix-agent-pane-drop-the-dead-tab-strip-gap-above-my-agents-o-5r6w.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): drop the dead tab-strip gap above My Agents on a fresh pane

--- a/.changesets/1788764363-fix-statusbar-lan-diamond-now-shows-all-three-states-peers-o-ajtk.md
+++ b/.changesets/1788764363-fix-statusbar-lan-diamond-now-shows-all-three-states-peers-o-ajtk.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(statusbar): LAN diamond now shows all three states (peers / on-but-idle / off)

--- a/.changesets/1788764607-docs-regenerate-the-specs-index-the-committed-header-count-9-9hmj.md
+++ b/.changesets/1788764607-docs-regenerate-the-specs-index-the-committed-header-count-9-9hmj.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: regenerate the specs index — the committed header count (95) disagreed with its own 96 rows, a merge artifact that failed the 'Specs index is current' gate on every PR including main

--- a/.changesets/1788764784-fix-memory-backfill-native-memory-versions-from-disk-and-rep-btae.md
+++ b/.changesets/1788764784-fix-memory-backfill-native-memory-versions-from-disk-and-rep-btae.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(memory): backfill native-memory versions from disk and repair rows mislabeled 'detected outside AgentMux'

--- a/.changesets/1788765349-feat-srv-agentmux-srv-migrate-verify-a-doctor-pass-that-asks-gqx8.md
+++ b/.changesets/1788765349-feat-srv-agentmux-srv-migrate-verify-a-doctor-pass-that-asks-gqx8.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): agentmux-srv migrate --verify — a doctor pass that asks every APPLIED migration for its post-condition (row counts, marker files) and exits 3 on any mismatch; 0007 and 0002 implement real checks (migration hardening Phase 1b)

--- a/.changesets/1788766335-ci-make-the-specs-index-merge-safe-by-dropping-the-derived-r-9cvl.md
+++ b/.changesets/1788766335-ci-make-the-specs-index-merge-safe-by-dropping-the-derived-r-9cvl.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-ci: make the specs index merge-safe by dropping the derived row count from its committed section headers (the one value that resolved wrongly when two spec-adding PRs merged, and 67% of recent CI failures); fix the create_no_window_flag_set flake by pre-warming node.exe outside the measured window

--- a/.changesets/1788767990-fix-srv-migrations-run-under-a-cross-process-lock-two-srv-pr-8d46.md
+++ b/.changesets/1788767990-fix-srv-migrations-run-under-a-cross-process-lock-two-srv-pr-8d46.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(srv): migrations run under a cross-process lock — two srv processes booting against the same data dir can no longer both apply the same migration (migration hardening Phase 3)

--- a/.changesets/1788768360-feat-abf-authoring-ui-for-per-provider-instruction-overrides-ir4m.md
+++ b/.changesets/1788768360-feat-abf-authoring-ui-for-per-provider-instruction-overrides-ir4m.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(abf): authoring UI for per-provider instruction overrides (instructions_by_provider)

--- a/.changesets/1788769847-feat-jekt-cross-channel-sender-verification-delivery-channel-l48g.md
+++ b/.changesets/1788769847-feat-jekt-cross-channel-sender-verification-delivery-channel-l48g.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(jekt): cross-channel sender verification — DELIVERY=channel, TRUST=channel-verified (spec Phase B)

--- a/.changesets/1788771120-feat-muxspect-migrations-command-the-migrate-verify-doctor-r-1fyo.md
+++ b/.changesets/1788771120-feat-muxspect-migrations-command-the-migrate-verify-doctor-r-1fyo.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(muxspect): migrations command — the migrate --verify doctor report from inside a live instance (hardening Phase 1c)

--- a/.changesets/1788771767-test-migrations-phase-5-regression-suite-stale-marker-incide-fpt9.md
+++ b/.changesets/1788771767-test-migrations-phase-5-regression-suite-stale-marker-incide-fpt9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-test(migrations): Phase 5 regression suite — stale-marker incident, crash-before-mark resume, multi-version upgrade, bootstrap stamping

--- a/.changesets/1788772081-chore-deps-drop-the-unused-react-dependency-left-over-from-t-lti0.md
+++ b/.changesets/1788772081-chore-deps-drop-the-unused-react-dependency-left-over-from-t-lti0.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(deps): drop the unused react dependency left over from the React→SolidJS migration

--- a/.changesets/1788772837-feat-docs-weekly-docs-stale-sweep-flags-current-claiming-doc-d9aq.md
+++ b/.changesets/1788772837-feat-docs-weekly-docs-stale-sweep-flags-current-claiming-doc-d9aq.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(docs): weekly docs stale-sweep — flags current-claiming docs whose cited files changed or vanished, posted to a standing issue (docs-lifecycle Phase 5)

--- a/.changesets/1788783501-fix-migrations-0002-block-zones-migration-no-longer-trusts-i-o5k1.md
+++ b/.changesets/1788783501-fix-migrations-0002-block-zones-migration-no-longer-trusts-i-o5k1.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(migrations): 0002 block-zones migration no longer trusts its marker file — content-idempotent re-run, content-checked bootstrap stamping and verify (hardening Phase 2)

--- a/.changesets/1788783575-refactor-mcp-split-agentmux-mcp-src-main-rs-50-tool-schemas--2bbe.md
+++ b/.changesets/1788783575-refactor-mcp-split-agentmux-mcp-src-main-rs-50-tool-schemas--2bbe.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(mcp): split agentmux-mcp/src/main.rs — 50 tool schemas into tool_schemas.rs and the window capture/discovery cluster into window_capture.rs (audit step 17); no behavior change

--- a/.changesets/1788783591-ci-docs-scope-the-specs-index-gate-to-prs-that-touch-docs-sp-f7bb.md
+++ b/.changesets/1788783591-ci-docs-scope-the-specs-index-gate-to-prs-that-touch-docs-sp-f7bb.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-ci(docs): scope the specs-index gate to PRs that touch docs/specs

--- a/.changesets/1788784010-chore-retire-the-misleading-tauri-era-comments-and-log-label-l944.md
+++ b/.changesets/1788784010-chore-retire-the-misleading-tauri-era-comments-and-log-label-l944.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore: retire the misleading Tauri-era comments and log labels outside the CEF crate (Tauri->CEF migration residue)

--- a/.changesets/1788785889-fix-ci-generate-the-specs-index-from-tracked-files-not-a-fil-kc4u.md
+++ b/.changesets/1788785889-fix-ci-generate-the-specs-index-from-tracked-files-not-a-fil-kc4u.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ci): generate the specs index from tracked files, not a filesystem glob

--- a/.changesets/1788786183-refactor-srv-record-each-rpc-command-s-request-response-type-88z4.md
+++ b/.changesets/1788786183-refactor-srv-record-each-rpc-command-s-request-response-type-88z4.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(srv): record each RPC command's request/response types at registration (RpcSchema + register_typed) — the mapping a bindings generator needs, which did not previously exist as data

--- a/.changesets/1788786719-feat-storage-db-agents-carries-the-latest-launch-state-sessi-5yo1.md
+++ b/.changesets/1788786719-feat-storage-db-agents-carries-the-latest-launch-state-sessi-5yo1.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(storage): db_agents carries the latest launch state (session/status/started/ended) — schema v29 + backfill from db_agent_instances (agent consolidation Phase 3b, PR 1)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.38"
+version = "0.55.39"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.38"
+version = "0.55.39"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.38"
+version = "0.55.39"
 dependencies = [
  "base64",
  "dirs 5.0.1",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.38"
+version = "0.55.39"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.38"
+version = "0.55.39"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.38"
+version = "0.55.39"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.38"
+version = "0.55.39"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,40 @@
 # AgentMux Version History
 
+## 0.55.39 — 2026-09-07
+
+- feat(tray): macOS menu-bar backend + headless AppKit pump for background-service mode (issue #2977 WS1)
+- DRY contained cleanups: one MenuRows renderer in flyoutmenu, TreeNode prop pass-through in file-tree, single Connect-CTA arm in PreLaunchAuthPanel, migrations freeze-copy policy, audit report corrections
+- docs: large-migrations completion audit — 14 initiatives scored, 4 stale status claims corrected (CLAUDE.md transcript_request, migration framework, SolidJS analysis, master reducer status)
+- TileLayout: one shared core (createTileLayout) with per-platform hook objects for win32/linux/darwin instead of three near-identical copies; no behavior change
+- fix(srv): a failed data migration is now fatal — srv emits AGENTMUXSRV-MIGRATION-FAILED and exits 1 before ESTART instead of booting against a half-migrated store; launcher and CEF host surface the reason immediately (migration hardening Phase 1a)
+- storage: one generic ManagedResource implementation behind the skill_* and mcp_server_* store methods (agent- and bundle-level list/get/bind/unbind/upsert/access checks); public API, messages and tests unchanged
+- refactor(agent-pane): route agent-view's 11 raw store dispatches through its AgentPaneModel handle (A9 of #1549) — post-unmount dispatches now drop safely instead of throwing, and all pane commands hit the crash-trail
+- docs: Phase 2 RPC-bindings codegen design spec and Phase 5 saga/reducer decision record for the DRY audit; report progress note updated
+- fix(launcher,cef): migration-failure reason can no longer lose a select! race to the closed ESTART channel — biased poll order plus a post-loop buffered-reason check, so a failed migration always surfaces as MigrationFailed instead of degrading to the generic channel-closed error
+- fix(lan): make the mDNS instance label unique and dot-free so two hosts on the same version discover each other
+- feat(settings): toggle to disable the startup splash screen
+- refactor(agent-pane): drop the AgentAtoms mirror — the pane model exposes the reducer state and document nodes reactively (A6 of #1549); adding a reducer field is now a one-place change, and the two detailsOpen writes that bypassed the reducer go through it
+- fix(agent-pane): drop the dead tab-strip gap above My Agents on a fresh pane
+- fix(statusbar): LAN diamond now shows all three states (peers / on-but-idle / off)
+- docs: regenerate the specs index — the committed header count (95) disagreed with its own 96 rows, a merge artifact that failed the 'Specs index is current' gate on every PR including main
+- fix(memory): backfill native-memory versions from disk and repair rows mislabeled 'detected outside AgentMux'
+- feat(srv): agentmux-srv migrate --verify — a doctor pass that asks every APPLIED migration for its post-condition (row counts, marker files) and exits 3 on any mismatch; 0007 and 0002 implement real checks (migration hardening Phase 1b)
+- ci: make the specs index merge-safe by dropping the derived row count from its committed section headers (the one value that resolved wrongly when two spec-adding PRs merged, and 67% of recent CI failures); fix the create_no_window_flag_set flake by pre-warming node.exe outside the measured window
+- fix(srv): migrations run under a cross-process lock — two srv processes booting against the same data dir can no longer both apply the same migration (migration hardening Phase 3)
+- feat(abf): authoring UI for per-provider instruction overrides (instructions_by_provider)
+- feat(jekt): cross-channel sender verification — DELIVERY=channel, TRUST=channel-verified (spec Phase B)
+- feat(muxspect): migrations command — the migrate --verify doctor report from inside a live instance (hardening Phase 1c)
+- test(migrations): Phase 5 regression suite — stale-marker incident, crash-before-mark resume, multi-version upgrade, bootstrap stamping
+- chore(deps): drop the unused react dependency left over from the React→SolidJS migration
+- feat(docs): weekly docs stale-sweep — flags current-claiming docs whose cited files changed or vanished, posted to a standing issue (docs-lifecycle Phase 5)
+- fix(migrations): 0002 block-zones migration no longer trusts its marker file — content-idempotent re-run, content-checked bootstrap stamping and verify (hardening Phase 2)
+- refactor(mcp): split agentmux-mcp/src/main.rs — 50 tool schemas into tool_schemas.rs and the window capture/discovery cluster into window_capture.rs (audit step 17); no behavior change
+- ci(docs): scope the specs-index gate to PRs that touch docs/specs
+- chore: retire the misleading Tauri-era comments and log labels outside the CEF crate (Tauri->CEF migration residue)
+- fix(ci): generate the specs index from tracked files, not a filesystem glob
+- refactor(srv): record each RPC command's request/response types at registration (RpcSchema + register_typed) — the mapping a bindings generator needs, which did not previously exist as data
+- feat(storage): db_agents carries the latest launch state (session/status/started/ended) — schema v29 + backfill from db_agent_instances (agent consolidation Phase 3b, PR 1)
+
 ## 0.55.38 — 2026-09-06
 
 - docs: stop agents sleep-polling — decision table for waiting without polling

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.38",
+  "version": "0.55.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.38",
+      "version": "0.55.39",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.38",
+  "version": "0.55.39",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Routine release PR: consumes all **32 pending changesets** and bumps `0.55.38 -> 0.55.39`, prepared with `task release -- --as patch` (the patch **override**).

## Why the override

The computed bump from the queued changesets was **`minor`** — two `type: minor` changesets were pending. `--as patch` forces a patch release; the script printed its expected loud warning that a lower bump than requested is being forced. Both minor-level changes ship under this patch version, same as the precedent in #3038 and #3003.

## Version invariant

All five locations verified in agreement at **0.55.39** (by `scripts/release.sh`'s own post-bump re-read, and independently re-checked):

| Location | Value |
|---|---|
| `VERSION_HISTORY.md` head | `## 0.55.39 — 2026-09-07` |
| `package.json` | 0.55.39 |
| `Cargo.toml` `[workspace.package]` | 0.55.39 |
| `Cargo.lock` (workspace members) | 0.55.39 |
| `package-lock.json` root | 0.55.39 |

## Contents

Branched off `main` at cb5cc301d. 32 changesets consumed and deleted, and `VERSION_HISTORY.md` gains exactly 32 matching bullets under the 0.55.39 section. Highlights include the migration-hardening series (Phases 1a/1b/1c/2/3/5), `feat(jekt)` cross-channel sender verification, `feat(tray)` macOS menu-bar backend, the ABF per-provider instruction authoring UI, and the specs-index CI fixes.

No code changes beyond the version bump and changeset consumption.

## Review notes

- **[P2] changeset count (ReAgent)** — fixed. The description previously said 33; the correct figure is **32**. The 33 came from a naive `ls .changesets/*.md | wc -l`, which counts `.changesets/README.md` as a changeset. `.changesets/` held 34 tracked paths at the merge-base: 32 real changesets + `README.md` + `.gitkeep`. Confirmed 32 deletions in the commit and 32 added VERSION_HISTORY bullets. No content was dropped; description-only inaccuracy, now corrected.

<!-- agentmux:agent_id=camper -->