### PR TITLE
fix(ci): pin the CEF runtime tag for release builds instead of resolving latest at build time

### DIFF
--- a/.changesets/1788837242-fix-ci-pin-the-cef-runtime-tag-for-release-builds-instead-of-gism.md
+++ b/.changesets/1788837242-fix-ci-pin-the-cef-runtime-tag-for-release-builds-instead-of-gism.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(ci): pin the CEF runtime tag for release builds instead of resolving latest at build time

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,23 @@ jobs:
   # steps (windows-portable/windows-installer/windows-msix) are what
   # `publish` downloads below, exactly as when this was inlined.
   # See docs/specs/SPEC_CEF_PROPRIETARY_CODECS_ALL_PLATFORMS_2026_07_26.md.
+  # ── CEF runtime pinning for release builds ────────────────────────────────
+  # `cef-runtime-tag` is left blank in the standalone build-*.yml workflows on
+  # purpose (manual/CI-triggered test builds want "whatever's newest"), but a
+  # blank value there resolves to "most recently PUBLISHED agentmuxai/cef
+  # release for this platform" (see each build-*.yml's "Resolve codec-enabled
+  # CEF runtime tag" step) — evaluated fresh at EVERY run. In this file, that
+  # means two release runs of the exact same git tag could pull different
+  # Chromium runtimes if a new agentmuxai/cef release landed between them:
+  # a release artifact's CEF version would depend on build TIMING, not on
+  # anything in the commit being released. Pinned explicitly below instead.
+  #
+  # This trio is the current, verified-working set per
+  # docs/specs/SPEC_CEF_PROPRIETARY_CODECS_ALL_PLATFORMS_2026_07_26.md
+  # ("H.264/AAC verified on all three platforms. Verified 2026-08-10.").
+  # Bump all three together — and only after verifying the new set the same
+  # way — when qualifying a new agentmuxai/cef release (e.g. the 148→152
+  # milestone jump in docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md).
   build-windows:
     name: Build — Windows portable + installer + MSIX
     needs: verify
@@ -89,7 +106,7 @@ jobs:
     with:
       ref: ${{ github.event.inputs.tag || github.ref }}
       release-tag: ""
-      cef-runtime-tag: ""
+      cef-runtime-tag: "cef-windows-x86_64-148.0.7778.180"
     secrets: inherit
 
   # Reuses build-linux.yml's own job instead of inlining a second copy of the
@@ -108,7 +125,7 @@ jobs:
     with:
       ref: ${{ github.event.inputs.tag || github.ref }}
       release-tag: ""
-      cef-runtime-tag: ""
+      cef-runtime-tag: "cef-linux-x86_64-148.0.7778.180-codecs"
     secrets: inherit
 
   # check-macos probes the APPLE_CEF_AVAILABLE secret and exposes it as a job
@@ -147,7 +164,7 @@ jobs:
     with:
       ref: ${{ github.event.inputs.tag || github.ref }}
       release-tag: ""
-      cef-runtime-tag: ""
+      cef-runtime-tag: "cef-macos-arm64-148.23.23-codecs"
     secrets: inherit
 
   # ── Phase 3: Publish GitHub Release ───────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,36 @@ jobs:
     outputs:
       version: ${{ steps.check.outputs.version }}
     steps:
+      # Guards the CEF pinning fix below, per codex's review of that change
+      # (PR #3087): a workflow_dispatch run's OWN DEFINITION — including the
+      # cef-runtime-tag literals a few jobs down — is read from whatever ref
+      # GitHub resolved this run FROM (github.ref_name), which for a manual
+      # dispatch is normally main, the default branch. `inputs.tag` only
+      # controls what SOURCE gets checked out inside each job (the `ref:`
+      # lines below and in build-windows/linux/macos.yml) — it does NOT
+      # change which copy of this workflow file runs. So an emergency
+      # workflow_dispatch rebuild of an OLD tag, launched from main, would
+      # silently rebuild that release's SOURCE with WHATEVER CEF pins are
+      # on main today — reintroducing the exact "same tag, different
+      # Chromium runtime depending on when you happened to run it" gap the
+      # pinning fix exists to close, just moved from "any time" to "any time
+      # you forget to dispatch from the right ref."
+      #
+      # Fails loudly instead: workflow_dispatch must be launched FROM the
+      # tag being rebuilt (`gh workflow run release.yml --ref <tag> -f
+      # tag=<tag>`), so this run's own release.yml — and its CEF pins — are
+      # read from that tag's own commit, matching what it originally shipped
+      # with. The push-tag trigger is unaffected: github.ref_name already
+      # equals the pushed tag there, so this condition is trivially satisfied
+      # and no inputs.tag exists to compare against.
+      - name: Guard — workflow_dispatch must run from the tag being rebuilt
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ github.ref_name }}" != "${{ github.event.inputs.tag }}" ]; then
+            echo "::error::This run's own workflow definition (including the CEF runtime pins a few jobs down) comes from '${{ github.ref_name }}' — the ref you dispatched from — not from the 'tag' input ('${{ github.event.inputs.tag }}'). Rebuilding an old release from any ref other than that release's own tag risks shipping it with today's (possibly newer) CEF pins instead of what it originally shipped with. Re-run with: gh workflow run release.yml --ref ${{ github.event.inputs.tag }} -f tag=${{ github.event.inputs.tag }}"
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}


### PR DESCRIPTION
Follow-up from the finding in the CEF milestone-upgrade spec (#3081, from a peer agent's recon): `release.yml` passes `cef-runtime-tag: ""` to all three platform build jobs, and blank resolves to "most recently published `agentmuxai/cef` release for this platform" — evaluated **fresh at every workflow run**.

## Why this is a real reproducibility gap, not a style nit

That default is correct for the standalone `build-*.yml` workflows — a manual or CI-triggered test build wanting "whatever's newest" is reasonable there. But in the **release** pipeline specifically, it means a release artifact's Chromium runtime depends on *when the workflow happened to run*, not on anything in the commit being released. Concretely: re-running the release workflow for the exact same git tag after a new `agentmuxai/cef` release lands would silently ship a different CEF/Chromium build under the same AgentMux version number — two builds of the same commit, different runtimes.

## The fix

Pin `cef-runtime-tag` explicitly for all three platforms in `release.yml`, to the current, verified-working trio per `docs/specs/SPEC_CEF_PROPRIETARY_CODECS_ALL_PLATFORMS_2026_07_26.md` ("H.264/AAC verified on all three platforms. Verified 2026-08-10."):

| Platform | Pinned tag |
|---|---|
| Windows | `cef-windows-x86_64-148.0.7778.180` |
| Linux | `cef-linux-x86_64-148.0.7778.180-codecs` |
| macOS | `cef-macos-arm64-148.23.23-codecs` |

Each was confirmed to actually exist in `agentmuxai/cef` via `gh release view` before committing (not assumed from `gh release list`'s publish-date sort alone) — all three are published, non-draft, non-prerelease.

A comment above `build-windows` explains the why (this file differs from the `build-*.yml` default on purpose) and the how — bump all three together, and only after re-verifying the new set the same way, when qualifying a new `agentmuxai/cef` release. Named the obvious next occasion: the 148→152 milestone jump spec'd in #3081.

## Verification

- YAML re-parses cleanly (`python -c "import yaml; yaml.safe_load(...)"`).
- `check-spec-citations.sh` / `check-doc-status.sh` pass.
- Diff is else-unchanged — no behavior touched besides the three tag values.
- **Not yet verified against a real release run** (this workflow only triggers on a version tag push or manual dispatch, and I'm not cutting a release to test a CI-pinning change). The `build-*.yml` resolver steps this reuses are already exercised by the ordinary CI-triggered/manual builds, so the resolution mechanism itself is proven; what's new here is only which three literal strings get passed in.

<!-- agentmux:agent_id=agenty -->