### PR TITLE
Claude@gamerlove: fix(reactive): fix compile error on main from #3084

### DIFF
--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -3034,8 +3034,8 @@ fn reentrant_try_get_agent_by_block_fails_fast_not_hangs() {
              INCIDENT_2026_09_07's permanent srv deadlock one call later \
              than try_register_agent_with_nonce alone would catch",
         );
-    assert_eq!(
-        reentrant_result, None,
+    assert!(
+        reentrant_result.is_none(),
         "a same-thread reentrant lookup must yield None (not hang, and not \
          fabricate a result) — the caller degrades to no-cleanup, which is \
          safe, rather than deadlocking",


### PR DESCRIPTION
## Urgent: main is currently broken

PR #3084 (merged as `13910a60e`) shipped a compile error:
`AgentRegistration` doesn't derive `PartialEq`, so
`assert_eq!(reentrant_result, None, ...)` in
`reentrant_try_get_agent_by_block_fails_fast_not_hangs`
(`agentmux-srv/src/backend/reactive/tests.rs`) fails with `E0369`. Every
PR branched from `main` since will fail its Rust test-matrix check,
regardless of what it touches — confirmed on #3100 (a completely
unrelated docs-only PR).

## Fix

`assert!(reentrant_result.is_none(), ...)` instead of `assert_eq!`
against `None` — checks the identical property without needing
`PartialEq` on `AgentRegistration`. Checked every other `assert_eq!`
added in that PR; none of the others compare a non-primitive type
directly.

## How this got merged

`check --tests + test` does not appear to be a required status check on
this repo's branch protection — auto-merge fired once `doc status + grep
gates` and `vitest` passed, without the Rust matrix having finished (it
was still `in_progress` when merge happened). Worth someone checking
that setting separately; flagging here rather than fixing it as part of
this PR.

## Test plan

- [ ] Not compiled locally — no Rust toolchain on this machine, same gap
      as the PR that introduced this. This is exactly the failure mode
      that gap predicted. Please prioritize actually building this one.

<!-- agentmux:agent_id=claude -->