### PR TITLE
fix(ci): require an emergency release rebuild to dispatch from the tag it is rebuilding

### DIFF
--- a/.changesets/1788838567-fix-ci-require-an-emergency-release-rebuild-to-dispatch-from-c8wu.md
+++ b/.changesets/1788838567-fix-ci-require-an-emergency-release-rebuild-to-dispatch-from-c8wu.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(ci): require an emergency release rebuild to dispatch from the tag it is rebuilding

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,36 @@ jobs:
     outputs:
       version: ${{ steps.check.outputs.version }}
     steps:
+      # Guards the CEF pinning fix below, per codex's review of that change
+      # (PR #3087): a workflow_dispatch run's OWN DEFINITION — including the
+      # cef-runtime-tag literals a few jobs down — is read from whatever ref
+      # GitHub resolved this run FROM (github.ref_name), which for a manual
+      # dispatch is normally main, the default branch. `inputs.tag` only
+      # controls what SOURCE gets checked out inside each job (the `ref:`
+      # lines below and in build-windows/linux/macos.yml) — it does NOT
+      # change which copy of this workflow file runs. So an emergency
+      # workflow_dispatch rebuild of an OLD tag, launched from main, would
+      # silently rebuild that release's SOURCE with WHATEVER CEF pins are
+      # on main today — reintroducing the exact "same tag, different
+      # Chromium runtime depending on when you happened to run it" gap the
+      # pinning fix exists to close, just moved from "any time" to "any time
+      # you forget to dispatch from the right ref."
+      #
+      # Fails loudly instead: workflow_dispatch must be launched FROM the
+      # tag being rebuilt (`gh workflow run release.yml --ref <tag> -f
+      # tag=<tag>`), so this run's own release.yml — and its CEF pins — are
+      # read from that tag's own commit, matching what it originally shipped
+      # with. The push-tag trigger is unaffected: github.ref_name already
+      # equals the pushed tag there, so this condition is trivially satisfied
+      # and no inputs.tag exists to compare against.
+      - name: Guard — workflow_dispatch must run from the tag being rebuilt
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ github.ref_name }}" != "${{ github.event.inputs.tag }}" ]; then
+            echo "::error::This run's own workflow definition (including the CEF runtime pins a few jobs down) comes from '${{ github.ref_name }}' — the ref you dispatched from — not from the 'tag' input ('${{ github.event.inputs.tag }}'). Rebuilding an old release from any ref other than that release's own tag risks shipping it with today's (possibly newer) CEF pins instead of what it originally shipped with. Re-run with: gh workflow run release.yml --ref ${{ github.event.inputs.tag }} -f tag=${{ github.event.inputs.tag }}"
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,17 @@ jobs:
       # and no inputs.tag exists to compare against.
       - name: Guard — workflow_dispatch must run from the tag being rebuilt
         if: github.event_name == 'workflow_dispatch'
+        env:
+          # ReAgent P2: inputs.tag is operator-supplied free text, interpolated
+          # here four times (comparison, ::error:: message, twice in the
+          # suggested command) — raw ${{ }} interpolation repeated that many
+          # times in one script is worth hardening even though triggering
+          # workflow_dispatch already requires repo write access. One `env:`
+          # substitution instead of four raw interpolations.
+          TAG: ${{ github.event.inputs.tag }}
         run: |
-          if [ "${{ github.ref_name }}" != "${{ github.event.inputs.tag }}" ]; then
-            echo "::error::This run's own workflow definition (including the CEF runtime pins a few jobs down) comes from '${{ github.ref_name }}' — the ref you dispatched from — not from the 'tag' input ('${{ github.event.inputs.tag }}'). Rebuilding an old release from any ref other than that release's own tag risks shipping it with today's (possibly newer) CEF pins instead of what it originally shipped with. Re-run with: gh workflow run release.yml --ref ${{ github.event.inputs.tag }} -f tag=${{ github.event.inputs.tag }}"
+          if [ "${{ github.ref_name }}" != "$TAG" ]; then
+            echo "::error::This run's own workflow definition (including the CEF runtime pins a few jobs down) comes from '${{ github.ref_name }}' — the ref you dispatched from — not from the 'tag' input ('$TAG'). Rebuilding an old release from any ref other than that release's own tag risks shipping it with today's (possibly newer) CEF pins instead of what it originally shipped with. Re-run with: gh workflow run release.yml --ref $TAG -f tag=$TAG"
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,16 +63,21 @@ jobs:
       - name: Guard — workflow_dispatch must run from the tag being rebuilt
         if: github.event_name == 'workflow_dispatch'
         env:
-          # ReAgent P2: inputs.tag is operator-supplied free text, interpolated
-          # here four times (comparison, ::error:: message, twice in the
-          # suggested command) — raw ${{ }} interpolation repeated that many
-          # times in one script is worth hardening even though triggering
-          # workflow_dispatch already requires repo write access. One `env:`
-          # substitution instead of four raw interpolations.
+          # codex P2 (round 2): git ref/tag names permit backticks, $(), quotes
+          # and ; — git-check-ref-format does NOT exclude shell metacharacters,
+          # only things like spaces and control chars — so github.ref_name is
+          # NOT safe to treat as inert just because it's "GitHub-controlled."
+          # Raw ${{ }} interpolation is substituted into this YAML string
+          # BEFORE bash ever parses it, so an attacker-crafted ref name could
+          # inject arbitrary shell commands here, running with this job's own
+          # permissions. Both values go through env: now — REF_NAME added
+          # alongside the TAG hardening from round 1 — and are referenced only
+          # as quoted shell variables from here on.
           TAG: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.ref_name }}" != "$TAG" ]; then
-            echo "::error::This run's own workflow definition (including the CEF runtime pins a few jobs down) comes from '${{ github.ref_name }}' — the ref you dispatched from — not from the 'tag' input ('$TAG'). Rebuilding an old release from any ref other than that release's own tag risks shipping it with today's (possibly newer) CEF pins instead of what it originally shipped with. Re-run with: gh workflow run release.yml --ref $TAG -f tag=$TAG"
+          if [ "$REF_NAME" != "$TAG" ]; then
+            echo "::error::This run's own workflow definition (including the CEF runtime pins a few jobs down) comes from '$REF_NAME' — the ref you dispatched from — not from the 'tag' input ('$TAG'). Rebuilding an old release from any ref other than that release's own tag risks shipping it with today's (possibly newer) CEF pins instead of what it originally shipped with. Re-run with: gh workflow run release.yml --ref $TAG -f tag=$TAG"
             exit 1
           fi
 


### PR DESCRIPTION
Follow-up from #3087. That PR pinned `release.yml`'s `cef-runtime-tag` for all three platforms — but while it was in review, **#3086** landed the exact same pin independently (another agent, working the same gap from the CEF-upgrade spec scoping). Since the pin itself is already on `main`, closing #3087 as superseded rather than merging a duplicate.

**This PR is the one piece of #3087 that #3086 doesn't have**: Codex's review of #3087 caught a real gap in the pin itself, and I'm carrying that forward here rather than letting it get lost with the superseded PR.

## The gap

A `workflow_dispatch` run's own workflow *definition* — including the `cef-runtime-tag` pins #3086 added — is read from whatever ref GitHub resolved the run **from** (`github.ref_name`), which for a manual dispatch defaults to `main`. The `tag` input only controls what *source* gets checked out inside each job; it never changes which copy of `release.yml` actually runs.

So an emergency `workflow_dispatch` rebuild of an old tag, launched from `main` (the likely default — nobody thinks to pass `--ref <tag>` for an emergency rebuild), would rebuild that release's source with whatever CEF pins are on `main` **today**. That's the exact "same tag, different Chromium runtime depending on when you happen to run it" gap #3086 closed for the push-tag trigger — just relocated to the dispatch path.

## The fix

A guard as the first step of the `verify` job: for `workflow_dispatch` specifically, fail loudly unless `github.ref_name` (the ref this run's own workflow definition comes from) equals the `tag` input (what's being rebuilt). The error names the exact `gh workflow run --ref <tag> ...` invocation that satisfies it.

Push-tag runs are unaffected — the guard's own `if` is gated on `event_name == 'workflow_dispatch'`, so it never evaluates for that trigger; `github.ref_name` already equals the pushed tag there regardless.

## Verification

- Cherry-picked cleanly onto current `main` (post-#3086) — no conflict, since #3086 never touched the `verify` job.
- YAML re-parses (`python -c "import yaml; yaml.safe_load(...)"`).
- `check-doc-status.sh` / `check-spec-citations.sh` pass.
- **Not exercised against a real dispatch** — same caveat as #3086: this workflow only triggers on a version-tag push or manual dispatch, and I'm not cutting a release to test a guard. The logic is a plain shell string comparison with no external dependency, so the risk surface is small, but it's worth someone actually running an intentionally-mismatched dispatch once to see the guard fire before the first *real* emergency rebuild needs it.

<!-- agentmux:agent_id=agenty -->