### PR TITLE
Camper@narko: docs: regenerate specs index + fix section order in the session-persistence spec

### DIFF
--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -371,6 +371,7 @@ partial list.
 | [`SPEC_BROWSER_PANE_FAVICON_TITLE_2026-05-15`](SPEC_BROWSER_PANE_FAVICON_TITLE_2026-05-15.md) | Browser Pane: Live Favicon + Page Title in Pane Header |
 | [`SPEC_COMPOSER_STRIP_DROP_CENTER_STATS_2026_08_31`](SPEC_COMPOSER_STRIP_DROP_CENTER_STATS_2026_08_31.md) | Spec: Drop the composer strip's centered token/elapsed stats |
 | [`SPEC_COMPOSER_STRIP_ROW_BASED_LAYOUT_2026_08_26`](SPEC_COMPOSER_STRIP_ROW_BASED_LAYOUT_2026_08_26.md) | SPEC: Composer Strip — Row-Based Layout (Rev 7) |
+| [`SPEC_CONTINUOUS_SESSION_PERSISTENCE_2026_09_08`](SPEC_CONTINUOUS_SESSION_PERSISTENCE_2026_09_08.md) | SPEC: Continuous session persistence + trustworthy shutdown |
 | [`SPEC_DEFAULT_TAB_NAME_TAB_N_2026_09_02`](SPEC_DEFAULT_TAB_NAME_TAB_N_2026_09_02.md) | Spec: default tab names — "Tab N", not "tabN" |
 | [`SPEC_DEFAULT_WIDGETS_REORDER_2026_08_25`](SPEC_DEFAULT_WIDGETS_REORDER_2026_08_25.md) | SPEC: Default fresh-start widgets — Agent, Swarm, Armory, Sysinfo |
 | [`SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27`](SPEC_DEPENDENCY_UPGRADE_PROCESS_2026_08_27.md) | SPEC — A repeatable process for Claude model catalog + CLI version upgrades |

--- a/docs/specs/SPEC_CONTINUOUS_SESSION_PERSISTENCE_2026_09_08.md
+++ b/docs/specs/SPEC_CONTINUOUS_SESSION_PERSISTENCE_2026_09_08.md
@@ -110,7 +110,7 @@ mislabeled in its own header.
 |---|---|---|
 | Restore-on-relaunch (Feature 1 of the 08-13 spec) | **Shipped** (PR #2560) despite that spec's header still saying "Proposed — not yet implemented" | `agentmux-srv/src/server/service/session_restore.rs` (875 lines), called from `window_close.rs:143,229` and `window_create.rs:56` |
 | Snapshot storage | **Shipped** | JSON blob at `Client.meta["session:last_topology"]` — `SNAPSHOT_META_KEY`, `session_restore.rs:41`. Generic `meta` sidecar, no schema migration needed |
-| Named saved "Layouts" (Feature 2 of the 08-13 spec) | Not built | Proposed only; **out of scope here** (§8) |
+| Named saved "Layouts" (Feature 2 of the 08-13 spec) | Not built | Proposed only; **out of scope here** (§6.2) |
 | Shutdown countdown + progress modal | **Proposed, not built** | `SPEC_SHUTDOWN_COUNTDOWN_MODAL_2026_09_04.md` (PR #2981) |
 | Continuous/debounced auto-persist of the *layout tree* | **Shipped** | `frontend/layout/lib/layoutPersistence.ts:396-420` — 100ms debounce |
 | Interval + dirty-gated snapshot with serialized writer | **Shipped** | `frontend/app/view/agent/hooks/useSnapshotPersistence.ts:43,51,73,139` — `SNAPSHOT_INTERVAL_MS = 30_000` |
@@ -194,6 +194,23 @@ failed to save is told nothing, and finds out only on next launch.
 Four phases, independently shippable, in dependency order. Phase 0 alone
 fixes the motivating incident; Phase A delivers most of the remaining value.
 
+### 4.0 Phase 0 — handle OS shutdown notifications
+
+**Ship this first.** It is the smallest change here and independently
+valuable even if nothing else in this spec is ever built: today, an OS restart
+loses a workspace that a manual close would have preserved, which is a
+surprising and hard-to-explain inconsistency for users. (It does *not* fix the
+§1 incident — nothing needs to, that was intended behavior — but it is
+verified real per §1.1.)
+
+Handle `WM_QUERYENDSESSION`/`WM_ENDSESSION` on Windows and
+`applicationShouldTerminate:`/`NSWorkspaceWillPowerOffNotification` on macOS,
+routing both into the same snapshot-flush the graceful close already performs
+(§3.0). Ordering note: this must flush the snapshot but must **not** attempt
+the full `delete_workspace` teardown cascade — the OS is about to reclaim
+everything anyway, and the 5s-per-shell grace will not fit in the OS's
+shutdown budget. Save, then let the process die.
+
 ### 4.1 Phase A — continuous session record
 
 **Mechanism:** promote the session snapshot from write-once-at-close to a
@@ -252,23 +269,6 @@ the migration-marker reasoning already established in
 `SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03.md` Phase 0a/0b — a marker's
 *existence* is not proof of *effect*, so the marker must be written after the
 work it attests to, not before.
-
-### 4.0 Phase 0 — handle OS shutdown notifications
-
-**Ship this first.** It is the smallest change here and independently
-valuable even if nothing else in this spec is ever built: today, an OS restart
-loses a workspace that a manual close would have preserved, which is a
-surprising and hard-to-explain inconsistency for users. (It does *not* fix the
-§1 incident — nothing needs to, that was intended behavior — but it is
-verified real per §1.1.)
-
-Handle `WM_QUERYENDSESSION`/`WM_ENDSESSION` on Windows and
-`applicationShouldTerminate:`/`NSWorkspaceWillPowerOffNotification` on macOS,
-routing both into the same snapshot-flush the graceful close already performs
-(§3.0). Ordering note: this must flush the snapshot but must **not** attempt
-the full `delete_workspace` teardown cascade — the OS is about to reclaim
-everything anyway, and the 5s-per-shell grace will not fit in the OS's
-shutdown budget. Save, then let the process die.
 
 ### 4.3 Phase C — make the shutdown path worth trusting
 


### PR DESCRIPTION
## Summary

Follow-up to #3098, fixing two defects that landed on `main` because that PR auto-merged before these commits made it in.

- **`docs/specs/INDEX.md` was stale on main** — the new spec was added without regenerating the index. This is the more urgent of the two: `gen-docs-index.sh --check` is what the `doc status + grep gates` job runs, so leaving it stale means that gate keeps failing.
- **Section 4.0 was physically out of order** — the design section read 4.1, 4.2, **4.0**, 4.3, while the surrounding text tells the reader to ship Phase 0 first. Also fixes a cross-reference pointing at §8 ("Testing") for "out of scope" when Non-goals is §6.2.

Both are `git cherry-pick`s of commits that were already pushed to #3098's branch (`a76108a7d`, `c27fe906c`) but hadn't been picked up when it merged.

## How this happened — worth recording

I armed `--auto` merge on #3098 while the `doc status + grep gates` check was already failing, assuming auto-merge would gate on it. It didn't, because that job **is not a required status check** — per `ci-pr.yml`'s own comment, only `check --tests + test (windows-latest)` and `vitest` are enforced in branch protection. So the PR merged the moment those two went green, carrying the stale index and the failing gate with it.

Compounding it, GitHub then stopped syncing #3098's head: the branch API showed `c27fe906c` while the PR's own commit list stopped at `0ed8bb46d`, with `mergeable: null` for 10+ minutes. That wasn't lag — the PR had already merged at the older SHA, which is why it never advanced.

**The generalizable lesson:** "approved + auto-merge armed" is not the same as "all checks will be respected." Before arming `--auto`, either confirm the failing check is non-required *and* that shipping it red is acceptable, or fix it first. Here it wasn't acceptable — a stale index breaks the gate for everyone else touching `docs/specs`.

## Verification

```
check-doc-status:     ok (2 doc(s) checked)
check-spec-citations: ok (2 file(s) checked)
gen-docs-index.sh:    single-row addition, no other drift
```

<!-- agentmux:agent_id=camper -->