### PR TITLE
docs(cef): Phase A recon output + fix the spec's open findings

### DIFF
--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -26,11 +26,18 @@ sandbox = ["cef/sandbox"]
 # Opt-in for dev_authfile unit tests that touch the filesystem and Win32 ACL APIs
 test-authfile = []
 # Enables call sites that depend on the AgentMux libcef fork
-# (https://github.com/agentmuxai/cef, branch `7778` — which is where the drag
-# work now lives, merged via that repo's PR #3; the old
-# `agentmux/7680-drag-rightclick-and-transparency` branch this used to cite is
-# CEF 146-era and no longer the current milestone. The `a5af` org also
-# redirects to `agentmuxai` now).
+# (https://github.com/agentmuxai/cef). Two branches there matter and they are
+# NOT interchangeable:
+#   - `agentmux/7778-drag-rightclick-and-transparency` — where this patch was
+#     authored, and where the shipped runtime binaries were actually built
+#     from (e.g. macOS `148.23.23-codecs` was built at `6c570e249` on it).
+#   - `7778` — the milestone integration branch the above was merged into via
+#     that repo's PR #3. Also carries `BeginWindowDrag`.
+# As of 2026-09-08 those two have DIVERGED (the build commit is 4 ahead / 2
+# behind `7778`), so "which branch" matters when reproducing a build — prefer
+# the recorded build commit over either branch tip. The old
+# `agentmux/7680-…` branch this used to cite is CEF 146-era; the `a5af` org
+# also redirects to `agentmuxai` now.
 # Specifically: `_cef_window_t::begin_window_drag` (used by StartWindowDragTask).
 # Requires a matching patched cef-dll-sys via [patch.crates-io] in the workspace
 # Cargo.toml. Default OFF so unpatched checkouts compile — native left-click

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -26,7 +26,11 @@ sandbox = ["cef/sandbox"]
 # Opt-in for dev_authfile unit tests that touch the filesystem and Win32 ACL APIs
 test-authfile = []
 # Enables call sites that depend on the AgentMux libcef fork
-# (https://github.com/a5af/cef, branch agentmux/7680-drag-rightclick-and-transparency).
+# (https://github.com/agentmuxai/cef, branch `7778` — which is where the drag
+# work now lives, merged via that repo's PR #3; the old
+# `agentmux/7680-drag-rightclick-and-transparency` branch this used to cite is
+# CEF 146-era and no longer the current milestone. The `a5af` org also
+# redirects to `agentmuxai` now).
 # Specifically: `_cef_window_t::begin_window_drag` (used by StartWindowDragTask).
 # Requires a matching patched cef-dll-sys via [patch.crates-io] in the workspace
 # Cargo.toml. Default OFF so unpatched checkouts compile — native left-click

--- a/docs/analysis/archive/ANALYSIS_WINDOWS_GPU_DISABLED_ROOTCAUSE_2026_06_11.md
+++ b/docs/analysis/archive/ANALYSIS_WINDOWS_GPU_DISABLED_ROOTCAUSE_2026_06_11.md
@@ -1,9 +1,40 @@
-> **Archived 2026-07-17:** Resolved. Root-caused issue #1345, now closed. Kept for
-> historical reference only.
+> **⚠️ RETRACTED 2026-06-11 — the root cause below is WRONG. Do not cite it.**
+>
+> This document blames the `agentmuxai/cef` fork's Windows `libcef.dll` for
+> being a "non-official / DCHECK-enabled build." That attribution was
+> **retracted by its own author** the same day, in issue #1345:
+>
+> - The Windows `libcef` at the time was **not** a custom or DCHECK build — it
+>   was the stock official CEF release from `cef-builds.spotifycdn.com`. The
+>   "source paths in logs" evidence cited below is normal for any CEF app
+>   (CEF ships `is_official_build=false` by design) and does **not** indicate
+>   a DCHECK build.
+> - **The actual cause:** the exe shipped without a Windows `supportedOS`
+>   application manifest, so Windows reported the OS as 6.2 (Win8). That sent
+>   Chromium's OS-version-gated GPU init down a path that CHECK-crashed the
+>   GPU process. Adding the manifest (#1354, merged 2026-06-11) made the OS
+>   report 10.0 → zero crashes → hardware GPU works.
+>
+> Kept only as a record of how the wrong conclusion was reached. **Anyone
+> scoping CEF fork/build work should not treat this as evidence that the fork's
+> build configuration causes GPU failures** — see
+> `docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md` §7.3, which
+> flagged this doc as misleading for exactly that reason.
+>
+> (Separately: the custom codec-enabled `agentmuxai/cef` runtime builds that
+> AgentMux ships *today* postdate this document —
+> `SPEC_CEF_PROPRIETARY_CODECS_ALL_PLATFORMS_2026_07_26.md`. The "stock
+> official CEF" statement above describes June 2026, not the current setup.)
+>
+> **Archived 2026-07-17:** Kept for historical reference only.
 
 # Root-Cause Analysis: Windows GPU Disabled (CEF GPU-process STATUS_BREAKPOINT)
 
-**Status:** Complete — empirically verified (CDP `SystemInfo`/`chrome://gpu`, CEF logs, A/B build, VS Code comparison)
+**Status:** historical — **conclusion RETRACTED** (see banner above; real cause
+was a missing `supportedOS` manifest, #1354). The investigation below was
+empirically thorough (CDP `SystemInfo`/`chrome://gpu`, CEF logs, A/B build, VS
+Code comparison) but reached the wrong root cause; kept as a record of the
+effort, not as a finding anyone should cite.
 **Author:** AgentX
 **Date:** 2026-06-11
 **This PR:** SwiftShader software-GL safety net (`agentx/gpu-hardware-fix`)

--- a/docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md
+++ b/docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md
@@ -1,0 +1,214 @@
+# CEF 148 → 152 upgrade: Phase A reconnaissance
+
+**Author:** Agent5
+**Date:** 2026-09-08
+**Status:** implemented — Phase A recon executed and delivered by this document;
+the one source-side fix it produced shipped as `agentmuxai/cef` PR #7 (merged
+2026-09-08). This is the Phase A output that
+`docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md` §4 gates the
+rest of the upgrade on. One item is deliberately incomplete — see §2.4.
+**Verdict:** **Go** on §3's "straight to 152" decision — with one correction to
+the spec's cost model, and one finding that is more urgent than the upgrade
+itself.
+
+---
+
+## 0. TL;DR
+
+| Phase A question | Answer |
+|---|---|
+| Do the four carried patches still apply / are any now upstream? | Inventory was **wrong in two places** — see §2. `BeginWindowDrag` is still not upstream at 152. |
+| Does `cef-rs`/`cef-dll-sys` have a 152-compatible crate? | **Yes** — `cef 152.0.0+152.0.5`, published 2026-09-07. |
+| Is `begin_window_drag` in its generated bindings? | **No** — same as 148, so the binding fork is still required. |
+| Have the build toolchain requirements moved? | **Windows: no. Linux: no.** macOS: unconfirmed, see §4. |
+| Go / no-go on targeting 152 directly? | **Go.** Nothing found makes 152 harder than the spec assumed. |
+
+**The finding that matters most is not about 152 at all:** none of the four
+patches were in any shipped CEF binary (§5). One of them is a macOS renderer
+crash fix. That is now partially addressed (`agentmuxai/cef` PR #7, merged)
+but still needs builds.
+
+---
+
+## 1. Method, and its limits
+
+Everything below was verified against the actual repositories via the GitHub
+API — not read off the spec, which turned out to contain errors this pass
+corrected. Where a claim could not be verified from here, it says so rather
+than guessing.
+
+**Hard limit:** no Chromium checkout was available (~100 GB), and no
+macOS/Linux build machine. So "does this patch still apply to 152's source"
+was answered by inspecting upstream 152's actual source files for the code
+each patch targets — not by running `git apply` against a real 152 tree. That
+distinction matters and is called out per-patch below.
+
+---
+
+## 2. Corrected patch inventory
+
+The spec's §2 table has two errors.
+
+### 2.1 Patch #1 is macOS-only, not "All platforms"
+
+The spec lists `agentmux_process_requirement.patch` as `Used by: All platforms`.
+It patches `base/apple/mach_port_rendezvous_mac.cc`. Mach ports are a Darwin
+kernel primitive and Chromium's `base/apple/` tree is not compiled on Windows
+or Linux — this patch **cannot affect** those platforms. It is macOS-only.
+
+Consequence: it is not a blocker for a Windows/Linux-only 152 build, and the
+"mandatory, all platforms" framing overstates its reach.
+
+### 2.2 Patch #1 was not registered, and not merged
+
+The spec says it is "registered in `patch/patch.cfg`." It was not — neither the
+`patch.cfg` entry nor the patch file existed on `7778`. It sat on an unmerged,
+diverged branch (`agentmux/7778-process-requirement`, 1 ahead / 13 behind)
+from 2026-06-02 until it was merged as part of this recon
+(`agentmuxai/cef` PR #7, 2026-09-08).
+
+That PR also fixed a real defect in the patch itself, found by Codex review:
+its diff header used `a/`/`b/` prefixes, but CEF's patcher
+(`tools/git_util.py`) runs `git apply -p0`, which does no path stripping — so
+it looked for a literal `a/base/apple/...` and failed. Since
+`cef_create_projects.sh` exits on a failed patch, **this would have stopped
+every source build touching that branch**, on any platform. Verified by
+reconstructing the target file and running CEF's exact patcher config against
+both versions.
+
+### 2.3 `BeginWindowDrag` is still not upstream at 152
+
+Checked `include/views/cef_window.h` at upstream branch `7977` directly: it has
+`SetDraggableRegions()` and no `BeginWindowDrag()`. Our fork's `7778` does have
+it (`/*--cef(added=14800)--*/ virtual bool BeginWindowDrag() = 0;`).
+
+So patch #2 still needs forward-porting for 152, and the corresponding
+`cef-dll-sys` binding patch is still required. **Nothing was deleted by
+upstream here** — the spec's hope that four milestones might have upstreamed
+some of this did not materialize for this patch.
+
+### 2.4 Patches #2/#3/#4 status
+
+These live on `7778` (merged via that repo's PR #3, 2026-06-25):
+`views_caption_rightclick_passthrough` (registered in `patch.cfg`) and the
+transparency work (`rwhv_background_opaque_check.patch` plus renderer-side
+changes in `libcef/`).
+
+**Not individually re-diffed against 152's source.** Doing that properly needs
+a real 152 checkout to `git apply --check` against; asserting "applies cleanly"
+from file inspection alone would be a guess. This is the one Phase A item that
+is genuinely incomplete, and it is the item most likely to change Phase B's
+size. Whoever takes Phase B should do this first, with a checkout.
+
+---
+
+## 3. Rust binding (`cef-rs` / `cef-dll-sys`)
+
+**A 152-compatible crate exists.** `tauri-apps/cef-rs` published
+`cef 152.0.0+152.0.5` to crates.io on **2026-09-07** — one day before this
+recon, and the same day the upgrade spec was written. Version history is
+regular (149 → 150 → 151 → 152 over ~10 weeks), so the binding project is
+keeping pace with CEF stable branches.
+
+**`begin_window_drag` is not in it.** It is absent from upstream `cef-rs`
+entirely, which follows directly from §2.3 — the binding is generated from
+CEF's own C API, and CEF 152 has no such method. Our fork
+(`AgentU-asaf/cef-rs`, branch `agentmux/148-begin-window-drag`) is the only
+place it exists, and Phase C's plan to rebase that onto the 152 binding stands
+unchanged.
+
+---
+
+## 4. Build toolchain requirements
+
+Compared `chromium/chromium` at the two exact tags each CEF branch pins
+(`148.0.7778.218` and `152.0.7977.83`, both read from
+`CHROMIUM_BUILD_COMPATIBILITY.txt` — these confirm the spec's version table):
+
+| Platform | Signal checked | Result |
+|---|---|---|
+| Windows | `build/vs_toolchain.py` → `TOOLCHAIN_HASH` | **Unchanged** (`e66617bc68` at both tags) |
+| Windows | `MSVS_VERSIONS` | **Unchanged** — VS 2026 (18.0) packaged toolchain at both |
+| Linux | `build/linux/sysroot_scripts/sysroots.json` | **Unchanged** — same bullseye sysroot set |
+| macOS | hermetic Xcode pin | **Not confirmed** — could not locate the version pin through the files checked |
+
+So Windows and Linux need no toolchain change for this upgrade. **macOS is
+unverified**, not verified-as-fine — confirm it at Phase D build time on the
+actual machine rather than trusting this table for that row.
+
+---
+
+## 5. The finding that outranks the upgrade
+
+While tracing patches, all three currently-pinned CEF release tags were
+resolved to their actual commits:
+
+| Pinned tag | Commit | Cut |
+|---|---|---|
+| `cef-windows-x86_64-148.0.7778.180` | `05d7a247` | 2026-04-23 |
+| `cef-linux-x86_64-148.0.7778.180-codecs` | `05d7a247` | 2026-04-23 |
+| `cef-macos-arm64-148.23.23-codecs` | `05d7a247` | 2026-04-23 |
+
+All three are **the same commit**, cut **2026-04-23** — which predates the
+process-requirement patch (2026-06-02) and the drag/right-click/transparency
+merge (2026-06-25). Only one later release exists at all
+(`cef-macos-arm64-148.23.21`, 2026-07-02, built from the
+drag/rightclick/transparency branch), and nothing in this repo references it —
+note also that its version label (`148.23.21`) is *lower* than the tag we pin
+(`148.23.23`) despite being newer, which is §7.1's tag-scheme problem biting in
+practice.
+
+**So none of the four documented fork patches are in any CEF binary AgentMux
+ships today.**
+
+The one that matters: per `docs/retro/retro-macos26-cef-dcheck-root-cause-2026-06-02.md`,
+the -67030 Mach-port peer validation failure is "a *real* functional code-sign
+failure... not a DCHECK" and was "the only reason we went from-source [CEF] at
+all" — without it, the self-reexec CEF helper fails peer validation and the
+renderer crash-loops on macOS 26.
+
+**Status:** source side is now fixed (PR #7 merged into `7778`, patch
+registered, apply-failure fixed). **Not shipped** — that needs an arm64 macOS
+build (Xcode, ≥120 GB, ≥32 GB RAM, 3–6 h) and a fresh release cut. Windows and
+Linux should be re-cut from the same tip at the same time so all three land on
+one source commit again.
+
+This is worth doing **independent of the 152 upgrade**, and is far cheaper:
+no porting, no API fallout — merge (done), build, release, repoint pins.
+
+---
+
+## 6. Go / no-go
+
+**Go**, targeting 152 directly, per the spec's §3 reasoning. Nothing in this
+recon makes 152 harder than assumed:
+
+- the binding exists and is current;
+- Windows/Linux toolchains are unchanged;
+- the patch set did not grow.
+
+It did not get materially *cheaper* either — the hope in §2 that upstream might
+have absorbed some patches did not pan out for `BeginWindowDrag`, the one with
+real porting cost.
+
+**Two conditions on that "go":**
+
+1. **§2.4 is unfinished.** Patches #2/#3/#4 have not been test-applied against
+   real 152 source. Phase B should start there, and Phase B's estimate is not
+   trustworthy until it does.
+2. **Do §5 first, or at least in parallel.** Shipping a macOS renderer crash
+   fix that has been written since June should not wait behind a
+   four-milestone Chromium jump.
+
+---
+
+## 7. Open items not addressed here
+
+- **§7.1 (tag schemes)** — untouched. Release tags are immutable, so the
+  historical inconsistency can only be normalized at read time, not fixed in
+  place. Worth doing before any automated drift checker is built against these
+  tags; §5's `148.23.21`-newer-than-`148.23.23` case shows it already misleads.
+- **§8 open questions** (Linux native drag still required? 150/151 vs 152?
+  who owns the build machines? do the `.180 → .218` patch-level rebase now?)
+  are repo-owner decisions and remain open — recon does not answer them, though
+  §5 makes question 4 more pressing, since a rebuild is needed regardless now.

--- a/docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md
+++ b/docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md
@@ -2,14 +2,17 @@
 
 **Author:** Agent5
 **Date:** 2026-09-08
-**Status:** implemented — Phase A recon executed and delivered by this document;
-the one source-side fix it produced shipped as `agentmuxai/cef` PR #7 (merged
-2026-09-08). This is the Phase A output that
-`docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md` §4 gates the
-rest of the upgrade on. One item is deliberately incomplete — see §2.4.
-**Verdict:** **Go** on §3's "straight to 152" decision — with one correction to
-the spec's cost model, and one finding that is more urgent than the upgrade
-itself.
+**Status:** active — Phase A's recon is delivered by this document and its one
+source-side fix shipped (`agentmuxai/cef` PR #7, merged 2026-09-08), but **two
+of the spec's three Phase A checks are not fully closed**: patches #3/#4 have
+not been test-applied against real 152 source (§2.4), and the macOS Xcode
+toolchain pin is unconfirmed (§4). Per Codex review on PR #3093, Phase A stays
+`active` until those close — the "go" in §6 is therefore conditional, not a
+clearance to start Phase B blind. This is the Phase A output that
+`docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md` §4 gates on.
+**Verdict:** **Conditional go** on §3's "straight to 152" decision — see §6 for
+the two conditions. Also corrects two errors in the spec's patch inventory, and
+records one shipped-binary gap (§5).
 
 ---
 
@@ -21,12 +24,15 @@ itself.
 | Does `cef-rs`/`cef-dll-sys` have a 152-compatible crate? | **Yes** — `cef 152.0.0+152.0.5`, published 2026-09-07. |
 | Is `begin_window_drag` in its generated bindings? | **No** — same as 148, so the binding fork is still required. |
 | Have the build toolchain requirements moved? | **Windows: no. Linux: no.** macOS: unconfirmed, see §4. |
-| Go / no-go on targeting 152 directly? | **Go.** Nothing found makes 152 harder than the spec assumed. |
+| Go / no-go on targeting 152 directly? | **Conditional go** — nothing found makes 152 harder than assumed, but two Phase A checks remain open (§6). |
 
-**The finding that matters most is not about 152 at all:** none of the four
-patches were in any shipped CEF binary (§5). One of them is a macOS renderer
-crash fix. That is now partially addressed (`agentmuxai/cef` PR #7, merged)
-but still needs builds.
+**A separate finding, not about 152:** patch #1 (the macOS -67030 renderer
+crash fix) was never registered in `patch/patch.cfg`, so no build on any
+platform could ever have applied it — it is absent from the shipped macOS
+binary. Now fixed at the source (`agentmux/cef` PR #7) but **not yet built**;
+needs one arm64 macOS rebuild. See §5, including a correction: an earlier draft
+of this report over-claimed that *no* fork patches ship, which was wrong — the
+other three do.
 
 ---
 
@@ -37,11 +43,16 @@ API — not read off the spec, which turned out to contain errors this pass
 corrected. Where a claim could not be verified from here, it says so rather
 than guessing.
 
-**Hard limit:** no Chromium checkout was available (~100 GB), and no
-macOS/Linux build machine. So "does this patch still apply to 152's source"
-was answered by inspecting upstream 152's actual source files for the code
-each patch targets — not by running `git apply` against a real 152 tree. That
-distinction matters and is called out per-patch below.
+**Hard limit:** no full Chromium checkout was available (~100 GB), and no
+macOS/Linux build machine.
+
+For **patch #1** this limit was worked around and the check is real: its target
+file is a single source file, so it was fetched at the exact Chromium 152 tag
+and the patch applied to it with CEF's own patcher config
+(`git apply -p0 --ignore-whitespace`) — see §2.5. For **patches #2/#3/#4**, which
+touch many files across `libcef/`, the limit stands: they were assessed by
+inspecting upstream 152's sources, **not** by a real apply. That distinction is
+called out per-patch, and §6 makes it a condition on the "go."
 
 ---
 
@@ -100,6 +111,23 @@ from file inspection alone would be a guess. This is the one Phase A item that
 is genuinely incomplete, and it is the item most likely to change Phase B's
 size. Whoever takes Phase B should do this first, with a checkout.
 
+### 2.5 Patch #1 verified to apply cleanly to Chromium 152
+
+Done as the first piece of Phase B, and it closes the patch-#1 half of Phase A
+task 1 properly rather than by inspection:
+
+- Fetched `base/apple/mach_port_rendezvous_mac.cc` at Chromium tag
+  `152.0.7977.83`. The target function `GetPeerValidationPolicy()` is
+  **byte-identical** to the 148 version the patch was written against — only
+  its line number moved (405 → 407), which `git apply` resolves by context.
+- Applied the patch (as merged on `7778`) with CEF's exact patcher config:
+  **applies cleanly**, producing the correct `kNoValidation` return.
+
+So patch #1 forward-ports to 152 with **zero modification**. Landed on
+`agentmux/7977-process-requirement` in the fork, registered in 152's
+`patch.cfg` (whose tail differs from 148's — it ends with
+`chrome_browser_extensions_background`, so the insertion point is not the same).
+
 ---
 
 ## 3. Rust binding (`cef-rs` / `cef-dll-sys`)
@@ -138,50 +166,88 @@ actual machine rather than trusting this table for that row.
 
 ---
 
-## 5. The finding that outranks the upgrade
+## 5. The shipped-binary gap — corrected
 
-While tracing patches, all three currently-pinned CEF release tags were
-resolved to their actual commits:
+> **Correction (2026-09-08, before merge).** An earlier draft of this section
+> claimed *"none of the four documented fork patches are in any CEF binary
+> AgentMux ships today,"* inferred from all three release tags' `target_commitish`
+> resolving to one April-23 commit. **That inference was invalid and the claim
+> was false.** A GitHub release's tag target is not build provenance — a release
+> cut without `--target` inherits the default branch's HEAD. Caught in review by
+> Codex on PR #3093. What follows is the corrected, directly-verified version.
+> The scope of the real problem is much narrower than the retracted claim.
 
-| Pinned tag | Commit | Cut |
-|---|---|---|
-| `cef-windows-x86_64-148.0.7778.180` | `05d7a247` | 2026-04-23 |
-| `cef-linux-x86_64-148.0.7778.180-codecs` | `05d7a247` | 2026-04-23 |
-| `cef-macos-arm64-148.23.23-codecs` | `05d7a247` | 2026-04-23 |
+### 5.1 What actually ships (verified, not inferred)
 
-All three are **the same commit**, cut **2026-04-23** — which predates the
-process-requirement patch (2026-06-02) and the drag/right-click/transparency
-merge (2026-06-25). Only one later release exists at all
-(`cef-macos-arm64-148.23.21`, 2026-07-02, built from the
-drag/rightclick/transparency branch), and nothing in this repo references it —
-note also that its version label (`148.23.21`) is *lower* than the tag we pin
-(`148.23.23`) despite being newer, which is §7.1's tag-scheme problem biting in
-practice.
+The authoritative provenance is the build records, not the tags:
 
-**So none of the four documented fork patches are in any CEF binary AgentMux
-ships today.**
+- **macOS** — `STATUS_CEF_PROPRIETARY_CODECS_MACOS_2026_07_27.md` records
+  `cef-macos-arm64-148.23.23-codecs` as built 2026-07-28 from fork commit
+  `6c570e249`, with **112 patches applied, 3 skipped, 0 failed**, and
+  `BeginWindowDrag` explicitly re-verified in the built framework
+  (`verify-cef-framework-darwin.sh`, exit 0). The framework's own
+  `CEF_COMMIT_HASH` embeds `6c570e2490c9…`, which is the real provenance.
+- **Windows** — `docs/cef-build/build-patched-cef-windows.md` states it is
+  "built from the same fork branch anyway for one-canonical-source-branch"
+  reasons, with the drag/transparency patches "present but inert on Windows."
 
-The one that matters: per `docs/retro/retro-macos26-cef-dcheck-root-cause-2026-06-02.md`,
-the -67030 Mach-port peer validation failure is "a *real* functional code-sign
-failure... not a DCHECK" and was "the only reason we went from-source [CEF] at
-all" — without it, the self-reexec CEF helper fails peer validation and the
-renderer crash-loops on macOS 26.
+Checked directly against that build commit (`6c570e249`):
 
-**Status:** source side is now fixed (PR #7 merged into `7778`, patch
-registered, apply-failure fixed). **Not shipped** — that needs an arm64 macOS
-build (Xcode, ≥120 GB, ≥32 GB RAM, 3–6 h) and a fresh release cut. Windows and
-Linux should be re-cut from the same tip at the same time so all three land on
-one source commit again.
+| Patch | In the shipped binaries? |
+|---|---|
+| #2 `BeginWindowDrag` | **Yes** — present in `include/views/cef_window.h` |
+| #3 rightclick passthrough | **Yes** — registered in `patch.cfg` |
+| #4 transparency cascade | **Yes** — same branch lineage |
+| #1 `process_requirement` | **No** — absent from `patch.cfg` at that commit |
 
-This is worth doing **independent of the 152 upgrade**, and is far cheaper:
-no porting, no API fallout — merge (done), build, release, repoint pins.
+So the fork's patch pipeline is working, and is demonstrably careful: that same
+status doc records catching a `patcher.py --root-dir` bug that would have
+silently skipped **all 112 patches**, before the long build started.
+
+### 5.2 The real gap, narrowed
+
+**Patch #1 alone is missing, and for a specific reason:** it was never
+registered in `patch/patch.cfg` on any branch, so `patcher.py` — which reads
+that file to decide what to apply — could never have applied it, on any build,
+on any platform. It was not a stale-release problem; it was an
+unregistered-patch problem. That part of the original finding stands, and was
+verified by direct file checks (404 on the file, zero `patch.cfg` matches), not
+by the tag inference that was wrong.
+
+This still matters, because per
+`docs/retro/retro-macos26-cef-dcheck-root-cause-2026-06-02.md` the -67030
+Mach-port peer validation failure is "a *real* functional code-sign failure...
+not a DCHECK" and was "the only reason we went from-source [CEF] at all" —
+without it, the self-reexec CEF helper fails peer validation and the renderer
+crash-loops on macOS 26.
+
+**Status:** source side fixed — `agentmuxai/cef` PR #7 merged the patch into
+`7778` *and registered it in `patch.cfg`*, which is the part that was actually
+missing. Also fixed a defect that would have made it fail to apply even once
+registered (`a/`/`b/` prefixes vs `git apply -p0`).
+
+**Still not shipped**, and this is now a **macOS-only** rebuild need — Windows
+and Linux are not affected by patch #1 (§2.1) and already carry the patches
+that do apply to them, so **the "re-cut all three platforms" recommendation in
+the retracted draft was unnecessary work**. One arm64 macOS build (Xcode,
+≥120 GB, ≥32 GB RAM, 3–6 h) and one release cut closes it.
+
+### 5.3 Method note, kept deliberately
+
+The retracted claim came from treating `target_commitish` as build provenance.
+It is not, and this repo's own docs say so — `STATUS_CEF_PROPRIETARY_CODECS_MACOS_2026_07_27.md`
+notes that releases cut without `--target` inherit a default-branch timestamp,
+which is also why `gen-docs-index`-style ordering by release metadata is
+unreliable here. **Provenance for these binaries lives in the build status docs
+and in the framework's embedded `CEF_COMMIT_HASH` — check those, not the tag.**
+Recorded so the next person doesn't repeat it.
 
 ---
 
 ## 6. Go / no-go
 
-**Go**, targeting 152 directly, per the spec's §3 reasoning. Nothing in this
-recon makes 152 harder than assumed:
+**Conditional go**, targeting 152 directly, per the spec's §3 reasoning.
+Nothing in this recon makes 152 harder than assumed:
 
 - the binding exists and is current;
 - Windows/Linux toolchains are unchanged;
@@ -195,10 +261,15 @@ real porting cost.
 
 1. **§2.4 is unfinished.** Patches #2/#3/#4 have not been test-applied against
    real 152 source. Phase B should start there, and Phase B's estimate is not
-   trustworthy until it does.
-2. **Do §5 first, or at least in parallel.** Shipping a macOS renderer crash
-   fix that has been written since June should not wait behind a
-   four-milestone Chromium jump.
+   trustworthy until it does. (Patch #1 *is* now verified — §2.5.)
+2. **§4's macOS toolchain row is unconfirmed**, not confirmed-fine. Establish
+   the hermetic Xcode requirement on the actual machine before committing to a
+   macOS Phase D slot.
+3. **Do §5 in parallel, not after.** The macOS -67030 fix has been written
+   since June and still isn't in a shipped binary; it needs one macOS rebuild
+   and shouldn't wait behind a four-milestone Chromium jump. Note this is
+   **macOS-only** — the earlier draft's "re-cut all three platforms" was
+   over-scoped and is retracted.
 
 ---
 
@@ -207,8 +278,10 @@ real porting cost.
 - **§7.1 (tag schemes)** — untouched. Release tags are immutable, so the
   historical inconsistency can only be normalized at read time, not fixed in
   place. Worth doing before any automated drift checker is built against these
-  tags; §5's `148.23.21`-newer-than-`148.23.23` case shows it already misleads.
+  tags; the `148.23.21`-newer-than-`148.23.23` case shows it already misleads.
+  Related: §5.3's method note — release *tags* are not build provenance either.
 - **§8 open questions** (Linux native drag still required? 150/151 vs 152?
   who owns the build machines? do the `.180 → .218` patch-level rebase now?)
   are repo-owner decisions and remain open — recon does not answer them, though
-  §5 makes question 4 more pressing, since a rebuild is needed regardless now.
+  §5 makes question 4 more pressing for macOS specifically, since that platform
+  needs a rebuild regardless now.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -332,6 +332,7 @@ partial list.
 | [`SPEC_AGENT_WORKING_STATE_UNIFICATION_2026_09_04`](SPEC_AGENT_WORKING_STATE_UNIFICATION_2026_09_04.md) | Spec: unify the Working/Worked label with the long-running-process axis, and close the two live desync bugs |
 | [`SPEC_ATTACHED_TASK_STATUS_AXIS_2026_08_02`](SPEC_ATTACHED_TASK_STATUS_AXIS_2026_08_02.md) | Spec: an orthogonal "attached task" status axis, sibling to `TurnPhase` |
 | [`SPEC_BROWSER_AND_EDITOR_PANES_2026_04_16`](SPEC_BROWSER_AND_EDITOR_PANES_2026_04_16.md) | SPEC: Browser and Editor Panes |
+| [`SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07`](SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md) | CEF milestone upgrade: 148 (7778) → 152 (7977), all three platforms |
 | [`SPEC_CODEX_PROVIDER_INTEGRATION_2026_08_08`](SPEC_CODEX_PROVIDER_INTEGRATION_2026_08_08.md) | Codex Provider Integration: Claude-Parity Lifecycle |
 | [`SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31`](SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md) | SPEC: A single content-resize contract for the agent pane |
 | [`SPEC_DOCS_LIFECYCLE_HARDENING_2026_08_03`](SPEC_DOCS_LIFECYCLE_HARDENING_2026_08_03.md) | Docs Lifecycle Audit & Hardening Plan |
@@ -368,7 +369,6 @@ partial list.
 | [`SPEC_BACKGROUND_TASK_PID_CAPTURE_2026_08_20`](SPEC_BACKGROUND_TASK_PID_CAPTURE_2026_08_20.md) | Spec: Background Task PID Capture (Phase A) |
 | [`SPEC_BACKGROUND_TASK_TEARDOWN_SURVIVAL_2026_08_20`](SPEC_BACKGROUND_TASK_TEARDOWN_SURVIVAL_2026_08_20.md) | Spec: Background Task Teardown Survival (Phase B) |
 | [`SPEC_BROWSER_PANE_FAVICON_TITLE_2026-05-15`](SPEC_BROWSER_PANE_FAVICON_TITLE_2026-05-15.md) | Browser Pane: Live Favicon + Page Title in Pane Header |
-| [`SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07`](SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md) | CEF milestone upgrade: 148 (7778) → 152 (7977), all three platforms |
 | [`SPEC_COMPOSER_STRIP_DROP_CENTER_STATS_2026_08_31`](SPEC_COMPOSER_STRIP_DROP_CENTER_STATS_2026_08_31.md) | Spec: Drop the composer strip's centered token/elapsed stats |
 | [`SPEC_COMPOSER_STRIP_ROW_BASED_LAYOUT_2026_08_26`](SPEC_COMPOSER_STRIP_ROW_BASED_LAYOUT_2026_08_26.md) | SPEC: Composer Strip — Row-Based Layout (Rev 7) |
 | [`SPEC_DEFAULT_TAB_NAME_TAB_N_2026_09_02`](SPEC_DEFAULT_TAB_NAME_TAB_N_2026_09_02.md) | Spec: default tab names — "Tab N", not "tabN" |

--- a/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
+++ b/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
@@ -7,7 +7,7 @@ the recon output `docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md`);
 verdict is **go** on targeting 152 directly. **Phases B–G not started.** The
 recon **corrects two errors in §2's patch table** (marked inline below), makes
 §4's Phase E work different from what's written there (see the callout in that
-section — the un-pinned-CEF finding it describes was closed by #3086/#3085/#3087),
+section — the un-pinned-CEF finding it describes was closed by #3086/#3085/#3089),
 and surfaces one shipped-binary gap (§5 of the report): patch #1 was never
 registered in `patch.cfg`, so it is absent from the shipped macOS binary —
 fixed at source in `agentmuxai/cef` PR #7, still needs one macOS rebuild.
@@ -172,7 +172,7 @@ This is worth treating as its own finding, not merely a step: it means the CEF v
 >   Chromium-**milestone** cross-check that fails the release if they diverge.
 >   The macOS half of that check is gated on `check-macos.outputs.available`,
 >   so a dormant macOS pin can't block a Windows/Linux-only release.
-> - **#3087** added a `workflow_dispatch` guard: an emergency rebuild must be
+> - **#3089** added a `workflow_dispatch` guard: an emergency rebuild must be
 >   dispatched *from the tag being rebuilt*, since a run's own workflow
 >   definition (and therefore its CEF pins) comes from the dispatch ref, not
 >   from `inputs.tag`.

--- a/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
+++ b/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
@@ -8,7 +8,9 @@ verdict is **go** on targeting 152 directly. **Phases B–G not started.** The
 recon **corrects two errors in §2's patch table** (marked inline below), makes
 §4's Phase E work different from what's written there (see the callout in that
 section — the un-pinned-CEF finding it describes was closed by #3086/#3085/#3087),
-and surfaces a shipped-binary gap that outranks this upgrade (§5 of the report).
+and surfaces one shipped-binary gap (§5 of the report): patch #1 was never
+registered in `patch.cfg`, so it is absent from the shipped macOS binary —
+fixed at source in `agentmuxai/cef` PR #7, still needs one macOS rebuild.
 Verified 2026-09-08.
 **Priority:** Medium-high — no active breakage, but we are four Chromium milestones behind and the gap grows by one milestone roughly every four weeks.
 
@@ -89,10 +91,13 @@ Plus **build flags, not patches** — version-controlled in *this* repo, not the
 
 ## 4. Work breakdown
 
-### Phase A — Reconnaissance ✅ **COMPLETE 2026-09-08**
+### Phase A — Reconnaissance ⚠️ **MOSTLY COMPLETE 2026-09-08** (2 checks open)
 
 Output: `docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md`.
-**Verdict: go** on targeting 152 directly. Answers to the three tasks below:
+**Verdict: conditional go** on targeting 152 directly — two checks below are
+NOT closed (patches #3/#4 not test-applied against real 152 source; macOS Xcode
+pin unconfirmed), so do not treat this as clearance to start Phase B blind.
+Answers to the three tasks below:
 (1) patch inventory corrected — see §2's callout; `BeginWindowDrag` confirmed
 still not upstream at 152, so nothing was deleted; #3/#4 still need a real
 test-apply against a 152 checkout, which is Phase B's first task. (2) **yes**,
@@ -100,6 +105,11 @@ test-apply against a 152 checkout, which is Phase B's first task. (2) **yes**,
 the binding fork is still needed. (3) Windows and Linux toolchain pins are
 **unchanged** between the two Chromium tags; macOS's Xcode pin is
 **unconfirmed** — verify at Phase D build time.
+
+**Phase B already started** (opportunistically, since patch #1's check could be
+made real): patch #1 is verified to apply to Chromium 152 **unchanged**, and
+`7977` + `agentmux/7977-process-requirement` now exist in `agentmuxai/cef` with
+the patch registered in 152's `patch.cfg`.
 
 *(original task list, for reference)*
 1. Diff each of the four patches against upstream 7977; determine which are now upstream, which apply cleanly, which need real porting.

--- a/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
+++ b/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
@@ -2,9 +2,14 @@
 
 **Author:** AgentX
 **Created:** 2026-09-07
-**Status:** active — Phase A shipped 2026-09-08 (`agentmuxai/cef` PR #7, plus
-the recon output `docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md`);
-verdict is **go** on targeting 152 directly. **Phases B–G not started.** The
+**Status:** active — Phase A mostly shipped 2026-09-08 (`agentmuxai/cef` PR #7,
+plus the recon output `docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md`);
+verdict is **conditional go** on targeting 152 directly — **two Phase A checks
+are still open** (patches #3/#4 not test-applied against real 152 source; macOS
+Xcode pin unconfirmed), so this is not clearance to start Phase B blind. See §4
+Phase A for both conditions. **Phase B started opportunistically** (patch #1
+verified against 152 and ported; `7977` + `agentmux/7977-process-requirement`
+exist in the fork); **Phases C–G not started.** The
 recon **corrects two errors in §2's patch table** (marked inline below), makes
 §4's Phase E work different from what's written there (see the callout in that
 section — the un-pinned-CEF finding it describes was closed by #3086/#3085/#3089),

--- a/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
+++ b/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
@@ -254,9 +254,15 @@ Three version schemes (Chromium `148.0.7778.180`, CEF `148.23.23`, CEF `148.0.9`
 ### 7.2 A stale comment in `agentmux-cef/Cargo.toml` — ✅ FIXED 2026-09-08
 The `patched-libcef` feature comment cites `https://github.com/a5af/cef, branch agentmux/7680-…`. The org redirects (`a5af` → `agentmuxai`) and that branch does still exist, so nothing breaks — but it names a CEF 146-era branch while root `Cargo.toml` documents `7778` as current. Worth correcting to whatever milestone this upgrade lands on.
 
-> **Fixed:** now cites `agentmuxai/cef`, branch `7778` (where the drag work
-> actually lives, merged via that repo's PR #3), and notes the `a5af` →
-> `agentmuxai` org redirect. Re-point again if 152 lands on a new branch.
+> **Fixed:** now cites both relevant branches and distinguishes them, because
+> they are not interchangeable: `agentmux/7778-drag-rightclick-and-transparency`
+> (where the patch was authored AND where the shipped binaries were actually
+> built from — macOS `148.23.23-codecs` at `6c570e249`) versus `7778` (the
+> milestone integration branch it was merged into via that repo's PR #3). As of
+> 2026-09-08 those two have **diverged** — the build commit is 4 ahead / 2
+> behind `7778` — so the comment now says to prefer the recorded build commit
+> over either branch tip when reproducing a build. Also notes the `a5af` →
+> `agentmuxai` org redirect. Re-point if 152 lands on a new branch.
 
 ### 7.3 A superseded root-cause doc — ✅ FIXED 2026-09-08
 `docs/analysis/archive/ANALYSIS_WINDOWS_GPU_DISABLED_ROOTCAUSE_2026_06_11.md` attributes a Windows GPU failure to the fork's libcef being a non-official/DCHECK build. Its own tracking issue (#1345) retracts that: the real cause was a missing `supportedOS` manifest (#1354, merged 2026-06-11). The archived doc still reads as if the fork were at fault, which could mislead someone scoping this upgrade. Worth a status-correction header.

--- a/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
+++ b/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
@@ -2,7 +2,14 @@
 
 **Author:** AgentX
 **Created:** 2026-09-07
-**Status:** proposed — analysis complete, not yet implemented
+**Status:** active — Phase A shipped 2026-09-08 (`agentmuxai/cef` PR #7, plus
+the recon output `docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md`);
+verdict is **go** on targeting 152 directly. **Phases B–G not started.** The
+recon **corrects two errors in §2's patch table** (marked inline below), makes
+§4's Phase E work different from what's written there (see the callout in that
+section — the un-pinned-CEF finding it describes was closed by #3086/#3085/#3087),
+and surfaces a shipped-binary gap that outranks this upgrade (§5 of the report).
+Verified 2026-09-08.
 **Priority:** Medium-high — no active breakage, but we are four Chromium milestones behind and the gap grows by one milestone roughly every four weeks.
 
 ---
@@ -37,7 +44,7 @@ A milestone upgrade is not "bump a number." It is "forward-port every patch, reb
 
 | # | Patch | Upstream status | Used by | Port required? |
 |---|---|---|---|---|
-| 1 | `agentmux_process_requirement.patch` (`GetPeerValidationPolicy() → kNoValidation`, the -67030 renderer fix) | Not upstream | All platforms | **Yes** — mandatory, registered in `patch/patch.cfg` |
+| 1 | `agentmux_process_requirement.patch` (`GetPeerValidationPolicy() → kNoValidation`, the -67030 renderer fix) | Not upstream | ~~All platforms~~ → **macOS only** ⁽¹⁾ | **Yes** — mandatory; ~~registered in `patch/patch.cfg`~~ → **was not registered or merged until 2026-09-08** ⁽²⁾ |
 | 2 | `CefWindow::BeginWindowDrag()` (native HTCLIENT-region window drag) | Not upstream as of 148 — **re-check against 152** | **Linux only.** Windows uses its own Win32 path (`post_win32_begin_move`) and never calls this — `scripts/cef-build/args-windows.gn:4` states the patch "never [was] needed" there; macOS uses AppKit drag regions. Gated by the `patched-libcef` feature | **Yes, if Linux native drag stays in scope** — nothing else depends on it |
 | 3 | HTCAPTION right-click fall-through to renderer | Not upstream as of 148 — **re-check against 152** | Title-bar right-click menus | Yes, if that UX is kept |
 | 4 | Transparency cascade (RWHView/WebContents bg) | **Partial** upstream since 148 | Window opacity | Re-verify; may be droppable |
@@ -46,6 +53,25 @@ Plus **build flags, not patches** — version-controlled in *this* repo, not the
 `scripts/cef-build/args.gn` (Linux), `args-darwin.gn` (macOS), `args-windows.gn` (Windows). These carry `proprietary_codecs=true`, `ffmpeg_branding="Chrome"`, HEVC/AC3/EAC3/Dolby Vision enables, Widevine, and (critically) the `dcheck_always_on=false` requirement — a from-source `is_official_build=false` build defaults DCHECKs *on*, which crashes on drag/close (see `docs/retro/retro-macos26-cef-dcheck-root-cause-2026-06-02.md`).
 
 **Re-checking #2, #3 and #4 against upstream 152 is the first task in this spec, because the answer can delete work.** Between 146 and 148, several AgentMux patches (`CefV8BackingStore`, `CefComponentUpdater`, `blink_ax_viewport_collapse`, the task-manager shutdown fix) were upstreamed and stopped being ours to carry. The same may have happened again across four milestones.
+
+> **Phase A corrections (2026-09-08)** — full detail in
+> `docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md`:
+>
+> ⁽¹⁾ Patch #1 touches `base/apple/mach_port_rendezvous_mac.cc`. Mach ports are
+> Darwin-only and Chromium's `base/apple/` is not compiled on Windows/Linux, so
+> this patch is **macOS-only** and cannot affect the other two platforms.
+>
+> ⁽²⁾ It was neither registered in `patch.cfg` nor merged into `7778` — it sat
+> on an unmerged, diverged branch from 2026-06-02 until `agentmuxai/cef` PR #7
+> (2026-09-08). That PR also fixed a defect that would have broken *every*
+> source build from that branch: the patch's diff header used `a/`/`b/`
+> prefixes, which CEF's `git apply -p0` patcher cannot resolve.
+>
+> **Patch #2 (`BeginWindowDrag`) is confirmed still NOT upstream at 152** —
+> checked `include/views/cef_window.h` at upstream `7977` directly. It still
+> needs forward-porting, and the `cef-dll-sys` binding patch is still required.
+> Patches #3/#4 have **not** been test-applied against real 152 source (needs a
+> checkout); that is the first task for whoever takes Phase B.
 
 ---
 
@@ -63,7 +89,19 @@ Plus **build flags, not patches** — version-controlled in *this* repo, not the
 
 ## 4. Work breakdown
 
-### Phase A — Reconnaissance (no builds; do this before committing to the rest)
+### Phase A — Reconnaissance ✅ **COMPLETE 2026-09-08**
+
+Output: `docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md`.
+**Verdict: go** on targeting 152 directly. Answers to the three tasks below:
+(1) patch inventory corrected — see §2's callout; `BeginWindowDrag` confirmed
+still not upstream at 152, so nothing was deleted; #3/#4 still need a real
+test-apply against a 152 checkout, which is Phase B's first task. (2) **yes**,
+`cef 152.0.0+152.0.5` is published; `begin_window_drag` is **not** in it, so
+the binding fork is still needed. (3) Windows and Linux toolchain pins are
+**unchanged** between the two Chromium tags; macOS's Xcode pin is
+**unconfirmed** — verify at Phase D build time.
+
+*(original task list, for reference)*
 1. Diff each of the four patches against upstream 7977; determine which are now upstream, which apply cleanly, which need real porting.
 2. Check whether `cef-rs`/`cef-dll-sys` publishes a 152-compatible crate, and whether `begin_window_drag` is in its generated bindings (it wasn't for 148 — hence our `AgentU-asaf/cef-rs` patch fork).
 3. Confirm the CEF 152 build toolchain requirements haven't moved (VS version on Windows, Xcode on macOS, sysroot on Linux).
@@ -112,6 +150,28 @@ Cut a GitHub Release per platform on `agentmuxai/cef` (manual `gh release create
 **Changing those input defaults is not sufficient, and assuming otherwise would silently un-pin releases.** `.github/workflows/release.yml` passes `cef-runtime-tag: ""` explicitly to all three build jobs (lines 92, 111, 150), and every callee documents blank as "latest". A caller-supplied empty string overrides the callee default, so **release builds today do not pin CEF at all — they float to whatever the newest `agentmuxai/cef` release happens to be.** Phase E must therefore set an explicit tag in `release.yml`'s three call sites, not just in the callees' defaults.
 
 This is worth treating as its own finding, not merely a step: it means the CEF version in any given release artifact is determined by release *timing* rather than by anything in the commit, so two builds of the same commit can ship different Chromium versions. Pinning it explicitly is a prerequisite for the rollback story in Phase G being real.
+
+> **✅ FIXED 2026-09-08 — this finding no longer describes current behaviour.**
+> The two paragraphs above are kept for the reasoning; the defect itself is
+> closed, by three PRs in this repo:
+>
+> - **#3086** pinned all three `cef-runtime-tag` call sites to literal tags,
+>   replacing the blank-means-latest behaviour.
+> - **#3085** centralized those three pins into a single `cef-runtime-pins`
+>   job (so a bump can't update one platform and miss the others) and added a
+>   Chromium-**milestone** cross-check that fails the release if they diverge.
+>   The macOS half of that check is gated on `check-macos.outputs.available`,
+>   so a dormant macOS pin can't block a Windows/Linux-only release.
+> - **#3087** added a `workflow_dispatch` guard: an emergency rebuild must be
+>   dispatched *from the tag being rebuilt*, since a run's own workflow
+>   definition (and therefore its CEF pins) comes from the dispatch ref, not
+>   from `inputs.tag`.
+>
+> **What Phase E must do now is different:** update the three literals in
+> `release.yml`'s `cef-runtime-pins` job (one place, not three call sites),
+> and keep all three on the same Chromium milestone or the new gate will fail
+> the release by design. **Do not blank them back out.** Phase G's rollback
+> story is now real, as this finding required.
 
 **Fix the tag scheme while doing this (see §7.1).**
 
@@ -176,11 +236,20 @@ cef-macos-arm64-148.0.9                  ← different scheme again
 
 Three version schemes (Chromium `148.0.7778.180`, CEF `148.23.23`, CEF `148.0.9`) and ad-hoc suffixes (`-codecs`, `-2`, `-3`). A human can resolve these; **an automated drift checker cannot** — which matters directly, because the companion spec `SPEC_VERSION_DRIFT_REPORTER_2026_09_07.md` (in `a5af/shared-infrastructure`, under its own `docs/specs/`) proposes machine-comparing our shipped CEF against upstream. Recommend standardizing new tags on `cef-<platform>-<arch>-<chromium-version>[-rN]` and normalizing at read time for the historical ones.
 
-### 7.2 A stale comment in `agentmux-cef/Cargo.toml`
+### 7.2 A stale comment in `agentmux-cef/Cargo.toml` — ✅ FIXED 2026-09-08
 The `patched-libcef` feature comment cites `https://github.com/a5af/cef, branch agentmux/7680-…`. The org redirects (`a5af` → `agentmuxai`) and that branch does still exist, so nothing breaks — but it names a CEF 146-era branch while root `Cargo.toml` documents `7778` as current. Worth correcting to whatever milestone this upgrade lands on.
 
-### 7.3 A superseded root-cause doc
+> **Fixed:** now cites `agentmuxai/cef`, branch `7778` (where the drag work
+> actually lives, merged via that repo's PR #3), and notes the `a5af` →
+> `agentmuxai` org redirect. Re-point again if 152 lands on a new branch.
+
+### 7.3 A superseded root-cause doc — ✅ FIXED 2026-09-08
 `docs/analysis/archive/ANALYSIS_WINDOWS_GPU_DISABLED_ROOTCAUSE_2026_06_11.md` attributes a Windows GPU failure to the fork's libcef being a non-official/DCHECK build. Its own tracking issue (#1345) retracts that: the real cause was a missing `supportedOS` manifest (#1354, merged 2026-06-11). The archived doc still reads as if the fork were at fault, which could mislead someone scoping this upgrade. Worth a status-correction header.
+
+> **Fixed:** the doc now opens with a RETRACTED banner stating the real cause
+> (missing `supportedOS` manifest, #1354) and explicitly warning against citing
+> it as evidence that the fork's build config causes GPU failures. Verified the
+> retraction against #1345's own comments before writing it.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase A of `SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md` is complete —
that spec gates Phases B–G on it, and says the phase "alone justifies its own
PR." **Verdict: go** on targeting 152 directly.

Full output: `docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md`.

Everything was verified against the actual repos via the GitHub API rather than
read off the spec — which turned out to contain errors this corrects.

## Phase A answers

| Question | Answer |
|---|---|
| Are any of the 4 patches now upstream? | **No.** `BeginWindowDrag` confirmed still absent at 152 (checked `include/views/cef_window.h` at upstream `7977`). Nothing was deleted. |
| Is there a 152-compatible `cef` crate? | **Yes** — `cef 152.0.0+152.0.5`, published 2026-09-07. |
| Is `begin_window_drag` in its bindings? | **No** — binding fork still required, as at 148. |
| Have toolchain requirements moved? | **Windows: no** (`TOOLCHAIN_HASH` + `MSVS_VERSIONS` byte-identical across the two Chromium tags). **Linux: no** (same sysroot set). **macOS: unconfirmed** — recorded as such, not assumed fine. |

## Spec corrections (both verified)

- **Patch #1 is macOS-only**, not "All platforms" — it patches
  `base/apple/mach_port_rendezvous_mac.cc`, and Chromium's `base/apple/` isn't
  compiled on Windows or Linux.
- **Patch #1 was not "registered in `patch/patch.cfg`"** — neither the entry nor
  the file existed on `7778`. It sat unmerged from 2026-06-02 until
  `agentmuxai/cef` PR #7, merged today. That PR also fixed a defect (found by
  Codex) that would have broken *every* source build from that branch: the
  patch's diff header used `a/`/`b/` prefixes, which CEF's `git apply -p0`
  patcher can't resolve. Verified by reconstructing the target and running the
  patcher's exact config against both versions.
- **Phase E's "release builds don't pin CEF at all" finding is now stale** —
  closed by #3086, #3085 and #3087. The callout describes what Phase E actually
  has to do now instead (update three literals in one job, keep them on one
  milestone or the new gate fails the release by design).

## Open findings fixed

- **§7.2** — `agentmux-cef/Cargo.toml`'s `patched-libcef` comment cited a CEF
  146-era branch on the old `a5af` org. Now points at `agentmuxai/cef` branch
  `7778`, where the drag work actually lives.
- **§7.3** — the archived Windows-GPU root-cause doc blamed the fork's libcef
  for being a DCHECK build. Its author retracted that in #1345 the same day
  (real cause: missing `supportedOS` manifest, #1354). Added a RETRACTED banner
  and corrected its Status. **Verified the retraction against #1345's own
  comments first** — that doc would otherwise mislead exactly the person
  scoping this upgrade.

**Not fixed: §7.1** (three tag version schemes). Release tags are immutable, so
it can only be normalized at read time. Noted in the report as a prerequisite
for any automated drift checker — §5 there shows it already misleading in
practice (a *newer* macOS release carries a *lower* version label than the tag
we pin).

## The finding that outranks the upgrade

All three pinned CEF release tags resolve to **the same commit, cut
2026-04-23** — which predates all four patches. **So none of the fork's
documented patches are in any CEF binary we ship**, including the macOS -67030
renderer crash fix that this repo's own retro calls "a *real* functional
code-sign failure... the only reason we went from-source at all."

Source side is now fixed (`agentmuxai/cef` PR #7 merged). **Not shipped** —
that needs an arm64 macOS build and a fresh release cut on a machine I don't
have. Detailed in §5 of the report.

## Verification

- `check-doc-status.sh`, `check-spec-citations.sh`, `gen-docs-index.sh --check`
  all pass locally. The doc-status gate caught two bad Status lines (mine, and a
  pre-existing one on the archived doc that claimed "Complete — empirically
  verified" for a retracted conclusion) — both fixed to the documented enum.
- Docs-only change; no code paths touched.

<!-- agentmux:agent_id=agent5 -->