### PR TITLE
fix(cef): linux userns-sandbox probe false-positives on AppArmor hosts

### DIFF
--- a/.changesets/1788960467-fix-cef-linux-userns-sandbox-probe-false-positives-on-apparm-o68w.md
+++ b/.changesets/1788960467-fix-cef-linux-userns-sandbox-probe-false-positives-on-apparm-o68w.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): linux userns-sandbox probe false-positives on AppArmor hosts

--- a/agentmux-cef/src/linux_sandbox.rs
+++ b/agentmux-cef/src/linux_sandbox.rs
@@ -138,6 +138,17 @@ mod imp {
     /// — it never spawns the async runtime, CEF, or any additional thread;
     /// this function is the entire lifetime of the process.
     pub fn run_internal_userns_probe_and_exit() -> ! {
+        // Must be read BEFORE unshare(): once inside the new namespace,
+        // getuid() returns the overflow UID (65534, "nobody") until
+        // uid_map is written — the new namespace's mapping starts empty,
+        // so the kernel has no UID to report yet (user_namespaces(7)).
+        // An unprivileged process may only map its own real (parent-ns)
+        // UID into uid_map; writing the overflow UID instead would always
+        // be rejected, permanently flipping this probe from "always false
+        // positive" to "always false negative" — even after the AppArmor
+        // fix is installed, every launch would loop back to the recovery
+        // dialog (codex P1 on this same PR).
+        let real_uid = unsafe { libc::getuid() };
         // SAFETY: unshare() takes a single integer flag argument and
         // touches no Rust-managed memory; this process has no other
         // threads (see doc comment) so there is no concurrent state for
@@ -164,7 +175,7 @@ mod imp {
         // user_namespaces(7) it additionally requires
         // /proc/self/setgroups=deny first, but uid_map alone already
         // proves whether CAP_SYS_ADMIN is available in the new ns.
-        let mapping = format!("0 {} 1\n", unsafe { libc::getuid() });
+        let mapping = format!("0 {} 1\n", real_uid);
         let ok = std::fs::write("/proc/self/uid_map", mapping).is_ok();
         std::process::exit(if ok { 0 } else { 1 });
     }

--- a/agentmux-cef/src/linux_sandbox.rs
+++ b/agentmux-cef/src/linux_sandbox.rs
@@ -122,9 +122,15 @@ mod imp {
     use super::*;
     use std::process::Command;
 
-    /// Run the actual `unshare(CLONE_NEWUSER)` syscall and exit — called
-    /// from the very top of `lib.rs::run()`, before any other startup work,
-    /// when this process was re-exec'd with `INTERNAL_PROBE_USERNS_FLAG`.
+    /// Run `unshare(CLONE_NEWUSER)` followed by a `uid_map` write, and
+    /// exit reflecting whether both succeeded — called from the very top
+    /// of `lib.rs::run()`, before any other startup work, when this
+    /// process was re-exec'd with `INTERNAL_PROBE_USERNS_FLAG`. The
+    /// `uid_map` write is load-bearing, not defensive: `unshare()` alone
+    /// always succeeds under Ubuntu's AppArmor userns restriction, which
+    /// instead denies CAP_SYS_ADMIN inside the new namespace — the
+    /// capability `uid_map` (and CEF's own sandbox setup) actually needs.
+    /// See the exit-code comment below for the audit-log evidence.
     ///
     /// Safe to call `libc::unshare()` directly in-process here (unlike the
     /// general fork()-in-a-multithreaded-process hazard noted elsewhere in
@@ -137,7 +143,30 @@ mod imp {
         // threads (see doc comment) so there is no concurrent state for
         // the namespace change to race with.
         let rc = unsafe { libc::unshare(libc::CLONE_NEWUSER) };
-        std::process::exit(if rc == 0 { 0 } else { 1 });
+        if rc != 0 {
+            std::process::exit(1);
+        }
+        // A bare unshare(CLONE_NEWUSER) succeeds unconditionally under
+        // Ubuntu's AppArmor userns restriction — confirmed via the audit
+        // log: `apparmor="AUDIT" operation="userns_create" ...
+        // profile="unconfined"` (not a denial). The restriction instead
+        // transitions the process into a synthetic `unprivileged_userns`
+        // profile *inside* the new namespace that denies CAP_SYS_ADMIN
+        // (`apparmor="DENIED" ... capability=21 capname="sys_admin"`),
+        // which is what writing uid_map/gid_map — and CEF's own
+        // subsequent mount/pivot_root calls — needs. Stopping at
+        // unshare() alone is a false positive: it reports "available"
+        // even when policy blocks the sandbox, so the recovery dialog
+        // never fires and CEF's real sandbox init hits Chromium's hard
+        // FATAL check instead (zygote_host_impl_linux.cc "No usable
+        // sandbox!"). Writing uid_map exercises the exact capability the
+        // policy actually gates. gid_map is left untouched: per
+        // user_namespaces(7) it additionally requires
+        // /proc/self/setgroups=deny first, but uid_map alone already
+        // proves whether CAP_SYS_ADMIN is available in the new ns.
+        let mapping = format!("0 {} 1\n", unsafe { libc::getuid() });
+        let ok = std::fs::write("/proc/self/uid_map", mapping).is_ok();
+        std::process::exit(if ok { 0 } else { 1 });
     }
 
     /// Deterministically test whether unprivileged user-namespace creation

--- a/docs/incident/INCIDENT_2026_09_09_LINUX_SANDBOX_PROBE_FALSE_POSITIVE.md
+++ b/docs/incident/INCIDENT_2026_09_09_LINUX_SANDBOX_PROBE_FALSE_POSITIVE.md
@@ -1,5 +1,6 @@
 # Incident: Linux userns-sandbox probe reports "available" when AppArmor blocks it
 
+**Status:** implemented — fix in PR #3117 (`run_internal_userns_probe_and_exit`, `agentmux-cef/src/linux_sandbox.rs`). Not yet verified end-to-end on the affected VM (blocked on a CI-built artifact).
 **Date:** 2026-09-09
 **Component:** `agentmux-cef/src/linux_sandbox.rs` (landed via PR #2783, 2026-08-24)
 **Symptom:** On an AppArmor-restricted Ubuntu host with no `agentmux-userns` profile

--- a/docs/incident/INCIDENT_2026_09_09_LINUX_SANDBOX_PROBE_FALSE_POSITIVE.md
+++ b/docs/incident/INCIDENT_2026_09_09_LINUX_SANDBOX_PROBE_FALSE_POSITIVE.md
@@ -1,0 +1,81 @@
+# Incident: Linux userns-sandbox probe reports "available" when AppArmor blocks it
+
+**Date:** 2026-09-09
+**Component:** `agentmux-cef/src/linux_sandbox.rs` (landed via PR #2783, 2026-08-24)
+**Symptom:** On an AppArmor-restricted Ubuntu host with no `agentmux-userns` profile
+installed yet, launching AgentMux never shows the "sandbox blocked by system policy"
+recovery dialog. Instead the CEF host process crash-loops every ~1.2s, each attempt
+killed by Chromium's own hard check:
+
+```
+[pid:pid:...] FATAL:content/browser/zygote_host/zygote_host_impl_linux.cc:128]
+No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro
+that has disabled unprivileged user namespaces with AppArmor, ...
+```
+
+## Root cause
+
+`probe_userns_available()` re-execs the current binary with
+`--internal-probe-userns`, which calls `run_internal_userns_probe_and_exit()`. That
+function used to do exactly one thing: call `unshare(CLONE_NEWUSER)` and exit 0 if
+the syscall returned 0.
+
+That syscall **always returns 0** under Ubuntu's `apparmor_restrict_unprivileged_userns`
+policy, even when the sandbox will not actually work. Confirmed directly on the
+affected VM via `auditd`:
+
+```
+apparmor="AUDIT" operation="userns_create" class="namespace" \
+  info="Userns create - transitioning profile" profile="unconfined" \
+  comm="agentmux-cef" requested="userns_create" target="unprivileged_userns"
+
+apparmor="DENIED" operation="capable" class="cap" \
+  profile="unprivileged_userns" comm="agentmux-cef" \
+  capability=21 capname="sys_admin"
+```
+
+`unshare(CLONE_NEWUSER)` itself is never denied — the process is transitioned into a
+synthetic, restrictive `unprivileged_userns` AppArmor profile *inside* the new
+namespace, and *that* profile denies `CAP_SYS_ADMIN`. Writing `uid_map`/`gid_map`
+(and CEF's subsequent mount/pivot_root calls for its own sandbox) require
+`CAP_SYS_ADMIN` inside the new namespace — exactly the operation the probe never
+attempted. Reproduced directly:
+
+```
+$ unshare --user --map-root-user echo ok
+unshare: write failed /proc/self/uid_map: Operation not permitted
+
+$ python3 -c 'import ctypes,os; libc=ctypes.CDLL(None,use_errno=True); \
+    print(libc.unshare(0x10000000)); open("/proc/self/uid_map","w").write(f"0 {os.getuid()} 1")'
+0
+# uid_map write raises PermissionError
+```
+
+So the probe reported "available" (false positive) on every launch, the `while
+!probe_userns_available()` loop in `lib.rs::run()` never entered its body, no dialog
+ever appeared, and CEF proceeded straight into its real (blocked) sandbox init.
+
+Confirmed this wasn't a build/wiring issue first: the `sandbox` feature is on by
+default and stays on with `cargo build --features patched-libcef` (features are
+additive, not replacing); `strings` on the shipped binary shows both the pure
+profile-text constants and the feature-gated dialog strings ("sandbox fix
+installed", "no dialog tool"); `AGENTMUX_UNSAFE_NOSANDBOX` is unset in the real
+launch environment; the launcher forwards no `--type=`-prefixed argument to the
+top-level host spawn (`agentmux-launcher/src/host_spawn.rs::spawn_host_unix` only
+forwards the launcher's own argv, which is empty on a normal desktop launch) so
+`is_subprocess` is correctly `false` for the browser process.
+
+## Fix
+
+`run_internal_userns_probe_and_exit()` now writes `uid_map` after a successful
+`unshare(CLONE_NEWUSER)`, and only exits 0 if that write also succeeds — testing the
+capability AppArmor's policy actually gates, not just namespace creation. This
+correctly flips `probe_userns_available()` to `false` on affected hosts, which
+routes through the existing (already-implemented, already-tested) dialog → pkexec
+one-time-fix → relaunch flow instead of falling through to Chromium's crash.
+
+No change to the AppArmor profile itself (`build_apparmor_profile()`) — granting
+`userns,` to the confined binary makes it keep its normal (unconfined) capability
+set inside the new namespace instead of being downgraded to the restrictive
+synthetic profile, which is the correct fix and was already implemented correctly.
+Only the *detection* was wrong.


### PR DESCRIPTION
## Summary
- `probe_userns_available()` reports "sandbox available" on Ubuntu hosts with the AppArmor unprivileged-userns restriction, because `unshare(CLONE_NEWUSER)` alone always succeeds under that policy -- the restriction denies `CAP_SYS_ADMIN` inside the new namespace instead, confirmed via `auditd` on the affected VM.
- Result: the existing sandbox-recovery dialog (PR #2783) never fires; CEF falls through into its real (blocked) sandbox init and crash-loops on Chromium's own `FATAL: No usable sandbox!` check.
- Fix: the probe now also writes `uid_map` after `unshare()` and only reports success if that succeeds too -- the actual capability AppArmor's policy gates, and the one CEF's own sandbox setup needs.
- Root-caused and verified live on an Ubuntu 24.04 VM (kernel restriction on, no AppArmor profile installed yet) via `auditd` audit records and a standalone reproduction (`unshare --user --map-root-user` fails on the `uid_map` write; the shipped binary's own `--internal-probe-userns` mode returned success despite that). See `docs/incident/INCIDENT_2026_09_09_LINUX_SANDBOX_PROBE_FALSE_POSITIVE.md` for full evidence.
- No change to the AppArmor profile text or the dialog/pkexec fix flow -- both were already correct; only detection was wrong.

## Test plan
- [ ] CI build (Linux)
- [ ] Deploy resulting AppImage to the affected VM and confirm the recovery dialog now fires on first launch, and that accepting "Fix it now" installs the profile and the app launches sandboxed afterward