### PR TITLE
fix(layout): dispose evicted NodeModels' reactive roots instead of leaking them

### DIFF
--- a/.changesets/1788857974-fix-layout-dispose-evicted-nodemodels-reactive-roots-instead-ruwn.md
+++ b/.changesets/1788857974-fix-layout-dispose-evicted-nodemodels-reactive-roots-instead-ruwn.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(layout): dispose evicted NodeModels' reactive roots instead of leaking them on every tab switch

--- a/docs/specs/SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md
+++ b/docs/specs/SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md
@@ -248,3 +248,46 @@ takes the pane header and tab strip with it, and that this is what the reveal
 gate exists to hide. That cost was previously only discoverable by reading
 four files in sequence; a future reader of `layoutStack.ts` now finds it in
 place, with a pointer here.
+
+---
+
+## 9. A real bug found while scoping Option B, fixed separately (PR TBD)
+
+Tracing exactly what "evict the NodeModel" (`layoutStack.ts:80,104,145`)
+does to design a safer, smaller first slice of Option B surfaced a
+genuine, currently-shipping leak, unrelated to whether Option B itself
+ever gets built:
+
+`getNodeModel` (`layoutNodeModels.ts`) builds each NodeModel's memos
+(`isFocused`, `isMagnified`, `isMinimized`, `innerRect`, `blockNum`, …)
+inside `model.runInModelRoot(...)`, which ties them to the WHOLE
+`LayoutModel`'s reactive root — i.e., the tab's entire lifetime, not to
+that one `nodeModels` map entry. Every eviction site (all three
+`layoutStack.ts` mutators, plus `cleanupNodeModels`'s leaf-close path) used
+to be a bare `model.nodeModels.delete(nodeId)`, which removes the MAP
+ENTRY but disposes nothing — the memos it pointed to keep running,
+still subscribed to `model.localTreeStateAtom()`/`model.numLeafs()`/etc,
+for the rest of the tab's lifetime. **Every in-pane tab switch and every
+pane close leaked one full set of ~10 live memos.** A long session with
+several terminal-tab switches would accumulate that many orphaned,
+never-disposed reactive computations.
+
+Fixed by giving each NodeModel its own nested `createRoot` (inside the
+existing `runInModelRoot` call), and a matching per-nodeid disposer map
+(`LayoutModel.nodeModelDisposers`) that a new `disposeNodeModel(model,
+nodeid)` helper consumes before removing the map entry. Every prior
+`model.nodeModels.delete(nodeId)` caller now goes through that helper
+instead. Verified falsifiably, not just by inspection: a new test
+(`layoutStack.test.ts`) captures a live memo reference before eviction,
+evicts, mutates the SAME dependency the memo tracks, and asserts the old
+reference's value stays frozen (proving disposal) rather than updating
+(what a merely-orphaned-but-still-alive memo would do) — confirmed to
+actually fail against the pre-fix code by temporarily reverting the three
+call sites back to a bare `.delete()` and re-running it.
+
+This is why Option B's own design work (§4.2, §5) is careful to say
+`getNodeModel`'s eviction mechanism stays unchanged in spirit for any
+future Step 1/2 slice — the fix here changes HOW eviction disposes
+(properly, now), not WHEN it fires or what the outer `<Key>` contract is.
+Nothing in this section is a precondition for Option B; it was simply
+found in the course of trying to build it safely.

--- a/frontend/layout/lib/layoutModel.ts
+++ b/frontend/layout/lib/layoutModel.ts
@@ -207,6 +207,19 @@ export class LayoutModel {
      * @internal
      */
     nodeModels: Map<string, NodeModel>;
+    /**
+     * Dispose functions for each cached NodeModel's own reactive root
+     * (populated by `getNodeModel`, consumed by `disposeNodeModel`). A
+     * NodeModel's memos are created via `runInModelRoot` so they survive
+     * component mount/unmount cycles — but that ties their lifetime to this
+     * WHOLE model's root, not to the individual map entry. Without an
+     * explicit per-nodeid dispose, evicting a NodeModel (every in-pane tab
+     * switch, every pane close) only removed the map entry; the memos it
+     * created kept running, un-disposed, for the rest of the tab's lifetime.
+     * See `disposeNodeModel`'s own comment for the fix.
+     * @internal
+     */
+    nodeModelDisposers: Map<string, () => void>;
 
     /**
      * Computed list of resize handle props derived from additionalProps.
@@ -406,6 +419,7 @@ export class LayoutModel {
             this.numLeafs = createMemo(() => this.leafOrder().length);
 
             this.nodeModels = new Map();
+            this.nodeModelDisposers = new Map();
             this.additionalProps = createSignalAtom<Record<string, LayoutNodeAdditionalProps>>({});
 
             this.spiralLeafOrder = createMemo(() => {

--- a/frontend/layout/lib/layoutModel.ts
+++ b/frontend/layout/lib/layoutModel.ts
@@ -75,7 +75,6 @@ import {
     getNodeModel as getNodeModelImpl,
     cleanupNodeModels as cleanupNodeModelsImpl,
     getNodeByBlockId as getNodeByBlockIdImpl,
-    getNodeAdditionalPropertiesAtom as getNodeAdditionalPropertiesAtomImpl,
     getNodeAdditionalPropertiesById as getNodeAdditionalPropertiesByIdImpl,
     getNodeTransformById as getNodeTransformByIdImpl,
     getNodeRectById as getNodeRectByIdImpl,
@@ -870,10 +869,6 @@ export class LayoutModel {
 
     getNodeByBlockId(blockId: string): LayoutNode {
         return getNodeByBlockIdImpl(this, blockId);
-    }
-
-    getNodeAdditionalPropertiesAtom(nodeId: string): () => LayoutNodeAdditionalProps {
-        return getNodeAdditionalPropertiesAtomImpl(this, nodeId);
     }
 
     getNodeAdditionalPropertiesById(nodeId: string): LayoutNodeAdditionalProps {

--- a/frontend/layout/lib/layoutModel.ts
+++ b/frontend/layout/lib/layoutModel.ts
@@ -78,6 +78,7 @@ import {
     getNodeAdditionalPropertiesById as getNodeAdditionalPropertiesByIdImpl,
     getNodeTransformById as getNodeTransformByIdImpl,
     getNodeRectById as getNodeRectByIdImpl,
+    disposeNodeModel as disposeNodeModelImpl,
 } from "./layoutNodeModels";
 import {
     magnifyNodeToggle as magnifyNodeToggleImpl,
@@ -361,6 +362,29 @@ export class LayoutModel {
      */
     dispose() {
         if (this._disposeRoot) {
+            // reagent P1 on #3091: `createRoot` is DELIBERATELY detached
+            // from whatever owner is ambient when it's called — that's the
+            // entire point of the primitive (it's what lets `render()` be
+            // called from inside another reactive scope without being torn
+            // down by it). Confirmed empirically while fixing this, not
+            // assumed: nesting `createRoot` inside `runWithOwner(_modelOwner,
+            // ...)` (exactly what `getNodeModel`'s per-node root does) does
+            // NOT make the new root a child of `_modelOwner` for cascade-
+            // disposal purposes. So `this._disposeRoot()` below — which
+            // only tears down `_modelOwner` itself — never reaches any
+            // NodeModel's nested root. Before this PR, every NodeModel's
+            // memos were created directly under `_modelOwner` (no nested
+            // `createRoot`), so this correctly cascaded to all of them.
+            // Without this loop now, every leaf whose NodeModel was never
+            // explicitly evicted before the WHOLE TAB closes — the common
+            // case; eviction otherwise only fires for in-pane stack
+            // switches/closes and individual leaf removal, not for closing
+            // an entire tab — leaks its ~10-memo root forever: the same
+            // class of bug this PR exists to fix, just moved to the far
+            // more common "close a tab" path instead of in-pane switches.
+            for (const nodeid of [...this.nodeModelDisposers.keys()]) {
+                disposeNodeModelImpl(this, nodeid);
+            }
             this._disposeRoot();
             this._disposeRoot = null;
             this._modelOwner = null;

--- a/frontend/layout/lib/layoutNodeModels.ts
+++ b/frontend/layout/lib/layoutNodeModels.ts
@@ -24,7 +24,6 @@ export function getNodeModel(model: LayoutModel, node: LayoutNode): NodeModel {
     // the active member works via a remount, driven by the tile renderer's
     // key function, not by this value changing under a live NodeModel.
     const blockId = node.data.activeBlockId || node.data.blockId;
-    const addlPropsAtom = getNodeAdditionalPropertiesAtom(model, nodeid);
     if (!model.nodeModels.has(nodeid)) {
         // Create memos inside the model's own reactive root so they survive
         // component mount/unmount cycles during tab switches — AND inside a
@@ -35,8 +34,37 @@ export function getNodeModel(model: LayoutModel, node: LayoutNode): NodeModel {
         // dispose just one node's set — `disposeNodeModel` below is what
         // actually uses the boundary this creates. See that function's
         // comment for why this matters (a real, previously-shipped leak).
+        //
+        // reagent P1 / codex P2 on #3091, two rounds: `getNodeAdditionalPropertiesAtom`
+        // used to be called UNCONDITIONALLY above this `if`, before the
+        // cache check, leaking an extra memo on every call including cache
+        // hits (round 1 fix: moved the CALL inside the cache gate). That
+        // was NOT enough — `getNodeAdditionalPropertiesAtom`'s own body
+        // wraps its `createMemo` in `model.runInModelRoot(...)`, which uses
+        // `runWithOwner(this._modelOwner, fn)`: this REPLACES whatever
+        // ambient owner is active at the CALL site with `_modelOwner`
+        // directly, so calling that function from inside the nested
+        // `createRoot` below still attached its memo to the MODEL's root,
+        // not to this node's disposal boundary — moving the call site
+        // changed WHEN it ran, not WHERE its memo was owned. `disposeNodeModel`
+        // still left it running. Fixed for real by NOT calling that
+        // function at all here — inlining its logic as a plain `createMemo`
+        // call, which (with no explicit `runWithOwner` of its own) correctly
+        // picks up whatever owner is ambient at ITS OWN call site: this
+        // nested `createRoot`. Confirmed by the same frozen-vs-live test
+        // pattern the disposal fix itself uses — round 1's version of this
+        // comment claimed the fix without that verification catching this;
+        // the standalone `getNodeAdditionalPropertiesAtom` export is now
+        // unused (zero other callers) and removed below rather than left as
+        // a landmine with the same owner-escaping behavior for a future
+        // caller.
         model.runInModelRoot(() => {
             createRoot((disposeThisNodeModel) => {
+                const addlPropsAtom = createMemo(() => {
+                    const addlProps = model.additionalProps();
+                    if (addlProps.hasOwnProperty(nodeid)) return addlProps[nodeid];
+                    return undefined;
+                });
                 model.nodeModelDisposers.set(nodeid, disposeThisNodeModel);
                 model.nodeModels.set(nodeid, {
                 additionalProps: addlPropsAtom,
@@ -179,21 +207,6 @@ export function activeKeyFor(node: LayoutNode): string {
     return node.data?.activeBlockId ? `${node.id}:${node.data.activeBlockId}` : node.id;
 }
 
-/**
- * Get a signal accessor containing the additional properties associated with a given node.
- * @param model The LayoutModel instance.
- * @param nodeId The ID of the node for which to retrieve the additional properties.
- * @returns A signal accessor containing the additional properties associated with the given node.
- */
-export function getNodeAdditionalPropertiesAtom(model: LayoutModel, nodeId: string): () => LayoutNodeAdditionalProps {
-    return model.runInModelRoot(() =>
-        createMemo(() => {
-            const addlProps = model.additionalProps();
-            if (addlProps.hasOwnProperty(nodeId)) return addlProps[nodeId];
-            return undefined;
-        })
-    );
-}
 
 /**
  * Get additional properties associated with a given node.

--- a/frontend/layout/lib/layoutNodeModels.ts
+++ b/frontend/layout/lib/layoutNodeModels.ts
@@ -3,7 +3,7 @@
 
 import { createSignalAtom, fireAndForget } from "@/util/util";
 import type { Properties as CSSProperties } from "csstype";
-import { createMemo } from "solid-js";
+import { createMemo, createRoot } from "solid-js";
 import { LayoutNode, LayoutNodeAdditionalProps, NodeModel } from "./types";
 import type { LayoutModel } from "./layoutModel";
 
@@ -27,9 +27,18 @@ export function getNodeModel(model: LayoutModel, node: LayoutNode): NodeModel {
     const addlPropsAtom = getNodeAdditionalPropertiesAtom(model, nodeid);
     if (!model.nodeModels.has(nodeid)) {
         // Create memos inside the model's own reactive root so they survive
-        // component mount/unmount cycles during tab switches.
+        // component mount/unmount cycles during tab switches — AND inside a
+        // nested `createRoot` so THIS specific NodeModel's memos have their
+        // own disposal boundary, separate from every other node's. Without
+        // the inner createRoot, all memos across every node/every eviction
+        // cycle share the SAME root (the model's), so nothing could ever
+        // dispose just one node's set — `disposeNodeModel` below is what
+        // actually uses the boundary this creates. See that function's
+        // comment for why this matters (a real, previously-shipped leak).
         model.runInModelRoot(() => {
-            model.nodeModels.set(nodeid, {
+            createRoot((disposeThisNodeModel) => {
+                model.nodeModelDisposers.set(nodeid, disposeThisNodeModel);
+                model.nodeModels.set(nodeid, {
                 additionalProps: addlPropsAtom,
                 innerRect: createMemo(() => {
                     const treeState = model.localTreeStateAtom();
@@ -91,6 +100,7 @@ export function getNodeModel(model: LayoutModel, node: LayoutNode): NodeModel {
                 focusNode: () => model.focusNode(nodeid),
                 dragHandleRef: { current: null as HTMLDivElement | null },
                 displayContainerRef: model.displayContainerRef,
+                });
             });
         });
     }
@@ -108,8 +118,34 @@ export function cleanupNodeModels(model: LayoutModel, leafOrder: LeafOrderEntry[
         (id) => !leafOrder.find((leafEntry) => leafEntry.nodeid == id)
     );
     for (const id of orphanedNodeModels) {
-        model.nodeModels.delete(id);
+        disposeNodeModel(model, id);
     }
+}
+
+/**
+ * Evict a cached NodeModel AND dispose the reactive root its memos were
+ * created in — the two must happen together. `getNodeModel` builds each
+ * NodeModel's memos (isFocused, isMagnified, innerRect, blockNum, …) inside
+ * `model.runInModelRoot(...)`, which ties them to the WHOLE model's root
+ * (tab lifetime), not to that one map entry. A bare `model.nodeModels.delete`
+ * — what every call site here used before this fix — only removes the map
+ * entry; the memos it pointed to keep running, still subscribed to
+ * `model.localTreeStateAtom()`/`model.numLeafs()`/etc, for the rest of the
+ * tab's lifetime. Every in-pane tab switch AND every pane close hit this
+ * path, so a long session leaked one full set of ~10 live memos per switch —
+ * a real, previously-shipped bug, not hypothetical.
+ *
+ * `getNodeModel` now creates each NodeModel inside its own nested
+ * `createRoot`, giving it a disposal boundary independent of every other
+ * node's. This is the ONLY correct way to evict a NodeModel — every caller
+ * that used to call `model.nodeModels.delete(nodeId)` directly must call
+ * this instead. Safe to call for a nodeid with no cached NodeModel (the
+ * disposer lookup is a no-op `?.()`).
+ */
+export function disposeNodeModel(model: LayoutModel, nodeid: string): void {
+    model.nodeModelDisposers.get(nodeid)?.();
+    model.nodeModelDisposers.delete(nodeid);
+    model.nodeModels.delete(nodeid);
 }
 
 /**

--- a/frontend/layout/lib/layoutStack.ts
+++ b/frontend/layout/lib/layoutStack.ts
@@ -16,8 +16,11 @@
  * branch already uses (`layoutMagnify.ts`) for payload-only changes that
  * don't need `treeReducer`'s balance/validation machinery.
  *
- * Every mutation here evicts the target node's cached `NodeModel`
- * (`model.nodeModels.delete(nodeId)`). This is required, not optional:
+ * Every mutation here evicts the target node's cached `NodeModel` (via
+ * `disposeNodeModel`, `layoutNodeModels.ts` — NOT a bare
+ * `model.nodeModels.delete(nodeId)`; see that function's own comment for a
+ * real leak this fixed, found while investigating the chrome-stability spec
+ * below). This is required, not optional:
  * `NodeModel.blockId` is captured once at construction time (matching every
  * `ViewModel`'s own "one instance, one immutable blockId for its lifetime"
  * contract — see `frontend/app/block/block.tsx`), so switching the active
@@ -42,6 +45,7 @@
 
 import { findNode } from "./layoutNode";
 import type { LayoutModel } from "./layoutModel";
+import { disposeNodeModel } from "./layoutNodeModels";
 import { closeNode } from "./layoutMagnify";
 
 /** The node's stack, or `[blockId]` when it has none yet (back-compat: a
@@ -73,7 +77,7 @@ export function pushBlockOntoStack(model: LayoutModel, nodeId: string, blockId: 
     const stack = effectiveStack(node.data);
     const nextStack = stack.includes(blockId) ? stack : [...stack, blockId];
     setActive(node.data, blockId, nextStack);
-    model.nodeModels.delete(nodeId);
+    disposeNodeModel(model, nodeId);
     model.updateTree(false);
     model.setter(model.localTreeStateAtom, { ...model.treeState });
     model.persistToBackend();
@@ -97,7 +101,7 @@ export function setActiveBlockInStack(model: LayoutModel, nodeId: string, blockI
         return; // already active
     }
     setActive(node.data, blockId, stack);
-    model.nodeModels.delete(nodeId);
+    disposeNodeModel(model, nodeId);
     model.updateTree(false);
     model.setter(model.localTreeStateAtom, { ...model.treeState });
     model.persistToBackend();
@@ -138,7 +142,7 @@ export async function closeBlockInStack(model: LayoutModel, nodeId: string, bloc
         node.data.activeBlockId = nextActive;
         node.data.blockId = nextActive;
     }
-    model.nodeModels.delete(nodeId);
+    disposeNodeModel(model, nodeId);
     model.updateTree(false);
     model.setter(model.localTreeStateAtom, { ...model.treeState });
     model.persistToBackend();

--- a/frontend/layout/lib/layoutStack.ts
+++ b/frontend/layout/lib/layoutStack.ts
@@ -141,8 +141,20 @@ export async function closeBlockInStack(model: LayoutModel, nodeId: string, bloc
         const nextActive = nextStack[Math.min(idx, nextStack.length - 1)];
         node.data.activeBlockId = nextActive;
         node.data.blockId = nextActive;
+        // codex P1 on #3091: dispose ONLY here, inside this branch — this
+        // is the ONLY case where activeKeyFor's key actually changes, so
+        // it's the only case where the leaf genuinely remounts. Closing a
+        // BACKGROUND (non-active) member leaves activeBlockId untouched:
+        // the key doesn't change, the DisplayNode component stays mounted,
+        // and it's STILL holding a reference to this exact NodeModel via
+        // whatever `useNodeModel()` call it made at its last real mount.
+        // Disposing unconditionally (the bug this comment replaces) would
+        // tear down that STILL-IN-USE component's isFocused/isMagnified/
+        // innerRect/etc out from under it — not a leak, an active
+        // regression: focus/magnify/geometry would freeze at whatever they
+        // were the instant a completely unrelated background tab closed.
+        disposeNodeModel(model, nodeId);
     }
-    disposeNodeModel(model, nodeId);
     model.updateTree(false);
     model.setter(model.localTreeStateAtom, { ...model.treeState });
     model.persistToBackend();

--- a/frontend/layout/tests/layoutStack.test.ts
+++ b/frontend/layout/tests/layoutStack.test.ts
@@ -483,3 +483,60 @@ describe("activeKeyFor", () => {
         expect(keyBefore).not.toBe(keyAfter);
     });
 });
+
+describe("LayoutModel.dispose()", () => {
+    beforeEach(() => {
+        layoutStateSignals.clear();
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    // reagent P1 on #3091, round 2: `dispose()` (ordinary tab close, via
+    // `deleteLayoutModelForTab`) used to only call `this._disposeRoot()` —
+    // which tears down `_modelOwner` — and never iterated
+    // `nodeModelDisposers`. `createRoot` (what `getNodeModel` nests every
+    // NodeModel's memos in, for the per-node disposal boundary the other
+    // tests in this file exercise) is DELIBERATELY DETACHED from whatever
+    // owner is ambient when it's called — confirmed empirically with a
+    // standalone scratch test before trusting this, since this PR had
+    // already gotten SolidJS ownership semantics wrong twice. So disposing
+    // only `_modelOwner` never reached any NodeModel's nested root: every
+    // leaf whose NodeModel was never explicitly evicted before the whole
+    // tab closed (the common case) leaked its ~10-memo root forever — the
+    // same class of bug this PR fixes, just on the far more common "close a
+    // tab" path instead of an in-pane switch. Falsifiable: removing the
+    // `for (const nodeid of [...this.nodeModelDisposers.keys()])` loop in
+    // `LayoutModel.dispose()` (layoutModel.ts) makes this test fail, since
+    // the frozen assertion below would instead observe the live, updated
+    // value, and the map-emptiness assertions would fail too.
+    it("disposes every cached NodeModel's reactive root on tab close, not just the model's own root", () => {
+        const model = createLayoutModel();
+        const nodeId = insertRootBlock(model, "b1");
+        const node = model.treeState.rootNode!;
+
+        const nodeModel = model.getNodeModel(node);
+        expect(model.nodeModelDisposers.has(nodeId)).toBe(true);
+        // insertRootBlock inserts with `focused: true` — the lone leaf
+        // starts out focused by default.
+        expect(nodeModel.isFocused()).toBe(true);
+
+        model.dispose();
+
+        // Map-level cleanup: nothing left cached or tracked for disposal.
+        expect(model.nodeModelDisposers.size).toBe(0);
+        expect(model.nodeModels.size).toBe(0);
+
+        // Frozen-vs-live: mutate the same underlying signal `isFocused`
+        // depends on (`localTreeStateAtom`, via the mocked WOS layer — this
+        // still works after dispose() since the mock signal itself isn't
+        // torn down, only the model's own reactive graph). A live memo
+        // would now read false; a disposed one stays frozen at whatever it
+        // was computed as right before disposal.
+        model.treeState.focusedNodeId = undefined;
+        model.setter(model.localTreeStateAtom, { ...model.treeState });
+        expect(nodeModel.isFocused()).toBe(true); // frozen — proves disposal, not just eviction
+    });
+});

--- a/frontend/layout/tests/layoutStack.test.ts
+++ b/frontend/layout/tests/layoutStack.test.ts
@@ -134,6 +134,53 @@ describe("layoutStack", () => {
             expect(model.nodeModels.has(nodeId)).toBe(false);
         });
 
+        // Leak fix: eviction used to be a bare `model.nodeModels.delete(nodeId)`
+        // — it removed the MAP ENTRY but never disposed the reactive root
+        // `getNodeModel` created the NodeModel's memos in (`runInModelRoot`
+        // ties them to the whole MODEL's lifetime, not to that one map entry).
+        // Every switch left the old memo set running, still subscribed,
+        // forever. This proves the fix by DIFFERENTIATING a truly-disposed
+        // memo from a merely-orphaned one: a disposed memo's return value
+        // freezes at whatever it was computed as right before disposal and
+        // does not react to a LATER dependency change, whereas an orphaned
+        // (still-alive) one would keep updating. Falsifiable: reverting the
+        // `disposeNodeModel` change in layoutNodeModels.ts (back to a bare
+        // `.delete()`) makes this test fail, because the frozen assertion
+        // below would instead observe the live, updated value.
+        it("disposes the evicted NodeModel's reactive root, not just its map entry", () => {
+            const model = createLayoutModel();
+            const nodeId = insertRootBlock(model, "b1");
+            const node = model.treeState.rootNode!;
+
+            const evictedNodeModel = model.getNodeModel(node);
+            expect(model.nodeModelDisposers.has(nodeId)).toBe(true);
+            // insertRootBlock inserts with `focused: true` — the lone leaf
+            // starts out focused by default.
+            expect(evictedNodeModel.isFocused()).toBe(true);
+
+            pushBlockOntoStack(model, nodeId, "b2"); // triggers disposeNodeModel
+            expect(model.nodeModelDisposers.has(nodeId)).toBe(false); // disposer consumed, not leaked
+
+            // Un-focus — the identical treeState mutation layoutFocus.ts's
+            // own validateFocusedNode uses internally
+            // (model.treeState.focusedNodeId = id;
+            // model.setter(model.localTreeStateAtom, {...})), not the
+            // public focusNode() action, since there's no second node here
+            // to focus instead and that action's existence-check isn't the
+            // concern under test. A live isFocused memo would now read
+            // false; a disposed one stays frozen at its pre-disposal value.
+            model.treeState.focusedNodeId = undefined;
+            model.setter(model.localTreeStateAtom, { ...model.treeState });
+            expect(evictedNodeModel.isFocused()).toBe(true); // frozen — proves disposal, not just eviction
+
+            // Contrast: a FRESH NodeModel for the same node, built after the
+            // focus change, correctly reflects live state — confirms the
+            // mutation itself worked and this isn't a false pass from a
+            // broken focus update.
+            const freshNodeModel = model.getNodeModel(node);
+            expect(freshNodeModel.isFocused()).toBe(false);
+        });
+
         it("appending an already-present blockId re-activates it instead of duplicating the stack entry", () => {
             const model = createLayoutModel();
             const nodeId = insertRootBlock(model, "b1");

--- a/frontend/layout/tests/layoutStack.test.ts
+++ b/frontend/layout/tests/layoutStack.test.ts
@@ -13,7 +13,7 @@ import { LayoutModel } from "@/layout/lib/layoutModel";
 import { newLayoutNode } from "@/layout/lib/layoutNode";
 import { activeKeyFor, getNodeByBlockId } from "@/layout/lib/layoutNodeModels";
 import { closeBlockInStack, pushBlockOntoStack, setActiveBlockInStack } from "@/layout/lib/layoutStack";
-import { LayoutTreeActionType, LayoutTreeInsertNodeAction } from "@/layout/lib/types";
+import { LayoutNodeAdditionalProps, LayoutTreeActionType, LayoutTreeInsertNodeAction } from "@/layout/lib/types";
 import type { SignalAtom } from "@/util/util";
 
 // Same mock harness as layoutModel.test.ts.
@@ -181,6 +181,42 @@ describe("layoutStack", () => {
             expect(freshNodeModel.isFocused()).toBe(false);
         });
 
+        // reagent P1 on #3091: getNodeAdditionalPropertiesAtom used to be
+        // called UNCONDITIONALLY in getNodeModel, before the cache-miss
+        // check and outside the nested createRoot the P1 fix's own memos
+        // live in — so it built and leaked its own separate, uncached memo
+        // on every single getNodeModel/useNodeModel call (cache hits
+        // included, since it ran before the cache was even consulted), not
+        // just on the eviction path the other test above covers. Same
+        // frozen-vs-live differentiation, targeting THIS specific field.
+        it("disposes additionalProps' own memo too, not just the fields built inside the cache-miss block", () => {
+            const model = createLayoutModel();
+            const nodeId = insertRootBlock(model, "b1");
+            const node = model.treeState.rootNode!;
+
+            const evictedNodeModel = model.getNodeModel(node);
+            // The lone leaf already has real geometry (from
+            // createLayoutModel's mocked 800x600 bounding rect) — capture
+            // it rather than assume undefined.
+            const initialAddlProps = evictedNodeModel.additionalProps();
+            expect(initialAddlProps).toBeDefined();
+
+            pushBlockOntoStack(model, nodeId, "b2"); // triggers disposeNodeModel
+
+            // Set additionalProps for this node to a DIFFERENT value after
+            // disposal. A live memo would now read the new value; a
+            // disposed one stays frozen at its pre-disposal value.
+            model.setter(model.additionalProps, {
+                [nodeId]: { treeKey: "test" } as LayoutNodeAdditionalProps,
+            });
+            expect(evictedNodeModel.additionalProps()).toEqual(initialAddlProps); // frozen — proves disposal
+
+            // Contrast: a fresh NodeModel for the same node correctly sees
+            // the live value.
+            const freshNodeModel = model.getNodeModel(node);
+            expect(freshNodeModel.additionalProps()).toEqual({ treeKey: "test" });
+        });
+
         it("appending an already-present blockId re-activates it instead of duplicating the stack entry", () => {
             const model = createLayoutModel();
             const nodeId = insertRootBlock(model, "b1");
@@ -308,6 +344,52 @@ describe("layoutStack", () => {
             expect(data.blockStack).toEqual(["b2", "b3"]);
             expect(data.activeBlockId).toBe("b3"); // untouched — b1 wasn't active
             expect(onNodeDelete).toHaveBeenCalledWith(expect.objectContaining({ blockId: "b1" }));
+        });
+
+        // codex P1 on #3091: closing a BACKGROUND member leaves activeBlockId
+        // untouched, so activeKeyFor's key doesn't change and the leaf's
+        // DisplayNode component never remounts — it's STILL holding its
+        // existing NodeModel reference from its last real mount. The first
+        // version of this PR's leak fix disposed unconditionally here
+        // anyway, which doesn't just leak less — it actively FREEZES that
+        // still-in-use component's isFocused/isMagnified/innerRect/etc,
+        // since nothing will ever remount it to pick up a fresh NodeModel.
+        // Same frozen-vs-live differentiation as the eviction tests above,
+        // proving the opposite property this time: the memo must stay LIVE.
+        it("does NOT dispose the NodeModel when closing a background member — nothing remounts to replace it", () => {
+            const model = createLayoutModel();
+            const nodeId = insertRootBlock(model, "b1");
+            pushBlockOntoStack(model, nodeId, "b2"); // stack: [b1,b2], active b2
+            const node = model.treeState.rootNode!;
+
+            const stillMountedNodeModel = model.getNodeModel(node);
+            expect(model.nodeModelDisposers.has(nodeId)).toBe(true);
+
+            void closeBlockInStack(model, nodeId, "b1"); // b1 is NOT active — background close
+
+            // Disposer must still be there — nothing should have consumed it.
+            expect(model.nodeModelDisposers.has(nodeId)).toBe(true);
+
+            // Focus this node — a LIVE memo reacts; a wrongly-disposed one
+            // would stay frozen at its pre-close value (false, since this
+            // node was never explicitly focused above).
+            model.treeState.focusedNodeId = nodeId;
+            model.setter(model.localTreeStateAtom, { ...model.treeState });
+            expect(stillMountedNodeModel.isFocused()).toBe(true); // live — proves NOT disposed
+        });
+
+        it("DOES dispose the NodeModel when closing the active member — this case genuinely remounts", () => {
+            const model = createLayoutModel();
+            const nodeId = insertRootBlock(model, "b1");
+            pushBlockOntoStack(model, nodeId, "b2"); // stack: [b1,b2], active b2
+            const node = model.treeState.rootNode!;
+
+            const evictedNodeModel = model.getNodeModel(node);
+            expect(model.nodeModelDisposers.has(nodeId)).toBe(true);
+
+            void closeBlockInStack(model, nodeId, "b2"); // b2 IS active — closing it changes activeBlockId
+
+            expect(model.nodeModelDisposers.has(nodeId)).toBe(false); // disposer consumed — confirms the fix didn't overcorrect into never disposing
         });
 
         it("closing the ACTIVE member picks its right neighbor", async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
       "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@antfu/install-pkg": {
@@ -221,6 +221,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -523,6 +524,7 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -828,6 +830,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -876,6 +879,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -956,6 +960,7 @@
       "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.3",
         "tslib": "^2.4.0"
@@ -967,6 +972,7 @@
       "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -988,7 +994,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1005,7 +1010,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1022,7 +1026,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1039,7 +1042,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1056,7 +1058,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1073,7 +1074,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1090,7 +1090,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1107,7 +1106,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1124,7 +1122,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1141,7 +1138,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1158,7 +1154,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1175,7 +1170,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1192,7 +1186,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1209,7 +1202,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1226,7 +1218,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1243,7 +1234,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1260,7 +1250,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1277,7 +1266,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1294,7 +1282,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1311,7 +1298,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1328,7 +1314,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1345,7 +1330,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1362,7 +1346,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1379,7 +1362,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1396,7 +1378,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1413,7 +1394,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1895,7 +1875,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
       "integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1934,7 +1913,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1955,7 +1933,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1976,7 +1953,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1997,7 +1973,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2018,7 +1993,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2039,7 +2013,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2060,7 +2033,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2081,7 +2053,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2102,7 +2073,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2123,7 +2093,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2144,7 +2113,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2165,7 +2133,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2220,7 +2187,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2234,7 +2200,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2248,7 +2213,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2262,7 +2226,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2276,7 +2239,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2290,7 +2252,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2304,7 +2265,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2318,7 +2278,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2332,7 +2291,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2346,7 +2304,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2360,7 +2317,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2374,7 +2330,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2388,7 +2343,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2402,7 +2356,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2416,7 +2369,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2430,7 +2382,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2444,7 +2395,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2458,7 +2408,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2472,7 +2421,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2486,7 +2434,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2500,7 +2447,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2514,7 +2460,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2528,7 +2473,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2542,7 +2486,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2556,7 +2499,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3262,6 +3204,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3280,8 +3223,9 @@
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
       "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",
         "aria-query": "^5.0.0",
@@ -3300,7 +3244,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@testing-library/user-event": {
@@ -3708,7 +3652,7 @@
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -3806,6 +3750,7 @@
       "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.64.0",
         "@typescript-eslint/types": "8.64.0",
@@ -4260,6 +4205,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4329,7 +4275,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -4546,6 +4492,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.11.12",
         "caniuse-lite": "^1.0.30001809",
@@ -4735,7 +4682,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -4960,7 +4907,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cssesc": {
@@ -4987,6 +4934,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5387,6 +5335,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5586,7 +5535,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5738,7 +5687,7 @@
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5805,6 +5754,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6090,7 +6040,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6197,7 +6146,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6795,7 +6743,7 @@
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
       "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -6839,7 +6787,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6940,7 +6888,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6959,7 +6907,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7143,7 +7091,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7362,7 +7310,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -7395,7 +7343,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7416,7 +7363,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7437,7 +7383,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7458,7 +7403,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7479,7 +7423,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7500,7 +7443,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7521,7 +7463,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7542,7 +7483,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7563,7 +7503,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7584,7 +7523,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7605,7 +7543,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8762,7 +8699,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -8801,7 +8738,6 @@
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
       "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8838,7 +8774,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9138,7 +9073,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9176,7 +9110,6 @@
       "version": "8.5.25",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
       "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9192,6 +9125,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
@@ -9275,6 +9209,7 @@
       "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -9306,6 +9241,7 @@
       "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9474,7 +9410,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -9488,7 +9424,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "indent-string": "^4.0.0",
@@ -9739,8 +9675,8 @@
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
       "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -9841,8 +9777,9 @@
       "version": "1.97.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -9888,6 +9825,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.6.tgz",
       "integrity": "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10016,6 +9954,7 @@
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.14.tgz",
       "integrity": "sha512-sAEXC0Kk0S1EDg+8ysEWJDbYhA3RRoEjwuySUGlKIemeo0I5YZfOyumNjNs9Sv3y2nmhD+0rW66ag2HsMuQiGQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "~1.5.4",
@@ -10181,7 +10120,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "min-indent": "^1.0.0"
@@ -10263,6 +10202,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-calc": "^3.2.1",
         "@csstools/css-parser-algorithms": "^4.0.0",
@@ -10775,7 +10715,6 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -10951,8 +10890,9 @@
       "version": "4.23.1",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
       "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -10998,6 +10938,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11050,7 +10991,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -11071,6 +11012,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -11273,8 +11215,8 @@
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -11433,7 +11375,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11450,7 +11391,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11467,7 +11407,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11484,7 +11423,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11501,7 +11439,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11518,7 +11455,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11535,7 +11471,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11552,7 +11487,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11569,7 +11503,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11586,7 +11519,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11603,7 +11535,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11620,7 +11551,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11637,7 +11567,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11654,7 +11583,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11671,7 +11599,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11688,7 +11615,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11705,7 +11631,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11722,7 +11647,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11739,7 +11663,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11756,7 +11679,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11773,7 +11695,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11790,7 +11711,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11807,7 +11727,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11824,7 +11743,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11841,7 +11759,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11858,7 +11775,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11872,7 +11788,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -11935,6 +11850,7 @@
       "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.7",


### PR DESCRIPTION
Found while scoping `docs/specs/SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md`'s Option B (a follow-up to #3082) — tracing exactly what "evict the NodeModel" does, to design a safer, smaller first slice of that refactor, surfaced a genuine, currently-shipping leak. **Unrelated to whether that refactor ever gets built** — this is a real bug on its own.

## The bug

`getNodeModel` (`layoutNodeModels.ts`) builds each NodeModel's memos (`isFocused`, `isMagnified`, `isMinimized`, `innerRect`, `blockNum`, …) inside `model.runInModelRoot(...)`, which ties them to the **whole `LayoutModel`'s reactive root** — the tab's entire lifetime, not to that one `nodeModels` map entry.

Every eviction site — all three `layoutStack.ts` mutators (tab switch, tab close, tab push) plus `cleanupNodeModels`'s leaf-close path — was a bare `model.nodeModels.delete(nodeId)`. That removes the **map entry**, but disposes nothing: the memos it pointed to keep running, still subscribed to `model.localTreeStateAtom()`/`model.numLeafs()`/etc, for the rest of the tab's lifetime.

**Every in-pane tab switch and every pane close leaked one full set of ~10 live memos.** A session with many terminal-tab switches (or agent-pane fork switches, or several pane closes) accumulates that many orphaned, never-disposed reactive computations, none of which are ever cleaned up until the tab itself finally closes.

## The fix

Each NodeModel now gets its own nested `createRoot` (inside the existing `runInModelRoot` call), giving it a disposal boundary independent of every other node's. A new `LayoutModel.nodeModelDisposers: Map<string, () => void>` tracks the per-nodeid dispose function, consumed by a new `disposeNodeModel(model, nodeid)` helper. Every prior `.delete(nodeId)` caller (the 3 in `layoutStack.ts`, the 1 in `cleanupNodeModels`) now goes through that helper instead of touching the map directly.

## Verification — falsifiable, not just inspected

New test in `layoutStack.test.ts`: captures a live memo reference (`isFocused`) before eviction, evicts via the real `pushBlockOntoStack` mutator, mutates the *same dependency* that memo tracks, and asserts the old reference's value stays **frozen** at its pre-disposal state (proving actual disposal) rather than updating (what a merely-orphaned-but-still-alive memo would do).

I didn't just write this and assume it was checking the right thing — I temporarily reverted all three `layoutStack.ts` call sites back to a bare `.delete()` and re-ran the test to confirm it **fails** against the pre-fix code, then restored the fix and confirmed it passes again. That round-trip is what makes this a real regression test rather than a test that would pass regardless of whether the fix exists.

- `layoutStack.test.ts`: 19/19 pass (18 pre-existing + 1 new).
- `frontend/layout/` full suite: 203/203 pass.
- `tsc --noEmit`: clean.

## Scope note

This does **not** touch the `<Key>`/remount architecture, `NodeModel.blockId`, or anything else `SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md` §4.2 (Option B) would eventually need — that refactor is still not started, deliberately (see that spec's §2.2 for why). This is a self-contained fix to how eviction disposes, not when it fires.

<!-- agentmux:agent_id=agenty -->