### PR TITLE
Camper@narko: docs: rename claudius -> narko in live and example references

### DIFF
--- a/.changesets/1788933817-docs-rename-claudius-narko-in-live-references-sud7.md
+++ b/.changesets/1788933817-docs-rename-claudius-narko-in-live-references-sud7.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs: rename claudius -> narko in live references

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -428,7 +428,7 @@ EOF
 
 # Shared identity ONLY — gh-agent.sh fell back to GenericAgentX-<host> (see
 # "Which GitHub account am I acting as?" below): ALSO prepend the PR TITLE
-# with "<AgentName>@<host>: " (natural casing, e.g. "Korp@claudius:") — the
+# with "<AgentName>@<host>: " (natural casing, e.g. "Korp@narko:") — the
 # body tag above is machine-read only, so a human scanning the PR list still
 # can't tell shared-identity agents apart without opening each PR. See
 # SPEC_PR_TITLE_AGENT_HOST_PREFIX_2026_08_22.md. Do NOT use this form if you

--- a/agentmux-srv/src/backend/lan_discovery.rs
+++ b/agentmux-srv/src/backend/lan_discovery.rs
@@ -324,7 +324,7 @@ impl LanDiscovery {
 
         // Register this instance. mdns-sd requires the host name passed to
         // `ServiceInfo::new` to end with `.local.` — we always normalize so
-        // a raw OS hostname like "claudius" becomes "claudius.local.".
+        // a raw OS hostname like "narko" becomes "narko.local.".
         // Unique per INSTANCE and dot-free — see `mdns_instance_label`. The
         // version still travels in the TXT record (`instance_id` below), which
         // is where peers actually read it from; it just must not be the
@@ -1267,29 +1267,29 @@ mod tests {
 
     #[test]
     fn appends_local_dot_to_bare_hostname() {
-        assert_eq!(mdns_hostname("claudius"), "claudius.local.");
+        assert_eq!(mdns_hostname("narko"), "narko.local.");
     }
 
     #[test]
     fn preserves_already_fully_qualified_name() {
-        assert_eq!(mdns_hostname("claudius.local."), "claudius.local.");
+        assert_eq!(mdns_hostname("narko.local."), "narko.local.");
     }
 
     #[test]
     fn appends_trailing_dot_to_local_suffix() {
         // mdns-sd needs the trailing dot; we add it without doubling .local.
-        assert_eq!(mdns_hostname("claudius.local"), "claudius.local.");
+        assert_eq!(mdns_hostname("narko.local"), "narko.local.");
     }
 
     #[test]
     fn handles_trailing_dot_on_bare_hostname() {
-        assert_eq!(mdns_hostname("claudius."), "claudius.local.");
+        assert_eq!(mdns_hostname("narko."), "narko.local.");
     }
 
     #[test]
     fn does_not_double_suffix() {
         // Two passes through the normalizer produce the same result.
-        let once = mdns_hostname("claudius");
+        let once = mdns_hostname("narko");
         let twice = mdns_hostname(&once);
         assert_eq!(twice, once);
     }
@@ -1663,17 +1663,17 @@ mod handle_event_tests {
 
         // Same host, two instances -> different labels (differing ports).
         assert_ne!(
-            super::mdns_instance_label("claudius", 59859),
-            super::mdns_instance_label("claudius", 60237),
+            super::mdns_instance_label("narko", 59859),
+            super::mdns_instance_label("narko", 60237),
         );
         // Two hosts on the SAME version -> different labels. This is the
         // property the old version-derived name did not have.
         assert_ne!(
-            super::mdns_instance_label("claudius", 59859),
+            super::mdns_instance_label("narko", 59859),
             super::mdns_instance_label("gamerlove", 59859),
         );
         // No version anywhere in it, deliberately.
-        assert!(!super::mdns_instance_label("claudius", 59859).contains("0.55"));
+        assert!(!super::mdns_instance_label("narko", 59859).contains("0.55"));
     }
 
     #[test]

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -97,7 +97,7 @@ pub struct AppState {
     /// See `docs/retro/RETRO_DEV_BUILD_SHARED_AGENT_SESSION_COLLISION_2026_07_29.md`.
     pub boot_id: Arc<str>,
     pub version: String,
-    /// OS hostname of the machine this instance runs on (e.g. "claudius").
+    /// OS hostname of the machine this instance runs on (e.g. "narko").
     /// Already computed at boot for LAN discovery's mDNS TXT records; kept
     /// here so `/agentmux/discovery` can name its own host too — `local_url`
     /// is always loopback, so without this a client has no way to say which


### PR DESCRIPTION
## Summary

The dev machine was renamed **`claudius` → `narko`** on 2026-09-08 (to stop it colliding with "Claude" in conversation). This updates the references where a stale hostname actually misleads, and deliberately leaves the ones where it doesn't.

## Updated (4 sites)

| Where | Why |
|---|---|
| `CLAUDE.md` — the PR-title example `"Korp@claudius:"` | **Instructional.** It tells agents what to write *today*, so it has to name the machine that exists. |
| `agentmux-srv/src/server/mod.rs:100` | Doc-comment example of an OS hostname |
| `agentmux-srv/src/backend/lan_discovery.rs:327` | Same — doc-comment example in the mDNS helper |
| `lan_discovery.rs` test fixtures (12) | `"claudius"` was an arbitrary example hostname string in `mdns_hostname`/`mdns_instance_label` assertions. **All 39 `lan_discovery` tests pass** after the rename. |

## Deliberately NOT updated (16 references)

Every remaining hit is a **dated record of what was true when written**:

- `docs/retro/retro-commit-restart-reclaim-2026-07-16.md` — a machine-specs note for a July experiment
- `docs/retro/retro-shared-git-identity-committer-misattribution-2026-08-22.md` — quotes real commit authorship
- `docs/reports/REPORT_OUT_OF_WORKSPACE_CLONE_AUDIT_2026_09_05.md`, `REPORT_ZOOM_BINDINGS_AUDIT_2026_09_06.md` — `Author: Loap #2 @ claudius`
- `SPEC_ACCOUNT_ADOPTION_PIGGYBACK_LOGIN_2026_08_09.md`, `SPEC_AGENT_BUSY_ANTS_REFINEMENT_2026_06_22.md`, `SPEC_PERSISTENT_SPAWN_GENERATION_...` — dated repros and verifications
- `SPEC_PR_TITLE_AGENT_HOST_PREFIX_2026_08_22.md` — **quotes real merged PR titles** that still read `Korp@claudius:` in git history
- `claude-translator.ts` / `.test.ts` — `repro: claudius v0.54.14 Agent1, 2026-08-09`

Rewriting these would falsify the record rather than update it — and in the PR-title spec's case would make the doc disagree with the git history it's citing.

## Related

The rename is recorded in `a5af/shared-infrastructure`'s `SPEC_MULTI_HOST_LAN_ACCESS_2026_09_08.md` (separate PR), which documents *live* infrastructure — which host reaches which, over what account — so all 46 of its references were updated, with a note explaining why external ones were left alone. Same IP (192.168.1.230), same accounts, same keys; only the name changed.

<!-- agentmux:agent_id=camper -->