### PR TITLE
Posa@Area54: docs: update the Ninja path after retiring C:\Systems

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,9 +199,10 @@ CMake and Ninja are required for `cef-dll-sys` (builds CEF's C wrapper). Both mu
 | **Linux** | `apt install cmake` | `apt install ninja-build` |
 
 On this dev machine, Ninja is at `/c/tools/bin/ninja.exe` (copied from VS 2022; previously
-`/c/Systems/bin/`, retired in the 2026-09-08 host cleanup — see the audit's §2.4 for why that
-path was load-bearing rather than clutter). If `cargo build` fails with "CMake was unable to
-find a build program corresponding to Ninja", verify `ninja --version` works.
+`/c/Systems/bin/`, before that whole directory — an unversioned accumulation of stale repo
+clones and a dormant credential set, unrelated to this repo — was retired on 2026-09-08). If
+`cargo build` fails with "CMake was unable to find a build program corresponding to Ninja",
+verify `ninja --version` works.
 
 ### After Code Changes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,11 +194,14 @@ CMake and Ninja are required for `cef-dll-sys` (builds CEF's C wrapper). Both mu
 
 | Platform | CMake | Ninja |
 |----------|-------|-------|
-| **Windows** | Ships with Visual Studio | Copy from VS: `cp "/c/Program Files/Microsoft Visual Studio/*/Community/Common7/IDE/CommonExtensions/Microsoft/CMake/Ninja/ninja.exe" /c/Systems/bin/` |
+| **Windows** | Ships with Visual Studio | Copy from VS: `cp "/c/Program Files/Microsoft Visual Studio/*/Community/Common7/IDE/CommonExtensions/Microsoft/CMake/Ninja/ninja.exe" /c/tools/bin/` |
 | **macOS** | `brew install cmake` | `brew install ninja` |
 | **Linux** | `apt install cmake` | `apt install ninja-build` |
 
-On this dev machine, Ninja is at `/c/Systems/bin/ninja.exe` (copied from VS 2022). If `cargo build` fails with "CMake was unable to find a build program corresponding to Ninja", verify `ninja --version` works.
+On this dev machine, Ninja is at `/c/tools/bin/ninja.exe` (copied from VS 2022; previously
+`/c/Systems/bin/`, retired in the 2026-09-08 host cleanup — see the audit's §2.4 for why that
+path was load-bearing rather than clutter). If `cargo build` fails with "CMake was unable to
+find a build program corresponding to Ninja", verify `ninja --version` works.
 
 ### After Code Changes
 


### PR DESCRIPTION
Docs-only follow-up to a host cleanup done at the operator's request (audit + execution, not tracked as its own PR since it's machine-local, not repo content).

`C:\Systems` accumulated ~2.3 GB of stale repo clones, a dormant separate Claude Code identity with its own live credentials, and a plaintext AgentMux auth token sitting in a loose `.mcp.json` — none of it version-controlled or backed up anywhere else. Retired it entirely.

**The one thing that made this not just a cleanup:** `CLAUDE.md`'s own Build Prerequisites section named `C:\Systems\bin\ninja.exe` as this dev machine's Ninja location — a live build dependency, not clutter. Deleting the folder outright would have broken `cargo build`'s CEF step for anyone relying on that PATH entry.

Sequence followed:
1. Copied `bin/`'s binaries (`ninja.exe`, `zig.exe`, `gh.exe`, `sqlite3.exe`, `handle64.exe`) to `C:\tools\bin`
2. Verified both build-critical ones work from the new location (`ninja --version` → `1.12.1`, `zig version` → `0.13.0`)
3. Only then removed the old directory
4. This PR updates the two lines in `CLAUDE.md` that named the old path

Historical docs (`docs/analysis/`, `docs/archive/`, `docs/reports/`) also reference the old path — left untouched, since they describe past incidents rather than live instructions.

No code changes.

<!-- agentmux:agent_id=posa -->