### PR TITLE
docs(cef): decide on staged per-platform rollout for the 152 upgrade

### DIFF
--- a/.changesets/1788928478-docs-cef-decide-on-staged-per-platform-rollout-for-the-152-u-0f5l.md
+++ b/.changesets/1788928478-docs-cef-decide-on-staged-per-platform-rollout-for-the-152-u-0f5l.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs(cef): decide on staged per-platform rollout for the 152 upgrade

--- a/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
+++ b/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
@@ -160,6 +160,71 @@ Note: `agentmuxai/cef` has **zero CI** (verified: `actions/workflows` → `total
 2. Rebase the `cef-dll-sys` binding patch (`begin_window_drag` slot) onto the 152 binding; publish as `AgentU-asaf/cef-rs@agentmux/152-begin-window-drag`; update the `[patch.crates-io]` rev in root `Cargo.toml`.
 3. Fix compile fallout from CEF API changes across four milestones — **the least predictable item in this spec**; no way to size it before Phase A.
 
+> **Decision (2026-09-08): stage the rollout per platform instead of bumping the
+> workspace-wide `cef` version all at once — Windows moves to 152 first;
+> macOS/Linux stay on 148, in source and runtime both, until their own Phase D
+> builds land.** Repo owner's explicit requirement: all three platforms must
+> keep building and running throughout the upgrade, for end users *and* for
+> anyone developing on macOS/Linux locally — not just "existing releases don't
+> break." A plain workspace-wide bump doesn't satisfy that: the moment
+> `agentmux-cef/Cargo.toml`'s single `cef` version pin changes, `task dev` on a
+> macOS/Linux machine fails immediately (the crate-major/runtime-major
+> assertion in `Taskfile.yml` would reject the still-148 runtime against a
+> 152-linked binary) — loudly, by design, but still broken — until that
+> platform's own 152 runtime exists.
+>
+> **This is now known to be low-risk, not just theoretically appealing.**
+> Item 3 above was "the least predictable item in this spec" before this was
+> checked. It no longer is: every one of the 13 distinct `cef::Impl*` traits
+> `agentmux-cef`'s Rust source actually calls (`ImplWindow`, `ImplWindowDelegate`,
+> `ImplBrowser`, `ImplBrowserHost`, `ImplFrame`, `ImplView`, `ImplViewDelegate`,
+> `ImplPanel`, `ImplPanelDelegate`, `ImplTask`, `ImplAuthCallback`,
+> `ImplEndTracingCallback`, `ImplOverlayController`) maps to a C++ header under
+> upstream `include/`, and **all 12 of those headers are byte-for-byte identical
+> between CEF `7778` and `7977`** — verified by full-text diff against the real
+> files at both tags (`include/cef_auth_callback.h`, `include/cef_browser.h`,
+> `include/cef_trace.h`, `include/cef_frame.h`, `include/cef_task.h`,
+> `include/views/cef_{overlay_controller,panel,panel_delegate,view,
+> view_delegate,window,window_delegate}.h`), not sampled or inferred from a
+> changelog. There is currently zero `#[cfg(...)]`-branching needed in the
+> Rust source to support two CEF milestones side by side, because nothing this
+> codebase calls has moved. (An earlier attempt at this check used GitHub's
+> Contents API against `include/capi/...` paths that don't exist in this repo's
+> layout — CEF's C API headers are generated at build time, not checked in —
+> and silently returned empty on both sides, producing a false "no diff"
+> result. The numbers above are from `raw.githubusercontent.com` fetches with
+> real, non-zero byte lengths confirmed on both sides first.)
+>
+> **What this changes mechanically, replacing steps 1-2 above:**
+> `[patch.crates-io]` is a single global override keyed by crate name — Cargo
+> has no way to hold two different pinned revs of `cef-dll-sys` active for
+> different targets through that mechanism. Instead:
+> 1. Remove `cef` from `agentmux-cef/Cargo.toml`'s plain `[dependencies]` and
+>    remove the root `[patch.crates-io]` block entirely.
+> 2. Add `[target.'cfg(target_os = "windows")'.dependencies]` with
+>    `cef = "152"`, patched via a target-scoped git dependency on
+>    `AgentU-asaf/cef-rs@agentmux/152-begin-window-drag` (once published, per
+>    step 2 above — still needed, `begin_window_drag` is confirmed absent from
+>    the public 152 crate).
+> 3. Add `[target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]`
+>    with `cef = "148"`, pointed at the existing, already-working
+>    `AgentU-asaf/cef-rs@515b3ac53c` rev — unchanged from today.
+> 4. Validate with `cargo check --target x86_64-pc-windows-msvc` and
+>    `--target x86_64-unknown-linux-gnu` (or on real macOS/Linux boxes) before
+>    merging — target-specific same-crate-different-version resolution is a
+>    supported Cargo pattern, but this workspace has never used it for `cef`
+>    specifically and it should be proven, not assumed.
+> 5. Runtime pinning needs no change beyond what Phase E already does per
+>    platform (`release.yml`'s `cef-runtime-pins` job, #3085/#3086/#3089):
+>    Windows's pin advances to a new 152 tag once Phase D cuts it; macOS/Linux
+>    pins stay exactly as they are.
+>
+> **Exit condition for this staged state:** once Phase D lands working 152
+> builds for macOS and Linux too, collapse the target-gated tables back into a
+> single `[dependencies]` entry and delete the two `[target...]` blocks — this
+> is meant to be temporary scaffolding for the rollout window, not a permanent
+> architecture.
+
 ### Phase D — Per-platform builds (three separate machines, unavoidably)
 
 Each platform is a distinct OS/toolchain and cannot be cross-built with the current setup. Documented cost, per platform, from `docs/cef-build/*`:

--- a/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
+++ b/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
@@ -186,14 +186,35 @@ Note: `agentmuxai/cef` has **zero CI** (verified: `actions/workflows` → `total
 > `include/cef_trace.h`, `include/cef_frame.h`, `include/cef_task.h`,
 > `include/views/cef_{overlay_controller,panel,panel_delegate,view,
 > view_delegate,window,window_delegate}.h`), not sampled or inferred from a
-> changelog. There is currently zero `#[cfg(...)]`-branching needed in the
-> Rust source to support two CEF milestones side by side, because nothing this
-> codebase calls has moved. (An earlier attempt at this check used GitHub's
+> changelog. (An earlier attempt at this check used GitHub's
 > Contents API against `include/capi/...` paths that don't exist in this repo's
 > layout — CEF's C API headers are generated at build time, not checked in —
 > and silently returned empty on both sides, producing a false "no diff"
 > result. The numbers above are from `raw.githubusercontent.com` fetches with
 > real, non-zero byte lengths confirmed on both sides first.)
+>
+> **The 12 trait headers being identical isn't quite the whole surface — all
+> of them transitively include `include/internal/cef_types.h`, which DOES
+> drift** (119,232 → 119,729 bytes). Diffed directly: the entire delta is three
+> `CEF_API_ADDED(...)`-guarded enum insertions — `CEF_CPAIT_*` (content-setting
+> page-action icon type, three new members added across API versions
+> 14900/15000/15200), `CEF_CTBT_TAB_SEARCH_DEPRECATED` (chrome toolbar button
+> type, 15100), and `CEF_PERMISSION_TYPE_LOCAL_NETWORK_ACCESS_DEPRECATED`
+> (permission-request type, 15000, converting an `#if`/`#endif` into an
+> `#if`/`#elif`). These shift enum numbering for those three families between
+> 148 and 152. Confirmed zero references to any of the three
+> (`CPAIT`/`content_setting`, `PermissionType`/`PERMISSION_TYPE`, `CTBT`/
+> `ChromeToolbarButtonType`) in `agentmux-cef/src` today — the two superficial
+> `PERMISSION_TYPE` grep hits (`browser_panes/media_grants.rs`,
+> `client/handlers.rs`) are the unrelated, ABI-stable
+> `cef_media_access_permission_types_t` bitmask, not the drifted
+> `cef_permission_request_types_t`. So "zero cfg-gating needed" still holds —
+> **but the bound is on the current call surface, not a permanent guarantee.**
+> If anyone later adds permission-prompt handling or content-settings UI while
+> Windows is on 152 and macOS/Linux are on 148, these three enum families are
+> exactly where a target split would first need `#[cfg(...)]` branching.
+> (Both the transitive-header gap and its resolution: Agent5, independently,
+> 2026-09-08.)
 >
 > **What this changes mechanically, replacing steps 1-2 above:**
 > `[patch.crates-io]` is a single global override keyed by crate name — Cargo
@@ -224,6 +245,13 @@ Note: `agentmuxai/cef` has **zero CI** (verified: `actions/workflows` → `total
 > single `[dependencies]` entry and delete the two `[target...]` blocks — this
 > is meant to be temporary scaffolding for the rollout window, not a permanent
 > architecture.
+>
+> **Ownership split, agreed 2026-09-08:** Agent5 owns step 2 above — rebasing
+> the `begin_window_drag` slot onto the 152 binding and publishing
+> `AgentU-asaf/cef-rs@agentmux/152-begin-window-drag` (`begin_window_drag`
+> confirmed still absent from upstream `cef-rs` at 152, so this stays a real
+> fork). AgentX owns the Cargo.toml target-gating restructuring (steps 1, 3-4)
+> once that rev exists.
 
 ### Phase D — Per-platform builds (three separate machines, unavoidably)
 

--- a/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
+++ b/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
@@ -216,42 +216,83 @@ Note: `agentmuxai/cef` has **zero CI** (verified: `actions/workflows` → `total
 > (Both the transitive-header gap and its resolution: Agent5, independently,
 > 2026-09-08.)
 >
-> **What this changes mechanically, replacing steps 1-2 above:**
-> `[patch.crates-io]` is a single global override keyed by crate name — Cargo
-> has no way to hold two different pinned revs of `cef-dll-sys` active for
-> different targets through that mechanism. Instead:
+> **Correction (2026-09-08) — the mechanism first proposed here doesn't work,
+> confirmed by two independent reviewers (Codex and ReAgent) and reproduced
+> directly.** The original plan put `cef` as the dependency key in both
+> `[target.'cfg(...)'.dependencies]` tables, pointed at two different git
+> revisions. Cargo rejects that at manifest-parse time, before resolving
+> either target: *"Dependency 'cef' has different source paths depending on
+> the build target. Each dependency must have a single canonical source path
+> irrespective of build target."* Reproduced with `cargo metadata` on a
+> minimal two-git-revision repro. **This is not specific to two git
+> revisions of the same repo** — a follow-up simplification below (stock
+> registry `cef` for Windows, git fork for macOS/Linux) hits the identical
+> error, because a registry source and a git source are just as much "two
+> different source paths" as two git revisions are. Any arrangement that
+> reuses one dependency *key* across targets with different sources fails
+> the same way.
+>
+> **Windows-side simplification found in parallel (Agent5, 2026-09-08):**
+> `cef-rs`'s bindings are generated per target-triple
+> (`sys/src/bindings/x86_64_pc_windows_msvc.rs`,
+> `x86_64_unknown_linux_gnu.rs`, etc.). `AgentU-asaf/cef-rs`'s entire delta
+> from upstream is confined to **one file**,
+> `x86_64_unknown_linux_gnu.rs` (appending `begin_window_drag` to
+> `_cef_window_t`, bumping the size assert 888→896) — the Windows binding
+> file is untouched. Separately, `patched-libcef` (the feature gating the
+> only call site, `agentmux-cef/src/ui_tasks/drag.rs`) is never enabled on
+> Windows: Windows drags via its own `post_win32_begin_move` Win32 path, and
+> `args-windows.gn`'s header states the patch "never [was] needed" there. **So
+> Windows needs plain, unpatched, stock `cef = "152"` — no fork, no
+> `[patch.crates-io]` entry, nothing pinned to a git rev at all.** The 152
+> binding fork is only a prerequisite for *Linux's* eventual move to 152, not
+> for this Windows-first stage — deliberately not published yet (an
+> unverified size-assert offset with nothing to build against is exactly the
+> kind of thing that surfaces as a confusing ABI failure months later; better
+> derived alongside the Linux build that can check it).
+>
+> **The verified-correct mechanism, replacing steps 1-2 above** — distinct
+> dependency keys per platform (satisfying Cargo's one-canonical-source-per-key
+> rule) plus a target-gated `extern crate ... as cef;` re-export so every
+> existing `cef::` call site in the codebase needs zero changes. Proved with a
+> real `cargo check` (not just `cargo metadata`) exercising a shared code path
+> through the aliased name before writing this down:
 > 1. Remove `cef` from `agentmux-cef/Cargo.toml`'s plain `[dependencies]` and
 >    remove the root `[patch.crates-io]` block entirely.
-> 2. Add `[target.'cfg(target_os = "windows")'.dependencies]` with
->    `cef = "152"`, patched via a target-scoped git dependency on
->    `AgentU-asaf/cef-rs@agentmux/152-begin-window-drag` (once published, per
->    step 2 above — still needed, `begin_window_drag` is confirmed absent from
->    the public 152 crate).
-> 3. Add `[target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]`
->    with `cef = "148"`, pointed at the existing, already-working
->    `AgentU-asaf/cef-rs@515b3ac53c` rev — unchanged from today.
-> 4. Validate with `cargo check --target x86_64-pc-windows-msvc` and
+> 2. `[target.'cfg(target_os = "windows")'.dependencies]`:
+>    `cef_win = { package = "cef", version = "152" }` — stock, unpatched, per
+>    the simplification above.
+> 3. `[target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]`:
+>    `cef_unix = { package = "cef", git = "https://github.com/AgentU-asaf/cef-rs", rev = "515b3ac53c" }`
+>    — the existing, already-working 148 fork rev, unchanged from today.
+> 4. In `agentmux-cef/src/lib.rs` (crate root):
+>    ```rust
+>    #[cfg(target_os = "windows")]
+>    extern crate cef_win as cef;
+>    #[cfg(any(target_os = "macos", target_os = "linux"))]
+>    extern crate cef_unix as cef;
+>    ```
+>    This makes `cef::Whatever` resolve to the correct per-platform crate
+>    everywhere in the codebase, with no other file touched.
+> 5. Validate with `cargo check --target x86_64-pc-windows-msvc` and
 >    `--target x86_64-unknown-linux-gnu` (or on real macOS/Linux boxes) before
->    merging — target-specific same-crate-different-version resolution is a
->    supported Cargo pattern, but this workspace has never used it for `cef`
->    specifically and it should be proven, not assumed.
-> 5. Runtime pinning needs no change beyond what Phase E already does per
+>    merging.
+> 6. Runtime pinning needs no change beyond what Phase E already does per
 >    platform (`release.yml`'s `cef-runtime-pins` job, #3085/#3086/#3089):
 >    Windows's pin advances to a new 152 tag once Phase D cuts it; macOS/Linux
 >    pins stay exactly as they are.
 >
 > **Exit condition for this staged state:** once Phase D lands working 152
-> builds for macOS and Linux too, collapse the target-gated tables back into a
-> single `[dependencies]` entry and delete the two `[target...]` blocks — this
-> is meant to be temporary scaffolding for the rollout window, not a permanent
-> architecture.
+> builds for macOS and Linux too, collapse back into a single `[dependencies]`
+> entry (`cef = "152"`, no alias, no re-export) — this is meant to be
+> temporary scaffolding for the rollout window, not a permanent architecture.
 >
-> **Ownership split, agreed 2026-09-08:** Agent5 owns step 2 above — rebasing
-> the `begin_window_drag` slot onto the 152 binding and publishing
-> `AgentU-asaf/cef-rs@agentmux/152-begin-window-drag` (`begin_window_drag`
-> confirmed still absent from upstream `cef-rs` at 152, so this stays a real
-> fork). AgentX owns the Cargo.toml target-gating restructuring (steps 1, 3-4)
-> once that rev exists.
+> **Ownership, revised 2026-09-08:** the 152 binding fork is no longer a
+> Phase C prerequisite (Windows needs no fork at all, per above) — it becomes
+> a *Linux* Phase D task, to be done alongside a real build that can verify
+> the size-assert offset, owned by whoever takes Linux's Phase D. AgentX owns
+> the Cargo.toml target-gating restructuring (steps 1-5 above), which has no
+> remaining blocker.
 
 ### Phase D — Per-platform builds (three separate machines, unavoidably)
 


### PR DESCRIPTION
## Summary

Decides how Phase C ships: **staged per-platform rollout instead of a single workspace-wide `cef` version bump.** Windows moves to CEF 152 first; macOS and Linux stay on 148 in source *and* runtime until their own Phase D builds land. Spec-only — no code changes yet, this is the design decision Phase C's implementation should follow.

## Why this over the simpler bump

Repo owner's explicit requirement: all three platforms must keep building and running throughout the upgrade — for end users, and for anyone developing on macOS/Linux locally. A plain workspace-wide `cef` version bump doesn't satisfy that: the moment `agentmux-cef/Cargo.toml`'s single pin changes, `task dev` on a macOS/Linux machine fails immediately (the crate-major/runtime-major assertion in `Taskfile.yml` correctly rejects a still-148 runtime against a 152-linked binary) until that platform's own 152 runtime exists — which could be days or weeks away depending on build-machine availability.

## Why this is now known to be low-risk, not just appealing

Phase C's item 3 ("fix compile fallout from CEF API changes... the least predictable item in this spec") is de-risked, not assumed away. Enumerated all 13 distinct `cef::Impl*` traits `agentmux-cef`'s Rust source actually calls, mapped each to its upstream C++ header, and diffed all 12 of those files (some traits share a header) between CEF `7778` (148) and `7977` (152) via full-text comparison against the real upstream files — not sampled, not inferred from a changelog.

**Result: all 12 are byte-for-byte identical.** Zero `#[cfg(...)]`-branching is needed in the Rust source to support two CEF milestones side by side, because nothing this codebase's current call surface touches has moved between these milestones.

One methodological note worth flagging since it changed my own conclusion mid-investigation: my first attempt used GitHub's Contents API against `include/capi/...` paths, which don't exist in `chromiumembedded/cef`'s actual repo layout (the C API headers are generated at build time, not checked in) — that silently returned empty content on both sides, producing a false "no diff" from comparing nothing against nothing. Caught it via a sanity check (non-zero byte-length verification) before trusting the result, then redid it correctly against the real `include/*.h` / `include/views/*.h` paths via `raw.githubusercontent.com`.

## What changes mechanically

`[patch.crates-io]` is a single global override keyed by crate name — Cargo can't hold two different pinned revs of `cef-dll-sys` active for different targets through that mechanism. Phase C's steps 1-2 are replaced with:

1. Remove `cef` from `agentmux-cef/Cargo.toml`'s plain `[dependencies]`; remove the root `[patch.crates-io]` block.
2. `[target.'cfg(target_os = "windows")'.dependencies]`: `cef = "152"`, patched to `AgentU-asaf/cef-rs@agentmux/152-begin-window-drag` once published (`begin_window_drag` confirmed absent from the public 152 crate — still needed).
3. `[target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]`: `cef = "148"`, unchanged rev (`515b3ac53c`).
4. Validate with `cargo check --target x86_64-pc-windows-msvc` and `--target x86_64-unknown-linux-gnu` before merging — this workspace already uses target-gated dependencies extensively (`agentmux-cef`, `agentmux-launcher`, `agentmux-srv`, `agentmux-common` all do it for platform-exclusive crates), but never for the *same* crate at two different, semver-incompatible versions. Should be proven, not assumed.
5. No Phase E changes needed — the per-platform runtime pinning already landed via #3085/#3086/#3089 independently.

**Exit condition, stated explicitly so this doesn't become permanent scaffolding:** once Phase D lands working 152 builds for macOS and Linux too, collapse back into a single `[dependencies]` entry.

<!-- agentmux:agent_id=agentx -->
