### PR TITLE
fix(cef): macOS nightly build broken since #3030 — unqualified Arc<AppState>

### DIFF
--- a/.changesets/1788960406-fix-cef-macos-build-broken-native-window-visible-referenced--7okv.md
+++ b/.changesets/1788960406-fix-cef-macos-build-broken-native-window-visible-referenced--7okv.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): macOS build broken — native_window_visible referenced Arc<AppState> without an import on macOS

--- a/agentmux-cef/src/client/navigation.rs
+++ b/agentmux-cef/src/client/navigation.rs
@@ -413,8 +413,18 @@ fn takes_pane_path(kind: Option<&crate::state::BrowserKind>, client_is_browser_p
 /// Native-layer visibility for a label's bound HWND. `None` when no HWND is
 /// bound (or off Windows) — callers must treat that as "no extra information",
 /// not as hidden.
+///
+/// Fully-qualified `std::sync::Arc<crate::state::AppState>` rather than the
+/// bare `Arc<AppState>` the Windows arm could get away with — same reason as
+/// `reveal_top_level_window` just below: the top-of-file `use` for both
+/// names is gated `#[cfg(any(target_os = "linux", target_os = "windows"))]`,
+/// so a bare reference resolves on Linux (this arm compiles there too) but
+/// not on macOS. The nightly macOS build is the only CI leg that builds
+/// `agentmux-cef` for macOS at all — `ci-pr.yml`'s matrix is
+/// `[windows-latest, ubuntu-latest]` — so this broke silently on `main` for
+/// two nights running before anyone saw a macOS compile.
 #[cfg(target_os = "windows")]
-fn native_window_visible(state: &Arc<AppState>, label: Option<&str>) -> Option<bool> {
+fn native_window_visible(state: &std::sync::Arc<crate::state::AppState>, label: Option<&str>) -> Option<bool> {
     let label = label?;
     let hwnd = *state.window_hwnds.lock().get(label)?;
     // SAFETY: IsWindowVisible tolerates stale/invalid handles (returns FALSE).
@@ -427,7 +437,7 @@ fn native_window_visible(state: &Arc<AppState>, label: Option<&str>) -> Option<b
 }
 
 #[cfg(not(target_os = "windows"))]
-fn native_window_visible(_state: &Arc<AppState>, _label: Option<&str>) -> Option<bool> {
+fn native_window_visible(_state: &std::sync::Arc<crate::state::AppState>, _label: Option<&str>) -> Option<bool> {
     None
 }
 


### PR DESCRIPTION
Both `nightly-artifacts` macOS jobs failed for **two nights running** (9/8, 9/9); `ci-nightly-build.yml` stayed green throughout, which is why it looked clean at a glance — the failing workflow is `ci-nightly-artifacts.yml`.

```
error[E0425]: cannot find type `Arc` in this scope
  --> agentmux-cef/src/client/navigation.rs:430:35
error[E0425]: cannot find type `AppState` in this scope
  --> agentmux-cef/src/client/navigation.rs:430:39
```

## Root cause

#3030 added

```rust
#[cfg(target_os = "windows")]
fn native_window_visible(state: &Arc<AppState>, ...) -> Option<bool> { ... }

#[cfg(not(target_os = "windows"))]
fn native_window_visible(_state: &Arc<AppState>, ...) -> Option<bool> { None }
```

but this file's `Arc`/`AppState` imports (from #2968) are gated

```rust
#[cfg(any(target_os = "linux", target_os = "windows"))]
use std::sync::Arc;
#[cfg(any(target_os = "linux", target_os = "windows"))]
use crate::state::AppState;
```

— three platforms, but the new function is split two-way (windows / not-windows). The `not(windows)` arm compiles on Linux, where the import is present, and fails only on macOS, where it isn't.

**No CI leg could have caught this before nightly**: `ci-pr.yml`'s matrix is `[windows-latest, ubuntu-latest]`, so `agentmux-cef` is never built for macOS on a PR. The nightly macOS job is the only thing that ever compiles this crate for that target, and it did exactly its job — twice — with nobody looking at the nightly-artifacts result in between.

## Fix

Fully-qualified `std::sync::Arc<crate::state::AppState>` in both arms, rather than a bare `Arc<AppState>`. This isn't a new pattern — the very next function in the same file, `reveal_top_level_window`, already does exactly this for the identical reason (its own doc comment explains it). Pure type-path change; no logic touched, both call sites unaffected.

## Verification

- `cargo check -p agentmux-cef` on this Mac: was 2 errors, now clean.
- `cargo test -p agentmux-cef`: 375 passed.
- Diff is two lines plus a comment — reviewed by inspection that it changes nothing at runtime on any platform.

<!-- agentmux:agent_id=agento -->