### PR TITLE
fix(build): fail bundle:* loudly on stub ANGLE GL libraries

### DIFF
--- a/.changesets/1788960693-fix-build-fail-bundle-loudly-on-stub-angle-gl-libraries-inst-noly.md
+++ b/.changesets/1788960693-fix-build-fail-bundle-loudly-on-stub-angle-gl-libraries-inst-noly.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(build): fail bundle:* loudly on stub ANGLE GL libraries instead of shipping a broken GFX-off build

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -706,6 +706,12 @@ tasks:
                 # window). Fail loudly here instead of shipping a broken build.
                 # See docs/specs/SPEC_WINDOWS_CEF_BUNDLE_VERSION_INTEGRITY_2026_06_03.md.
                 bash scripts/verify-cef-version.sh "$cefDir" || exit 1
+                # Guard: a locally-rebuilt CEF tree can silently produce stub
+                # ANGLE libraries that pass a plain existence check but crash
+                # the GPU process at init ("eglGetProcAddress not found"),
+                # leaving GFX permanently "off" with no build-time signal.
+                # See scripts/verify-angle-libs.sh.
+                bash scripts/verify-angle-libs.sh "$cefDir" libEGL.dll libGLESv2.dll || exit 1
                 # Advisory-only, same posture as bundle:darwin's unpatched-
                 # framework warning: don't fail `task dev`/`task package` on
                 # the stock cef-dll-sys fallback (that's still a legitimate,
@@ -829,6 +835,11 @@ tasks:
                     echo "❌ Framework Libraries/ directory missing: $libs_dir" >&2
                     exit 1
                 fi
+                # Guard: a locally-rebuilt CEF tree can silently produce stub
+                # ANGLE libraries that pass a plain existence check but crash
+                # the GPU process at init, leaving GFX permanently "off" with
+                # no build-time signal. See scripts/verify-angle-libs.sh.
+                bash scripts/verify-angle-libs.sh "$libs_dir" libEGL.dylib libGLESv2.dylib || exit 1
                 for lib in "$libs_dir/"*.dylib; do
                     cp -f "$lib" "dist/cef/$(basename "$lib")"
                 done
@@ -851,6 +862,11 @@ tasks:
                 # still works on the upstream cef-dll-sys fallback (no 3-hour CEF
                 # build required). The hard release gate is in build-appimage-linux.sh.
                 bash scripts/verify-cef-patch.sh "$CEF_DIR" || true
+                # Guard: a locally-rebuilt CEF tree can silently produce stub
+                # ANGLE libraries that pass a plain existence check but crash
+                # the GPU process at init, leaving GFX permanently "off" with
+                # no build-time signal. See scripts/verify-angle-libs.sh.
+                bash scripts/verify-angle-libs.sh "$CEF_DIR" libEGL.so libGLESv2.so || exit 1
                 mkdir -p dist/cef/locales
                 cp -f "$CEF_DIR/libcef.so" dist/cef/
                 cp -f "$CEF_DIR/libEGL.so" dist/cef/ 2>/dev/null || true

--- a/scripts/verify-angle-libs.sh
+++ b/scripts/verify-angle-libs.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Verify that ANGLE's EGL/GLESv2 shared libraries in a CEF runtime directory
+# are genuine builds, not empty/stub artifacts from a broken or partial
+# Chromium build.
+#
+# A real ANGLE libEGL/libGLESv2 for any recent Chromium milestone is several
+# MB and exports eglGetProcAddress / glGetString by name. An interrupted or
+# misconfigured local rebuild has been observed silently producing ~460KB
+# placeholder files that pass a plain `-f` existence check, get bundled, and
+# only fail at runtime: the GPU process dies at init with "eglGetProcAddress
+# not found", falls through the SwiftShader software path too, and Chromium
+# disables GPU entirely — the status bar's GFX indicator reads "off" instead
+# of "HW"/"SW" with no build-time signal pointing at the cause.
+#
+# Usage: verify-angle-libs.sh <dir> <egl-lib-filename> <glesv2-lib-filename>
+# Exit 0 if both libs (that exist) look like real ANGLE builds. A missing
+# file is not this script's concern — the caller already decides whether
+# absence is fatal — so a missing lib is skipped, not flagged.
+# Exit 1 on a lib that exists but looks like a stub (hard fail — do NOT ship).
+set -uo pipefail
+
+dir="${1:?usage: verify-angle-libs.sh <dir> <egl-lib-filename> <glesv2-lib-filename>}"
+egl_name="${2:?usage: verify-angle-libs.sh <dir> <egl-lib-filename> <glesv2-lib-filename>}"
+gles_name="${3:?usage: verify-angle-libs.sh <dir> <egl-lib-filename> <glesv2-lib-filename>}"
+
+# Real ANGLE shared libraries are multi-MB; the broken stubs observed so far
+# were ~460KB. 1MB leaves comfortable margin either way.
+min_bytes=1000000
+
+ok=0
+
+check_one() {
+  local path="$1" symbol="$2" size
+  [ -f "$path" ] || return 0
+
+  size=$(wc -c <"$path" 2>/dev/null | tr -d ' ')
+  if [ -z "$size" ] || [ "$size" -lt "$min_bytes" ]; then
+    echo "❌ verify-angle-libs: $path is only ${size:-0} bytes — too small to be a real ANGLE build (expect several MB)." >&2
+    return 1
+  fi
+  if ! grep -a -q "$symbol" "$path"; then
+    echo "❌ verify-angle-libs: $path does not export '$symbol' — not a genuine ANGLE build." >&2
+    return 1
+  fi
+  return 0
+}
+
+check_one "$dir/$egl_name" "eglGetProcAddress" || ok=1
+check_one "$dir/$gles_name" "glGetString" || ok=1
+
+if [ "$ok" -ne 0 ]; then
+  echo "" >&2
+  echo "⚠️  ANGLE GL libraries in '$dir' look like broken/stub build output, not a real ANGLE build." >&2
+  echo "    Shipping these produces 'GFX off' at runtime with no build-time warning: the GPU" >&2
+  echo "    process fails at init ('eglGetProcAddress not found'), the SwiftShader software" >&2
+  echo "    fallback fails too, and Chromium disables GPU entirely." >&2
+  echo "    Fix: rebuild ANGLE in the source CEF tree (a full rebuild, not an incremental one" >&2
+  echo "    that only touched a subset of targets), then re-run bundling." >&2
+  exit 1
+fi
+
+echo "✓ ANGLE GL libraries OK: $egl_name / $gles_name in '$dir' look like real builds"
+exit 0


### PR DESCRIPTION
## Summary

- `bundle:windows`/`bundle:darwin`/`bundle:linux` only checked that `libEGL`/`libGLESv2` *exist* before copying them into the shipped runtime — never that they're genuine ANGLE builds.
- A locally-rebuilt CEF tree (`~/cef-build`) can silently produce tiny placeholder libs that pass that check but crash the GPU process at init (`eglGetProcAddress not found`, `ui/gl/init/gl_initializer_win.cc:101`), fail the SwiftShader software fallback too, and leave GFX permanently **"off"** in the status bar — with zero build-time signal.
- Reproduced live: a running instance's bundled `libEGL.dll`/`libGLESv2.dll` were both exactly 470016 bytes, imported only `KERNEL32.dll`, and contained none of ANGLE's EGL/GLES export symbols (real ANGLE builds are multi-MB). Traced to the source CEF tree at `~/cef-build/.../Release_GN_x64`, where those two files were touched by a recent (incomplete?) rebuild while `libcef.dll` itself was untouched.

## Change

- Add `scripts/verify-angle-libs.sh`: checks a GL lib (when present) is >1MB and exports `eglGetProcAddress`/`glGetString`; skips silently if the file is simply absent (a separate, already-handled case). Same fail-loud posture as the existing `verify-cef-version.sh` guard.
- Wire it into all three `bundle:*` tasks, right where each resolves its CEF source directory, before the libs get copied into `dist/cef/`.

## Test plan

- [x] Ran the new script directly against the actual broken DLLs in `~/cef-build/chromium_git/chromium/src/out/Release_GN_x64` — fails loudly with the expected diagnostic (confirmed the exact real-world regression this guards against).
- [x] Ran it against a missing dir/files — passes (skip, not this script's concern).
- [x] Ran it against synthetic >1MB files with/without the expected symbol strings — passes / fails as expected.
- [x] `task --list` still parses `Taskfile.yml` cleanly after the edits.
- [ ] Not run end-to-end through a full `task bundle:windows`/`task package` (would require rebuilding `agentmux-cef` from a clean `target/release`, which wasn't necessary to validate the guard logic itself — the script is invoked with the exact same args used in the task).

<!-- agentmux:agent_id=agent3 -->