### PR TITLE
fix(ci): pin cef-runtime-tag explicitly in release.yml instead of floating to latest

### DIFF
--- a/.changesets/1788837169-fix-ci-pin-cef-runtime-tag-explicitly-in-release-yml-instead-nkvi.md
+++ b/.changesets/1788837169-fix-ci-pin-cef-runtime-tag-explicitly-in-release-yml-instead-nkvi.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(ci): pin cef-runtime-tag explicitly in release.yml instead of floating to latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,20 @@ jobs:
   # steps (windows-portable/windows-installer/windows-msix) are what
   # `publish` downloads below, exactly as when this was inlined.
   # See docs/specs/SPEC_CEF_PROPRIETARY_CODECS_ALL_PLATFORMS_2026_07_26.md.
+  #
+  # cef-runtime-tag is PINNED below (not blank), one tag per platform. It used
+  # to be left blank on all three, which each build-*.yml resolves to "latest
+  # published release for that platform" -- meaning a release build's CEF
+  # version was decided by release TIMING, not by anything in the commit: two
+  # builds of the identical commit could ship different Chromium versions, and
+  # reverting a consumer PR to roll back CEF would not actually roll anything
+  # back, since the next release would still resolve to whatever is newest on
+  # agentmuxai/cef. Found while scoping the CEF 148->152 milestone upgrade
+  # (docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md).
+  #
+  # To bump: cut the new agentmuxai/cef release(s) first, then update the
+  # three tags below in the same PR as the consumer-side change (Cargo.toml /
+  # Taskfile / docs). Do not blank these back out.
   build-windows:
     name: Build — Windows portable + installer + MSIX
     needs: verify
@@ -89,7 +103,7 @@ jobs:
     with:
       ref: ${{ github.event.inputs.tag || github.ref }}
       release-tag: ""
-      cef-runtime-tag: ""
+      cef-runtime-tag: "cef-windows-x86_64-148.0.7778.180"
     secrets: inherit
 
   # Reuses build-linux.yml's own job instead of inlining a second copy of the
@@ -108,7 +122,7 @@ jobs:
     with:
       ref: ${{ github.event.inputs.tag || github.ref }}
       release-tag: ""
-      cef-runtime-tag: ""
+      cef-runtime-tag: "cef-linux-x86_64-148.0.7778.180-codecs"
     secrets: inherit
 
   # check-macos probes the APPLE_CEF_AVAILABLE secret and exposes it as a job
@@ -147,7 +161,7 @@ jobs:
     with:
       ref: ${{ github.event.inputs.tag || github.ref }}
       release-tag: ""
-      cef-runtime-tag: ""
+      cef-runtime-tag: "cef-macos-arm64-148.23.23-codecs"
     secrets: inherit
 
   # ── Phase 3: Publish GitHub Release ───────────────────────────────────────


### PR DESCRIPTION
## Summary

`release.yml` passes `cef-runtime-tag: ""` to all three `build-{windows,linux,macos}.yml` call sites. Every callee resolves a blank tag to "newest published release for that platform on `agentmuxai/cef`" — so a release build's CEF version is decided by **release timing**, not by anything in the commit. Two builds of the identical commit could ship different Chromium versions.

This also makes the CEF-upgrade spec's rollback story (`docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md` §4G) not actually work: reverting a consumer PR back to the 148 pins wouldn't restore CEF 148, because the next release would still resolve to whatever is newest on the fork.

Split out on its own rather than folded into the upgrade spec's Phase E — this is a reproducibility bug independent of whether that upgrade ever ships (credit to Korp for the framing).

## Change

Pin all three `cef-runtime-tag` inputs in `release.yml` to today's actually-resolved tags:

| Platform | Pinned tag |
|---|---|
| Windows | `cef-windows-x86_64-148.0.7778.180` |
| Linux | `cef-linux-x86_64-148.0.7778.180-codecs` |
| macOS | `cef-macos-arm64-148.23.23-codecs` |

Each was verified against that platform's own resolver logic in `build-{windows,linux,macos}.yml` (filter by tag prefix, sort by `publishedAt`, take newest) — **this changes nothing about what currently ships**, it only stops it from being able to silently drift between release runs.

Added a comment explaining why these are pinned and how to bump them (cut the new `agentmuxai/cef` release first, then update the tag here in the same PR as the consumer-side change — never blank them back out).

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` — valid YAML.
- Each pinned tag confirmed to currently be exactly what `TAG=""` resolves to today, via the same platform-prefix-filter + `publishedAt`-sort query each `build-*.yml` runs.

<!-- agentmux:agent_id=agentx -->
