### PR TITLE
fix(srv): jekt notifications addressed to the stable AGENTMUX_AGENT_ID now resolve

### DIFF
--- a/.changesets/1788961597-fix-srv-jekt-notifications-for-a-renamed-agent-s-stable-agen-lmfg.md
+++ b/.changesets/1788961597-fix-srv-jekt-notifications-for-a-renamed-agent-s-stable-agen-lmfg.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(srv): jekt notifications for a renamed agent's stable AGENTMUX_AGENT_ID now resolve

--- a/agentmux-srv/src/backend/blockcontroller/mod.rs
+++ b/agentmux-srv/src/backend/blockcontroller/mod.rs
@@ -249,6 +249,25 @@ pub trait Controller: Send + Sync {
     /// override [`agent_id`](Controller::agent_id) either.
     fn set_agent_id(&self, _id: Option<String>) {}
 
+    /// This block's STABLE jekt identity — `AGENTMUX_AGENT_ID` as captured
+    /// once at spawn, never refreshed. Distinct from [`agent_id`](Controller::agent_id),
+    /// which tracks the LIVE, renameable display name and is deliberately
+    /// refreshed every turn (see that method's doc comment on #2697).
+    /// AGENTMUX_AGENT_ID is embedded verbatim in PR-body tags specifically
+    /// because it does NOT change if the agent is later renamed — but
+    /// `ReactiveHandler`'s registry only tracks one key per block, and
+    /// every turn's `agent_id()` refresh evicts whatever this block was
+    /// previously registered under. `ReactiveHandler::inject_message_inner`'s
+    /// recipient-identity check (#2695) uses this alongside `agent_id()` so
+    /// a jekt addressed to the stable ID is validated correctly even after
+    /// the primary registry key has moved on to the live display name. See
+    /// `INCIDENT_2026_09_09_JEKT_STABLE_ID_ALIAS.md`. Default `None`,
+    /// mirroring `agent_id`'s default — only `PersistentSubprocessController`
+    /// currently overrides this.
+    fn stable_agent_id(&self) -> Option<String> {
+        None
+    }
+
     /// Downcast support for concrete controller types.
     fn as_any(&self) -> &dyn Any;
 }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -738,6 +738,15 @@ pub struct PersistentSubprocessController {
     /// carefully-ordered spawn/resume/queue state transitions. `None` for a
     /// persistent block with no muxbus identity set (a non-agent process).
     agent_id: Mutex<Option<String>>,
+    /// The STABLE jekt identity (`AGENTMUX_AGENT_ID`), captured once in
+    /// `spawn_process` and never overwritten afterward — unlike `agent_id`
+    /// above, which `input.rs`'s Register-tail deliberately refreshes every
+    /// turn to track the live, renameable display name (#2697). Exists
+    /// specifically so `Controller::stable_agent_id()` can back the jekt
+    /// registry's alias entry and the #2695 recipient-identity check even
+    /// after `agent_id` has moved on to a post-rename value. See
+    /// `INCIDENT_2026_09_09_JEKT_STABLE_ID_ALIAS.md`.
+    stable_agent_id: Mutex<Option<String>>,
 }
 
 /// How long to wait after delivering an AskUserQuestion answer before assuming
@@ -850,6 +859,7 @@ impl PersistentSubprocessController {
             stdout_seq: Arc::new(AtomicU64::new(0)),
             self_ref: Mutex::new(None),
             agent_id: Mutex::new(None),
+            stable_agent_id: Mutex::new(None),
         }
     }
 
@@ -2791,6 +2801,15 @@ impl PersistentSubprocessController {
         // See SPEC_MUXBUS_AGENT_DISCOVERY_AND_PERSISTENT_DELIVERY_2026_06_16.
         let agent_id_for_muxbus = muxbus_agent_id_from_env(&config.env_vars);
         *self.agent_id.lock().unwrap() = agent_id_for_muxbus.clone();
+        // Write-once: unlike `agent_id` above (refreshed every turn by
+        // `input.rs`'s Register-tail), `stable_agent_id` is only ever set
+        // here, at spawn, and never touched again — see its field doc
+        // comment. `spawn_process` can in principle run again for the same
+        // controller on a respawn; re-writing the SAME env-derived value
+        // each time is harmless (idempotent), and a respawn with genuinely
+        // different env (rare, config change) correctly updates the alias
+        // to match, same as the primary registration already does.
+        *self.stable_agent_id.lock().unwrap() = agent_id_for_muxbus.clone();
         // Defaults to this spawn's own nonce; overridden below if
         // registration is skipped (reagent P1 on PR #3084 — see the `Err`
         // arm just below for why `my_registration_nonce` alone is wrong
@@ -2813,7 +2832,21 @@ impl PersistentSubprocessController {
             // `ReactiveHandler::try_register_agent_with_nonce`'s doc comment
             // and `docs/incident/INCIDENT_2026_09_07_BACKEND_UPTIME_TIMER_FROZEN.md`.
             match crate::backend::reactive::get_global_handler()
-                .try_register_agent_with_nonce(agent_id, &self.block_id, Some(&self.tab_id), my_registration_nonce)
+                .try_register_agent_with_nonce(
+                    agent_id,
+                    &self.block_id,
+                    Some(&self.tab_id),
+                    my_registration_nonce,
+                    // Also park `agent_id` (== AGENTMUX_AGENT_ID here) as a
+                    // permanent alias for this block, independent of the
+                    // primary registration key — `input.rs`'s Register-tail
+                    // will re-key the primary registration to the live
+                    // display name on this agent's very first turn, which
+                    // would otherwise evict this exact string with nothing
+                    // left to answer a jekt tagged with the stable ID. See
+                    // `INCIDENT_2026_09_09_JEKT_STABLE_ID_ALIAS.md`.
+                    Some(agent_id.as_str()),
+                )
             {
                 Ok(()) => {
                     tracing::info!(
@@ -4345,6 +4378,10 @@ impl Controller for PersistentSubprocessController {
 
     fn set_agent_id(&self, id: Option<String>) {
         *self.agent_id.lock().unwrap() = id;
+    }
+
+    fn stable_agent_id(&self) -> Option<String> {
+        self.stable_agent_id.lock().unwrap().clone()
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/agentmux-srv/src/backend/reactive/handler.rs
+++ b/agentmux-srv/src/backend/reactive/handler.rs
@@ -312,6 +312,18 @@ impl Handler {
         if let Some(block_id) = self.agent_to_block.remove(&agent_key) {
             self.block_to_agent.remove(&block_id);
             self.log_audit_registration("unregister", agent_id, &block_id, None, None);
+            // See `unregister_block`'s matching cleanup for why (reagent P1 /
+            // codex P2 on this PR): without this, the HTTP `/agentmux/reactive/
+            // unregister` teardown path — the normal graceful agent-close path
+            // — leaves a dangling alias that outlives the block it pointed to.
+            // Safe for the ordinary rename case too: a rename never calls
+            // `unregister_agent` (it re-registers the SAME block_id under a
+            // new primary key via `register_agent_with_nonce`, which does
+            // NOT touch the alias maps — see that method's doc comment), so
+            // this only ever fires on a genuine teardown.
+            if let Some(alias) = self.block_to_alias.remove(&block_id) {
+                self.alias_to_block.remove(&alias);
+            }
         }
         self.agent_info.remove(&agent_key);
     }

--- a/agentmux-srv/src/backend/reactive/handler.rs
+++ b/agentmux-srv/src/backend/reactive/handler.rs
@@ -98,6 +98,20 @@ pub struct Handler {
     agent_to_block: HashMap<String, String>,
     block_to_agent: HashMap<String, String>,
     agent_info: HashMap<String, AgentRegistration>,
+    /// Secondary, alias lookup for a block — checked by `inject_message_inner`
+    /// only after `agent_to_block` misses. Exists because `agent_to_block`
+    /// (via `block_to_agent`) only ever holds ONE key per block: `input.rs`'s
+    /// Register-tail re-keys the primary registration to the live,
+    /// renameable display name every turn, which would otherwise evict a
+    /// spawn-time registration under the STABLE `AGENTMUX_AGENT_ID` — the
+    /// identity GitHub PR-body tags embed, specifically because it doesn't
+    /// change on rename. See `PersistentSubprocessController::spawn_process`'s
+    /// `try_register_agent_with_nonce` call and
+    /// `INCIDENT_2026_09_09_JEKT_STABLE_ID_ALIAS.md`.
+    alias_to_block: HashMap<String, String>,
+    /// Inverse of `alias_to_block`, for O(1) cleanup on unregister and to
+    /// evict a block's own stale prior alias before writing a new one.
+    block_to_alias: HashMap<String, String>,
     input_sender: Option<InputSender>,
     /// Controller-aware delivery for non-PTY agents (persistent stream-json / ACP).
     /// When set, it is tried before the PTY keystroke path so messages reach (and
@@ -108,6 +122,15 @@ pub struct Handler {
     /// `agent_to_block` map. See `AgentIdentityConfirmer`'s doc comment and
     /// `set_agent_identity_confirmer`.
     agent_identity_confirmer: Option<AgentIdentityConfirmer>,
+    /// Same shape as `agent_identity_confirmer`, but backed by
+    /// `Controller::stable_agent_id()` (the frozen `AGENTMUX_AGENT_ID`)
+    /// instead of `Controller::agent_id()` (the live, renameable display
+    /// name). Checked as an alternative match in `inject_message_inner`'s
+    /// #2695 identity check — a jekt resolved via `alias_to_block` targets
+    /// the stable ID, which `agent_identity_confirmer` alone would always
+    /// report as a mismatch once the primary key has moved on to a
+    /// post-rename display name. See `alias_to_block`'s doc comment.
+    stable_agent_identity_confirmer: Option<AgentIdentityConfirmer>,
     audit_log: Vec<AuditLogEntry>,
     rate_limiter: RateLimiter,
     include_source_in_message: bool,
@@ -125,9 +148,12 @@ impl Handler {
             agent_to_block: HashMap::new(),
             block_to_agent: HashMap::new(),
             agent_info: HashMap::new(),
+            alias_to_block: HashMap::new(),
+            block_to_alias: HashMap::new(),
             input_sender: None,
             message_sender: None,
             agent_identity_confirmer: None,
+            stable_agent_identity_confirmer: None,
             audit_log: Vec::with_capacity(AUDIT_LOG_MAX),
             rate_limiter: RateLimiter::new(RATE_LIMIT_MAX),
             include_source_in_message: false,
@@ -156,6 +182,11 @@ impl Handler {
         self.agent_identity_confirmer = Some(confirmer);
     }
 
+    /// See `stable_agent_identity_confirmer`'s field doc comment.
+    pub fn set_stable_agent_identity_confirmer(&mut self, confirmer: AgentIdentityConfirmer) {
+        self.stable_agent_identity_confirmer = Some(confirmer);
+    }
+
     /// Set whether to include source agent prefix in injected messages.
     #[allow(dead_code)]
     pub fn set_include_source(&mut self, include: bool) {
@@ -169,7 +200,7 @@ impl Handler {
         block_id: &str,
         tab_id: Option<&str>,
     ) -> Result<(), String> {
-        self.register_agent_with_nonce(agent_id, block_id, tab_id, 0)
+        self.register_agent_with_nonce(agent_id, block_id, tab_id, 0, None)
     }
 
     /// [`register_agent`], recording the registering persistent-controller
@@ -178,12 +209,23 @@ impl Handler {
     /// can later compare-and-remove ([`unregister_block_if_nonce`])
     /// instead of blindly wiping a fallback respawn's fresh registration
     /// (issue #2363).
+    ///
+    /// `alias`, if given, is ALSO registered for `block_id` in the separate
+    /// `alias_to_block` map — see that field's doc comment for why this
+    /// exists (a jekt addressed to `AGENTMUX_AGENT_ID` must still resolve
+    /// after the primary key has moved on to the live display name).
+    /// Independent of the primary registration above: written even when it
+    /// duplicates the primary key's value at this exact call (that's the
+    /// common case, at spawn — the point is for it to KEEP pointing at
+    /// `block_id` after a later call changes the primary key to something
+    /// else).
     pub fn register_agent_with_nonce(
         &mut self,
         agent_id: &str,
         block_id: &str,
         tab_id: Option<&str>,
         registration_nonce: u64,
+        alias: Option<&str>,
     ) -> Result<(), String> {
         if !validate_agent_id(agent_id) {
             return Err(format!("invalid agent ID: {}", agent_id));
@@ -229,7 +271,39 @@ impl Handler {
             evicted_agent.as_deref(),
         );
 
+        if let Some(alias) = alias {
+            if validate_agent_id(alias) {
+                self.register_alias(alias, block_id);
+            }
+        }
+
         Ok(())
+    }
+
+    /// Point `alias` (case-insensitively) at `block_id` in `alias_to_block`,
+    /// independent of and never evicted by the primary `agent_to_block`
+    /// registration above. Evicts any OTHER block previously holding this
+    /// alias, and this block's own prior alias if it differs — the same
+    /// one-key-per-{alias,block} bijection `agent_to_block`/`block_to_agent`
+    /// maintain, kept separately so the two registries can't evict each
+    /// other. See `alias_to_block`'s field doc comment.
+    fn register_alias(&mut self, alias: &str, block_id: &str) {
+        let alias_key = alias.to_lowercase();
+
+        if let Some(old_block) = self.alias_to_block.remove(&alias_key) {
+            if old_block != block_id {
+                self.block_to_alias.remove(&old_block);
+            }
+        }
+        if let Some(old_alias) = self.block_to_alias.remove(block_id) {
+            if old_alias != alias_key {
+                self.alias_to_block.remove(&old_alias);
+            }
+        }
+
+        self.alias_to_block
+            .insert(alias_key.clone(), block_id.to_string());
+        self.block_to_alias.insert(block_id.to_string(), alias_key);
     }
 
     /// Unregister an agent.
@@ -248,6 +322,15 @@ impl Handler {
             self.agent_to_block.remove(&agent_id);
             self.agent_info.remove(&agent_id);
             self.log_audit_registration("unregister", &agent_id, block_id, None, None);
+        }
+        // Also drop this block's alias, if any — otherwise a dead block's
+        // stable-ID alias would keep resolving after the block itself is
+        // gone (e.g. a block reused by a later, unrelated spawn would
+        // silently inherit the OLD block's alias instead of getting its
+        // own, since `register_alias` is only called when a NEW alias is
+        // actually supplied).
+        if let Some(alias) = self.block_to_alias.remove(block_id) {
+            self.alias_to_block.remove(&alias);
         }
     }
 
@@ -380,8 +463,16 @@ impl Handler {
         // Sanitize message
         let sanitized = sanitize_message(&req.message);
 
-        // Look up block ID
-        let block_id = match self.agent_to_block.get(&req.target_agent.to_lowercase()) {
+        // Look up block ID — primary registry first, then the alias
+        // registry (see `alias_to_block`'s doc comment: a jekt addressed to
+        // the stable AGENTMUX_AGENT_ID resolves here once the primary key
+        // has moved on to the live display name).
+        let target_key = req.target_agent.to_lowercase();
+        let block_id = match self
+            .agent_to_block
+            .get(&target_key)
+            .or_else(|| self.alias_to_block.get(&target_key))
+        {
             Some(id) => id.clone(),
             None => {
                 let err = format!("agent not found: {}", req.target_agent);
@@ -426,17 +517,45 @@ impl Handler {
         // this codebase's existing jekt trust philosophy elsewhere (see the
         // TRUST=/ESCALATE= rules): only an ACTIVE mismatch is a red flag,
         // mere absence of proof is not.
-        if let Some(confirmer) = &self.agent_identity_confirmer {
-            if let Some(actual_agent_id) = confirmer(&block_id) {
-                if actual_agent_id.to_lowercase() != req.target_agent.to_lowercase() {
+        //
+        // Checked against BOTH the live identity (`agent_identity_confirmer`)
+        // and the stable one (`stable_agent_identity_confirmer`) — a target
+        // resolved via the alias registry is legitimately the stable ID, not
+        // the live display name, and would otherwise always fail this check
+        // once the primary key has moved on post-rename. Either source
+        // reporting a match is sufficient; both reporting `None` is
+        // "unverifiable" exactly as before.
+        if self.agent_identity_confirmer.is_some() || self.stable_agent_identity_confirmer.is_some() {
+            let live_agent_id = self
+                .agent_identity_confirmer
+                .as_ref()
+                .and_then(|c| c(&block_id));
+            let stable_agent_id = self
+                .stable_agent_identity_confirmer
+                .as_ref()
+                .and_then(|c| c(&block_id));
+            // Both `None` is "unverifiable" (see above) — only proceed to
+            // the check below if at least one source reported an identity.
+            if live_agent_id.is_some() || stable_agent_id.is_some() {
+                let target_lower = req.target_agent.to_lowercase();
+                let matches = |id: &Option<String>| {
+                    id.as_deref().is_some_and(|id| id.to_lowercase() == target_lower)
+                };
+                if !matches(&live_agent_id) && !matches(&stable_agent_id) {
                     let err = format!(
-                        "identity mismatch: block {} resolved for target '{}' but its own live identity is '{}'",
-                        block_id, req.target_agent, actual_agent_id
+                        "identity mismatch: block {} resolved for target '{}' but its own identity is '{}'",
+                        block_id,
+                        req.target_agent,
+                        live_agent_id
+                            .as_deref()
+                            .or(stable_agent_id.as_deref())
+                            .unwrap_or("<unknown>")
                     );
                     tracing::error!(
                         target = %req.target_agent,
                         block_id = %block_id,
-                        actual_agent_id = %actual_agent_id,
+                        live_agent_id = ?live_agent_id,
+                        stable_agent_id = ?stable_agent_id,
                         "reactive inject: recipient identity mismatch — rejecting delivery"
                     );
                     self.log_audit(
@@ -1118,6 +1237,14 @@ impl ReactiveHandler {
             .set_agent_identity_confirmer(confirmer);
     }
 
+    /// See the inner [`Handler::set_stable_agent_identity_confirmer`].
+    pub fn set_stable_agent_identity_confirmer(&self, confirmer: AgentIdentityConfirmer) {
+        self.inner
+            .lock()
+            .unwrap()
+            .set_stable_agent_identity_confirmer(confirmer);
+    }
+
     #[allow(dead_code)]
     pub fn set_include_source(&self, include: bool) {
         self.inner.lock().unwrap().set_include_source(include);
@@ -1142,11 +1269,12 @@ impl ReactiveHandler {
         block_id: &str,
         tab_id: Option<&str>,
         registration_nonce: u64,
+        alias: Option<&str>,
     ) -> Result<(), String> {
         self.inner
             .lock()
             .unwrap()
-            .register_agent_with_nonce(agent_id, block_id, tab_id, registration_nonce)
+            .register_agent_with_nonce(agent_id, block_id, tab_id, registration_nonce, alias)
     }
 
     /// Like [`register_agent_with_nonce`], but never blocks: if the lock is
@@ -1198,6 +1326,7 @@ impl ReactiveHandler {
         block_id: &str,
         tab_id: Option<&str>,
         registration_nonce: u64,
+        alias: Option<&str>,
     ) -> Result<(), String> {
         // Bounded retry, not a single attempt (reagent P1 on PR #3084 —
         // review of INCIDENT_2026_09_07_BACKEND_UPTIME_TIMER_FROZEN.md's
@@ -1223,7 +1352,7 @@ impl ReactiveHandler {
         for attempt in 1..=MAX_ATTEMPTS {
             match self.inner.try_lock() {
                 Ok(mut guard) => {
-                    return guard.register_agent_with_nonce(agent_id, block_id, tab_id, registration_nonce);
+                    return guard.register_agent_with_nonce(agent_id, block_id, tab_id, registration_nonce, alias);
                 }
                 Err(std::sync::TryLockError::WouldBlock) => {
                     if attempt == MAX_ATTEMPTS {

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -222,6 +222,214 @@ fn test_handler_unregister_block() {
     assert!(handler.get_agent("agent1").is_none());
 }
 
+// -- Alias registration tests (INCIDENT_2026_09_09_JEKT_STABLE_ID_ALIAS.md) --
+
+/// The alias registered alongside a primary registration resolves via
+/// `inject_message`'s lookup exactly like the primary key does.
+#[tokio::test]
+async fn test_handler_alias_resolves_to_same_block() {
+    let sent = Arc::new(Mutex::new(Vec::<(String, Vec<u8>)>::new()));
+    let sent_clone = sent.clone();
+
+    let mut handler = Handler::new();
+    handler.set_input_sender(Arc::new(move |block_id: &str, data: &[u8]| {
+        sent_clone
+            .lock()
+            .unwrap()
+            .push((block_id.to_string(), data.to_vec()));
+        Ok(())
+    }));
+    handler
+        .register_agent_with_nonce("claude", "block1", None, 0, Some("agentg"))
+        .unwrap();
+
+    let resp = handler.inject_message(InjectionRequest {
+        target_agent: "agentg".to_string(),
+        message: "hello".to_string(),
+        source_agent: None,
+        request_id: Some("req-alias".to_string()),
+        priority: None,
+        wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: None,
+        forward_hops: 0,
+        ..Default::default()
+    });
+
+    assert!(resp.success, "{:?}", resp.error);
+    assert_eq!(resp.block_id.as_deref(), Some("block1"));
+    assert!(!sent.lock().unwrap().is_empty());
+}
+
+/// The whole point of the alias: it must survive the primary key being
+/// re-registered to a different value for the SAME block (simulating
+/// `input.rs`'s Register-tail re-keying the primary registration to the
+/// live display name after a rename, on every turn).
+#[test]
+fn test_handler_alias_survives_primary_key_change() {
+    let mut handler = Handler::new();
+    handler
+        .register_agent_with_nonce("agentg", "block1", None, 0, Some("agentg"))
+        .unwrap();
+
+    // Simulate input.rs's every-turn Register-tail re-keying the primary
+    // registration to a post-rename live display name, with no alias
+    // passed (mirrors the real call site, which only ever supplies an
+    // alias from `spawn_process`, not from the per-turn Register-tail).
+    handler
+        .register_agent("claude", "block1", None)
+        .unwrap();
+
+    assert_eq!(
+        handler.get_agent("claude").unwrap().block_id,
+        "block1",
+        "the live-name primary registration should have taken over"
+    );
+    assert!(
+        handler.get_agent("agentg").is_none(),
+        "the OLD primary registration is correctly evicted"
+    );
+
+    let resp = handler.inject_message(InjectionRequest {
+        target_agent: "agentg".to_string(),
+        message: "hello".to_string(),
+        source_agent: None,
+        request_id: Some("req-alias-survives".to_string()),
+        priority: None,
+        wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: None,
+        forward_hops: 0,
+        ..Default::default()
+    });
+
+    // No input sender configured — this only asserts resolution, not
+    // delivery, so the meaningful failure mode ("agent not found") is
+    // distinguishable from the uninteresting one ("input sender not
+    // configured").
+    assert!(
+        resp.error.as_deref() != Some("agent not found: agentg"),
+        "the alias must still resolve to block1 after the primary key moved on: {:?}",
+        resp.error
+    );
+}
+
+/// `unregister_block` must clean up the alias too — otherwise a dead
+/// block's stable-ID alias keeps resolving after the block itself, and a
+/// LATER, unrelated spawn reusing that block_id would silently inherit it.
+#[test]
+fn test_handler_unregister_block_also_removes_alias() {
+    let mut handler = Handler::new();
+    handler
+        .register_agent_with_nonce("claude", "block1", None, 0, Some("agentg"))
+        .unwrap();
+    handler.unregister_block("block1");
+
+    let resp = handler.inject_message(InjectionRequest {
+        target_agent: "agentg".to_string(),
+        message: "hello".to_string(),
+        source_agent: None,
+        request_id: Some("req-alias-cleanup".to_string()),
+        priority: None,
+        wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: None,
+        forward_hops: 0,
+        ..Default::default()
+    });
+
+    assert_eq!(resp.error.as_deref(), Some("agent not found: agentg"));
+}
+
+/// The #2695 recipient-identity check must accept a target resolved via
+/// the alias registry when `stable_agent_identity_confirmer` (not the live
+/// `agent_identity_confirmer`) reports a match — this is exactly the
+/// post-rename jekt-delivery case the alias mechanism exists for.
+#[tokio::test]
+async fn test_handler_inject_proceeds_when_stable_confirmer_matches_alias_target() {
+    let sent = Arc::new(Mutex::new(Vec::<(String, Vec<u8>)>::new()));
+    let sent_clone = sent.clone();
+
+    let mut handler = Handler::new();
+    handler.set_input_sender(Arc::new(move |block_id: &str, data: &[u8]| {
+        sent_clone
+            .lock()
+            .unwrap()
+            .push((block_id.to_string(), data.to_vec()));
+        Ok(())
+    }));
+    handler
+        .register_agent_with_nonce("claude", "block1", None, 0, Some("agentg"))
+        .unwrap();
+    // Live identity is "claude" (post-rename); stable identity is "agentg"
+    // (frozen at spawn) — mirrors `Controller::agent_id()` vs
+    // `Controller::stable_agent_id()` on a renamed agent.
+    handler.set_agent_identity_confirmer(Arc::new(|_block_id: &str| {
+        Some("claude".to_string())
+    }));
+    handler.set_stable_agent_identity_confirmer(Arc::new(|_block_id: &str| {
+        Some("agentg".to_string())
+    }));
+
+    let resp = handler.inject_message(InjectionRequest {
+        target_agent: "agentg".to_string(),
+        message: "hello".to_string(),
+        source_agent: None,
+        request_id: Some("req-stable-confirm".to_string()),
+        priority: None,
+        wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: None,
+        forward_hops: 0,
+        ..Default::default()
+    });
+
+    assert!(resp.success, "{:?}", resp.error);
+    assert!(!sent.lock().unwrap().is_empty());
+}
+
+/// A target matching NEITHER the live nor the stable confirmed identity is
+/// still rejected — the dual-confirmer check must not degrade into an
+/// always-allow.
+#[tokio::test]
+async fn test_handler_inject_rejects_when_neither_confirmer_matches() {
+    let mut handler = Handler::new();
+    handler.set_input_sender(Arc::new(|_block_id: &str, _data: &[u8]| Ok(())));
+    handler
+        .register_agent_with_nonce("claude", "block1", None, 0, Some("agentg"))
+        .unwrap();
+    handler.set_agent_identity_confirmer(Arc::new(|_block_id: &str| {
+        Some("claude".to_string())
+    }));
+    handler.set_stable_agent_identity_confirmer(Arc::new(|_block_id: &str| {
+        Some("agentg".to_string())
+    }));
+
+    // Force resolution through the alias entry so the check runs, but
+    // address a THIRD identity neither confirmer will vouch for. Re-registering
+    // the same primary key with a different alias just swaps the alias
+    // (see `register_alias`'s eviction behavior).
+    handler
+        .register_agent_with_nonce("claude", "block1", None, 0, Some("intruder"))
+        .unwrap();
+
+    let resp = handler.inject_message(InjectionRequest {
+        target_agent: "intruder".to_string(),
+        message: "hello".to_string(),
+        source_agent: None,
+        request_id: Some("req-neither-match".to_string()),
+        priority: None,
+        wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: None,
+        forward_hops: 0,
+        ..Default::default()
+    });
+
+    assert!(!resp.success);
+    assert!(resp.error.as_deref().unwrap().contains("identity mismatch"));
+}
+
 #[test]
 fn test_handler_register_audits_registration_event() {
     let mut handler = Handler::new();
@@ -299,13 +507,13 @@ fn test_handler_unregister_block_audits_unregistration() {
 fn test_handler_unregister_block_if_nonce_spares_a_newer_registration() {
     let mut handler = Handler::new();
     handler
-        .register_agent_with_nonce("agent1", "block1", None, 5)
+        .register_agent_with_nonce("agent1", "block1", None, 5, None)
         .unwrap();
     // A fallback respawn (or a resync_controller replacement) re-registers
     // the same agent/block under its own nonce before the dying spawn's
     // exit-handler reaches cleanup.
     handler
-        .register_agent_with_nonce("agent1", "block1", None, 6)
+        .register_agent_with_nonce("agent1", "block1", None, 6, None)
         .unwrap();
 
     assert!(
@@ -1873,7 +2081,7 @@ async fn test_record_supervisor_decision_nudge_ceiling_resets_on_new_registratio
     let mut handler = Handler::new();
     handler.set_input_sender(Arc::new(|_block_id: &str, _data: &[u8]| Ok(())));
     handler
-        .register_agent_with_nonce("agent1", "block1", None, 1)
+        .register_agent_with_nonce("agent1", "block1", None, 1, None)
         .unwrap();
 
     for i in 0..MAX_CONSECUTIVE_AUTO_CONTINUES {
@@ -1902,7 +2110,7 @@ async fn test_record_supervisor_decision_nudge_ceiling_resets_on_new_registratio
 
     // Respawn: same agent name, new nonce.
     handler
-        .register_agent_with_nonce("agent1", "block1", None, 2)
+        .register_agent_with_nonce("agent1", "block1", None, 2, None)
         .unwrap();
 
     let resp = handler
@@ -2926,7 +3134,7 @@ fn reentrant_registration_from_the_message_sender_fails_fast_not_hangs() {
         // (as it is in production via `block_in_place`) while
         // `inject_message`'s lock is held.
         let result = handler_for_sender.try_register_agent_with_nonce(
-            "agent1", "block1", None, 999,
+            "agent1", "block1", None, 999, None,
         );
         reentrant_result_tx.send(result).unwrap();
         Ok(true)
@@ -2975,7 +3183,7 @@ fn reentrant_registration_from_the_message_sender_fails_fast_not_hangs() {
 fn non_reentrant_try_register_agent_with_nonce_still_registers() {
     let handler = super::handler::ReactiveHandler::new();
 
-    let result = handler.try_register_agent_with_nonce("agent1", "block1", None, 1);
+    let result = handler.try_register_agent_with_nonce("agent1", "block1", None, 1, None);
     assert!(result.is_ok(), "an uncontended call must succeed: {result:?}");
 
     let agent = handler.get_agent("agent1").expect("agent must now be registered");
@@ -3054,7 +3262,7 @@ fn reentrant_try_get_agent_by_block_fails_fast_not_hangs() {
 fn non_reentrant_try_get_agent_by_block_finds_the_registration() {
     let handler = super::handler::ReactiveHandler::new();
     handler
-        .register_agent_with_nonce("agent1", "block1", None, 42)
+        .register_agent_with_nonce("agent1", "block1", None, 42, None)
         .unwrap();
 
     let found = handler

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -341,6 +341,34 @@ fn test_handler_unregister_block_also_removes_alias() {
     assert_eq!(resp.error.as_deref(), Some("agent not found: agentg"));
 }
 
+/// Sibling of `test_handler_unregister_block_also_removes_alias`, for the
+/// OTHER teardown path (reagent P2 on this PR's `unregister_agent` fix):
+/// the HTTP `/agentmux/reactive/unregister` endpoint calls
+/// `unregister_agent`, not `unregister_block` — both must clear the alias.
+#[test]
+fn test_handler_unregister_agent_also_removes_alias() {
+    let mut handler = Handler::new();
+    handler
+        .register_agent_with_nonce("claude", "block1", None, 0, Some("agentg"))
+        .unwrap();
+    handler.unregister_agent("claude");
+
+    let resp = handler.inject_message(InjectionRequest {
+        target_agent: "agentg".to_string(),
+        message: "hello".to_string(),
+        source_agent: None,
+        request_id: Some("req-alias-cleanup-via-unregister-agent".to_string()),
+        priority: None,
+        wait_for_idle: false,
+        jekt_tier: None,
+        delivery_tier: None,
+        forward_hops: 0,
+        ..Default::default()
+    });
+
+    assert_eq!(resp.error.as_deref(), Some("agent not found: agentg"));
+}
+
 /// The #2695 recipient-identity check must accept a target resolved via
 /// the alias registry when `stable_agent_identity_confirmer` (not the live
 /// `agent_identity_confirmer`) reports a match — this is exactly the

--- a/agentmux-srv/src/bootstrap.rs
+++ b/agentmux-srv/src/bootstrap.rs
@@ -1059,6 +1059,13 @@ pub fn spawn_background_subsystems(
     reactive_handler.set_agent_identity_confirmer(Arc::new(|block_id: &str| {
         backend::blockcontroller::get_controller(block_id).and_then(|c| c.agent_id())
     }));
+    // Stable counterpart to the above (`AGENTMUX_AGENT_ID`, frozen at spawn)
+    // — see `Controller::stable_agent_id`'s and `Handler::alias_to_block`'s
+    // doc comments for why a jekt tagged with the stable ID needs its own,
+    // independently-sourced confirmer instead of reusing the live one.
+    reactive_handler.set_stable_agent_identity_confirmer(Arc::new(|block_id: &str| {
+        backend::blockcontroller::get_controller(block_id).and_then(|c| c.stable_agent_id())
+    }));
     let poller = Arc::new(Poller::new(
         PollerConfig {
             muxbus_url: None,

--- a/docs/incident/INCIDENT_2026_09_09_JEKT_CASE_MISMATCH_SUBSCRIPTION.md
+++ b/docs/incident/INCIDENT_2026_09_09_JEKT_CASE_MISMATCH_SUBSCRIPTION.md
@@ -1,0 +1,52 @@
+# INCIDENT 2026-09-09 — investigated a claimed "claude" vs "Claude" WAN-subscription case mismatch; disproved it, reconfirmed #3100 is still open
+
+**Status:** historical / research only — no code changed. The case-mismatch hypothesis that motivated this investigation is **disproven** by source citations below. The actual live risk in this session is the *same, still-unfixed* mechanism documented in `INCIDENT_2026_09_08_REAGENT_JEKT_NOT_DELIVERED.md` (merged as #3100) — none of its §6 options have been implemented since.
+
+**Date:** 2026-09-09
+
+## 1. The hypothesis this investigation was asked to check
+
+A `DiscoverAgents` call in this session returned `host.agents`/`host.addressable` with `agent_id`/`name: "Claude"` (capital C, the live UI display name) alongside `wan.local_agents_subscribed: ["claude"]` (lowercase). The hypothesis: if the cloud relay or github-router matches an inbound jekt's target agent name against the WAN subscriber list *case-sensitively*, while local delivery normalizes case, a post-rename capitalization drift alone could explain "jekts never arrive, local messaging still works" — a distinct bug from #3100's `agentg`-vs-`claude` (different strings entirely, not a case variant of the same string).
+
+## 2. Why the hypothesis is wrong
+
+The case difference between `"Claude"` and `"claude"` in the `DiscoverAgents` payload is cosmetic and expected, not a bug. `host.agents`/`addressable` surface the display name as typed (from SQLite/live block meta); `wan.local_agents_subscribed` surfaces the *lowercased registration key*. The tool's own doc comment says so directly:
+
+- `agentmux-srv/src/server/mod.rs:741` — "Addressing is case-insensitive (registration lowercases the key)."
+- `agentmux-srv/src/server/mod.rs:746` — "Keep the live block_id per name (lowercased)..."
+
+Every comparison point in the actual delivery path — both local (agentmux-srv) and cloud (agentmux-cloud/muxbus) — normalizes to lowercase before comparing. Checked directly, this session:
+
+- `agentmux-srv/src/backend/reactive/handler.rs:192` — `register_agent`: `let agent_key = agent_id.to_lowercase();`
+- `agentmux-srv/src/backend/reactive/handler.rs:384` — `inject_message`'s block lookup: `self.agent_to_block.get(&req.target_agent.to_lowercase())`
+- `agentmux-srv/src/backend/reactive/handler.rs:431` — the recipient-identity check (#2695 mitigation) compares `actual_agent_id.to_lowercase() != req.target_agent.to_lowercase()` — both sides lowered, not just one
+- `agentmux-srv/src/backend/reactive/handler.rs:859` — the async injection path: `let target_key = target_agent.to_lowercase();`
+- `agentmux-cloud/muxbus/server/src/index.ts:103-105` — `normalizeAgentId(agentId) { return agentId.toLowerCase().trim(); }`
+- `agentmux-cloud/muxbus/server/src/index.ts:389` — `/reactive/inject`: `const normalizedTarget = normalizeAgentId(target_agent);`
+- `agentmux-cloud/muxbus/server/src/index.ts:579` — `/reactive/status/:injection_id`: same `normalizeAgentId` applied to both `source_agent` and `target_agent` before the caller-authorization comparison
+- `agentmux-cloud/muxbus/consumers/github/agent-mapping.ts:107` — `getAgentId`: `const lower = githubUsername.toLowerCase();`
+- `agentmux-cloud/muxbus/consumers/github/agent-mapping.ts:237` — `extractAgentIdFromBody` (the PR-body-tag fallback that actually resolved the target in #3100's incident): `return extracted.toLowerCase();`
+
+No raw, case-sensitive `===`/`==` comparison of an agent identifier exists anywhere on this path in either repo, as far as this investigation found. `shared-infrastructure/github-router` was re-checked (`grep -rn "muxbus\|agentmux" github-router/lambda/`, no hits) and, consistent with #3100 §2's finding, is confirmed uninvolved in jekt routing at all — it fans out raw webhooks + posts to Discord, nothing more.
+
+**Conclusion: case sensitivity is not, and could not be, the delivery-failure mechanism.** The `"Claude"`/`"claude"` difference visible in `DiscoverAgents` output is two different, both-correct views of the same underlying lowercased key, not two competing identity records.
+
+## 3. What actually is still broken (reconfirmed, not new)
+
+This session independently reproduces #3100's real mechanism, live, right now:
+
+- `env | grep AGENTMUX_AGENT_ID` → `agentg` (the stable slug, meant for PR-body tags per `agent_config.rs`'s `build_mcp_config()` doc comment)
+- `DiscoverAgents` → `wan.local_agents_subscribed: ["claude"]`, `host.agents[0].name: "Claude"` (the live display name, lowercased at registration)
+
+Same divergence, same session-vs-tag mismatch pattern #3100 described. `git log --oneline 6a5b45cbd..HEAD -- agentmux-srv/src/server/agent_handlers/input.rs agentmux-srv/src/backend/reactive/handler.rs` (6a5b45cbd = the #3100 merge commit) returns **no commits** — none of #3100 §6's three options (register under `AGENTMUX_AGENT_ID`; detect-and-surface the divergence; make `/reactive/inject` report delivery failure) have been implemented. A jekt tagged `<!-- agentmux:agent_id=agentg -->` today would fail to reach this session for exactly the reason #3100 already documented, not for any case-related reason.
+
+## 4. Proposed next step (not a decision, matches #3100 §6)
+
+No new fix is proposed here — this investigation found no new bug. The existing #3100 §6 options remain the right place to look, most directly option 1 (register the reactive handler under `AGENTMUX_AGENT_ID` in `input.rs`'s Register-tail, paired with fixing the #2695/#2697 stale-identity check some other way so it doesn't regress) or option 3 (make `/reactive/inject` / `injectToAgent()` surface "no active subscriber for target_agent" instead of reporting `response.ok` on mere queueing). Whoever picks this up should start from `input.rs:706-734` and `agentmux-cloud/muxbus/server/src/index.ts`'s `/reactive/inject` handler (~line 368-460), not from anything case-related.
+
+## 5. Evidence index
+
+- Live this session: `mcp__agentmux__DiscoverAgents` (`host.agents[0].name: "Claude"`, `wan.local_agents_subscribed: ["claude"]`), `mcp__agentmux__WhoAmI`, `env | grep AGENTMUX_AGENT_ID` (`agentg`).
+- Source, read directly, this session: `agentmux-srv/src/server/mod.rs:725-820` (discovery endpoint + its doc comment), `agentmux-srv/src/backend/reactive/handler.rs` (register_agent, inject_message, async injection path, recipient-identity check), `agentmux-cloud/muxbus/server/src/index.ts` (normalizeAgentId + both call sites), `agentmux-cloud/muxbus/consumers/github/agent-mapping.ts` (getAgentId, extractAgentIdFromBody), `shared-infrastructure/github-router/lambda/` (grepped for `muxbus|agentmux`, no matches).
+- `git log --oneline 6a5b45cbd..HEAD -- agentmux-srv/src/server/agent_handlers/input.rs agentmux-srv/src/backend/reactive/handler.rs` — empty, confirming #3100's fix options are still unimplemented.
+- Prior report: `docs/incident/INCIDENT_2026_09_08_REAGENT_JEKT_NOT_DELIVERED.md` (#3100).

--- a/docs/incident/INCIDENT_2026_09_09_JEKT_STABLE_ID_ALIAS.md
+++ b/docs/incident/INCIDENT_2026_09_09_JEKT_STABLE_ID_ALIAS.md
@@ -81,3 +81,18 @@ without disturbing the primary (live-name) registration at all:
 Scoped to `PersistentSubprocessController` only (the stream-json/ACP agent path this session runs
 on); `ShellController`'s PTY-based agents are unaffected (`Controller::stable_agent_id()` defaults
 to `None`, same as before this change for any controller type that doesn't override it).
+
+## Known follow-up gap (codex P1 on this PR, not fixed here)
+
+The alias is populated only in `spawn_process`. After an srv restart, a persistent controller can
+be registered in the primary registry (agentName) while its process hasn't spawned yet — it spawns
+lazily on the first message (`install_agent_turn_delivery`'s fallback, addressing
+`REPORT_JEKT_DELIVERY_DROPS_UNSPAWNED_PERSISTENT_AGENTS_2026_09_03`). In that window, a jekt
+addressed to the LIVE name still works (the lazy-spawn fallback starts the turn), but one addressed
+to the STABLE ID does not: the alias hasn't been written yet, so the lookup fails before that
+fallback is ever reached.
+
+Not fixed in this PR: closing it means capturing `AGENTMUX_AGENT_ID` from the block's *persisted*
+config at controller-construction time, not from a live process env — a genuinely different change
+to controller-lifecycle code this investigation didn't reach, and not something to rush into a file
+with this incident history. Scoped out deliberately; tracked here rather than silently dropped.

--- a/docs/incident/INCIDENT_2026_09_09_JEKT_STABLE_ID_ALIAS.md
+++ b/docs/incident/INCIDENT_2026_09_09_JEKT_STABLE_ID_ALIAS.md
@@ -1,0 +1,83 @@
+# Incident: jekt notifications never reach a renamed agent (stable ID vs. live display name)
+
+**Status:** implemented — fix in this PR (`agentmux-srv/src/backend/reactive/handler.rs`'s
+`alias_to_block`/`register_agent_with_nonce`, `agentmux-srv/src/backend/blockcontroller/persistent.rs`'s
+`stable_agent_id`, `agentmux-srv/src/backend/blockcontroller/mod.rs`'s `Controller::stable_agent_id`).
+Not yet verified against a live GitHub PR-review jekt end-to-end (verified via unit tests and a
+live `DiscoverAgents`/`env` reproduction of the underlying mismatch instead).
+
+**Date:** 2026-09-09
+
+## Background
+
+`docs/incident/INCIDENT_2026_09_08_REAGENT_JEKT_NOT_DELIVERED.md` (PR #3100) root-caused why
+GitHub PR-review notifications ("jekts") routed through the muxbus cloud relay were not reaching
+this agent, but that PR only *documented* the mechanism — it shipped no code change. This incident
+implements the fix its §6 pointed at.
+
+## Root cause
+
+Two identities exist for the same running agent, by design:
+
+- **`AGENTMUX_AGENT_ID`** — read from the spawn environment once, at
+  `PersistentSubprocessController::spawn_process` (`muxbus_agent_id_from_env`). Embedded verbatim
+  in PR-body tags specifically *because* it does not change if the agent is later renamed.
+- **The live display name** (`block.meta["agentName"]`) — mutable, refreshed into the controller
+  every turn by `input.rs`'s Register-tail (`ctrl.set_agent_id(Some(agent_name))`), added in #2697
+  specifically so a renamed agent's own jekts aren't rejected as a stale-identity mismatch.
+
+`ReactiveHandler`'s registry (`agent_to_block`/`block_to_agent`) only ever holds **one** key per
+block. At spawn, `spawn_process` registers the block under the stable ID. On this agent's very
+first turn, `input.rs`'s Register-tail re-registers the SAME block under the live display name —
+and `register_agent_with_nonce`'s eviction logic (by design, for the ordinary rename case) removes
+whatever the block was previously registered under. The stable-ID registration is gone within one
+turn of the process starting, permanently, until the next restart.
+
+Reproduced live, this session:
+
+```
+$ env | grep AGENTMUX_AGENT_ID
+AGENTMUX_AGENT_ID=agentg
+
+$ (DiscoverAgents MCP tool)
+wan.local_agents_subscribed: ["claude"]
+host.agents[0].name: "Claude"
+```
+
+A jekt tagged `<!-- agentmux:agent_id=agentg -->` (the standing tag, unchanged since before this
+agent was renamed to "Claude") has no live subscriber named `agentg` to resolve to — the message
+is queued server-side and never delivered. `git log --oneline <PR#3100 merge>..HEAD` confirmed
+none of #3100 §6's fix options had been implemented before this PR.
+
+(An earlier hypothesis in this investigation — that `"Claude"` vs `"claude"` in that same
+`DiscoverAgents` output was a case-sensitivity bug — was checked and disproven; see
+`INCIDENT_2026_09_09_JEKT_CASE_MISMATCH_SUBSCRIPTION.md`. Every comparison on this path already
+lowercases both sides. The real mismatch is `agentg` vs. `claude` — two different strings, not a
+case variant of one.)
+
+## Fix
+
+Added a second, independent registry entry — an **alias** — that a jekt can resolve through
+without disturbing the primary (live-name) registration at all:
+
+- `Handler::alias_to_block` / `block_to_alias` (new maps, `agentmux-srv/src/backend/reactive/handler.rs`):
+  populated by `register_agent_with_nonce`'s new optional `alias` parameter. Never evicted by an
+  ordinary (no-alias) call to `register_agent`/`register_agent_with_nonce` — only a call that
+  itself supplies a *new* alias for the same block replaces the old one. Cleaned up by
+  `unregister_block` alongside the primary entry.
+- `PersistentSubprocessController::spawn_process` now passes `AGENTMUX_AGENT_ID` as that alias on
+  its existing `try_register_agent_with_nonce` call — no new lock acquisition, reusing the exact
+  already-audited critical section from the #3084 deadlock fix.
+- `inject_message_inner`'s lookup now falls back to `alias_to_block` when `agent_to_block` misses.
+- The #2695 recipient-identity check (which independently re-verifies a resolved block's *live*
+  identity via `Controller::agent_id()`, to guard against a stale/reused registration) would
+  otherwise always reject an alias-resolved delivery, since the live display name legitimately
+  differs from the stable ID being targeted. Added `Controller::stable_agent_id()` (backed by a
+  new, write-once field on `PersistentSubprocessController`, distinct from the every-turn-refreshed
+  `agent_id`) and a parallel `stable_agent_identity_confirmer` on `Handler`, wired in
+  `bootstrap.rs`. The check now accepts a match against *either* the live or the stable identity —
+  closing the same stale-registration race #2695 closed, for both registry paths uniformly.
+
+Scoped to `PersistentSubprocessController` only (the stream-json/ACP agent path this session runs
+on); `ShellController`'s PTY-based agents are unaffected (`Controller::stable_agent_id()` defaults
+to `None`, same as before this change for any controller type that doesn't override it).


### PR DESCRIPTION
## Summary
- PR #3100 documented but never fixed jekt-delivery failure: `ReactiveHandler`'s registry holds one key per block, and `input.rs`'s Register-tail re-keys it to the live, renameable display name on every turn -- evicting the stable `AGENTMUX_AGENT_ID` a spawn registered it under moments earlier.
- GitHub PR-body tags embed that stable ID specifically because it survives renames -- a jekt tagged with it had nothing left to resolve to after the agent's first turn.
- Reproduced live this session: `AGENTMUX_AGENT_ID=agentg` in env, but the live WAN subscription is `claude` (the current display name).
- Fix: a second, independent alias registry (`Handler::alias_to_block`) that `spawn_process` also populates with `AGENTMUX_AGENT_ID`, never evicted by the ordinary per-turn re-key. `inject_message_inner` falls back to it on a primary-registry miss. The existing #2695 recipient-identity check gets a matching `stable_agent_identity_confirmer` (backed by a new, write-once `Controller::stable_agent_id()`) so an alias-resolved delivery isn't rejected for legitimately not matching the live display name.
- Scoped to `PersistentSubprocessController` only (the stream-json/ACP agent path). No change to `ShellController` or the ordinary rename/#2697 behavior.
- See `docs/incident/INCIDENT_2026_09_09_JEKT_STABLE_ID_ALIAS.md` for full root cause. Also includes `INCIDENT_2026_09_09_JEKT_CASE_MISMATCH_SUBSCRIPTION.md`, a research-only doc from checking (and disproving) a case-sensitivity hypothesis along the way.

## Test plan
- [x] New unit tests: alias resolves via `inject_message`, alias survives a primary-key change, `unregister_block` cleans up the alias, dual-confirmer accepts a stable-only match, dual-confirmer still rejects a target matching neither identity.
- [ ] CI build
- [ ] Verify against a live GitHub PR-review jekt end-to-end once merged and deployed