### PR TITLE
Loap #2@claudius: feat(lan): populate LAN peers' agent lists

### DIFF
--- a/.changesets/1788928077-feat-lan-peers-report-which-agents-they-host-s58f.md
+++ b/.changesets/1788928077-feat-lan-peers-report-which-agents-they-host-s58f.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(lan): peers report which agents they host

--- a/agentmux-srv/src/backend/lan_discovery.rs
+++ b/agentmux-srv/src/backend/lan_discovery.rs
@@ -242,6 +242,12 @@ pub struct LanDiscovery {
     /// `shutdown()` is `&self` and called from both an explicit live-toggle
     /// path and `Drop`.
     udp_cancel: Mutex<Option<oneshot::Sender<()>>>,
+    /// Cancels `agent_names_refresh_loop`. Needed for the same reason
+    /// `udp_cancel` is: that task holds its own `Arc<LanDiscovery>` clone, so
+    /// dropping the controller's Arc on `apply(false)` never reaches refcount
+    /// zero and the loop would otherwise keep issuing authenticated requests
+    /// to peers forever — leaking one orphaned task per disable/enable cycle.
+    agent_names_cancel: Mutex<Option<oneshot::Sender<()>>>,
 }
 
 /// Normalize an OS hostname into a valid mDNS host name by appending the
@@ -406,6 +412,7 @@ impl LanDiscovery {
             version,
             port,
             udp_cancel: Mutex::new(None),
+            agent_names_cancel: Mutex::new(None),
         });
 
         // Spawn event receiver on a blocking thread to avoid starving the tokio runtime
@@ -426,10 +433,16 @@ impl LanDiscovery {
         });
 
         // Keeps each peer's `agents` list populated (see
-        // `agent_names_refresh_loop`). Dropped along with the whole
-        // `LanDiscovery` when the setting is toggled off, same as the
-        // loops above.
-        tokio::spawn(discovery.clone().agent_names_refresh_loop());
+        // `agent_names_refresh_loop`). Cancelled explicitly by `shutdown()`
+        // via its own oneshot — NOT by Arc drop, since this task holds its
+        // own clone and would otherwise outlive `apply(false)` forever.
+        let (names_cancel_tx, names_cancel_rx) = oneshot::channel();
+        *discovery.agent_names_cancel.lock() = Some(names_cancel_tx);
+        tokio::spawn(
+            discovery
+                .clone()
+                .agent_names_refresh_loop(names_cancel_rx),
+        );
 
         tracing::info!(
             instance_id = %instance_id,
@@ -453,7 +466,7 @@ impl LanDiscovery {
     /// unreachable keeps its last-known list rather than being blanked, since
     /// staleness is already tracked by `last_seen` and a flapping list is
     /// worse than a slightly-old one.
-    async fn agent_names_refresh_loop(self: Arc<Self>) {
+    async fn agent_names_refresh_loop(self: Arc<Self>, mut cancel: oneshot::Receiver<()>) {
         let http = match reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(LAN_PEER_QUERY_TIMEOUT_SECS))
             .build()
@@ -466,10 +479,20 @@ impl LanDiscovery {
         };
 
         loop {
-            tokio::time::sleep(std::time::Duration::from_secs(
-                LAN_AGENT_NAMES_REFRESH_SECS,
-            ))
-            .await;
+            // Cancellation is checked at the sleep, not just between
+            // iterations: this task holds its own `Arc<LanDiscovery>`, so
+            // without an explicit signal `apply(false)` cannot stop it and it
+            // would keep hitting peers indefinitely (one leaked task per
+            // toggle cycle).
+            tokio::select! {
+                _ = tokio::time::sleep(std::time::Duration::from_secs(
+                    LAN_AGENT_NAMES_REFRESH_SECS,
+                )) => {}
+                _ = &mut cancel => {
+                    tracing::debug!("LAN agent-name refresh loop cancelled");
+                    return;
+                }
+            }
 
             // Snapshot (key, url, lan_key) so the lock is not held across any
             // await — the map is read by every inject/discovery call.
@@ -884,6 +907,13 @@ impl LanDiscovery {
             // Ignore send errors: an `Err` here just means the responder
             // task already exited on its own (e.g. the bind failed), which
             // is a no-op we're happy with.
+            let _ = tx.send(());
+        }
+        // Same contract as `udp_cancel` above — and load-bearing rather than
+        // tidy-up: the refresh task owns an `Arc<LanDiscovery>` clone, so
+        // without this signal it survives `apply(false)` and keeps issuing
+        // authenticated requests to LAN peers indefinitely.
+        if let Some(tx) = self.agent_names_cancel.lock().take() {
             let _ = tx.send(());
         }
         if let Err(e) = self.daemon.unregister(&self.service_fullname) {
@@ -1622,6 +1652,7 @@ mod handle_event_tests {
     use parking_lot::{Mutex, RwLock};
     use std::collections::HashMap;
     use std::sync::Arc;
+    use tokio::sync::oneshot;
 
     /// Build a `ServiceInfo` for `instance_id`, mirroring the exact
     /// `service_name`/host-name shape `LanDiscovery::start()` registers
@@ -1697,6 +1728,7 @@ mod handle_event_tests {
             version: String::new(),
             port: self_port,
             udp_cancel: Mutex::new(None),
+            agent_names_cancel: Mutex::new(None),
         }
     }
 
@@ -1903,6 +1935,36 @@ mod handle_event_tests {
         assert_eq!(instances.len(), 1);
         assert_eq!(instances[0].hostname, "");
         assert_eq!(instances[0].instance_id, "");
+    }
+
+    /// The refresh loop holds its own `Arc<LanDiscovery>`, so dropping the
+    /// controller's Arc on `apply(false)` can never stop it — only an explicit
+    /// signal can. Without this, disabling LAN discovery left the task issuing
+    /// authenticated requests to peers forever, leaking one per toggle cycle
+    /// (ReAgent P1 on PR #3102 — the first version of this code shipped a doc
+    /// comment claiming cancellation it did not actually implement, which is
+    /// exactly why this is asserted here rather than described).
+    #[tokio::test]
+    async fn shutdown_cancels_the_agent_names_refresh_loop() {
+        let discovery = Arc::new(test_discovery("cancel-host", 55123));
+
+        let (tx, rx) = oneshot::channel();
+        *discovery.agent_names_cancel.lock() = Some(tx);
+        let handle = tokio::spawn(discovery.clone().agent_names_refresh_loop(rx));
+
+        // Still parked on its sleep — nothing has cancelled it yet.
+        assert!(!handle.is_finished());
+
+        discovery.shutdown();
+
+        // Must return promptly on the signal rather than after the full
+        // LAN_AGENT_NAMES_REFRESH_SECS sleep, which is the whole point of
+        // selecting on the cancel inside the sleep.
+        let stopped = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
+        assert!(
+            stopped.is_ok(),
+            "refresh loop did not exit within 5s of shutdown() - it would outlive apply(false)"
+        );
     }
 }
 

--- a/agentmux-srv/src/backend/lan_discovery.rs
+++ b/agentmux-srv/src/backend/lan_discovery.rs
@@ -24,6 +24,12 @@ use super::eventbus::{EventBus, WSEventType};
 const SERVICE_TYPE: &str = "_agentmux._tcp.local.";
 const LAN_AGENT_CACHE_TTL_SECS: u64 = 60;
 const LAN_PEER_QUERY_TIMEOUT_SECS: u64 = 2;
+/// How often each known LAN peer is asked for its agent-name list. Peers are
+/// few (one per machine) and the request is a single small GET, so this is
+/// cheap; it's deliberately slower than `LAN_AGENT_CACHE_TTL_SECS` because
+/// this list is for *display* ("who lives on that host"), not for delivery
+/// routing — `find_agent` still does its own authoritative lookup.
+const LAN_AGENT_NAMES_REFRESH_SECS: u64 = 30;
 
 /// UDP broadcast discovery fallback (Layer 2), for LANs where mDNS multicast
 /// is filtered (common on corporate/guest WiFi). Mobile clients broadcast a
@@ -419,6 +425,12 @@ impl LanDiscovery {
             disc_udp.udp_responder_loop(cancel_rx).await;
         });
 
+        // Keeps each peer's `agents` list populated (see
+        // `agent_names_refresh_loop`). Dropped along with the whole
+        // `LanDiscovery` when the setting is toggled off, same as the
+        // loops above.
+        tokio::spawn(discovery.clone().agent_names_refresh_loop());
+
         tracing::info!(
             instance_id = %instance_id,
             port = port,
@@ -426,6 +438,94 @@ impl LanDiscovery {
         );
 
         Ok(discovery)
+    }
+
+    /// Periodically ask every known peer which agents it hosts, so
+    /// `LanInstance::agents` reflects reality instead of staying the empty
+    /// vec it's created with. Without this, a peer shows up with a correct
+    /// hostname/version/address but `agents: []`, so there is no way to
+    /// discover *which* agents live on another machine — you can only
+    /// address one blind by name and hope. See
+    /// `handle_reactive_agent_names`' doc comment for the security scoping
+    /// of the endpoint this calls (names only, `lan_key`-readable).
+    ///
+    /// Failures are deliberately non-destructive: a peer that's briefly
+    /// unreachable keeps its last-known list rather than being blanked, since
+    /// staleness is already tracked by `last_seen` and a flapping list is
+    /// worse than a slightly-old one.
+    async fn agent_names_refresh_loop(self: Arc<Self>) {
+        let http = match reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(LAN_PEER_QUERY_TIMEOUT_SECS))
+            .build()
+        {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(error = %e, "LAN agent-name refresh disabled: HTTP client build failed");
+                return;
+            }
+        };
+
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(
+                LAN_AGENT_NAMES_REFRESH_SECS,
+            ))
+            .await;
+
+            // Snapshot (key, url, lan_key) so the lock is not held across any
+            // await — the map is read by every inject/discovery call.
+            let targets: Vec<(String, String, String)> = {
+                let instances = self.instances.read();
+                instances
+                    .iter()
+                    .map(|(key, inst)| {
+                        (
+                            key.clone(),
+                            format!("http://{}:{}", inst.address, inst.port),
+                            inst.auth_key.clone(),
+                        )
+                    })
+                    .collect()
+            };
+
+            for (key, base_url, lan_key) in targets {
+                let url = format!("{base_url}/agentmux/reactive/agent-names");
+                let resp = http.get(&url).header("X-AuthKey", &lan_key).send().await;
+                let names = match resp {
+                    Ok(r) if r.status().is_success() => {
+                        match r.json::<serde_json::Value>().await {
+                            Ok(v) => v
+                                .get("agents")
+                                .and_then(|a| a.as_array())
+                                .map(|a| {
+                                    a.iter()
+                                        .filter_map(|n| n.as_str().map(str::to_string))
+                                        .collect::<Vec<String>>()
+                                }),
+                            Err(e) => {
+                                tracing::debug!(peer = %base_url, error = %e, "LAN agent-name refresh: bad JSON");
+                                None
+                            }
+                        }
+                    }
+                    Ok(r) => {
+                        // A peer running a build without this route answers
+                        // 404 — expected during a rolling upgrade, not an error.
+                        tracing::debug!(peer = %base_url, status = %r.status(), "LAN agent-name refresh: non-2xx");
+                        None
+                    }
+                    Err(e) => {
+                        tracing::debug!(peer = %base_url, error = %e, "LAN agent-name refresh: unreachable");
+                        None
+                    }
+                };
+
+                if let Some(names) = names {
+                    if let Some(entry) = self.instances.write().get_mut(&key) {
+                        entry.agents = names;
+                    }
+                }
+            }
+        }
     }
 
     /// Build the JSON response payload for this instance's identity — see
@@ -958,7 +1058,7 @@ impl LanDiscoveryController {
     /// peer versions — see `Config::lan_key`'s doc comment) is now a
     /// separate, narrowly-scoped credential, NOT the instance's full-access
     /// `auth_key`. A passive LAN listener who captures it gets standing
-    /// access to only the two LAN-forwarding routes
+    /// access to only the three LAN-forwarding routes
     /// (`lan_or_full_auth_middleware` in `server/mod.rs`) — not the full
     /// `/agentmux/service` surface this used to expose. Broadcasting
     /// *something* in cleartext to the LAN is still an accepted trade-off

--- a/agentmux-srv/src/backend/lan_discovery.rs
+++ b/agentmux-srv/src/backend/lan_discovery.rs
@@ -30,6 +30,22 @@ const LAN_PEER_QUERY_TIMEOUT_SECS: u64 = 2;
 /// this list is for *display* ("who lives on that host"), not for delivery
 /// routing — `find_agent` still does its own authoritative lookup.
 const LAN_AGENT_NAMES_REFRESH_SECS: u64 = 30;
+/// Hard cap on a single peer's `/agentmux/reactive/agent-names` response body
+/// (Codex P1 on PR #3102): the `lan_key` a peer advertised authenticates
+/// THIS client TO that peer, not the peer to us — anything that can fake an
+/// mDNS advertisement for `_agentmux._tcp.local` makes it into
+/// `self.instances` and gets polled by this loop. Enforced while reading, not
+/// via `Content-Length` (a malicious peer can omit or lie about that while
+/// still streaming an unbounded chunked body). 64 KiB is generous for a
+/// plain name list — real fleets are agents-per-machine, not per-thousand.
+const LAN_AGENT_NAMES_MAX_RESPONSE_BYTES: usize = 64 * 1024;
+/// Defense in depth past the byte cap above: even a response that fits in
+/// 64 KiB could be an adversarially compact array of many short strings.
+const LAN_AGENT_NAMES_MAX_COUNT: usize = 500;
+/// A legitimate agent name is short; anything absurdly long is more likely
+/// an attempt to waste memory than a real name, so it's dropped rather than
+/// truncated (truncating could quietly merge two distinct long names).
+const LAN_AGENT_NAMES_MAX_NAME_LEN: usize = 256;
 
 /// UDP broadcast discovery fallback (Layer 2), for LANs where mDNS multicast
 /// is filtered (common on corporate/guest WiFi). Mobile clients broadcast a
@@ -510,45 +526,130 @@ impl LanDiscovery {
                     .collect()
             };
 
-            for (key, base_url, lan_key) in targets {
-                let url = format!("{base_url}/agentmux/reactive/agent-names");
-                let resp = http.get(&url).header("X-AuthKey", &lan_key).send().await;
-                let names = match resp {
-                    Ok(r) if r.status().is_success() => {
-                        match r.json::<serde_json::Value>().await {
-                            Ok(v) => v
-                                .get("agents")
-                                .and_then(|a| a.as_array())
-                                .map(|a| {
-                                    a.iter()
-                                        .filter_map(|n| n.as_str().map(str::to_string))
-                                        .collect::<Vec<String>>()
-                                }),
-                            Err(e) => {
-                                tracing::debug!(peer = %base_url, error = %e, "LAN agent-name refresh: bad JSON");
-                                None
+            // Fan out concurrently, same pattern as `query_peers_concurrently`
+            // — sequential awaits here would let N stale/unreachable peers
+            // each burn their full LAN_PEER_QUERY_TIMEOUT_SECS in turn
+            // (Codex P2 on PR #3102), stretching the nominal 30s refresh
+            // interval by however many peers are currently slow to answer.
+            let outcomes: Vec<(String, Option<Vec<String>>)> = {
+                use futures_util::StreamExt as _;
+                let http_ref = &http;
+                let mut inflight = futures_util::stream::FuturesUnordered::new();
+                for (key, base_url, lan_key) in &targets {
+                    inflight.push(async move {
+                        (
+                            key.clone(),
+                            Self::fetch_peer_agent_names(http_ref, base_url, lan_key).await,
+                        )
+                    });
+                }
+                let mut out = Vec::with_capacity(targets.len());
+                while let Some(item) = inflight.next().await {
+                    out.push(item);
+                }
+                out
+            };
+
+            // Only broadcast `laninstances` when something actually changed
+            // (Codex P2 on PR #3102) — otherwise the display-oriented point
+            // of this loop is defeated: without this, a refresh that DOES
+            // find new names still leaves connected clients showing the
+            // stale `agents: []` from first mDNS resolution until some
+            // unrelated, unsynchronized mDNS event happens to fire.
+            let mut changed = false;
+            {
+                let mut instances = self.instances.write();
+                for (key, names) in outcomes {
+                    if let Some(names) = names {
+                        if let Some(entry) = instances.get_mut(&key) {
+                            if entry.agents != names {
+                                entry.agents = names;
+                                changed = true;
                             }
                         }
                     }
-                    Ok(r) => {
-                        // A peer running a build without this route answers
-                        // 404 — expected during a rolling upgrade, not an error.
-                        tracing::debug!(peer = %base_url, status = %r.status(), "LAN agent-name refresh: non-2xx");
-                        None
-                    }
-                    Err(e) => {
-                        tracing::debug!(peer = %base_url, error = %e, "LAN agent-name refresh: unreachable");
-                        None
-                    }
-                };
-
-                if let Some(names) = names {
-                    if let Some(entry) = self.instances.write().get_mut(&key) {
-                        entry.agents = names;
-                    }
                 }
             }
+            if changed {
+                self.broadcast_instances();
+            }
         }
+    }
+
+    /// One peer's contribution to `agent_names_refresh_loop`. Returns `None`
+    /// on any failure (unreachable, non-2xx, oversized, or malformed body) —
+    /// this list is display-only, so a bad peer response should leave the
+    /// last-known list in place rather than blank it (see the loop's own
+    /// "non-destructive" framing).
+    async fn fetch_peer_agent_names(
+        http: &reqwest::Client,
+        base_url: &str,
+        lan_key: &str,
+    ) -> Option<Vec<String>> {
+        let url = format!("{base_url}/agentmux/reactive/agent-names");
+        let resp = match http.get(&url).header("X-AuthKey", lan_key).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::debug!(peer = %base_url, error = %e, "LAN agent-name refresh: unreachable");
+                return None;
+            }
+        };
+        if !resp.status().is_success() {
+            // A peer running a build without this route answers 404 —
+            // expected during a rolling upgrade, not an error.
+            tracing::debug!(peer = %base_url, status = %resp.status(), "LAN agent-name refresh: non-2xx");
+            return None;
+        }
+
+        let body = match Self::read_body_capped(resp, LAN_AGENT_NAMES_MAX_RESPONSE_BYTES).await {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(peer = %base_url, error = %e, "LAN agent-name refresh: response too large, discarded");
+                return None;
+            }
+        };
+
+        let value: serde_json::Value = match serde_json::from_slice(&body) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::debug!(peer = %base_url, error = %e, "LAN agent-name refresh: bad JSON");
+                return None;
+            }
+        };
+
+        let names: Vec<String> = value
+            .get("agents")
+            .and_then(|a| a.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|n| n.as_str())
+                    .filter(|n| n.len() <= LAN_AGENT_NAMES_MAX_NAME_LEN)
+                    .take(LAN_AGENT_NAMES_MAX_COUNT)
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default();
+        Some(names)
+    }
+
+    /// Reads an HTTP response body up to `max_bytes`, erroring out as soon as
+    /// the cap is exceeded rather than buffering the full body first —
+    /// `Response::bytes()`/`.json()` have no size limit of their own, so a
+    /// peer that responds successfully but with an enormous body would
+    /// otherwise be read into memory in full before this code ever gets a
+    /// chance to reject it.
+    async fn read_body_capped(
+        mut resp: reqwest::Response,
+        max_bytes: usize,
+    ) -> Result<Vec<u8>, String> {
+        let mut buf = Vec::new();
+        while let Some(chunk) = resp.chunk().await.map_err(|e| e.to_string())? {
+            buf.extend_from_slice(&chunk);
+            if buf.len() > max_bytes {
+                return Err(format!("response exceeded {max_bytes}-byte cap"));
+            }
+        }
+        Ok(buf)
     }
 
     /// Build the JSON response payload for this instance's identity — see
@@ -2180,5 +2281,138 @@ mod self_resolution_tests {
     #[test]
     fn a_resolution_with_no_addresses_is_not_self() {
         assert!(!is_self_resolution(55019, &[], 55019, &own()));
+    }
+}
+
+/// `agent_names_refresh_loop`'s peer-response handling — real HTTP round
+/// trips against a raw fake server, same style as
+/// `server::tests::spawn_fake_browser_api`, because the behavior under test
+/// (bailing out mid-body, not just rejecting on `Content-Length`) can't be
+/// exercised through an in-process `tower::ServiceExt::oneshot` call.
+#[cfg(test)]
+mod agent_names_refresh_tests {
+    use super::{LanDiscovery, LAN_AGENT_NAMES_MAX_COUNT, LAN_AGENT_NAMES_MAX_NAME_LEN};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// Starts a raw TCP server that always answers
+    /// `/agentmux/reactive/agent-names` with `body` verbatim (caller supplies
+    /// correct headers/framing), and returns its `http://127.0.0.1:<port>`
+    /// base URL. One-shot: serves exactly one connection then stops, which is
+    /// all a single `fetch_peer_agent_names` call makes.
+    async fn spawn_fake_agent_names_server(response: &'static str) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let Ok((mut stream, _)) = listener.accept().await else { return };
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf).await;
+            let _ = stream.write_all(response.as_bytes()).await;
+        });
+        format!("http://127.0.0.1:{port}")
+    }
+
+    /// Codex P1 on PR #3102: the `lan_key` a peer advertises authenticates
+    /// THIS client to that peer, not the other way round — anything able to
+    /// fake an mDNS advertisement gets into `self.instances` and is polled.
+    /// A response larger than the cap must be rejected outright, not
+    /// buffered in full and then discarded.
+    #[tokio::test]
+    async fn oversized_response_is_rejected_not_buffered() {
+        // 4x the cap, filled with a repeating byte inside a JSON string so a
+        // parser that ignored the cap would otherwise succeed.
+        let oversized_len = 4 * super::LAN_AGENT_NAMES_MAX_RESPONSE_BYTES;
+        let filler = "a".repeat(oversized_len);
+        let json_body = format!(r#"{{"agents":["{filler}"]}}"#);
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            json_body.len(),
+            json_body
+        );
+        let leaked: &'static str = Box::leak(response.into_boxed_str());
+        let base_url = spawn_fake_agent_names_server(leaked).await;
+        let http = reqwest::Client::new();
+
+        let names = LanDiscovery::fetch_peer_agent_names(&http, &base_url, "irrelevant").await;
+        assert!(
+            names.is_none(),
+            "an oversized response must be discarded entirely, not truncated into a result"
+        );
+    }
+
+    /// The happy path, plus defense-in-depth entry capping: a valid response
+    /// with a name that's too long and more names than the count cap allows
+    /// should keep the good names and drop the rest, not fail outright.
+    #[tokio::test]
+    async fn valid_response_is_parsed_and_excess_entries_are_capped() {
+        let too_long_name = "x".repeat(LAN_AGENT_NAMES_MAX_NAME_LEN + 1);
+        let mut names_json: Vec<String> = (0..LAN_AGENT_NAMES_MAX_COUNT + 10)
+            .map(|i| format!("\"agent-{i}\""))
+            .collect();
+        names_json.push(format!("\"{too_long_name}\""));
+        let json_body = format!(r#"{{"agents":[{}]}}"#, names_json.join(","));
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            json_body.len(),
+            json_body
+        );
+        let leaked: &'static str = Box::leak(response.into_boxed_str());
+        let base_url = spawn_fake_agent_names_server(leaked).await;
+        let http = reqwest::Client::new();
+
+        let names = LanDiscovery::fetch_peer_agent_names(&http, &base_url, "irrelevant")
+            .await
+            .expect("a well-formed, appropriately-sized response must parse");
+
+        assert_eq!(names.len(), LAN_AGENT_NAMES_MAX_COUNT, "must truncate to the count cap");
+        assert!(names.contains(&"agent-0".to_string()));
+        assert!(
+            !names.iter().any(|n| n.len() > LAN_AGENT_NAMES_MAX_NAME_LEN),
+            "an over-length name must never survive into the result"
+        );
+    }
+
+    /// Codex P2 on PR #3102: sequential polling lets N stale/unreachable
+    /// peers each burn their full timeout in turn. Two peers that each take
+    /// ~300ms to answer must complete in ~300ms total, not ~600ms — proving
+    /// the fan-out is real concurrency, not just non-blocking syntax that
+    /// still executes one after another.
+    #[tokio::test]
+    async fn peers_are_polled_concurrently_not_sequentially() {
+        async fn spawn_slow_agent_names_server(delay_ms: u64) -> String {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let port = listener.local_addr().unwrap().port();
+            tokio::spawn(async move {
+                let Ok((mut stream, _)) = listener.accept().await else { return };
+                let mut buf = [0u8; 4096];
+                let _ = stream.read(&mut buf).await;
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                let body = r#"{"agents":["slow-agent"]}"#;
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(resp.as_bytes()).await;
+            });
+            format!("http://127.0.0.1:{port}")
+        }
+
+        let delay_ms = 300;
+        let url_a = spawn_slow_agent_names_server(delay_ms).await;
+        let url_b = spawn_slow_agent_names_server(delay_ms).await;
+        let http = reqwest::Client::new();
+
+        let started = std::time::Instant::now();
+        use futures_util::StreamExt as _;
+        let mut inflight = futures_util::stream::FuturesUnordered::new();
+        inflight.push(LanDiscovery::fetch_peer_agent_names(&http, &url_a, "k"));
+        inflight.push(LanDiscovery::fetch_peer_agent_names(&http, &url_b, "k"));
+        while inflight.next().await.is_some() {}
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_millis(delay_ms * 2 - 100),
+            "two {delay_ms}ms peers took {elapsed:?} — looks sequential, not concurrent"
+        );
     }
 }

--- a/agentmux-srv/src/bootstrap.rs
+++ b/agentmux-srv/src/bootstrap.rs
@@ -1349,7 +1349,7 @@ pub async fn bind_listeners_and_network(
     // socket on both counts. [reagent #3021 P0]
     //
     // The scoped `lan_key` (X-AuthKey header, broadcast in the mDNS TXT record)
-    // gates only the two LAN-forwarding routes (`lan_or_full_auth_middleware`)
+    // gates only the three LAN-forwarding routes (`lan_or_full_auth_middleware`)
     // — not the full auth_key previously broadcast here, which gated the entire
     // API surface (see Config::lan_key's doc comment).
     let bind_addr = backend::lan_listeners::STARTUP_BIND_ADDR;

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -85,7 +85,7 @@ pub struct HostIpc {
 pub struct AppState {
     pub auth_key: String,
     /// LAN peer-discovery credential — see `Config::lan_key`'s doc comment.
-    /// Accepted only by `lan_or_full_auth_middleware`'s two routes, never
+    /// Accepted only by `lan_or_full_auth_middleware`'s three routes, never
     /// the general `auth_middleware` gating everything else.
     pub lan_key: String,
     /// Random identifier generated once per process boot — NOT the
@@ -337,7 +337,7 @@ pub fn build_router(state: AppState) -> Router {
         // allow_origin comment above).
         .expose_headers(vec!["X-ZoneFileInfo".parse().unwrap()]);
 
-    // The two routes an LAN peer actually calls when forwarding a jekt or
+    // The routes an LAN peer actually calls when forwarding a jekt or
     // looking up which agents this instance hosts
     // (`LanDiscoveryController::find_agent`, `server/reactive.rs`'s Tier-3
     // forward). Kept OUT of `reactive_routes`/`authed_routes` deliberately
@@ -350,6 +350,13 @@ pub fn build_router(state: AppState) -> Router {
     let lan_forward_routes = Router::new()
         .route("/agentmux/reactive/inject", post(reactive::handle_reactive_inject))
         .route("/agentmux/reactive/agent", get(reactive::handle_reactive_agent))
+        // Names only — see `handle_reactive_agent_names`' doc comment for why
+        // this is deliberately not `/agentmux/reactive/agents` (which stays
+        // behind full auth because it serializes internal routing fields).
+        .route(
+            "/agentmux/reactive/agent-names",
+            get(reactive::handle_reactive_agent_names),
+        )
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
             lan_or_full_auth_middleware,
@@ -1759,7 +1766,7 @@ async fn auth_middleware(
 /// their own `lan_forward_routes` router in `router()`, not in
 /// `reactive_routes`.
 ///
-/// `state.lan_key` grants access to ONLY these two routes — never the rest
+/// `state.lan_key` grants access to ONLY these three routes — never the rest
 /// of `/agentmux/service`, `/agentmux/file`, shell creation, credential/
 /// identity endpoints, etc. See `Config::lan_key`'s doc comment for why
 /// this exists (SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md LAN P0-1).

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -1380,6 +1380,36 @@ pub(super) async fn handle_reactive_agents(
     Json(serde_json::to_value(&agents).unwrap_or(json!([])))
 }
 
+/// Agent NAMES only, for LAN peers — deliberately NOT
+/// [`handle_reactive_agents`], which serializes full `AgentRegistration`
+/// records (`block_id`, `tab_id`, `registered_at`, `last_seen`,
+/// `registration_nonce`). Those are internal delivery/routing details and
+/// stay behind full auth.
+///
+/// This route is reachable with the broadcast `lan_key`
+/// (`lan_or_full_auth_middleware`), so treat its output as public to anyone
+/// on the local network: `SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md`
+/// (LAN P0-1) deliberately shrank what a captured `lan_key` is worth, and
+/// this widens it by exactly one thing — enumerating agent names. That was
+/// an explicit, repo-owner-confirmed decision (2026-09-08): a `lan_key`
+/// holder could already confirm any *specific* name via
+/// `/agentmux/reactive/agent?id=…`, so this makes enumeration cheap rather
+/// than newly possible, and it's what lets a peer show which agents live on
+/// another host instead of the empty `agents: []` every LAN peer reported
+/// before. **Do not extend this response with anything beyond names**
+/// without revisiting that decision.
+pub(super) async fn handle_reactive_agent_names(
+    State(state): State<AppState>,
+) -> Json<serde_json::Value> {
+    let names: Vec<String> = state
+        .reactive_handler
+        .list_agents()
+        .into_iter()
+        .map(|a| a.agent_id)
+        .collect();
+    Json(json!({ "agents": names }))
+}
+
 #[derive(serde::Deserialize)]
 pub(super) struct AgentQuery {
     id: Option<String>,

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -1309,8 +1309,8 @@ async fn self_endpoint_resolves_seeded_agent() {
 
 // SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md LAN P0-1 — the scoped
 // `lan_key` (broadcast via mDNS/UDP for LAN peer discovery) must be
-// accepted by the two LAN-forwarding routes but rejected everywhere else,
-// and the full `auth_key` must keep working on those same two routes
+// accepted by the three LAN-forwarding routes but rejected everywhere else,
+// and the full `auth_key` must keep working on those same routes
 // (the normal, non-LAN case — e.g. agentmux-mcp's SendMessage tool).
 
 #[tokio::test]
@@ -1377,7 +1377,7 @@ async fn garbage_key_is_rejected_on_reactive_inject() {
 }
 
 /// The whole point of LAN P0-1: a captured `lan_key` must NOT grant access
-/// to the general API surface, only the two LAN-forwarding routes.
+/// to the general API surface, only the three LAN-forwarding routes.
 #[tokio::test]
 async fn lan_key_is_rejected_on_the_general_service_route() {
     let app = test_router();
@@ -1389,6 +1389,82 @@ async fn lan_key_is_rejected_on_the_general_service_route() {
         .unwrap();
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// The LAN peer agent-name list (2026-09-08): a `lan_key` holder may
+/// enumerate agent NAMES, so a peer can show which agents live on another
+/// host instead of the empty `agents: []` it reported before.
+#[tokio::test]
+async fn lan_key_can_list_agent_names() {
+    let state = test_state();
+    let unique = uuid::Uuid::new_v4();
+    let agent_id = format!("names-test-agent-{unique}");
+    state
+        .reactive_handler
+        .register_agent(&agent_id, &format!("names-test-block-{unique}"), None)
+        .unwrap();
+
+    let app = build_router(state);
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/agentmux/reactive/agent-names")
+        .header("X-AuthKey", "test-lan-key")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let names: Vec<&str> = json["agents"]
+        .as_array()
+        .expect("agents array")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+    assert!(names.contains(&agent_id.as_str()), "got {names:?}");
+}
+
+/// The security scoping that made the route above acceptable: it returns
+/// NAMES and nothing else. `AgentRegistration` also carries `block_id`,
+/// `tab_id`, `registered_at`, `last_seen` and `registration_nonce` —
+/// internal delivery/routing detail that must stay behind full auth (that's
+/// why this is a separate route from `/agentmux/reactive/agents`, which
+/// `lan_key_is_rejected_on_other_reactive_routes` pins at 401).
+#[tokio::test]
+async fn agent_names_exposes_names_only_not_registration_internals() {
+    let state = test_state();
+    let unique = uuid::Uuid::new_v4();
+    state
+        .reactive_handler
+        .register_agent(
+            &format!("names-only-agent-{unique}"),
+            &format!("names-only-block-{unique}"),
+            Some("tab-should-not-leak"),
+        )
+        .unwrap();
+
+    let app = build_router(state);
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/agentmux/reactive/agent-names")
+        .header("X-AuthKey", "test-lan-key")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let raw = String::from_utf8_lossy(&body);
+
+    for leaked in [
+        "block_id",
+        "tab_id",
+        "tab-should-not-leak",
+        "registration_nonce",
+        "registered_at",
+        "last_seen",
+    ] {
+        assert!(!raw.contains(leaked), "{leaked} leaked over the LAN route: {raw}");
+    }
 }
 
 #[tokio::test]

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -340,6 +340,7 @@ partial list.
 | [`SPEC_EDITOR_MCP_OPEN_BLANK_PREVIEW_AND_PANE_REUSE_2026_08_03`](SPEC_EDITOR_MCP_OPEN_BLANK_PREVIEW_AND_PANE_REUSE_2026_08_03.md) | Plan: MCP-opened markdown blank-preview investigation + Editor-pane reuse |
 | [`SPEC_HEADLESS_TRANSIENT_RETRY_2026_08_31`](SPEC_HEADLESS_TRANSIENT_RETRY_2026_08_31.md) | Transient-failure retry for turns with no rendered pane |
 | [`SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02`](SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md) | SPEC: Cross-channel jekt trust — closing the last unverifiable same-machine tier |
+| [`SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13`](SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md) | Spec: Securing LAN and WAN tier jekt delivery — closing cross-tenant and cross-network trust gaps |
 | [`SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03`](SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03.md) | Migration System Audit & Hardening Plan |
 | [`SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29`](SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29.md) | Spec: multi-tier discovery + remote API invocation over muxbus |
 | [`SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04`](SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md) | Spec: optional system-tray + persistent background service, cross-platform |
@@ -785,7 +786,6 @@ Fix one when you touch it and know its real state.
 | [`SPEC_HARD_CORNERS_2026_05_26`](SPEC_HARD_CORNERS_2026_05_26.md) | SPEC: Hard corners on buttons and modals |
 | [`SPEC_IDENTITY_DIRECT_LINKS_PHASE3_PRC_2026_07_10`](SPEC_IDENTITY_DIRECT_LINKS_PHASE3_PRC_2026_07_10.md) | Spec: Identity direct-links, PR-C (Armory read-only view + bundle-free agent creation) |
 | [`SPEC_INSTANCE_LIFECYCLE_CONSOLIDATION_2026_06_21`](SPEC_INSTANCE_LIFECYCLE_CONSOLIDATION_2026_06_21.md) | SPEC — Instance Lifecycle Consolidation |
-| [`SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13`](SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md) | Spec: Securing LAN and WAN tier jekt delivery — closing cross-tenant and cross-network trust gaps |
 | [`SPEC_LARGE_TIER_MODULARIZATION_INDEX_2026_07_02`](SPEC_LARGE_TIER_MODULARIZATION_INDEX_2026_07_02.md) | Large-Tier Modularization — Index & Sequencing |
 | [`SPEC_LAUNCH_MODAL_PANE_SCOPE_2026_05_25`](SPEC_LAUNCH_MODAL_PANE_SCOPE_2026_05_25.md) | SPEC: Move launch modal from tab-scope to pane-scope lock |
 | [`SPEC_LAYOUT_HEAL_ROOTNODE_ORPHAN`](SPEC_LAYOUT_HEAL_ROOTNODE_ORPHAN.md) | SPEC: Layout Healer Misses Rootnode-Is-Orphan Case |

--- a/docs/specs/SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md
+++ b/docs/specs/SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md
@@ -167,6 +167,21 @@ Not a code defect, a threat-model one: modern real-world "LAN"s routinely includ
 - Require an explicit **pairing step** (a short code shown in one instance's UI, typed into the other) rather than automatic broadcast trust, for users who want tighter control than "opt into LAN discovery" alone provides.
 - At minimum, gate the credential behind a **challenge-response** rather than handing the raw value to any listener/prober — even a lightweight HMAC challenge keyed on the LAN-scoped credential (once P0-1's scoping lands) meaningfully raises the bar over "broadcast the plaintext secret to anyone who asks."
 
+> **Scope amendment, 2026-09-08 (repo-owner-confirmed).** The scoped LAN
+> credential now also grants a third route: `GET
+> /agentmux/reactive/agent-names`, returning agent **names only** — no
+> `block_id`, `tab_id`, timestamps, or `registration_nonce` (those stay on
+> the full-auth `/agentmux/reactive/agents`, pinned at 401 for a `lan_key` by
+> `lan_key_is_rejected_on_other_reactive_routes`). This widens a captured
+> `lan_key`'s worth by exactly one capability: enumerating agent names.
+> Accepted deliberately because a holder could already confirm any *specific*
+> name via `/agentmux/reactive/agent?id=…`, so this makes enumeration cheap
+> rather than newly possible — and without it every LAN peer reports
+> `agents: []`, leaving no way to discover which agents live on another host.
+> The least-privilege intent of P0-1 above is otherwise unchanged; do not read
+> this as license to widen the LAN surface further without the same explicit
+> call.
+
 **P1-1 — Encrypt/authenticate peer-to-peer LAN forwarding.** Upgrade `http://` peer forwarding to something a passive LAN listener can't read — mTLS between discovered peers (using the pairing/scoped-credential material from P0-1 to bootstrap trust), or at minimum a signed-request scheme analogous to the host-tier HMAC work, so message content and any credential in flight aren't cleartext on the wire.
 
 **P2-1 — Make the "LAN = trusted" trade-off explicit in the opt-in UI copy.** The feature already defaults off, which is right — verify the enabling toggle's copy actually communicates "this instance's access credential will be discoverable by anything else on this network," not just "enable LAN discovery," so an informed user (not the code's own assumption) is the one deciding the trust boundary.

--- a/docs/specs/SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md
+++ b/docs/specs/SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md
@@ -2,9 +2,9 @@
 
 **Date:** 2026-08-13
 **Type:** Security design spec (cross-repo: `agentmux`, `agentmux-cloud`, `shared-infrastructure`)
-**Status:** §3 WAN P1-2 (reagent WAN signing) implemented 2026-08-14 — see
-"Implementation status" below. P0-1, P0-2, P1-1, P2-1 (WAN) and all of LAN
-remain proposed/not implemented. **The still-open WAN P0 findings remain
+**Status:** active — §3 WAN P1-2 (reagent WAN signing) implemented 2026-08-14
+— see "Implementation status" below. P0-1, P0-2, P1-1, P2-1 (WAN) and all of
+LAN remain proposed/not implemented. **The still-open WAN P0 findings remain
 blocker-severity; do not treat this as fully closed.**
 **Trigger:** User directive, after `SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md` shipped host-tier signing: "we need to get secure lan and wan tier, especially wan tier, it is a blocker." Then, after discovering this AgentMux instance had never completed muxbus login (root cause of "reagent's PR review jekts never arrive"): "lets get this system operational with the proper security for lan/wan, best practices... secure reagent jekt is top priority."
 **Builds on:** `SPEC_JEKT_TRUST_LAYER_COMPLETION_2026_08_13.md` (host-tier HMAC signing, shipped), `agentmux-cloud/muxbus/PLAN_PER_AGENT_CREDENTIAL_BINDING_2026_07_06.md` (the still-inert Cognito M2M binding check this spec elevates to P0), `docs/specs/SPEC_MUXBUS_MULTI_TENANT_SECURITY_2026_07_06.md` (prior roadmap; this spec supersedes its Phase 1/3 sequencing based on what's now confirmed live in code, not just planned).
@@ -221,7 +221,7 @@ Confirmed against current AWS documentation (docs.aws.amazon.com/cognito, checke
 
 **Consequence:** the per-agent-Cognito-app-client mechanism, as currently built, cannot be the long-term answer regardless of whether `ENFORCE_AGENT_BINDING` is flipped — it structurally cannot cover most real traffic at any meaningful scale. Flipping the flag today would protect only whichever small fraction of agents happened to provision before hitting the quota (and would start throwing Cognito API errors for new provisioning attempts once it's hit, if it isn't already — `provisionAgentClient` has no specific handling for a Cognito-side quota rejection distinct from its own `agent_provisions` billing-quota check).
 
-**Recommended redesign, not just a scale-up:** move to **one Cognito M2M app client per *account*** (bounded by customer count, not agent count — almost certainly well under 100 for the foreseeable future) with a **pre-token Lambda** injecting the authorized `agent_id` (or set of agent_ids) as a custom claim, based on server-side account state at token-issue time. This codebase already has exact precedent for this shape of mechanism: `SPEC_MUXBUS_OWNER_GATE_AND_COST_CAP_2026_08_11.md`'s `owner` billing tier is derived "exclusively from the Cognito-verified email in the pre-token Lambda, never from anything client-supplied" (`auth.ts`'s own doc comment on `BillingTier`). The same pattern — server-controlled claim injection at token-mint time — sidesteps the 100-client ceiling entirely, since it needs one client per account, not one per agent.
+**Recommended redesign, not just a scale-up:** move to **one Cognito M2M app client per *account*** (bounded by customer count, not agent count — almost certainly well under 100 for the foreseeable future) with a **pre-token Lambda** injecting the authorized `agent_id` (or set of agent_ids) as a custom claim, based on server-side account state at token-issue time. This codebase already has exact precedent for this shape of mechanism: the `owner` billing tier is derived "exclusively from the Cognito-verified email in the pre-token Lambda, never from anything client-supplied" (`auth.ts`'s own doc comment on `BillingTier`). The same pattern — server-controlled claim injection at token-mint time — sidesteps the 100-client ceiling entirely, since it needs one client per account, not one per agent.
 
 ### 5.2 The operational gap worth closing before flipping regardless of §5.1
 
@@ -264,7 +264,7 @@ Following this codebase's own dual-write/backfill/cutover precedent (`SPEC_ARMOR
 - `agentmux-cloud/muxbus/server/src/agent-provisioning.ts` (`provisionAgentClient`, `clientName` — one literal Cognito app client per `(user_id, agent_id)` pair, the mechanism §5.1 finds doesn't scale)
 - `agentmux-cloud/muxbus/PLAN_PER_AGENT_CREDENTIAL_BINDING_2026_07_06.md`
 - [Quotas in Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/quotas.html) (AWS documentation, confirms the 100-app-clients-per-user-pool default quota cited in §5.1, checked 2026-08-13)
-- `docs/specs/SPEC_MUXBUS_OWNER_GATE_AND_COST_CAP_2026_08_11.md` (the existing pre-token-Lambda custom-claim precedent §5.1's redesign proposal reuses)
+- `agentmux-cloud`'s `auth.ts` (`BillingTier`'s doc comment — the existing pre-token-Lambda custom-claim precedent §5.1's redesign proposal reuses). This entry previously cited an owner-gate/cost-cap spec by filename that exists in neither this repo nor anywhere in the agentmuxai org; the dead path is removed rather than repointed at a guess, per docs/specs/README.md.
 - `agentmux-cloud/muxbus/packages/muxbus-jekt/src/index.ts` (`wrapJektMessage` — TS-side trust-label derivation, confirmed all 4 live call sites hardcode/default `deliveryTier: 'wan'`, `'host'` is currently unreachable from any cloud-side caller)
 - `agentmux-srv/src/backend/lan_discovery.rs` (full file — mDNS advertisement, UDP broadcast responder, `find_agent` peer forwarding)
 - `agentmux-srv/src/bootstrap.rs:1237-1243` (confirms the LAN-broadcast key is the same instance-wide `auth_key`)


### PR DESCRIPTION
## Summary

Every LAN peer reported `agents: []` — always. `LanInstance::agents` existed
and was initialized empty at mDNS-resolve time, but nothing ever populated it.
Consequence: there is no way to discover *which* agents live on another
machine. Confirmed live on this network — `starpower` and `gamerlove` both
resolve with correct hostname/version/address and zero agents.

This is retro item A1 from `agentmux-mobile`'s
`docs/retro/retro-mobile-dev-and-discovery-session-2026-09-08.md`. I hit it
concretely: asked to message an agent on another host, the only option was to
address it blind by name and hope. (It worked — `SendMessage` resolves by name
across tiers — but discovery gave zero confirmation the target existed.)

## Approach

- New `GET /agentmux/reactive/agent-names` on the existing
  `lan_or_full_auth_middleware` group.
- A 30s refresh loop asks each known peer and fills in `LanInstance::agents`.
  Slower than `LAN_AGENT_CACHE_TTL_SECS` on purpose: this list is for
  *display*, not delivery routing — `find_agent` still does its own
  authoritative lookup.
- Refresh failures are **non-destructive**: a briefly-unreachable peer keeps
  its last-known list rather than flapping to empty (staleness is already
  tracked by `last_seen`). A peer on an older build answers 404, which is
  logged at debug and treated the same way — expected during a rolling upgrade.
- The snapshot of peers is taken under the read lock and released before any
  `await`, so the map isn't held across I/O.

## Security scoping — please review this part specifically

This **widens what a captured `lan_key` is worth**, so it was an explicit
decision (repo-owner-confirmed, 2026-09-08), not an incidental consequence.

The new route returns agent **names only**. `block_id`, `tab_id`,
`registered_at`, `last_seen` and `registration_nonce` stay behind full auth on
the existing `/agentmux/reactive/agents` — which
`lan_key_is_rejected_on_other_reactive_routes` still pins at 401, unchanged.

The tradeoff was accepted because a `lan_key` holder could **already** confirm
any *specific* agent name via `/agentmux/reactive/agent?id=…`, so this makes
enumeration cheap rather than newly possible. The alternative considered and
rejected for now was requiring a signed request (reusing
`SPEC_JEKT_LAN_TIER_SIGNING`'s per-agent Ed25519 keys) — stronger, meaningfully
more work, and can layer on later.

`SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md` gets a scope amendment
recording this, since that spec is what deliberately narrowed the credential
three weeks ago. The now-stale "two LAN-forwarding routes" comments across
`lan_discovery.rs`, `bootstrap.rs`, `server/mod.rs` and `tests.rs` are updated
to three.

## Testing

Two new tests, both passing:

- `lan_key_can_list_agent_names` — a registered agent's name is returned to a
  `lan_key` caller.
- `agent_names_exposes_names_only_not_registration_internals` — asserts the raw
  response body contains none of `block_id`, `tab_id`, the tab value itself,
  `registration_nonce`, `registered_at`, `last_seen`. This is the assertion
  that makes the scoping decision above enforceable rather than aspirational.

All 10 existing `lan_key_*` / `agent_names*` tests pass together, including the
pre-existing hardening tests that pin the general surface at 401.

<!-- agentmux:agent_id=loap #2 -->