### PR TITLE
docs(cef-build): fix a patcher.py invocation that silently applies zero patches

### DIFF
--- a/docs/cef-build/build-patched-cef-windows.md
+++ b/docs/cef-build/build-patched-cef-windows.md
@@ -141,7 +141,20 @@ Set-Location "$HOME\cef-build\chromium_git\chromium\src"
 # Reset to clean state -- patcher is NOT idempotent; double-apply produces .rej files
 git reset --hard HEAD
 Get-ChildItem -Recurse -Filter "*.rej" | Remove-Item
-python3 cef\tools\patcher.py --root-dir=cef
+
+# patcher.py takes NO arguments in its normal mode — it reads
+# cef/patch/patch.cfg itself, and accepts ONLY --patch-file / --patch-dir
+# (verified against tools/patcher.py's own OptionParser). Passing --root-dir
+# makes it fail, and a wrapper script has swallowed exactly that as a
+# non-fatal WARN and continued — applying ZERO of 112 patches and nearly
+# shipping an unpatched framework. Run it from inside cef/ with no args:
+Push-Location cef
+python3 tools\patcher.py
+Pop-Location
+
+# Verify it actually did something. A CLEAN tree here means zero patches
+# applied — that is the silent-failure signature, not success.
+git status --porcelain | Select-Object -First 5
 ```
 
 If you see "class member cannot be redeclared" compile errors later, the

--- a/docs/cef-build/build-patched-libcef.md
+++ b/docs/cef-build/build-patched-libcef.md
@@ -79,8 +79,18 @@ cd ~/cef-build/chromium_git/chromium/src
 # Reset to clean state — patcher is NOT idempotent; double-apply produces .rej files
 git reset --hard HEAD
 find . -name '*.rej' -delete
-# Now apply
-python3 cef/tools/patcher.py --root-dir=cef
+# Now apply.
+# patcher.py takes NO arguments in its normal mode — it reads
+# cef/patch/patch.cfg itself, and accepts ONLY --patch-file / --patch-dir
+# (verified against tools/patcher.py's own OptionParser). Passing --root-dir
+# makes it fail, and a wrapper script swallowed exactly that as a non-fatal
+# WARN and continued with ZERO of 112 patches applied, nearly shipping an
+# unpatched macOS framework. Run from inside cef/ with no args:
+( cd cef && python3 tools/patcher.py )
+
+# Verify it actually did something. A CLEAN tree here means zero patches
+# applied — that is the silent-failure signature, not success.
+git status --porcelain | head -5
 ```
 
 If you see "class member cannot be redeclared" compile errors later, the patcher likely double-applied — repeat the reset and re-run.

--- a/docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md
+++ b/docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md
@@ -4,16 +4,16 @@
 **Date:** 2026-09-08
 **Status:** active — Phase A's recon is delivered by this document and its one
 source-side fix shipped (`agentmuxai/cef` PR #7, merged 2026-09-08), **Patches #1/#2/#3 are verified against real 152
-source** (§2.4/§2.5). **Patch #4 is only PARTIALLY verified** — its Chromium-side
-file applies cleanly, but its five-commit CEF-side transparency cascade is not
-verified (§2.4 caveat, §5b). Also deferred: the macOS hermetic Xcode pin (§4), a
-Phase D build-time check. **Phase B's port is PARTIAL — 3 of 18 files** (§5b).
-Nothing is built. This is the Phase A output that
+source** (§2.4/§2.5). **Patch #4's five-commit CEF-side cascade is now ported**
+(§5b) — its Chromium-side file applies cleanly and the cascade merged cleanly
+onto 7977, but **none of it is compile-verified**. Also deferred: the macOS
+hermetic Xcode pin (§4), a Phase D build-time check. **Phase B's port is
+COMPLETE — 18 of 18 files** (§5b). Nothing is built. This is the Phase A output that
 `docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md` §4 gates on.
 **Verdict:** **Go** on §3's "straight to 152" decision — the *milestone target*
 is sound: nothing found makes 152 harder, and 16 of the 18 fork-modified CEF
 files are byte-identical upstream. **This is not a statement that the port is
-done or fully verified** — patch #4 is partially verified and Phase B is 3/18
+compile-verified** — Phase B is 18/18 ported (§5b), but nothing has been built
 (§2.4, §5b). Also corrects two errors in the spec's patch inventory, and records
 one shipped-binary gap (§5).
 
@@ -27,7 +27,7 @@ one shipped-binary gap (§5).
 | Does `cef-rs`/`cef-dll-sys` have a 152-compatible crate? | **Yes** — `cef 152.0.0+152.0.5`, published 2026-09-07. |
 | Is `begin_window_drag` in its generated bindings? | **No** — same as 148, so the binding fork is still required. |
 | Have the build toolchain requirements moved? | **Windows: no. Linux: no.** macOS: unconfirmed, see §4. |
-| Go / no-go on targeting 152 directly? | **Go on the target**, not on readiness. #1/#2/#3 verified vs real 152 source; **#4 only partially** (§2.4). 16 of 18 CEF files are byte-identical upstream so most of the port is free, but **Phase B is 3/18** and 2 files genuinely drifted. macOS Xcode pin deferred to Phase D. |
+| Go / no-go on targeting 152 directly? | **Go.** #1/#2/#3 verified vs real 152 source; #4's Chromium-side file verified and its CEF-side cascade ported (§5b). 16 of 18 CEF files byte-identical upstream; the 2 drifted merged cleanly. **Phase B 18/18 ported, nothing built.** macOS Xcode pin deferred to Phase D. |
 
 **A separate finding, not about 152:** patch #1 (the macOS -67030 renderer
 crash fix) was never registered in `patch/patch.cfg`, so no build on any
@@ -135,8 +135,8 @@ contains no `BeginWindowDrag` reference on either side and is **not** part of it
 > **Caveat on patch #4 (Codex, PR #3095).** The row above covers only patch #4's
 > single *Chromium-side* file. Patch #4's transparency cascade is five coupled
 > **CEF-side** commits as well; those are part of the 18-file surface in §5b and
-> are **not** all verified. Treat #1/#2/#3 as verified and #4 as partially
-> verified.
+> are ported (§5b) but **not compile-verified**. Treat #1/#2/#3 as
+> apply-verified and #4's cascade as ported-only.
 
 **Consequence: most of the patch surface costs little to move to 152** — 16 of
 18 fork-modified CEF files are byte-identical upstream, so they copy rather than
@@ -276,7 +276,7 @@ Recorded so the next person doesn't repeat it.
 
 ---
 
-## 5b. Phase B — patch port to 7977 (⚠️ PARTIAL — scope correction)
+## 5b. Phase B — patch port to 7977 (COMPLETE, 18/18 — not built)
 
 > **Scope correction (2026-09-08, Codex review on PR #3095).** An earlier
 > revision said "all four patches are ported" and §2.4 said all four were
@@ -325,10 +325,10 @@ registered on the 152 branch. This is the same divergence noted in §5.1: the
 build branch and the integration branch are 4 ahead / 2 behind each other, and
 they do not contain the same patch set.
 
-**Still unbuilt, and incomplete.** Phase B is source-only; nothing is compiled
-or tested, and `agentmuxai/cef` has no CI. 15 of 18 files remain unported
-(13 mechanical + 2 needing real merge work), so **Phase B is not ready for
-Phase D.**
+**Complete, but still unbuilt.** All 18 files are ported. Phase B is
+source-only; nothing is compiled or tested, and `agentmuxai/cef` has no CI —
+so "ported" here means "merges cleanly and is registered", **not** "known to
+compile". Phase D is the first thing that will actually exercise it.
 
 ---
 
@@ -347,12 +347,11 @@ real porting cost.
 
 **Two conditions on that "go":**
 
-1. **Patch applicability — PARTIALLY closed.** #1/#2/#3 are verified against
-   real 152 source (§2.4, §2.5). **#4 is not**: only its Chromium-side file was
-   test-applied; its five-commit CEF-side cascade is unverified (§5b). The
-   drift measurement (16 of 18 files byte-identical upstream) means the
-   remaining work is *probably* small, but "probably small" is not "verified" —
-   finish this with a checkout before Phase D.
+1. **Patch applicability — CLOSED.** #1/#2/#3 verified against real 152 source
+   (§2.4, §2.5); #4's Chromium-side file likewise, and its CEF-side cascade is
+   now ported via clean 3-way merge (§5b). All 18 files are on the 152
+   branches. **The remaining unknown is compilation** — none of this has been
+   built, which Phase D resolves.
 2. **§4's macOS toolchain row is unconfirmed**, not confirmed-fine. Establish
    the hermetic Xcode requirement on the actual machine before committing to a
    macOS Phase D slot.

--- a/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
+++ b/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
@@ -9,9 +9,10 @@ against real CEF/Chromium 152 source, and of the 18 fork-modified CEF files,
 **16 are byte-identical upstream 7778↔7977** (mechanical copy) with only **2
 genuinely drifted** (`include/internal/cef_types.h`,
 `libcef/renderer/render_manager.cc`). Open: the macOS hermetic Xcode pin
-(Phase D build-time check), and **patch #4 is only partially verified** — it is
-five coupled CEF-side commits, not just the one Chromium-side file that was
-test-applied (Codex, PR #3095). **Phase B's port is COMPLETE — all 18 of 18
+(Phase D build-time check). **Patch #4's five coupled CEF-side commits are now
+ported** (Codex correctly flagged on #3095 that test-applying only its one
+Chromium-side file didn't verify it) — ported via clean 3-way merge, but **not
+compile-verified**. **Phase B's port is COMPLETE — all 18 of 18
 files**, done as real per-file 3-way merges (base=upstream 7778, ours=fork,
 theirs=upstream 7977); all merged clean, zero conflicts. Both files that had
 drifted merged cleanly because our changes and upstream's sit in different
@@ -118,7 +119,8 @@ Output: `docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md`.
 **Verdict: go on the 152 target** — nothing found makes it harder, and 16 of the
 18 fork-modified CEF files are byte-identical upstream. **Not a readiness
 statement:** patches #1/#2/#3 are verified against real 152 source, **#4 only
-partially** (its CEF-side cascade is unverified), and Phase B is 3/18 files. The
+#4's Chromium-side file verified and its CEF-side cascade ported but not
+compile-verified. Phase B is **18/18 files ported**. The
 macOS hermetic Xcode pin also remains unconfirmed — a Phase D build-time check.
 See the report's §2.4/§2.5/§5b.
 Answers to the three tasks below:
@@ -126,20 +128,23 @@ Answers to the three tasks below:
 still not upstream at 152, so nothing was deleted. **Patches #1/#2/#3 are
 verified against real 152 source** (#1/#3 by real `git apply -p0`; #2's three
 target files `cmp`-identical between 7778 and 7977). **Patch #4 is only
-partially verified** — its Chromium-side file applies, its CEF-side cascade does
-not — report §2.4/§2.5/§5b. (2) **yes**,
+ported in full** — its Chromium-side file applies cleanly and its CEF-side
+cascade merged cleanly onto 7977, though the cascade is not compile-verified —
+report §2.4/§2.5/§5b. (2) **yes**,
 `cef 152.0.0+152.0.5` is published; `begin_window_drag` is **not** in it, so
 the binding fork is still needed. (3) Windows and Linux toolchain pins are
 **unchanged** between the two Chromium tags; macOS's Xcode pin is
 **unconfirmed** — verify at Phase D build time.
 
-**Phase B's port is PARTIAL** — see the report's §5b. 3 of 18 fork-modified CEF
+**Phase B's port is COMPLETE** — see the report's §5b. 18 of 18 fork-modified CEF
 files are on the 152 branches, with `patch.cfg` registrations for the
 `.patch`-file patches. Patch #2 needed no forward-porting (upstream never
 touched its three files in four milestones), and 16 of the 18 files are likewise
-byte-identical so they copy rather than port — but **2 drifted files need real
-merge + compile work**, and patch #4's five-commit CEF-side cascade is not fully
-ported or verified. A registration gap on `7778` (patch #4 registered only on
+byte-identical so they copied rather than ported. The **2 genuinely drifted
+files** (`include/internal/cef_types.h`, `libcef/renderer/render_manager.cc`)
+merged cleanly via 3-way merge — our changes and upstream's sit in different
+regions — and patch #4's five-commit CEF-side cascade is ported with them.
+**None of it is compile-verified.** A registration gap on `7778` (patch #4 registered only on
 the build branch, not the integration branch) was found and not carried forward.
 **Nothing is built — Phase D is the gate, and Phase B must finish first.**
 

--- a/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
+++ b/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
@@ -11,11 +11,13 @@ genuinely drifted** (`include/internal/cef_types.h`,
 `libcef/renderer/render_manager.cc`). Open: the macOS hermetic Xcode pin
 (Phase D build-time check), and **patch #4 is only partially verified** — it is
 five coupled CEF-side commits, not just the one Chromium-side file that was
-test-applied (Codex, PR #3095). **Phase B's port is PARTIAL — 3 of 18 files
-done, NOT ready for Phase D.** Branches `7977`,
-`agentmux/7977-process-requirement`, `agentmux/7977-drag-rightclick-and-transparency`
-exist. **Phases C–G not started; nothing is built or tested — `agentmuxai/cef`
-has no CI.** The
+test-applied (Codex, PR #3095). **Phase B's port is COMPLETE — all 18 of 18
+files**, done as real per-file 3-way merges (base=upstream 7778, ours=fork,
+theirs=upstream 7977); all merged clean, zero conflicts. Both files that had
+drifted merged cleanly because our changes and upstream's sit in different
+regions. Branches `7977`, `agentmux/7977-process-requirement`,
+`agentmux/7977-drag-rightclick-and-transparency`. **Phases C–G not started;
+nothing is built or tested — `agentmuxai/cef` has no CI.** The
 recon **corrects two errors in §2's patch table** (marked inline below), makes
 §4's Phase E work different from what's written there (see the callout in that
 section — the un-pinned-CEF finding it describes was closed by #3086/#3085/#3089),
@@ -88,10 +90,11 @@ Plus **build flags, not patches** — version-controlled in *this* repo, not the
 > copy rather than a forward-port. Done — see the report's §5b.
 > Patch #3 **has since been test-applied** against real Chromium 152 source and
 > applies cleanly, and patch #2's three target files are `cmp`-identical between
-> 7778 and 7977. **Patch #4 is only partially verified** — its Chromium-side
-> file applies cleanly, but its five-commit CEF-side transparency cascade
-> (`SPEC_CEF_148_LINUX_FORWARD_PORT_2026_06_04.md` §3) is not verified. See the
-> report's §2.4/§2.5/§5b.
+> 7778 and 7977. **Patch #4's CEF-side cascade is now ported** (it was the
+> gap behind the earlier "partially verified" note): the five coupled commits
+> live across `libcef/`, including `render_manager.cc`'s renderer half, and all
+> merged cleanly onto 7977. Ported ≠ built: still unverified by compilation.
+> See the report's §2.4/§2.5/§5b.
 
 ---
 


### PR DESCRIPTION
## The bug

Both CEF build docs instruct:

```
python3 cef/tools/patcher.py --root-dir=cef
```

**`patcher.py` has no `--root-dir` flag.** Verified against `tools/patcher.py`'s own `OptionParser` in a real 7977 checkout — it accepts exactly `--patch-file` and `--patch-dir`, and in normal mode takes **no arguments** (it reads `cef/patch/patch.cfg` itself).

## Why this matters more than a typo

`STATUS_CEF_PROPRIETARY_CODECS_MACOS_2026_07_27.md` records `rebuild-mac-cef.sh` making this exact call, the failure being **swallowed as a non-fatal `WARN:`**, and the script continuing with **zero of 112 patches applied**. It was caught only because someone manually noticed `chromium/src` was a clean tree before starting the long build. Had it not been, that would have been an unpatched framework shipped as patched.

The Windows doc was already self-contradictory: its gotchas section (line 33) says the flag doesn't exist, while line 144 still told you to use it.

## Fix

Both docs now run it from inside `cef/` with no arguments, and follow with:

```
git status --porcelain | head -5
```

because **a clean tree at that point is the silent-failure signature, not success.** That check is the thing that catches this class of failure before six hours of build time.

## What I deliberately did NOT change

Three other `--root-dir` occurrences invoke **`translator.py`**, which *does* accept `--root-dir` — also verified against its `OptionParser`. Blanket-replacing every `--root-dir` in these docs would have broken working commands. Only the two `patcher.py` calls were wrong.

## Also in here

Spec status update: **Phase B's port is complete — 18 of 18 files**, done as real per-file 3-way merges (base = upstream 7778, ours = fork, theirs = upstream 7977), all clean with zero conflicts. Both previously-drifted files merged cleanly because our changes and upstream's occupy different regions.

That also closes patch #4's "partially verified" note — its five-commit CEF-side transparency cascade is ported, including `render_manager.cc`'s renderer half. **Ported is not built:** nothing here is compiled, and `agentmuxai/cef` still has no CI.

Context: tracking issue #3108. A Windows 152 build is running on claudius now, which is what surfaced the doc bug.

<!-- agentmux:agent_id=agent5 -->