### PR TITLE
Clare@starpower: docs(cef): branch model + upgrade practice for the CEF fork, all three platforms

### DIFF
--- a/.changesets/1788964010-docs-cef-branch-model-upgrade-practice-for-the-cef-fork-all--iqa5.md
+++ b/.changesets/1788964010-docs-cef-branch-model-upgrade-practice-for-the-cef-fork-all--iqa5.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs(cef): branch model + upgrade practice for the CEF fork, all three platforms

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -393,6 +393,14 @@ History: `docs/retro/retro-release-version-desync-2026-05-22.md` — PR #964 sil
 
 ## Git Workflow
 
+**Never reuse a branch after its PR is merged.** Once merged, that branch is
+dead — cut a new one from the target for follow-up work. Continuing to commit to
+an already-merged branch is how a change that *was* merged quietly stops being in
+the integration branch: the branch keeps moving, nothing merges it forward, and
+no build ever fails. This is not hypothetical — it cost two months and nearly
+shipped a macOS transparency regression in the CEF fork. See
+[docs/cef-build/CEF_FORK_MAINTENANCE.md](./docs/cef-build/CEF_FORK_MAINTENANCE.md) §1.1.
+
 ```bash
 # Create feature branch
 git checkout -b feature-name

--- a/README.md
+++ b/README.md
@@ -230,6 +230,56 @@ Local build outputs from `task package` on the host platform:
 
 Release artifacts (macOS DMG, Windows installer, Linux AppImage) are built by CI workflows in this repo. See [§Releases](#releases).
 
+## CEF Fork — read before touching the Chromium layer
+
+AgentMux ships a **fork of CEF** (`agentmuxai/cef`) carrying five AgentMux-specific
+changes. Every Chromium milestone upgrade must carry all five forward, for Windows,
+Linux and macOS together. We have lost pieces twice, both times **silently** — no
+error, no conflict, no failed build. Full practice:
+[docs/cef-build/CEF_FORK_MAINTENANCE.md](./docs/cef-build/CEF_FORK_MAINTENANCE.md).
+
+**Our changes live in two layers, and they fail differently:**
+
+| | Layer A — Chromium-side patches | Layer B — libcef-side commits |
+|---|---|---|
+| What | `cef/patch/patches/*.patch` + `patch.cfg` | edits to `cef/libcef/**`, `cef/include/**` |
+| Applied by | `patcher.py` at build time | nothing — they are just commits on the branch |
+| Fails | loudly (`.rej`, non-zero exit) | **silently** — the tree still compiles |
+
+Layer B is where both incidents happened. Nothing checks it.
+
+**The rules:**
+
+- **Build and release only from `fork/<milestone>`** (`fork/7778`, `fork/7977`) —
+  never from a feature branch, even if the feature branch looks newer.
+- **Never reuse a feature branch after its PR is merged** — start a new one off
+  `fork/<milestone>`. This is the existing workspace rule; it applies to the CEF
+  fork too, and violating it is exactly what caused the 2026-07 gap.
+- **Merge the whole carry-set before cutting a release.** A milestone's work is
+  split across several branches; merging one and not the others silently drops
+  features.
+- **Newer-looking is not superset.** Before building, this must print nothing:
+  ```bash
+  git log --oneline <last-shipped-commit> --not fork/<milestone>
+  ```
+  Anything it prints is in the shipped artifact but not in what you are about to
+  build — a regression you are about to ship.
+
+**Three traps that produce a wrong binary with no error:**
+
+1. `patcher.py` takes **no arguments** in normal mode (only `--patch-file` /
+   `--patch-dir`, and those take a patch *name*, not a path). Passing `--root-dir`
+   fails, and a wrapper has swallowed that as a `WARN` and built anyway — applying
+   **zero of 112 patches**. After running it, `git status --porcelain` in the
+   Chromium tree must show *hundreds* of modified files; a clean tree means zero
+   patches applied.
+2. Verify patch symbols with **full `nm`**. They are local, not exported —
+   `nm -gU` misses every one and reports a false negative.
+3. **All three platform pins live in one place** (`release.yml`'s
+   `cef-runtime-pins`) and must be bumped together, from **one** fork commit.
+   The job only cross-checks the leading milestone, so two tags can agree on
+   `148` and still come from different fork commits with different carry-sets.
+
 ## Version Management (Changesets)
 
 **Feature PRs add a changeset, not a version bump.** RFC #857 Phase 2.

--- a/README.md
+++ b/README.md
@@ -260,7 +260,9 @@ Layer B is where both incidents happened. Nothing checks it.
 - **Merge the whole carry-set before cutting a release.** A milestone's work is
   split across several branches; merging one and not the others silently drops
   features.
-- **Newer-looking is not superset.** Before building, this must print nothing:
+- **Newer-looking is not superset.** Before building, this must print nothing
+  (**same milestone only** — across an upgrade the carry-set is re-ported as new
+  commits, so use the carry-set gate instead):
   ```bash
   git log --oneline <last-shipped-commit> --not <remote>/<milestone>
   ```

--- a/README.md
+++ b/README.md
@@ -232,8 +232,9 @@ Release artifacts (macOS DMG, Windows installer, Linux AppImage) are built by CI
 
 ## CEF Fork — read before touching the Chromium layer
 
-AgentMux ships a **fork of CEF** (`agentmuxai/cef`) carrying five AgentMux-specific
-changes. Every Chromium milestone upgrade must carry all five forward, for Windows,
+AgentMux ships a **fork of CEF** (`agentmuxai/cef`) carrying four AgentMux-specific
+changes — 18 CEF source files plus 3 Chromium-side patches. Every Chromium
+milestone upgrade must carry all of them forward, for Windows,
 Linux and macOS together. We have lost pieces twice, both times **silently** — no
 error, no conflict, no failed build. Full practice:
 [docs/cef-build/CEF_FORK_MAINTENANCE.md](./docs/cef-build/CEF_FORK_MAINTENANCE.md).

--- a/README.md
+++ b/README.md
@@ -250,17 +250,18 @@ Layer B is where both incidents happened. Nothing checks it.
 
 **The rules:**
 
-- **Build and release only from `fork/<milestone>`** (`fork/7778`, `fork/7977`) —
-  never from a feature branch, even if the feature branch looks newer.
+- **Build and release only from the integration branch** — named for the
+  milestone alone (`7778`, `7977`), never from a feature branch, even if the
+  feature branch looks newer.
 - **Never reuse a feature branch after its PR is merged** — start a new one off
-  `fork/<milestone>`. See the rule under [Git Workflow](./CLAUDE.md#git-workflow);
+  `<milestone>`. See the rule under [Git Workflow](./CLAUDE.md#git-workflow);
   violating it is exactly what caused the 2026-07 gap.
 - **Merge the whole carry-set before cutting a release.** A milestone's work is
   split across several branches; merging one and not the others silently drops
   features.
 - **Newer-looking is not superset.** Before building, this must print nothing:
   ```bash
-  git log --oneline <last-shipped-commit> --not fork/<milestone>
+  git log --oneline <last-shipped-commit> --not <remote>/<milestone>
   ```
   Anything it prints is in the shipped artifact but not in what you are about to
   build — a regression you are about to ship.

--- a/README.md
+++ b/README.md
@@ -253,8 +253,8 @@ Layer B is where both incidents happened. Nothing checks it.
 - **Build and release only from `fork/<milestone>`** (`fork/7778`, `fork/7977`) —
   never from a feature branch, even if the feature branch looks newer.
 - **Never reuse a feature branch after its PR is merged** — start a new one off
-  `fork/<milestone>`. This is the existing workspace rule; it applies to the CEF
-  fork too, and violating it is exactly what caused the 2026-07 gap.
+  `fork/<milestone>`. See the rule under [Git Workflow](./CLAUDE.md#git-workflow);
+  violating it is exactly what caused the 2026-07 gap.
 - **Merge the whole carry-set before cutting a release.** A milestone's work is
   split across several branches; merging one and not the others silently drops
   features.

--- a/docs/cef-build/CEF_FORK_MAINTENANCE.md
+++ b/docs/cef-build/CEF_FORK_MAINTENANCE.md
@@ -6,7 +6,8 @@
 [build-patched-cef-windows.md](./build-patched-cef-windows.md),
 [build-patched-framework-macos.md](./build-patched-framework-macos.md)
 
-We maintain a fork of CEF carrying five AgentMux-specific changes. Every Chromium
+We maintain a fork of CEF carrying **four** AgentMux-specific changes — spanning
+18 CEF source files and 3 Chromium-side patches (§3). Every Chromium
 milestone upgrade has to carry that set forward, for Windows, Linux and macOS
 together. This doc is the standing practice for doing that without losing pieces.
 
@@ -112,8 +113,19 @@ diverge in behaviour.
 
 ## 3. The carry-set (canonical inventory)
 
-**18 hand-written CEF source files** differ between upstream 7778 and the fork,
-plus **3 Chromium-side patches**. Measured, not estimated:
+**Four features.** Two of them are Layer B only, one is Layer A only, and one
+spans both — which is why a feature count and a file count are different
+questions and both get stated here:
+
+| Feature | Layer | Files |
+|---|---|---|
+| Drag (`BeginWindowDrag`) | B | 3 |
+| Transparency | B + A | 15 + 1 patch |
+| Right-click passthrough | A | 1 patch (Linux) |
+| Process requirement | A | 1 patch (macOS 26) |
+
+That totals **18 hand-written CEF source files** differing between upstream 7778
+and the fork, plus **3 Chromium-side patches**. Measured, not estimated:
 
 ```bash
 git diff --name-only <upstream-base> <branch> -- \
@@ -458,9 +470,9 @@ distinguish "patched build" from "pristine Chromium build" on any platform.
 
 | Platform | Check |
 |---|---|
-| **macOS** | Frameless window drags from an HTCLIENT region (#1); window background is actually transparent, not white (#2+#3); renderer does not crash-loop on macOS 26 (#5); H.264/HEVC playback works (codec flags) |
-| **Linux** | Right-click in the caption area passes through (#4); drag (#1); H.264 playback (codec build) |
-| **Windows** | Drag (#1); transparency (#2) |
+| **macOS** | **Drag**: frameless window drags from an HTCLIENT region. **Transparency**: window background is actually transparent, not white — needs *both* layers, see §3. **Process requirement**: renderer does not crash-loop on macOS 26. Plus H.264/HEVC playback (codec flags). |
+| **Linux** | **Right-click passthrough**: right-click in the caption area passes through. **Drag**. Plus H.264 playback (codec build). |
+| **Windows** | **Drag**. **Transparency**. |
 
 ---
 

--- a/docs/cef-build/CEF_FORK_MAINTENANCE.md
+++ b/docs/cef-build/CEF_FORK_MAINTENANCE.md
@@ -22,7 +22,7 @@ reports a feature that used to work.
 
 ### 1.1 The forward-merge gap (2026-07-01 → 2026-09-09, found in production path)
 
-`agentmux/7778-drag-rightclick-and-transparency` was merged into `fork/7778` via
+`agentmux/7778-drag-rightclick-and-transparency` was merged into `agentmuxai/7778` via
 PR #3 on Jun 24. Then PRs #4 and #5 added two **more** commits to that same
 branch on Jul 1 — the renderer-side transparency work and the macOS
 white-substitution fix. Nobody merged the branch forward a second time.
@@ -30,9 +30,9 @@ white-substitution fix. Nobody merged the branch forward a second time.
 ```
 2720ba103  (Jun 24)  drag branch
     │
-    ├──► merged into fork/7778 as 2d7833dec   (PR #3, Jun 24 18:57)
+    ├──► merged into agentmuxai/7778 as 2d7833dec   (PR #3, Jun 24 18:57)
     │         │
-    │         └──► 5387e4974  (PR #7, Sep 8)  ── fork/7778 tip
+    │         └──► 5387e4974  (PR #7, Sep 8)  ── agentmuxai/7778 tip
     │                                             has process_requirement
     │                                             MISSING #4 and #5
     │
@@ -44,12 +44,12 @@ white-substitution fix. Nobody merged the branch forward a second time.
 
 For two months this cost nothing, because the July macOS framework was built from
 the drag branch tip directly (`cef HEAD: 6c570e249` in the build log), not from
-`fork/7778`. It only bit when someone went to `fork/7778` to pick up the
+`agentmuxai/7778`. It only bit when someone went to `agentmuxai/7778` to pick up the
 `process_requirement` P0 fix — the reasonable, obvious move. Every signal pointed
-that way: `fork/7778` is the integration branch, it is named for the Chromium
+that way: `agentmuxai/7778` is the integration branch, it is named for the Chromium
 version, and it carried the newest commit (Sep 8 vs Jul 1).
 
-**Newer-looking is not the same as superset.** Building from `fork/7778` would
+**Newer-looking is not the same as superset.** Building from `agentmuxai/7778` would
 have fixed the renderer crash-loop and simultaneously regressed macOS window
 transparency, with nothing anywhere reporting a problem.
 
@@ -82,7 +82,7 @@ So, as a rule:
 
 One genuine asymmetry does remain, and it is the R4 case rather than a defect:
 `agentmux_process_requirement` is absent from the drag branch because it lives on
-`agentmux/7977-process-requirement`. Both must be merged into `fork/7977`. That
+`agentmux/7977-process-requirement`. Both must be merged into `agentmuxai/7977`. That
 split is precisely what produced §1.1 on 7778.
 
 ---
@@ -138,6 +138,15 @@ Notes that have already caused confusion:
 
 ## 4. Branch model — the rules
 
+> **Notation.** The integration branch is named for the milestone alone --
+> `7778`, `7977` (`refs/heads/7778` on `agentmuxai/cef`). Where this doc writes
+> `agentmuxai/7778` that is `<remote>/<branch>`, not a branch called
+> `agentmuxai/7778`. An earlier revision wrote `agentmuxai/7778`, using one checkout's
+> local remote name; a reviewer reasonably read that as the branch name and
+> concluded the checkout commands were wrong. If the notation can mislead a
+> careful reader it can mislead an operator, so it is spelled out here.
+
+
 The root cause of §1.1 is branch reuse after merge. The repo-level rule for
 this lives in [`CLAUDE.md`](../../CLAUDE.md) under Git Workflow:
 
@@ -147,18 +156,18 @@ It was added by the same PR as this document — it was *not* previously written
 down anywhere in the repo, which is part of why §1.1 happened. It applies to
 `agentmuxai/cef` as much as to this repo.
 
-**R1 — One integration branch per Chromium milestone.** `fork/<milestone>`
-(`fork/7778`, `fork/7977`). This is the *only* branch anyone builds or releases
+**R1 — One integration branch per Chromium milestone.** `agentmuxai/<milestone>`
+(`agentmuxai/7778`, `agentmuxai/7977`). This is the *only* branch anyone builds or releases
 from. It is upstream CEF's branch plus our carry-set, nothing else.
 
 **R2 — Feature branches are single-use.** Once `agentmux/<ms>-<topic>` is merged
-into `fork/<ms>`, it is dead. Follow-up work starts a new branch off
-`fork/<ms>`, never off the merged branch. This alone would have prevented §1.1.
+into `agentmuxai/<ms>`, it is dead. Follow-up work starts a new branch off
+`agentmuxai/<ms>`, never off the merged branch. This alone would have prevented §1.1.
 
 **R3 — Never build or release from a feature branch.** The July build used
 `agentmux/7778-drag-rightclick-and-transparency` directly. It produced a correct
 artifact *by luck* — that branch happened to be ahead. Building only from
-`fork/<ms>` makes R1 self-enforcing: if the integration branch is incomplete,
+`agentmuxai/<ms>` makes R1 self-enforcing: if the integration branch is incomplete,
 you find out immediately rather than two months later.
 
 **R4 — Merge the whole carry-set before cutting a release, not piecemeal.** The
@@ -166,7 +175,7 @@ you find out immediately rather than two months later.
 `7977-process-requirement`. Merging one without the other reproduces §1.1
 exactly. Merge both, then verify §5.
 
-**R5 — `fork/<ms>` must never lose a carry-set item.** It is append-only with
+**R5 — `agentmuxai/<ms>` must never lose a carry-set item.** It is append-only with
 respect to §3. If an upgrade legitimately drops one (upstream absorbed it), that
 requires an explicit commit saying so, referencing the upstream change.
 
@@ -174,48 +183,73 @@ requires an explicit commit saying so, referencing the upstream change.
 
 ## 5. Verifying a branch is complete
 
-Run this against any `fork/<ms>` before building or releasing from it. It is
+Run this against any `agentmuxai/<ms>` before building or releasing from it. It is
 cheap and it is the only thing that catches Layer B gaps.
 
 ```bash
-# From the cef checkout. BR is the branch under test.
-BR=fork/7778
+# Paste into a shell, then run:  cef_verify [milestone] [remote]
+# A function, not a bare script: a top-level `exit 1` would close the shell of
+# anyone who pasted this, which is a poor reward for following the doc.
+cef_verify() {
+  local MS="${1:-7778}"                 # milestone == the integration branch name
+  local REMOTE="${2:-${REMOTE:-agentmuxai}}"
+  local BR="$REMOTE/$MS"                # remote-tracking ref, e.g. agentmuxai/7778
 
-# MANDATORY. These branches get force-updated mid-port; a stale ref produces a
-# confident, wrong answer. See section 1.2 -- this exact step being skipped is
-# what put a false claim in an earlier revision of this doc.
-git fetch fork --prune
+  # REMOTE is whatever YOU named the agentmuxai/cef remote. The companion
+  # runbooks add it as 'agentmuxai'; some checkouts call it 'fork'. Hard-coding
+  # it either errors out or, worse, silently resolves a same-named ref from an
+  # unrelated remote -- the exact class of failure this gate exists to catch.
+  git remote get-url "$REMOTE" >/dev/null 2>&1 || {
+    echo "No remote '$REMOTE'. Pass it: cef_verify $MS <remote>  (see: git remote -v)" >&2
+    return 1
+  }
 
-# Layer A -- patch files present AND registered in patch.cfg
-for p in rwhv_background_opaque_check views_caption_rightclick_passthrough \
-         agentmux_process_requirement; do
-  git cat-file -e "${BR}:patch/patches/$p.patch" 2>/dev/null \
-    && git show "${BR}:patch/patch.cfg" | grep -q "'name': '$p'" \
-    && echo "OK   $p" || echo "MISS $p"
-done
+  # MANDATORY. These branches get force-updated mid-port; a stale ref produces a
+  # confident, wrong answer. Section 1.2 -- skipping this put a false claim in an
+  # earlier revision of this very doc.
+  git fetch "$REMOTE" --prune || return 1
+  git rev-parse --verify -q "$BR" >/dev/null || {
+    echo "No such branch '$BR'. The integration branch is named for the milestone alone." >&2
+    return 1
+  }
 
-# Layer B -- probe identifiers, not filenames.
-git show "${BR}:include/views/cef_window.h" | grep -q BeginWindowDrag \
-  && echo "OK   BeginWindowDrag" || echo "MISS BeginWindowDrag"
+  local ok=0 miss=0
+  _p() { if [ "$1" = OK ]; then ok=$((ok+1)); else miss=$((miss+1)); fi; printf '%-4s %s\n' "$1" "$2"; }
 
-# Transparency is a SEVEN-file cascade and must be probed as a unit. Checking
-# only blink_glue + mojom passes on a partial port while browser-side
-# propagation or render_manager.cc is still missing -- the gate would then
-# approve the very regression it exists to catch.
-probe() {  # probe <file> <identifier>
-  git show "${BR}:$1" 2>/dev/null | grep -q "$2" \
-    && echo "OK   $1" || echo "MISS $1"
+  # Layer A -- patch file present AND registered in patch.cfg
+  local name
+  for name in rwhv_background_opaque_check views_caption_rightclick_passthrough \
+              agentmux_process_requirement; do
+    if git cat-file -e "${BR}:patch/patches/${name}.patch" 2>/dev/null \
+       && git show "${BR}:patch/patch.cfg" | grep -q "'name': '${name}'"; then
+      _p OK "$name"; else _p MISS "$name"; fi
+  done
+
+  # Layer B -- probe identifiers, not filenames. Every one of these files exists
+  # upstream, so a file-existence check proves nothing.
+  _probe() {
+    if git show "${BR}:$1" 2>/dev/null | grep -q "$2"; then _p OK "$1"; else _p MISS "$1"; fi
+  }
+  _probe include/views/cef_window.h                  BeginWindowDrag
+
+  # Transparency is a SEVEN-file cascade, probed as a unit. Checking only
+  # blink_glue + mojom passes on a partial port while browser-side propagation
+  # or render_manager.cc is still absent -- the gate would then approve the very
+  # regression it exists to catch.
+  _probe libcef/renderer/blink_glue.h                SetBaseBackgroundColorOverrideTransparent
+  _probe libcef/renderer/blink_glue.cc               SetBaseBackgroundColorOverrideTransparent
+  _probe libcef/renderer/browser_config.h            background_transparent
+  _probe libcef/renderer/render_manager.cc           background_transparent
+  _probe libcef/common/mojom/cef.mojom               background_transparent
+  _probe libcef/browser/browser_platform_delegate.cc background_transparent
+  _probe libcef/browser/browser_info_manager.cc      background_transparent
+
+  echo "--- $BR: $ok OK, $miss MISS (expect 11 OK, 0 MISS) ---"
+  [ "$miss" -eq 0 ]
 }
-probe libcef/renderer/blink_glue.h              SetBaseBackgroundColorOverrideTransparent
-probe libcef/renderer/blink_glue.cc             SetBaseBackgroundColorOverrideTransparent
-probe libcef/renderer/browser_config.h          background_transparent
-probe libcef/renderer/render_manager.cc         background_transparent
-probe libcef/common/mojom/cef.mojom             background_transparent
-probe libcef/browser/browser_platform_delegate.cc  background_transparent
-probe libcef/browser/browser_info_manager.cc    background_transparent
 ```
 
-Expect **11 `OK`** against a complete `fork/<ms>`.
+Expect **11 `OK`** against a complete `agentmuxai/<ms>`.
 
 On a *feature* branch, `MISS agentmux_process_requirement` is normal rather than
 a defect -- it lives on `agentmux/<ms>-process-requirement`. That is the R4
@@ -225,20 +259,20 @@ branch.
 Keep the `${BR}:` braces — this is not stylistic, and it is shell-dependent.
 In **zsh** (the macOS default, so what these snippets usually get run in),
 `"$BR:libcef/..."` applies `:l` as a history-style modifier and resolves
-`fork/7778ibcef/...` — a false MISS on exactly the two probes that matter most.
+`agentmuxai/7778ibcef/...` — a false MISS on exactly the two probes that matter most.
 **bash expands the braced and unbraced forms identically**, so this reproduces
 for only some readers, which is worse than a consistent break.
 
 The modifier letters that bite include `a e h l q r t u`. Verified in zsh with
-`BR=fork/7778`:
+`BR=agentmuxai/7778`:
 
 ```
-$BR:libcef/x    -> fork/7778ibcef/x     ( :l  lowercase )
+$BR:libcef/x    -> agentmuxai/7778ibcef/x     ( :l  lowercase )
 $BR:head/x      -> forkead/x            ( :h  dirname   )
 $BR:tail/x      -> 7778ail/x            ( :t  basename  )
 $BR:upper/x     -> FORK/7778pper/x      ( :u  uppercase )
-$BR:include/x   -> fork/7778:include/x  ( :i  not a modifier - safe )
-$BR:patch/x     -> fork/7778:patch/x    ( :p  not a modifier - safe )
+$BR:include/x   -> agentmuxai/7778:include/x  ( :i  not a modifier - safe )
+$BR:patch/x     -> agentmuxai/7778:patch/x    ( :p  not a modifier - safe )
 ```
 
 `:include` and `:patch` being safe is why only the two `libcef` probes broke,
@@ -253,7 +287,7 @@ check.
 ```bash
 # Must print nothing. Anything printed is in the shipped artifact but not in
 # the branch you are about to build — i.e. a regression you are about to ship.
-git log --oneline "$LAST_SHIPPED_COMMIT" --not "fork/$MS"
+git log --oneline "$LAST_SHIPPED_COMMIT" --not "$REMOTE/$MS"
 ```
 
 That one command, run in September, would have caught §1.1 in a second.
@@ -262,7 +296,7 @@ That one command, run in September, would have caught §1.1 in a second.
 
 ## 6. Upgrade runbook (per Chromium milestone, all three platforms)
 
-1. **Create `fork/<new-ms>`** from upstream CEF's branch for that milestone.
+1. **Create `agentmuxai/<new-ms>`** from upstream CEF's branch for that milestone.
 2. **Port the carry-set** in §3. One commit per item, message
    `agentmux: port <item> to <ms> (Chromium <N>)` — the 7977 branch already
    follows this convention and it makes §5 auditable.
@@ -270,9 +304,9 @@ That one command, run in September, would have caught §1.1 in a second.
      Chromium source. Re-generate rather than force-apply.
    - Layer B: usually clean cherry-picks; re-check API signatures that Chromium
      changed underneath.
-3. **Merge every feature branch into `fork/<new-ms>`** (R4). Do not build from
+3. **Merge every feature branch into `agentmuxai/<new-ms>`** (R4). Do not build from
    the feature branches.
-4. **Run §5 against `fork/<new-ms>`.** All **11** probes must print `OK`.
+4. **Run §5 against `agentmuxai/<new-ms>`.** All **11** probes must print `OK`.
 5. **Build all three platforms from that one commit** — record the commit SHA.
 6. **Verify the built artifacts** (§7), per platform.
 7. **Cut three tags and update the pins together** (§8).
@@ -372,12 +406,12 @@ mechanical instead of a convention.
 
 ## 9. Checklists
 
-**Before merging a PR into `fork/<ms>`:**
-- [ ] Branched off `fork/<ms>`, not off an already-merged feature branch (R2)
-- [ ] `git log --oneline <last-shipped> --not fork/<ms>` prints nothing (§5)
+**Before merging a PR into `agentmuxai/<ms>`:**
+- [ ] Branched off `agentmuxai/<ms>`, not off an already-merged feature branch (R2)
+- [ ] `git log --oneline <last-shipped> --not agentmuxai/<ms>` prints nothing (§5)
 
 **Before building a release framework:**
-- [ ] Building from `fork/<ms>`, not a feature branch (R3)
+- [ ] Building from `agentmuxai/<ms>`, not a feature branch (R3)
 - [ ] All feature branches for this milestone are merged (R4)
 - [ ] All **11** §5 probes print `OK`
 - [ ] `patcher.py` run with no args; Chromium tree shows hundreds of modified files (§7.1)

--- a/docs/cef-build/CEF_FORK_MAINTENANCE.md
+++ b/docs/cef-build/CEF_FORK_MAINTENANCE.md
@@ -1,0 +1,326 @@
+# CEF Fork Maintenance — Branch Model and Upgrade Practice
+
+**Status:** living
+**Applies to:** `agentmuxai/cef` (our CEF fork), all three platforms
+**Companion docs:** [build-patched-libcef.md](./build-patched-libcef.md) (macOS/Linux),
+[build-patched-cef-windows.md](./build-patched-cef-windows.md),
+[build-patched-framework-macos.md](./build-patched-framework-macos.md)
+
+We maintain a fork of CEF carrying five AgentMux-specific changes. Every Chromium
+milestone upgrade has to carry that set forward, for Windows, Linux and macOS
+together. This doc is the standing practice for doing that without losing pieces.
+
+It exists because we lost pieces twice.
+
+---
+
+## 1. The two failures this prevents
+
+Both are **silent**. Neither produced an error, a conflict, or a failed build.
+That is the defining property of this class of bug: you find out when a user
+reports a feature that used to work.
+
+### 1.1 The forward-merge gap (2026-07-01 → 2026-09-09, found in production path)
+
+`agentmux/7778-drag-rightclick-and-transparency` was merged into `fork/7778` via
+PR #3 on Jun 24. Then PRs #4 and #5 added two **more** commits to that same
+branch on Jul 1 — the renderer-side transparency work and the macOS
+white-substitution fix. Nobody merged the branch forward a second time.
+
+```
+2720ba103  (Jun 24)  drag branch
+    │
+    ├──► merged into fork/7778 as 2d7833dec   (PR #3, Jun 24 18:57)
+    │         │
+    │         └──► 5387e4974  (PR #7, Sep 8)  ── fork/7778 tip
+    │                                             has process_requirement
+    │                                             MISSING #4 and #5
+    │
+    └──► 7ba6b59f4  (PR #4, Jul 1 19:19)      parent = 2720ba103
+              │
+              └──► 6c570e249 (PR #5, Jul 1 20:06)  ── drag branch tip
+                                                      what actually SHIPPED
+```
+
+For two months this cost nothing, because the July macOS framework was built from
+the drag branch tip directly (`cef HEAD: 6c570e249` in the build log), not from
+`fork/7778`. It only bit when someone went to `fork/7778` to pick up the
+`process_requirement` P0 fix — the reasonable, obvious move. Every signal pointed
+that way: `fork/7778` is the integration branch, it is named for the Chromium
+version, and it carried the newest commit (Sep 8 vs Jul 1).
+
+**Newer-looking is not the same as superset.** Building from `fork/7778` would
+have fixed the renderer crash-loop and simultaneously regressed macOS window
+transparency, with nothing anywhere reporting a problem.
+
+### 1.2 The same gap, already recurring on Chromium 152
+
+Checked while writing this doc. `fork/agentmux/7977-drag-rightclick-and-transparency`
+ports `BeginWindowDrag`, `rwhv_background_opaque_check` and
+`views_caption_rightclick_passthrough` to 152 — but **not** the renderer-side
+transparency work. Verified by probing for the exact identifiers
+`SetBaseBackgroundColorOverrideTransparent` and `background_transparent`: absent
+from `blink_glue.h`, `browser_config.h`, `cef.mojom` and `render_manager.cc` on
+that branch, present on the 7778 branch (positive control).
+
+So the 152 upgrade is currently set up to ship without transparency. It was found
+by inventory, not by any build failing.
+
+---
+
+## 2. Mental model: our changes live in two layers
+
+This is the single most important thing to internalise. The two layers have
+**completely different mechanics**, and conflating them is what makes the gaps
+invisible.
+
+| | Layer A — Chromium-side patches | Layer B — libcef-side commits |
+|---|---|---|
+| **What** | `.patch` files under `cef/patch/patches/` + registration in `cef/patch/patch.cfg` | Ordinary edits to `cef/libcef/**` and `cef/include/**` |
+| **Applied by** | `patcher.py`, at build time, into the surrounding Chromium tree | Nothing. They are just commits on the branch. |
+| **How it breaks** | Patch fails to apply, or `patcher.py` silently applies zero | Branch simply doesn't contain the commit |
+| **Detection** | Loud (`.rej` files, non-zero exit) — *unless* the invocation is wrong, see §6.1 | **Silent.** Nothing checks. |
+
+Layer B is where both failures happened. There is no tool that notices a missing
+libcef commit — the tree still compiles, because our additions are additive.
+
+A corollary that matters for the upgrade runbook: `patch.cfg` is a **single file
+shared by all three platforms**. There is no per-platform patch set. So all three
+platform builds must come from the *same fork commit*, or the platforms silently
+diverge in behaviour.
+
+---
+
+## 3. The carry-set (canonical inventory)
+
+Every one of these must survive every upgrade. Verified against
+`rebuild-7778-procreq-plus-transparency` on 2026-09-09.
+
+| # | Change | Layer | Files | Platform |
+|---|---|---|---|---|
+| 1 | `BeginWindowDrag` — native drag from an HTCLIENT region | B | `include/views/cef_window.h`, `libcef/browser/views/window_impl.{h,cc}` | All |
+| 2 | Renderer-side transparency (Blink base-bg override) | B | `libcef/renderer/blink_glue.{h,cc}`, `libcef/renderer/browser_config.h`, `libcef/renderer/render_manager.cc`, `libcef/common/mojom/cef.mojom`, `libcef/browser/browser_platform_delegate.cc`, `libcef/browser/browser_info_manager.cc` | All (**macOS-critical**) |
+| 3 | `rwhv_background_opaque_check` | A | `content/browser/renderer_host/render_widget_host_view_base.cc` | **macOS-critical**, no-op elsewhere |
+| 4 | `views_caption_rightclick_passthrough` | A | `ui/views/widget/desktop_aura/window_event_filter_linux.cc` | **Linux only** |
+| 5 | `agentmux_process_requirement` | A | `base/apple/mach_port_rendezvous_mac.cc` | **macOS 26 only** |
+
+Notes that have already caused confusion:
+
+- **#2 and #3 are one feature in two layers.** Transparency does not work with
+  either half alone. #3 was introduced as `mac_rwhv_transparent_background.patch`
+  in PR #4 and *replaced* by `rwhv_background_opaque_check.patch` in PR #5 — if
+  you find the old name on a branch, that branch predates the codex-review fix.
+- **#4 is Linux-only** despite the generic name. It patches
+  `window_event_filter_linux.cc`.
+- **#5 is not in the drag branch lineage at all**, which is exactly why the two
+  branches had to be merged and why the gap opened.
+
+---
+
+## 4. Branch model — the rules
+
+The root cause of §1.1 is a violation of a rule this repo already has, in
+`CLAUDE.md` under Workspace Rules:
+
+> **Never reuse a branch after its PR is merged; create a new branch.**
+
+That rule exists to prevent precisely this. It applies to `agentmuxai/cef` too.
+
+**R1 — One integration branch per Chromium milestone.** `fork/<milestone>`
+(`fork/7778`, `fork/7977`). This is the *only* branch anyone builds or releases
+from. It is upstream CEF's branch plus our carry-set, nothing else.
+
+**R2 — Feature branches are single-use.** Once `agentmux/<ms>-<topic>` is merged
+into `fork/<ms>`, it is dead. Follow-up work starts a new branch off
+`fork/<ms>`, never off the merged branch. This alone would have prevented §1.1.
+
+**R3 — Never build or release from a feature branch.** The July build used
+`agentmux/7778-drag-rightclick-and-transparency` directly. It produced a correct
+artifact *by luck* — that branch happened to be ahead. Building only from
+`fork/<ms>` makes R1 self-enforcing: if the integration branch is incomplete,
+you find out immediately rather than two months later.
+
+**R4 — Merge the whole carry-set before cutting a release, not piecemeal.** The
+152 work is split across `7977-drag-rightclick-and-transparency` and
+`7977-process-requirement`. Merging one without the other reproduces §1.1
+exactly. Merge both, then verify §5.
+
+**R5 — `fork/<ms>` must never lose a carry-set item.** It is append-only with
+respect to §3. If an upgrade legitimately drops one (upstream absorbed it), that
+requires an explicit commit saying so, referencing the upstream change.
+
+---
+
+## 5. Verifying a branch is complete
+
+Run this against any `fork/<ms>` before building or releasing from it. It is
+cheap and it is the only thing that catches Layer B gaps.
+
+```bash
+# From the cef checkout. BR is the branch under test.
+BR=fork/7778
+
+# Layer A — patch files present and registered
+for p in rwhv_background_opaque_check views_caption_rightclick_passthrough \
+         agentmux_process_requirement; do
+  git cat-file -e "${BR}:patch/patches/$p.patch" 2>/dev/null \
+    && git show "${BR}:patch/patch.cfg" | grep -q "'name': '$p'" \
+    && echo "OK   $p" || echo "MISS $p"
+done
+
+# Layer B — probe for the actual identifiers, not just the files
+git show "${BR}:include/views/cef_window.h"     | grep -q BeginWindowDrag \
+  && echo "OK   BeginWindowDrag" || echo "MISS BeginWindowDrag"
+git show "${BR}:libcef/renderer/blink_glue.h"   | grep -q SetBaseBackgroundColorOverrideTransparent \
+  && echo "OK   transparency (blink_glue)" || echo "MISS transparency (blink_glue)"
+git show "${BR}:libcef/common/mojom/cef.mojom"  | grep -q background_transparent \
+  && echo "OK   transparency (mojom)" || echo "MISS transparency (mojom)"
+```
+
+Keep the `${BR}:` braces. Written as `"$BR:libcef/..."` the shell eats the
+`:l` as a modifier and resolves `fork/7778ibcef/...`, which fails and reports a
+false MISS on exactly the two probes that matter most.
+
+**Probe identifiers, not filenames.** All of these files exist upstream. The 152
+gap in §1.2 is invisible to a file-existence check and obvious to an identifier
+check.
+
+**Also confirm the integration branch is a superset of whatever last shipped:**
+
+```bash
+# Must print nothing. Anything printed is in the shipped artifact but not in
+# the branch you are about to build — i.e. a regression you are about to ship.
+git log --oneline "$LAST_SHIPPED_COMMIT" --not "fork/$MS"
+```
+
+That one command, run in September, would have caught §1.1 in a second.
+
+---
+
+## 6. Upgrade runbook (per Chromium milestone, all three platforms)
+
+1. **Create `fork/<new-ms>`** from upstream CEF's branch for that milestone.
+2. **Port the carry-set** in §3. One commit per item, message
+   `agentmux: port <item> to <ms> (Chromium <N>)` — the 7977 branch already
+   follows this convention and it makes §5 auditable.
+   - Layer A: patches are context-sensitive and *will* need rebasing against new
+     Chromium source. Re-generate rather than force-apply.
+   - Layer B: usually clean cherry-picks; re-check API signatures that Chromium
+     changed underneath.
+3. **Merge every feature branch into `fork/<new-ms>`** (R4). Do not build from
+   the feature branches.
+4. **Run §5 against `fork/<new-ms>`.** All eight probes must print `OK`.
+5. **Build all three platforms from that one commit** — record the commit SHA.
+6. **Verify the built artifacts** (§7), per platform.
+7. **Cut three tags and update the pins together** (§8).
+
+---
+
+## 7. Verifying the built artifact, per platform
+
+A branch being correct does not prove the build consumed it. Both failure modes
+in §1 were about drift between intent and artifact, so check the binary.
+
+### 7.1 `patcher.py` silent-failure (all platforms)
+
+`patcher.py` takes **no arguments** in normal mode — it reads `patch/patch.cfg`
+itself and accepts only `--patch-file` / `--patch-dir`. Passing `--root-dir`
+makes it exit non-zero, and a wrapper script has swallowed exactly that as a
+non-fatal `WARN` and continued. Fixed in the build docs by PR #3113; the trap is
+worth restating because the failure applies **zero of 112 patches** and builds
+anyway.
+
+Two further traps, both hit in practice:
+
+- `--patch-file` takes the patch **name**, not a path. It appends `.patch`
+  itself, so `--patch-file patch/patches/foo.patch` looks for `foo.patch.patch`
+  and fails.
+- After running it, `git status --porcelain` in the Chromium tree must show
+  **hundreds** of modified files (444 for 7778). A clean tree here means zero
+  patches applied — that is the silent-failure signature, not success.
+
+### 7.2 Symbol probes on the built binary
+
+Our patch symbols are **local, not exported**. Use full `nm`. `nm -gU`
+(external-only) will miss every one of them and report a false negative.
+
+```bash
+# macOS
+BIN="Chromium Embedded Framework.framework/Versions/Current/Chromium Embedded Framework"
+nm "$BIN" | grep BeginWindowDrag      # expect __ZN13CefWindowImpl15BeginWindowDragEv (type 't')
+
+# Layer A landed at all? These come only from CEF's Chromium-side patches.
+for s in IsUniqueForCEF IsAlloyContents HasExternalParent; do
+  echo "$s: $(nm "$BIN" | grep -c "$s")"     # each must be > 0
+done
+```
+
+`libcef.dll` (Windows) and `libcef.so` (Linux) take the same approach with
+`dumpbin /symbols` and `nm -C` respectively. The `IsUniqueForCEF` /
+`IsAlloyContents` / `HasExternalParent` triple is the useful generic probe: those
+symbols exist **only** if CEF's Chromium-side patches were applied, so they
+distinguish "patched build" from "pristine Chromium build" on any platform.
+
+### 7.3 Platform-specific functional checks
+
+| Platform | Check |
+|---|---|
+| **macOS** | Frameless window drags from an HTCLIENT region (#1); window background is actually transparent, not white (#2+#3); renderer does not crash-loop on macOS 26 (#5); H.264/HEVC playback works (codec flags) |
+| **Linux** | Right-click in the caption area passes through (#4); drag (#1); H.264 playback (codec build) |
+| **Windows** | Drag (#1); transparency (#2) |
+
+---
+
+## 8. Release pinning across three platforms
+
+All three pins live in one place — `release.yml`'s `cef-runtime-pins` job — which
+is correct and was a deliberate fix (PR #3086 and its follow-up). Keep it that
+way; do not reintroduce per-job literals.
+
+Current pins:
+
+```
+WIN_TAG="cef-windows-x86_64-148.0.7778.180"
+LINUX_TAG="cef-linux-x86_64-148.0.7778.180-codecs"
+MACOS_TAG="cef-macos-arm64-148.23.23-codecs"
+```
+
+**Known sharp edge: the three tags use two different version schemes.** Windows
+and Linux carry the *Chromium* version (`148.0.7778.180`); macOS carries the
+*CEF* version (`148.23.23`). The job cross-checks only the leading milestone
+(`148`), which is the one component the schemes agree on. That check is real but
+weak: **two tags can agree on `148` and still come from different fork commits
+with different carry-sets.** That is exactly the divergence §1 is about, and
+nothing currently catches it.
+
+Practice until that is fixed:
+
+- **P1 — Build all three platforms from one fork commit, and record that SHA** in
+  the release PR body. It is the only thing that ties the three tags together.
+- **P2 — Bump all three pins in the same PR.** A PR touching one pin should be
+  treated as incomplete unless it says explicitly why the others stay.
+- **P3 — Re-run §5 against the fork commit** when bumping pins, not just §7.
+
+A worthwhile follow-up (not yet done): have the release job assert that all three
+tags resolve to the same `agentmuxai/cef` commit, which would make P1–P3
+mechanical instead of a convention.
+
+---
+
+## 9. Checklists
+
+**Before merging a PR into `fork/<ms>`:**
+- [ ] Branched off `fork/<ms>`, not off an already-merged feature branch (R2)
+- [ ] `git log --oneline <last-shipped> --not fork/<ms>` prints nothing (§5)
+
+**Before building a release framework:**
+- [ ] Building from `fork/<ms>`, not a feature branch (R3)
+- [ ] All feature branches for this milestone are merged (R4)
+- [ ] All eight §5 probes print `OK`
+- [ ] `patcher.py` run with no args; Chromium tree shows hundreds of modified files (§7.1)
+
+**Before updating the pins:**
+- [ ] All three platforms built from one recorded fork commit (P1)
+- [ ] §7.2 symbol probes pass on each artifact, using full `nm`
+- [ ] §7.3 functional checks pass per platform
+- [ ] All three pins bumped together (P2)

--- a/docs/cef-build/CEF_FORK_MAINTENANCE.md
+++ b/docs/cef-build/CEF_FORK_MAINTENANCE.md
@@ -62,11 +62,27 @@ itself worth keeping.
 
 The probe was real, but it ran against a stale local ref.
 `agentmux/7977-drag-rightclick-and-transparency` had been **force-updated**
-(`d6fe3d449` -> `55edc030a`); after `git fetch --prune` all seven transparency
-files probe `OK`. The 152 port is complete. Two existing documents already said
-so -- `docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md` and
+(`d6fe3d449` -> `55edc030a`). Two existing documents already said the port was
+done -- `docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md` and
 `docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md` -- and were not
 consulted.
+
+**Re-verified against the full 21-probe gate** (the first pass used only the
+then-current 7 transparency probes, which could not have spoken for the 8
+browser-side files §3 later added -- the same almost-complete-reads-as-complete
+trap, one level up):
+
+| Branch | Result |
+|---|---|
+| `agentmux/7977-drag-rightclick-and-transparency` | **20 OK, 1 MISS** |
+| `agentmux/7977-process-requirement` | supplies the 1 missing patch |
+| **`7977`** (the integration branch) | **0 OK, 21 MISS** |
+
+So the 152 *port* is genuinely complete across the two feature branches --
+including all 8 browser-side files. But **`7977` itself carries none of it**,
+because neither branch has been merged. Per R3 that is the branch a release
+would be built from, and per R4 both feature branches must land there first.
+This is §1.1 exactly, caught before the fact instead of two months after.
 
 So, as a rule:
 
@@ -80,11 +96,17 @@ So, as a rule:
 - A probe reporting `MISS` proves something is absent **from the ref you
   probed**. That is a weaker claim than "absent from the branch," and the
   difference is exactly the mistake made here.
+- **When the gate changes, re-run every claim the old gate made.** The
+  "complete" verdict above was first reached with 7 transparency probes and
+  survived unchanged when §3 grew to 18 files -- so for a while it asserted
+  something no probe had actually checked. A completeness claim is only ever as
+  strong as the inventory current *at the moment it was made*, and expanding the
+  inventory silently invalidates every earlier verdict.
 
-One genuine asymmetry does remain, and it is the R4 case rather than a defect:
-`agentmux_process_requirement` is absent from the drag branch because it lives on
-`agentmux/7977-process-requirement`. Both must be merged into `agentmuxai/7977`. That
-split is precisely what produced §1.1 on 7778.
+The single `MISS` on the drag branch is the R4 case rather than a defect:
+`agentmux_process_requirement` lives on `agentmux/7977-process-requirement`.
+Both branches must be merged into `7977`. That split is precisely what produced
+§1.1 on 7778, which is why R4 exists.
 
 ---
 

--- a/docs/cef-build/CEF_FORK_MAINTENANCE.md
+++ b/docs/cef-build/CEF_FORK_MAINTENANCE.md
@@ -528,30 +528,37 @@ cd out/Release_GN_arm64
 # success while the other is absent -- and the macOS-critical one is the second.
 check_patch() {  # check_patch <source-path> <object-path>
   local SRC="$1" OBJ="$2" ok=1
-  git -C ../.. show "HEAD:$SRC" > /tmp/unpatched.cc          # pristine upstream
-  local CMD; CMD=$(ninja -C . -t commands "$OBJ" | tail -1)  # the real compile line
+  local CMD; CMD=$(ninja -C . -t commands "$OBJ" | tail -1)
 
-  # ${VAR//a/b} and sed's /g are BOTH mandatory here. The object path appears
-  # TWICE in the command -- once as `-MF <obj>.d`, once as `-o <obj>` -- so a
-  # non-global replace redirects only the depfile and leaves `-o` pointing at
-  # the REAL object. That does not fail: it silently OVERWRITES your build
-  # output with an unpatched compile. It happened while writing this section.
-  local PATCHED_CMD="${CMD//$OBJ//tmp/patched.o}"
-  local UNPATCHED_CMD
-  UNPATCHED_CMD=$(echo "$CMD" | sed "s#$OBJ#/tmp/unpatched.o#g; s#\.\./\.\./$SRC#/tmp/unpatched.cc#g")
+  # ${VAR//a/b} and sed's /g are BOTH mandatory. The object path appears TWICE
+  # in the command -- `-MF <obj>.d` and `-o <obj>` -- so a non-global replace
+  # redirects only the depfile and leaves `-o` pointing at the REAL object. It
+  # does not fail: it OVERWRITES your build output. That happened while writing
+  # this section, which is why the guard below exists.
+  local A="${CMD//$OBJ//tmp/A.o}"
+  case "$A" in *"-o $OBJ"*) echo "ABORT $SRC: rewritten command still targets $OBJ"; return 1 ;; esac
 
-  # Refuse to run either command if it can still write to the real object.
-  case "$PATCHED_CMD$UNPATCHED_CMD" in
-    *"-o $OBJ"*) echo "ABORT $SRC: rewritten command still targets $OBJ"; return 1 ;;
-  esac
+  # (A) working-tree source at its ORIGINAL path, vs the shipped object.
+  # The path must not change here: under symbol_level=1 the compiler embeds the
+  # source path in DWARF, so compiling identical content from /tmp yields a
+  # DIFFERENT object. Verified: same content, different path -> objects differ.
+  eval "$A"
 
-  eval "$PATCHED_CMD"
-  eval "$UNPATCHED_CMD"
+  # (B) and (C) patched vs pristine content, both from the SAME synthetic path,
+  # so the only difference between them is content. Comparing the shipped object
+  # against a /tmp-compiled *pristine* build would be meaningless -- it always
+  # differs, on the path alone, whether or not the patch is present. An earlier
+  # revision of this recipe did exactly that, so its "shipped != unpatched" leg
+  # could never fire.
+  cp "../../$SRC" /tmp/probe.cc
+  eval "$(echo "${CMD//$OBJ//tmp/B.o}" | sed "s#\.\./\.\./$SRC#/tmp/probe.cc#g")"
+  git -C ../.. show "HEAD:$SRC" > /tmp/probe.cc
+  eval "$(echo "${CMD//$OBJ//tmp/C.o}" | sed "s#\.\./\.\./$SRC#/tmp/probe.cc#g")"
 
-  cmp -s /tmp/unpatched.o "$OBJ" && { echo "FAIL $SRC: shipped object is UNPATCHED"; ok=0; }
-  cmp -s /tmp/patched.o   "$OBJ" || { echo "FAIL $SRC: shipped object does not match patched source"; ok=0; }
+  cmp -s /tmp/A.o "$OBJ" || { echo "FAIL $SRC: shipped object does not match the working tree"; ok=0; }
+  cmp -s /tmp/B.o /tmp/C.o && { echo "FAIL $SRC: patch is a no-op — nothing distinguishes it from upstream"; ok=0; }
   [ "$ok" = 1 ] && echo "OK   $SRC"
-  rm -f /tmp/patched.o /tmp/unpatched.o /tmp/unpatched.cc
+  rm -f /tmp/A.o /tmp/B.o /tmp/C.o /tmp/probe.cc
   [ "$ok" = 1 ]
 }
 
@@ -564,10 +571,14 @@ check_patch content/browser/renderer_host/render_widget_host_view_base.cc \
 Expect **two** `OK` lines. `views_caption_rightclick_passthrough` is not listed
 because it adds a symbol and §7.2 already covers it.
 
-Both comparisons matter. `shipped == patched` alone is weak if the patch happens
-to compile to the same bytes as upstream; `shipped != unpatched` is what proves
-the patch actually changed the output. Confirmed for both patches on the
-2026-09-09 macOS build.
+Both comparisons matter, but **they must not be the pair you would first reach
+for.** `shipped == tree` (A) proves the artifact was built from what is checked
+out. It is weak alone, because a patch that compiled to the same bytes as
+upstream would also pass — so (B) vs (C) proves the patch materially changes
+codegen. The two are compared *at the same synthetic path*, because the
+alternative (shipped vs a `/tmp`-compiled pristine object) always differs on the
+embedded source path alone and therefore proves nothing. Confirmed for both
+patches on the 2026-09-09 macOS build.
 
 Do not try to read this off a disassembly. Attempting exactly that on
 `GetPeerValidationPolicy` produced a confident *wrong* answer — the patched

--- a/docs/cef-build/CEF_FORK_MAINTENANCE.md
+++ b/docs/cef-build/CEF_FORK_MAINTENANCE.md
@@ -98,7 +98,7 @@ invisible.
 | **What** | `.patch` files under `cef/patch/patches/` + registration in `cef/patch/patch.cfg` | Ordinary edits to `cef/libcef/**` and `cef/include/**` |
 | **Applied by** | `patcher.py`, at build time, into the surrounding Chromium tree | Nothing. They are just commits on the branch. |
 | **How it breaks** | Patch fails to apply, or `patcher.py` silently applies zero | Branch simply doesn't contain the commit |
-| **Detection** | Loud (`.rej` files, non-zero exit) — *unless* the invocation is wrong, see §6.1 | **Silent.** Nothing checks. |
+| **Detection** | Loud (`.rej` files, non-zero exit) — *unless* the invocation is wrong, see §7.1 | **Silent.** Nothing checks. |
 
 Layer B is where both failures happened. There is no tool that notices a missing
 libcef commit — the tree still compiles, because our additions are additive.
@@ -260,7 +260,12 @@ branch.
 Keep the `${BR}:` braces — this is not stylistic, and it is shell-dependent.
 In **zsh** (the macOS default, so what these snippets usually get run in),
 `"$BR:libcef/..."` applies `:l` as a history-style modifier and resolves
-`agentmuxai/7778ibcef/...` — a false MISS on exactly the two probes that matter most.
+`agentmuxai/7778ibcef/...` — a false MISS on **7 of the 11 probes**: every
+`libcef/`-prefixed one, which is the entire Layer B transparency cascade. The
+other four are safe only by luck of the first letter (`include/` -> `:i` and
+`patch/` -> `:p` are not modifiers), so a silent partial pass is the default
+outcome, not the edge case.
+
 **bash expands the braced and unbraced forms identically**, so this reproduces
 for only some readers, which is worse than a consistent break.
 
@@ -276,8 +281,10 @@ $BR:include/x   -> agentmuxai/7778:include/x  ( :i  not a modifier - safe )
 $BR:patch/x     -> agentmuxai/7778:patch/x    ( :p  not a modifier - safe )
 ```
 
-`:include` and `:patch` being safe is why only the two `libcef` probes broke,
-and why this survived a first reading.
+The safe/unsafe split falls on the first letter of the path, not on anything
+meaningful — which is why this survived a first reading. At the time the bug
+was found the block probed only two `libcef/` paths; expanding the cascade to
+seven widened the blast radius without changing the cause.
 
 **Probe identifiers, not filenames.** All of these files exist upstream. The 152
 gap in §1.2 is invisible to a file-existence check and obvious to an identifier

--- a/docs/cef-build/CEF_FORK_MAINTENANCE.md
+++ b/docs/cef-build/CEF_FORK_MAINTENANCE.md
@@ -112,27 +112,73 @@ diverge in behaviour.
 
 ## 3. The carry-set (canonical inventory)
 
-Every one of these must survive every upgrade. Verified against
-`rebuild-7778-procreq-plus-transparency` on 2026-09-09.
+**18 hand-written CEF source files** differ between upstream 7778 and the fork,
+plus **3 Chromium-side patches**. Measured, not estimated:
 
-| # | Change | Layer | Files | Platform |
-|---|---|---|---|---|
-| 1 | `BeginWindowDrag` — native drag from an HTCLIENT region | B | `include/views/cef_window.h`, `libcef/browser/views/window_impl.{h,cc}` | All |
-| 2 | Renderer-side transparency (Blink base-bg override) | B | `libcef/renderer/blink_glue.{h,cc}`, `libcef/renderer/browser_config.h`, `libcef/renderer/render_manager.cc`, `libcef/common/mojom/cef.mojom`, `libcef/browser/browser_platform_delegate.cc`, `libcef/browser/browser_info_manager.cc` | All (**macOS-critical**) |
-| 3 | `rwhv_background_opaque_check` | A | `content/browser/renderer_host/render_widget_host_view_base.cc` | **macOS-critical**, no-op elsewhere |
-| 4 | `views_caption_rightclick_passthrough` | A | `ui/views/widget/desktop_aura/window_event_filter_linux.cc` | **Linux only** |
-| 5 | `agentmux_process_requirement` | A | `base/apple/mach_port_rendezvous_mac.cc` | **macOS 26 only** |
+```bash
+git diff --name-only <upstream-base> <branch> -- \
+    'libcef/**' 'include/views/**' 'include/internal/**' \
+  | grep -vE 'capi/|libcef_dll/'      # exclude generated wrappers
+```
+
+The 18 agrees with `docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md`
+§5b, which reached it independently while scoping the 152 port.
+
+> An earlier revision of this table listed only 10 of the 18, omitting the entire
+> browser-side half of the transparency cascade. The §5 gate probed those 10 and
+> reported a clean bill of health, so a branch missing eight fork-modified files
+> would have passed. Caught by Codex review on PR #3121. The lesson is §2's: for
+> Layer B nothing fails loudly, so an inventory that is *almost* complete reads
+> exactly like one that is complete.
+
+### Layer B — CEF source (18 files, carried by the branch itself)
+
+| Feature | Files | Probe identifier |
+|---|---|---|
+| **Drag** (3) | `include/views/cef_window.h` | `BeginWindowDrag` |
+| | `libcef/browser/views/window_impl.h` | `BeginWindowDrag` |
+| | `libcef/browser/views/window_impl.cc` | `BeginWindowDrag` |
+| **Transparency — renderer** (5) | `libcef/renderer/blink_glue.h` | `SetBaseBackgroundColorOverrideTransparent` |
+| | `libcef/renderer/blink_glue.cc` | `SetBaseBackgroundColorOverrideTransparent` |
+| | `libcef/renderer/browser_config.h` | `background_transparent` |
+| | `libcef/renderer/render_manager.cc` | `background_transparent` |
+| | `libcef/common/mojom/cef.mojom` | `background_transparent` |
+| **Transparency — browser** (10) | `libcef/browser/browser_info_manager.cc` | `background_transparent` |
+| | `libcef/browser/browser_platform_delegate.cc` | `background_transparent` |
+| | `libcef/browser/browser_platform_delegate_create.cc` | `is_views_hosted` |
+| | `libcef/browser/browser_host_base.cc` | `IsWindowless() \|\| is_views_hosted()` |
+| | `libcef/browser/context.cc` | `is_transparent` |
+| | `libcef/browser/context.h` | `transparent_state` |
+| | `libcef/browser/views/browser_view_impl.cc` | `ApplyToCurrentRWHView` |
+| | `libcef/browser/views/browser_view_impl.h` | `LayerTreeHost` |
+| | `libcef/browser/views/window_view.cc` | `CalculateRenderPasses` |
+| | `include/internal/cef_types.h` | `or a frameless window` |
+
+Every probe identifier above is **absent upstream and present in the fork** —
+asserted for all 18, so each one actually discriminates rather than matching
+code that was already there.
+
+### Layer A — Chromium-side patches (3)
+
+| Patch | Patches | Platform |
+|---|---|---|
+| `rwhv_background_opaque_check` | `content/browser/renderer_host/render_widget_host_view_base.cc` | **macOS-critical**, no-op elsewhere |
+| `views_caption_rightclick_passthrough` | `ui/views/widget/desktop_aura/window_event_filter_linux.cc` | **Linux only** |
+| `agentmux_process_requirement` | `base/apple/mach_port_rendezvous_mac.cc` | **macOS 26 only** |
 
 Notes that have already caused confusion:
 
-- **#2 and #3 are one feature in two layers.** Transparency does not work with
-  either half alone. #3 was introduced as `mac_rwhv_transparent_background.patch`
-  in PR #4 and *replaced* by `rwhv_background_opaque_check.patch` in PR #5 — if
-  you find the old name on a branch, that branch predates the codex-review fix.
-- **#4 is Linux-only** despite the generic name. It patches
-  `window_event_filter_linux.cc`.
-- **#5 is not in the drag branch lineage at all**, which is exactly why the two
-  branches had to be merged and why the gap opened.
+- **Transparency is one feature spanning both layers and 16 files** (15 Layer B +
+  `rwhv_background_opaque_check`). It works with none of the halves alone.
+  `SPEC_CEF_148_LINUX_FORWARD_PORT_2026_06_04.md` §3 says these commits "should
+  be ported as a unit"; treat any partial port as broken, not partially working.
+- The Layer A patch was introduced as `mac_rwhv_transparent_background.patch` in
+  PR #4 and *replaced* by `rwhv_background_opaque_check.patch` in PR #5. Finding
+  the old name on a branch means it predates the codex-review fix.
+- **`views_caption_rightclick_passthrough` is Linux-only** despite the generic
+  name — it patches `window_event_filter_linux.cc`.
+- **`agentmux_process_requirement` is not in the drag branch lineage at all**,
+  which is why the two branches had to be merged and how §1.1's gap opened.
 
 ---
 
@@ -188,69 +234,98 @@ Run this against any `agentmuxai/<ms>` before building or releasing from it. It 
 cheap and it is the only thing that catches Layer B gaps.
 
 ```bash
-# Paste into a shell, then run:  cef_verify [milestone] [remote]
+# Paste into a shell, then run:
+#   cef_verify                      # integration branch 7778 on remote 'agentmuxai'
+#   cef_verify 7977 fork            # milestone 7977, remote named 'fork'
+#   cef_verify a1b2c3d4...          # an exact SHA -- see section 8, P3
+#
 # A function, not a bare script: a top-level `exit 1` would close the shell of
 # anyone who pasted this, which is a poor reward for following the doc.
 cef_verify() {
-  local MS="${1:-7778}"                 # milestone == the integration branch name
+  local REF="${1:-7778}"
   local REMOTE="${2:-${REMOTE:-agentmuxai}}"
-  local BR="$REMOTE/$MS"                # remote-tracking ref, e.g. agentmuxai/7778
+  local BR
 
-  # REMOTE is whatever YOU named the agentmuxai/cef remote. The companion
-  # runbooks add it as 'agentmuxai'; some checkouts call it 'fork'. Hard-coding
-  # it either errors out or, worse, silently resolves a same-named ref from an
-  # unrelated remote -- the exact class of failure this gate exists to catch.
-  git remote get-url "$REMOTE" >/dev/null 2>&1 || {
-    echo "No remote '$REMOTE'. Pass it: cef_verify $MS <remote>  (see: git remote -v)" >&2
-    return 1
-  }
+  if [[ "$REF" =~ ^[0-9]+$ ]]; then
+    # A bare milestone number means the integration branch on REMOTE.
+    # REMOTE is whatever YOU named the agentmuxai/cef remote. The companion
+    # runbooks add it as 'agentmuxai'; some checkouts call it 'fork'. Hard-coding
+    # it either errors out or silently resolves a same-named ref from an
+    # unrelated remote -- the class of failure this gate exists to catch.
+    git remote get-url "$REMOTE" >/dev/null 2>&1 || {
+      echo "No remote '$REMOTE'. Pass it: cef_verify $REF <remote>  (git remote -v)" >&2
+      return 1
+    }
+    # MANDATORY. These branches get force-updated mid-port; a stale ref gives a
+    # confident, wrong answer. Section 1.2 -- skipping this put a false claim in
+    # an earlier revision of this very doc.
+    git fetch "$REMOTE" --prune || return 1
+    BR="$REMOTE/$REF"
+  else
+    # Anything else is used verbatim: a tag, a full SHA, a local branch. This is
+    # what section 8's P3 needs -- verifying a RELEASE ARTIFACT means checking
+    # the commit it was built from, not whatever the branch has become since. A
+    # fix landed after the build would otherwise make the gate pass for an
+    # artifact that does not contain it.
+    BR="$REF"
+  fi
 
-  # MANDATORY. These branches get force-updated mid-port; a stale ref produces a
-  # confident, wrong answer. Section 1.2 -- skipping this put a false claim in an
-  # earlier revision of this very doc.
-  git fetch "$REMOTE" --prune || return 1
-  git rev-parse --verify -q "$BR" >/dev/null || {
-    echo "No such branch '$BR'. The integration branch is named for the milestone alone." >&2
+  git rev-parse --verify -q "${BR}^{commit}" >/dev/null || {
+    echo "Cannot resolve '$BR'. The integration branch is named for the milestone alone." >&2
     return 1
   }
 
   local ok=0 miss=0
-  _p() { if [ "$1" = OK ]; then ok=$((ok+1)); else miss=$((miss+1)); fi; printf '%-4s %s\n' "$1" "$2"; }
+  _probe() {  # _probe <path> <identifier-absent-upstream>
+    if git show "${BR}:$1" 2>/dev/null | grep -qF "$2"; then
+      ok=$((ok+1));   printf 'OK   %s\n' "$1"
+    else
+      miss=$((miss+1)); printf 'MISS %s\n' "$1"
+    fi
+  }
 
-  # Layer A -- patch file present AND registered in patch.cfg
+  # ---- Layer A: patch file present AND registered in patch.cfg ----
   local name
   for name in rwhv_background_opaque_check views_caption_rightclick_passthrough \
               agentmux_process_requirement; do
     if git cat-file -e "${BR}:patch/patches/${name}.patch" 2>/dev/null \
        && git show "${BR}:patch/patch.cfg" | grep -q "'name': '${name}'"; then
-      _p OK "$name"; else _p MISS "$name"; fi
+      ok=$((ok+1));   printf 'OK   patch/%s\n' "$name"
+    else
+      miss=$((miss+1)); printf 'MISS patch/%s\n' "$name"
+    fi
   done
 
-  # Layer B -- probe identifiers, not filenames. Every one of these files exists
-  # upstream, so a file-existence check proves nothing.
-  _probe() {
-    if git show "${BR}:$1" 2>/dev/null | grep -q "$2"; then _p OK "$1"; else _p MISS "$1"; fi
-  }
-  _probe include/views/cef_window.h                  BeginWindowDrag
+  # ---- Layer B: all 18 fork-modified CEF sources (section 3) ----
+  # Identifiers, not filenames: every one of these files exists upstream, so a
+  # file-existence check proves nothing. Each identifier is asserted absent
+  # upstream and present in the fork, so it actually discriminates.
+  _probe include/views/cef_window.h                        BeginWindowDrag
+  _probe libcef/browser/views/window_impl.h                BeginWindowDrag
+  _probe libcef/browser/views/window_impl.cc               BeginWindowDrag
+  _probe libcef/renderer/blink_glue.h                      SetBaseBackgroundColorOverrideTransparent
+  _probe libcef/renderer/blink_glue.cc                     SetBaseBackgroundColorOverrideTransparent
+  _probe libcef/renderer/browser_config.h                  background_transparent
+  _probe libcef/renderer/render_manager.cc                 background_transparent
+  _probe libcef/common/mojom/cef.mojom                     background_transparent
+  _probe libcef/browser/browser_info_manager.cc            background_transparent
+  _probe libcef/browser/browser_platform_delegate.cc       background_transparent
+  _probe libcef/browser/browser_platform_delegate_create.cc is_views_hosted
+  _probe libcef/browser/browser_host_base.cc               'IsWindowless() || is_views_hosted()'
+  _probe libcef/browser/context.cc                         is_transparent
+  _probe libcef/browser/context.h                          transparent_state
+  _probe libcef/browser/views/browser_view_impl.cc         ApplyToCurrentRWHView
+  _probe libcef/browser/views/browser_view_impl.h          LayerTreeHost
+  _probe libcef/browser/views/window_view.cc               CalculateRenderPasses
+  _probe include/internal/cef_types.h                      'or a frameless window'
 
-  # Transparency is a SEVEN-file cascade, probed as a unit. Checking only
-  # blink_glue + mojom passes on a partial port while browser-side propagation
-  # or render_manager.cc is still absent -- the gate would then approve the very
-  # regression it exists to catch.
-  _probe libcef/renderer/blink_glue.h                SetBaseBackgroundColorOverrideTransparent
-  _probe libcef/renderer/blink_glue.cc               SetBaseBackgroundColorOverrideTransparent
-  _probe libcef/renderer/browser_config.h            background_transparent
-  _probe libcef/renderer/render_manager.cc           background_transparent
-  _probe libcef/common/mojom/cef.mojom               background_transparent
-  _probe libcef/browser/browser_platform_delegate.cc background_transparent
-  _probe libcef/browser/browser_info_manager.cc      background_transparent
-
-  echo "--- $BR: $ok OK, $miss MISS (expect 11 OK, 0 MISS) ---"
+  unset -f _probe
+  echo "--- $BR: $ok OK, $miss MISS (expect 21 OK, 0 MISS) ---"
   [ "$miss" -eq 0 ]
 }
 ```
 
-Expect **11 `OK`** against a complete `agentmuxai/<ms>`.
+Expect **21 `OK`** against a complete `agentmuxai/<ms>`.
 
 On a *feature* branch, `MISS agentmux_process_requirement` is normal rather than
 a defect -- it lives on `agentmux/<ms>-process-requirement`. That is the R4
@@ -260,11 +335,23 @@ branch.
 Keep the `${BR}:` braces — this is not stylistic, and it is shell-dependent.
 In **zsh** (the macOS default, so what these snippets usually get run in),
 `"$BR:libcef/..."` applies `:l` as a history-style modifier and resolves
-`agentmuxai/7778ibcef/...` — a false MISS on **7 of the 11 probes**: every
-`libcef/`-prefixed one, which is the entire Layer B transparency cascade. The
-other four are safe only by luck of the first letter (`include/` -> `:i` and
-`patch/` -> `:p` are not modifiers), so a silent partial pass is the default
-outcome, not the edge case.
+`agentmuxai/7778ibcef/...` — a false MISS, silently.
+
+**The gate above avoids this structurally**, and that is deliberate: `_probe`
+takes the path as an *argument*, so the expansion is `${BR}:$1`, and zsh applies
+modifiers only to *literal* text after the colon. Verified:
+
+```
+${BR}:$f                                  -> agentmuxai/7778:libcef/renderer/blink_glue.h
+$BR:$f                                    -> agentmuxai/7778:libcef/renderer/blink_glue.h   (also fine)
+$BR:libcef/renderer/blink_glue.h          -> agentmuxai/7778ibcef/renderer/blink_glue.h     (broken)
+```
+
+So the hazard only bites if you **inline a path literally**. Do not — and if you
+do anyway, 16 of the 21 probes break: every `libcef/`-prefixed one. The
+remaining 5 are safe purely by first letter (`include/` -> `:i`, `patch/` ->
+`:p` are not modifiers), so a silent *partial* pass is the default outcome
+rather than an obvious total failure.
 
 **bash expands the braced and unbraced forms identically**, so this reproduces
 for only some readers, which is worse than a consistent break.
@@ -315,7 +402,7 @@ That one command, run in September, would have caught §1.1 in a second.
      changed underneath.
 3. **Merge every feature branch into `agentmuxai/<new-ms>`** (R4). Do not build from
    the feature branches.
-4. **Run §5 against `agentmuxai/<new-ms>`.** All **11** probes must print `OK`.
+4. **Run §5 against `agentmuxai/<new-ms>`.** All **21** probes must print `OK`.
 5. **Build all three platforms from that one commit** — record the commit SHA.
 6. **Verify the built artifacts** (§7), per platform.
 7. **Cut three tags and update the pins together** (§8).
@@ -422,7 +509,7 @@ mechanical instead of a convention.
 **Before building a release framework:**
 - [ ] Building from `agentmuxai/<ms>`, not a feature branch (R3)
 - [ ] All feature branches for this milestone are merged (R4)
-- [ ] All **11** §5 probes print `OK`
+- [ ] All **21** §5 probes print `OK`
 - [ ] `patcher.py` run with no args; Chromium tree shows hundreds of modified files (§7.1)
 
 **Before updating the pins:**

--- a/docs/cef-build/CEF_FORK_MAINTENANCE.md
+++ b/docs/cef-build/CEF_FORK_MAINTENANCE.md
@@ -407,6 +407,15 @@ meaningful — which is why this survived a first reading. At the time the bug
 was found the block probed only two `libcef/` paths; expanding the cascade to
 seven widened the blast radius without changing the cause.
 
+> **What this gate does not check.** It verifies the carry-set is *present*.
+> It says nothing about whether that code is *correct*, whether the Layer A
+> patches still apply to the milestone's Chromium source, or whether the result
+> builds. A concrete example: agentmuxai/agentmux#3127 — the Views transparency
+> sites are not gated on `is_frameless_`, which is reachable in AgentMux
+> (framed DevTools popups + a transparent global `background_color`). `7778`
+> reports `21 OK, 0 MISS` and carries that bug. **A green gate is not a release
+> sign-off**; §7 and a real build are still required.
+
 **Probe identifiers, not filenames.** All of these files exist upstream. The 152
 gap in §1.2 is invisible to a file-existence check and obvious to an identifier
 check.

--- a/docs/cef-build/CEF_FORK_MAINTENANCE.md
+++ b/docs/cef-build/CEF_FORK_MAINTENANCE.md
@@ -510,18 +510,46 @@ compare both against the object that was actually linked:
 
 ```bash
 cd out/Release_GN_arm64
-SRC=base/apple/mach_port_rendezvous_mac.cc
-OBJ=obj/base/base/mach_port_rendezvous_mac.o
 
-git -C ../.. show HEAD:$SRC > /tmp/unpatched.cc          # pristine upstream
-CMD=$(ninja -C . -t commands "$OBJ" | tail -1)           # the real compile line
+# BOTH no-symbol patches, as a pair. Checking only one lets the recipe report
+# success while the other is absent -- and the macOS-critical one is the second.
+check_patch() {  # check_patch <source-path> <object-path>
+  local SRC="$1" OBJ="$2" ok=1
+  git -C ../.. show "HEAD:$SRC" > /tmp/unpatched.cc          # pristine upstream
+  local CMD; CMD=$(ninja -C . -t commands "$OBJ" | tail -1)  # the real compile line
 
-eval "${CMD//$OBJ//tmp/patched.o}"                       # from the working tree
-eval "$(echo "$CMD" | sed "s#$OBJ#/tmp/unpatched.o#; s#\.\./\.\./$SRC#/tmp/unpatched.cc#")"
+  # ${VAR//a/b} and sed's /g are BOTH mandatory here. The object path appears
+  # TWICE in the command -- once as `-MF <obj>.d`, once as `-o <obj>` -- so a
+  # non-global replace redirects only the depfile and leaves `-o` pointing at
+  # the REAL object. That does not fail: it silently OVERWRITES your build
+  # output with an unpatched compile. It happened while writing this section.
+  local PATCHED_CMD="${CMD//$OBJ//tmp/patched.o}"
+  local UNPATCHED_CMD
+  UNPATCHED_CMD=$(echo "$CMD" | sed "s#$OBJ#/tmp/unpatched.o#g; s#\.\./\.\./$SRC#/tmp/unpatched.cc#g")
 
-cmp -s /tmp/unpatched.o "$OBJ" && echo 'FAIL: shipped object is UNPATCHED'
-cmp -s /tmp/patched.o   "$OBJ" && echo 'OK: shipped object matches patched source'
+  # Refuse to run either command if it can still write to the real object.
+  case "$PATCHED_CMD$UNPATCHED_CMD" in
+    *"-o $OBJ"*) echo "ABORT $SRC: rewritten command still targets $OBJ"; return 1 ;;
+  esac
+
+  eval "$PATCHED_CMD"
+  eval "$UNPATCHED_CMD"
+
+  cmp -s /tmp/unpatched.o "$OBJ" && { echo "FAIL $SRC: shipped object is UNPATCHED"; ok=0; }
+  cmp -s /tmp/patched.o   "$OBJ" || { echo "FAIL $SRC: shipped object does not match patched source"; ok=0; }
+  [ "$ok" = 1 ] && echo "OK   $SRC"
+  rm -f /tmp/patched.o /tmp/unpatched.o /tmp/unpatched.cc
+  [ "$ok" = 1 ]
+}
+
+check_patch base/apple/mach_port_rendezvous_mac.cc \
+            obj/base/base/mach_port_rendezvous_mac.o                    # agentmux_process_requirement
+check_patch content/browser/renderer_host/render_widget_host_view_base.cc \
+            obj/content/browser/browser/render_widget_host_view_base.o  # rwhv_background_opaque_check
 ```
+
+Expect **two** `OK` lines. `views_caption_rightclick_passthrough` is not listed
+because it adds a symbol and §7.2 already covers it.
 
 Both comparisons matter. `shipped == patched` alone is weak if the patch happens
 to compile to the same bytes as upstream; `shipped != unpatched` is what proves
@@ -597,7 +625,7 @@ mechanical instead of a convention.
 **Before updating the pins:**
 - [ ] All three platforms built from one recorded fork commit (P1)
 - [ ] §7.2 symbol probes pass on each artifact, using full `nm`
-- [ ] §7.2b differential compile passes for the two patches `nm` cannot see
-      (`agentmux_process_requirement`, `rwhv_background_opaque_check`)
+- [ ] §7.2b differential compile prints **two** `OK` lines — one per no-symbol
+      patch (`agentmux_process_requirement`, `rwhv_background_opaque_check`)
 - [ ] §7.3 functional checks pass per platform
 - [ ] All three pins bumped together (P2)

--- a/docs/cef-build/CEF_FORK_MAINTENANCE.md
+++ b/docs/cef-build/CEF_FORK_MAINTENANCE.md
@@ -53,18 +53,37 @@ version, and it carried the newest commit (Sep 8 vs Jul 1).
 have fixed the renderer crash-loop and simultaneously regressed macOS window
 transparency, with nothing anywhere reporting a problem.
 
-### 1.2 The same gap, already recurring on Chromium 152
+### 1.2 Always re-fetch before you judge a branch
 
-Checked while writing this doc. `fork/agentmux/7977-drag-rightclick-and-transparency`
-ports `BeginWindowDrag`, `rwhv_background_opaque_check` and
-`views_caption_rightclick_passthrough` to 152 — but **not** the renderer-side
-transparency work. Verified by probing for the exact identifiers
-`SetBaseBackgroundColorOverrideTransparent` and `background_transparent`: absent
-from `blink_glue.h`, `browser_config.h`, `cef.mojom` and `render_manager.cc` on
-that branch, present on the 7778 branch (positive control).
+An earlier revision of this doc claimed the Chromium 152 port had dropped the
+renderer-side transparency work. **That was wrong**, and the way it was wrong is
+itself worth keeping.
 
-So the 152 upgrade is currently set up to ship without transparency. It was found
-by inventory, not by any build failing.
+The probe was real, but it ran against a stale local ref.
+`agentmux/7977-drag-rightclick-and-transparency` had been **force-updated**
+(`d6fe3d449` -> `55edc030a`); after `git fetch --prune` all seven transparency
+files probe `OK`. The 152 port is complete. Two existing documents already said
+so -- `docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md` and
+`docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md` -- and were not
+consulted.
+
+So, as a rule:
+
+- **`git fetch --prune` immediately before running §5.** These branches get
+  force-updated during a port. A ref fetched yesterday is not evidence about
+  today.
+- **Cross-check against the milestone's own recon/spec docs** before reporting a
+  gap. A disagreement between your probe and a written port record means one of
+  them is stale -- find out which rather than trusting the probe because you ran
+  it yourself.
+- A probe reporting `MISS` proves something is absent **from the ref you
+  probed**. That is a weaker claim than "absent from the branch," and the
+  difference is exactly the mistake made here.
+
+One genuine asymmetry does remain, and it is the R4 case rather than a defect:
+`agentmux_process_requirement` is absent from the drag branch because it lives on
+`agentmux/7977-process-requirement`. Both must be merged into `fork/7977`. That
+split is precisely what produced §1.1 on 7778.
 
 ---
 
@@ -119,12 +138,14 @@ Notes that have already caused confusion:
 
 ## 4. Branch model — the rules
 
-The root cause of §1.1 is a violation of a rule this repo already has, in
-`CLAUDE.md` under Workspace Rules:
+The root cause of §1.1 is branch reuse after merge. The repo-level rule for
+this lives in [`CLAUDE.md`](../../CLAUDE.md) under Git Workflow:
 
-> **Never reuse a branch after its PR is merged; create a new branch.**
+> **Never reuse a branch after its PR is merged.**
 
-That rule exists to prevent precisely this. It applies to `agentmuxai/cef` too.
+It was added by the same PR as this document — it was *not* previously written
+down anywhere in the repo, which is part of why §1.1 happened. It applies to
+`agentmuxai/cef` as much as to this repo.
 
 **R1 — One integration branch per Chromium milestone.** `fork/<milestone>`
 (`fork/7778`, `fork/7977`). This is the *only* branch anyone builds or releases
@@ -160,7 +181,12 @@ cheap and it is the only thing that catches Layer B gaps.
 # From the cef checkout. BR is the branch under test.
 BR=fork/7778
 
-# Layer A — patch files present and registered
+# MANDATORY. These branches get force-updated mid-port; a stale ref produces a
+# confident, wrong answer. See section 1.2 -- this exact step being skipped is
+# what put a false claim in an earlier revision of this doc.
+git fetch fork --prune
+
+# Layer A -- patch files present AND registered in patch.cfg
 for p in rwhv_background_opaque_check views_caption_rightclick_passthrough \
          agentmux_process_requirement; do
   git cat-file -e "${BR}:patch/patches/$p.patch" 2>/dev/null \
@@ -168,14 +194,33 @@ for p in rwhv_background_opaque_check views_caption_rightclick_passthrough \
     && echo "OK   $p" || echo "MISS $p"
 done
 
-# Layer B — probe for the actual identifiers, not just the files
-git show "${BR}:include/views/cef_window.h"     | grep -q BeginWindowDrag \
+# Layer B -- probe identifiers, not filenames.
+git show "${BR}:include/views/cef_window.h" | grep -q BeginWindowDrag \
   && echo "OK   BeginWindowDrag" || echo "MISS BeginWindowDrag"
-git show "${BR}:libcef/renderer/blink_glue.h"   | grep -q SetBaseBackgroundColorOverrideTransparent \
-  && echo "OK   transparency (blink_glue)" || echo "MISS transparency (blink_glue)"
-git show "${BR}:libcef/common/mojom/cef.mojom"  | grep -q background_transparent \
-  && echo "OK   transparency (mojom)" || echo "MISS transparency (mojom)"
+
+# Transparency is a SEVEN-file cascade and must be probed as a unit. Checking
+# only blink_glue + mojom passes on a partial port while browser-side
+# propagation or render_manager.cc is still missing -- the gate would then
+# approve the very regression it exists to catch.
+probe() {  # probe <file> <identifier>
+  git show "${BR}:$1" 2>/dev/null | grep -q "$2" \
+    && echo "OK   $1" || echo "MISS $1"
+}
+probe libcef/renderer/blink_glue.h              SetBaseBackgroundColorOverrideTransparent
+probe libcef/renderer/blink_glue.cc             SetBaseBackgroundColorOverrideTransparent
+probe libcef/renderer/browser_config.h          background_transparent
+probe libcef/renderer/render_manager.cc         background_transparent
+probe libcef/common/mojom/cef.mojom             background_transparent
+probe libcef/browser/browser_platform_delegate.cc  background_transparent
+probe libcef/browser/browser_info_manager.cc    background_transparent
 ```
+
+Expect **11 `OK`** against a complete `fork/<ms>`.
+
+On a *feature* branch, `MISS agentmux_process_requirement` is normal rather than
+a defect -- it lives on `agentmux/<ms>-process-requirement`. That is the R4
+split, and it is why this block is meaningful only against the integration
+branch.
 
 Keep the `${BR}:` braces — this is not stylistic, and it is shell-dependent.
 In **zsh** (the macOS default, so what these snippets usually get run in),

--- a/docs/cef-build/CEF_FORK_MAINTENANCE.md
+++ b/docs/cef-build/CEF_FORK_MAINTENANCE.md
@@ -177,9 +177,27 @@ git show "${BR}:libcef/common/mojom/cef.mojom"  | grep -q background_transparent
   && echo "OK   transparency (mojom)" || echo "MISS transparency (mojom)"
 ```
 
-Keep the `${BR}:` braces. Written as `"$BR:libcef/..."` the shell eats the
-`:l` as a modifier and resolves `fork/7778ibcef/...`, which fails and reports a
-false MISS on exactly the two probes that matter most.
+Keep the `${BR}:` braces — this is not stylistic, and it is shell-dependent.
+In **zsh** (the macOS default, so what these snippets usually get run in),
+`"$BR:libcef/..."` applies `:l` as a history-style modifier and resolves
+`fork/7778ibcef/...` — a false MISS on exactly the two probes that matter most.
+**bash expands the braced and unbraced forms identically**, so this reproduces
+for only some readers, which is worse than a consistent break.
+
+The modifier letters that bite include `a e h l q r t u`. Verified in zsh with
+`BR=fork/7778`:
+
+```
+$BR:libcef/x    -> fork/7778ibcef/x     ( :l  lowercase )
+$BR:head/x      -> forkead/x            ( :h  dirname   )
+$BR:tail/x      -> 7778ail/x            ( :t  basename  )
+$BR:upper/x     -> FORK/7778pper/x      ( :u  uppercase )
+$BR:include/x   -> fork/7778:include/x  ( :i  not a modifier - safe )
+$BR:patch/x     -> fork/7778:patch/x    ( :p  not a modifier - safe )
+```
+
+`:include` and `:patch` being safe is why only the two `libcef` probes broke,
+and why this survived a first reading.
 
 **Probe identifiers, not filenames.** All of these files exist upstream. The 152
 gap in §1.2 is invisible to a file-existence check and obvious to an identifier

--- a/docs/cef-build/CEF_FORK_MAINTENANCE.md
+++ b/docs/cef-build/CEF_FORK_MAINTENANCE.md
@@ -272,7 +272,7 @@ That one command, run in September, would have caught §1.1 in a second.
      changed underneath.
 3. **Merge every feature branch into `fork/<new-ms>`** (R4). Do not build from
    the feature branches.
-4. **Run §5 against `fork/<new-ms>`.** All eight probes must print `OK`.
+4. **Run §5 against `fork/<new-ms>`.** All **11** probes must print `OK`.
 5. **Build all three platforms from that one commit** — record the commit SHA.
 6. **Verify the built artifacts** (§7), per platform.
 7. **Cut three tags and update the pins together** (§8).
@@ -379,7 +379,7 @@ mechanical instead of a convention.
 **Before building a release framework:**
 - [ ] Building from `fork/<ms>`, not a feature branch (R3)
 - [ ] All feature branches for this milestone are merged (R4)
-- [ ] All eight §5 probes print `OK`
+- [ ] All **11** §5 probes print `OK`
 - [ ] `patcher.py` run with no args; Chromium tree shows hundreds of modified files (§7.1)
 
 **Before updating the pins:**

--- a/docs/cef-build/CEF_FORK_MAINTENANCE.md
+++ b/docs/cef-build/CEF_FORK_MAINTENANCE.md
@@ -423,12 +423,25 @@ check.
 **Also confirm the integration branch is a superset of whatever last shipped:**
 
 ```bash
-# Must print nothing. Anything printed is in the shipped artifact but not in
-# the branch you are about to build — i.e. a regression you are about to ship.
+# SAME MILESTONE ONLY. Must print nothing. Anything printed is in the shipped
+# artifact but not in the branch you are about to build — a regression you are
+# about to ship.
 git log --oneline "$LAST_SHIPPED_COMMIT" --not "$REMOTE/$MS"
 ```
 
 That one command, run in September, would have caught §1.1 in a second.
+
+**Do not run this across a milestone upgrade.** `agentmuxai/7977` starts from
+upstream's 152 branch and the carry-set is *re-ported as new commits*, so 148's
+shipped commit is legitimately not an ancestor even when every change was
+carried correctly. The command would print real old fork commits and the
+checklist would read that as a regression — a guaranteed false positive on every
+upgrade, which is how a check gets ignored.
+
+Across milestones the equivalent question is *content*, not ancestry, and §5 is
+what answers it: the carry-set gate compares the same 21 things regardless of
+lineage. That is precisely how the 7977 gap in §1.2 was found, where this
+ancestry test could not have said anything.
 
 ---
 
@@ -614,7 +627,9 @@ mechanical instead of a convention.
 
 **Before merging a PR into `agentmuxai/<ms>`:**
 - [ ] Branched off `agentmuxai/<ms>`, not off an already-merged feature branch (R2)
-- [ ] `git log --oneline <last-shipped> --not agentmuxai/<ms>` prints nothing (§5)
+- [ ] **Same milestone only:** `git log --oneline <last-shipped> --not agentmuxai/<ms>`
+      prints nothing (§5). Across an upgrade this is expected to print — use the
+      §5 carry-set gate instead.
 
 **Before building a release framework:**
 - [ ] Building from `agentmuxai/<ms>`, not a feature branch (R3)

--- a/docs/cef-build/CEF_FORK_MAINTENANCE.md
+++ b/docs/cef-build/CEF_FORK_MAINTENANCE.md
@@ -488,6 +488,45 @@ done
 symbols exist **only** if CEF's Chromium-side patches were applied, so they
 distinguish "patched build" from "pristine Chromium build" on any platform.
 
+### 7.2b Patches that add no symbol — differential compile
+
+Symbol probes only work for patches that introduce a symbol. **Two of the three
+Layer A patches do not**: `agentmux_process_requirement` rewrites the body of an
+existing function, and `rwhv_background_opaque_check` changes one call inside
+one. `nm` cannot see either, so §7.2 alone cannot tell you whether they made it
+into the artifact.
+
+Compile the file twice — from the working tree, and from pristine upstream — and
+compare both against the object that was actually linked:
+
+```bash
+cd out/Release_GN_arm64
+SRC=base/apple/mach_port_rendezvous_mac.cc
+OBJ=obj/base/base/mach_port_rendezvous_mac.o
+
+git -C ../.. show HEAD:$SRC > /tmp/unpatched.cc          # pristine upstream
+CMD=$(ninja -C . -t commands "$OBJ" | tail -1)           # the real compile line
+
+eval "${CMD//$OBJ//tmp/patched.o}"                       # from the working tree
+eval "$(echo "$CMD" | sed "s#$OBJ#/tmp/unpatched.o#; s#\.\./\.\./$SRC#/tmp/unpatched.cc#")"
+
+cmp -s /tmp/unpatched.o "$OBJ" && echo 'FAIL: shipped object is UNPATCHED'
+cmp -s /tmp/patched.o   "$OBJ" && echo 'OK: shipped object matches patched source'
+```
+
+Both comparisons matter. `shipped == patched` alone is weak if the patch happens
+to compile to the same bytes as upstream; `shipped != unpatched` is what proves
+the patch actually changed the output. Confirmed for both patches on the
+2026-09-09 macOS build.
+
+Do not try to read this off a disassembly. Attempting exactly that on
+`GetPeerValidationPolicy` produced a confident *wrong* answer — the patched
+function had been inlined and the symbol at that address was a neighbouring one,
+so the control flow looked unpatched. The byte comparison is unambiguous where
+eyeballing assembly is not.
+
+---
+
 ### 7.3 Platform-specific functional checks
 
 | Platform | Check |
@@ -549,5 +588,7 @@ mechanical instead of a convention.
 **Before updating the pins:**
 - [ ] All three platforms built from one recorded fork commit (P1)
 - [ ] §7.2 symbol probes pass on each artifact, using full `nm`
+- [ ] §7.2b differential compile passes for the two patches `nm` cannot see
+      (`agentmux_process_requirement`, `rwhv_background_opaque_check`)
 - [ ] §7.3 functional checks pass per platform
 - [ ] All three pins bumped together (P2)

--- a/docs/cef-build/CEF_FORK_MAINTENANCE.md
+++ b/docs/cef-build/CEF_FORK_MAINTENANCE.md
@@ -141,7 +141,7 @@ Notes that have already caused confusion:
 > **Notation.** The integration branch is named for the milestone alone --
 > `7778`, `7977` (`refs/heads/7778` on `agentmuxai/cef`). Where this doc writes
 > `agentmuxai/7778` that is `<remote>/<branch>`, not a branch called
-> `agentmuxai/7778`. An earlier revision wrote `agentmuxai/7778`, using one checkout's
+> `agentmuxai/7778`. An earlier revision wrote `fork/7778`, using one checkout's
 > local remote name; a reviewer reasonably read that as the branch name and
 > concluded the checkout commands were wrong. If the notation can mislead a
 > careful reader it can mislead an operator, so it is spelled out here.
@@ -156,8 +156,9 @@ It was added by the same PR as this document — it was *not* previously written
 down anywhere in the repo, which is part of why §1.1 happened. It applies to
 `agentmuxai/cef` as much as to this repo.
 
-**R1 — One integration branch per Chromium milestone.** `agentmuxai/<milestone>`
-(`agentmuxai/7778`, `agentmuxai/7977`). This is the *only* branch anyone builds or releases
+**R1 — One integration branch per Chromium milestone**, named for the milestone
+alone: `7778`, `7977` (written `agentmuxai/7778` when referring to the
+remote-tracking ref). This is the *only* branch anyone builds or releases
 from. It is upstream CEF's branch plus our carry-set, nothing else.
 
 **R2 — Feature branches are single-use.** Once `agentmux/<ms>-<topic>` is merged
@@ -296,7 +297,8 @@ That one command, run in September, would have caught §1.1 in a second.
 
 ## 6. Upgrade runbook (per Chromium milestone, all three platforms)
 
-1. **Create `agentmuxai/<new-ms>`** from upstream CEF's branch for that milestone.
+1. **Create the integration branch `<new-ms>`** on `agentmuxai/cef`, from upstream
+   CEF's branch for that milestone.
 2. **Port the carry-set** in §3. One commit per item, message
    `agentmux: port <item> to <ms> (Chromium <N>)` — the 7977 branch already
    follows this convention and it makes §5 auditable.

--- a/docs/cef-build/CEF_FORK_MAINTENANCE.md
+++ b/docs/cef-build/CEF_FORK_MAINTENANCE.md
@@ -263,14 +263,14 @@ In **zsh** (the macOS default, so what these snippets usually get run in),
 **bash expands the braced and unbraced forms identically**, so this reproduces
 for only some readers, which is worse than a consistent break.
 
-The modifier letters that bite include `a e h l q r t u`. Verified in zsh with
-`BR=agentmuxai/7778`:
+The modifier letters that bite include `a e h l q r t u`. Real output, produced
+by running this with `BR=agentmuxai/7778` rather than hand-written:
 
 ```
 $BR:libcef/x    -> agentmuxai/7778ibcef/x     ( :l  lowercase )
-$BR:head/x      -> forkead/x            ( :h  dirname   )
-$BR:tail/x      -> 7778ail/x            ( :t  basename  )
-$BR:upper/x     -> FORK/7778pper/x      ( :u  uppercase )
+$BR:head/x      -> agentmuxaiead/x            ( :h  dirname   )
+$BR:tail/x      -> 7778ail/x                  ( :t  basename  )
+$BR:upper/x     -> AGENTMUXAI/7778pper/x      ( :u  uppercase )
 $BR:include/x   -> agentmuxai/7778:include/x  ( :i  not a modifier - safe )
 $BR:patch/x     -> agentmuxai/7778:patch/x    ( :p  not a modifier - safe )
 ```

--- a/docs/cef-build/build-patched-cef-windows.md
+++ b/docs/cef-build/build-patched-cef-windows.md
@@ -244,21 +244,22 @@ Compress-Archive -Path @(
 # Record the exact fork commit this artifact came from -- the only thing tying
 # the three platforms' tags together. See CEF_FORK_MAINTENANCE.md section 8 (P1).
 #
-# This MUST be the CEF fork clone, not the mirrored copy under chromium\src\cef.
-# The mirror is made with `robocopy /XD .git`, so it has no .git of its own --
-# and `git -C` on a directory with no .git silently WALKS UP and answers from the
-# enclosing Chromium checkout, returning CHROMIUM's HEAD. That SHA does not exist
-# in agentmuxai/cef, so --target and the notes would both be wrong, with no
-# error. The two asserts below make that impossible.
-$CefClone = if ($env:CEF_CLONE) { $env:CEF_CLONE } else { "$HOME\cef-build\chromium_git\cef" }
-
-$TopLevel = (git -C "$CefClone" rev-parse --show-toplevel 2>$null)
-if (-not $TopLevel -or (Resolve-Path $TopLevel).Path -ne (Resolve-Path $CefClone).Path) {
-  throw "$CefClone is not a git root; git would answer from the enclosing repo. Set CEF_CLONE."
+# Locate the fork clone rather than assuming a path. The mirrored copy under
+# chromium\src\cef is created with `robocopy /XD .git`, so it has no .git of its
+# own -- and `git -C` on such a directory does not fail, it silently WALKS UP and
+# answers from the enclosing Chromium checkout, returning CHROMIUM's HEAD. Take
+# the first candidate that is BOTH its own git root AND has the agentmuxai/cef
+# remote. Set $env:CEF_CLONE to override.
+$CefClone = $null
+foreach ($c in @($env:CEF_CLONE, "$HOME\cef-build\chromium_git\cef", "$HOME\cef-build\chromium\cef")) {
+  if (-not $c -or -not (Test-Path $c)) { continue }
+  $top = (git -C "$c" rev-parse --show-toplevel 2>$null)
+  if (-not $top -or (Resolve-Path $top).Path -ne (Resolve-Path $c).Path) { continue }
+  if (-not ((git -C "$c" remote -v 2>$null) -match 'agentmuxai/cef')) { continue }
+  $CefClone = $c; break
 }
-if (-not ((git -C "$CefClone" remote -v 2>$null) -match 'agentmuxai/cef')) {
-  throw "$CefClone is not the agentmuxai/cef fork. Set CEF_CLONE."
-}
+if (-not $CefClone) { throw "No agentmuxai/cef clone found (a .git-less mirror does not count). Set CEF_CLONE." }
+Write-Host "fork clone: $CefClone"
 
 # FULL sha: `gh release create --target` takes a branch or a full commit SHA.
 $CefForkSha = (git -C "$CefClone" rev-parse HEAD)

--- a/docs/cef-build/build-patched-cef-windows.md
+++ b/docs/cef-build/build-patched-cef-windows.md
@@ -243,11 +243,15 @@ Compress-Archive -Path @(
 
 # Record the exact fork commit this artifact came from -- the only thing tying
 # the three platforms' tags together. See CEF_FORK_MAINTENANCE.md section 8 (P1).
-$CefForkSha = (git -C "$HOME\cef-build\chromium_git\cef" rev-parse --short HEAD)
+# FULL sha: `gh release create --target` takes a branch or a full commit SHA.
+$CefForkSha = (git -C "$HOME\cef-build\chromium_git\cef" rev-parse HEAD)
+# Refuse to publish a release with no provenance rather than one with an empty field.
+if (-not $CefForkSha) { throw "Refusing to publish without a recorded fork commit" }
 
 gh release create "cef-windows-x86_64-$CefVersion" --repo agentmuxai/cef `
+  --target "$CefForkSha" `
   --title "Codec-enabled CEF -- Windows x86_64 CEF $CefVersion" `
-  --notes "proprietary_codecs + HEVC/AC3/EAC3/Dolby Vision. Built from agentmuxai/cef $CefForkSha (branch 7778; patches inert on Windows -- built for codec flags only)." `
+  --notes "proprietary_codecs + HEVC/AC3/EAC3/Dolby Vision. Built from agentmuxai/cef $($CefForkSha.Substring(0,12)) (branch 7778; patches inert on Windows -- built for codec flags only)." `
   "cef-windows-x86_64-$CefVersion.zip"
 ```
 

--- a/docs/cef-build/build-patched-cef-windows.md
+++ b/docs/cef-build/build-patched-cef-windows.md
@@ -119,11 +119,18 @@ python3 automate-git.py `
 Same fork/branch as Linux/macOS — see the header note above on why
 Windows uses this branch despite not needing its patches.
 
+> **Build from the integration branch, never a feature branch.**
+> `docs/cef-build/CEF_FORK_MAINTENANCE.md` §4 (R3). A feature branch may look
+> newer and still be missing part of the carry-set — that is exactly how the
+> 2026-07 transparency gap happened. Run §5 of that doc against this checkout
+> before building; it must report **11 `OK`**. If it does not, the integration
+> branch is incomplete and must be fixed first — do not build around it.
+
 ```powershell
 Set-Location "$HOME\cef-build\chromium_git\cef"
 git remote add agentmuxai https://github.com/agentmuxai/cef.git
-git fetch agentmuxai agentmux/7778-drag-rightclick-and-transparency
-git checkout agentmuxai/agentmux/7778-drag-rightclick-and-transparency
+git fetch agentmuxai --prune
+git checkout agentmuxai/7778   # integration branch for the milestone
 
 # Mirror to the chromium-side cef checkout
 robocopy "$HOME\cef-build\chromium_git\cef" "$HOME\cef-build\chromium_git\chromium\src\cef" /MIR /XD .git

--- a/docs/cef-build/build-patched-cef-windows.md
+++ b/docs/cef-build/build-patched-cef-windows.md
@@ -241,9 +241,13 @@ Compress-Archive -Path @(
     "locales"
 ) -DestinationPath "cef-windows-x86_64-$CefVersion.zip"
 
+# Record the exact fork commit this artifact came from -- the only thing tying
+# the three platforms' tags together. See CEF_FORK_MAINTENANCE.md section 8 (P1).
+$CefForkSha = (git -C "$HOME\cef-build\chromium_git\cef" rev-parse --short HEAD)
+
 gh release create "cef-windows-x86_64-$CefVersion" --repo agentmuxai/cef `
   --title "Codec-enabled CEF -- Windows x86_64 CEF $CefVersion" `
-  --notes "proprietary_codecs + HEVC/AC3/EAC3/Dolby Vision. Branch: agentmux/7778-drag-rightclick-and-transparency (inert on Windows -- built for codec flags only)." `
+  --notes "proprietary_codecs + HEVC/AC3/EAC3/Dolby Vision. Built from agentmuxai/cef $CefForkSha (branch 7778; patches inert on Windows -- built for codec flags only)." `
   "cef-windows-x86_64-$CefVersion.zip"
 ```
 

--- a/docs/cef-build/build-patched-cef-windows.md
+++ b/docs/cef-build/build-patched-cef-windows.md
@@ -123,7 +123,7 @@ Windows uses this branch despite not needing its patches.
 > `docs/cef-build/CEF_FORK_MAINTENANCE.md` §4 (R3). A feature branch may look
 > newer and still be missing part of the carry-set — that is exactly how the
 > 2026-07 transparency gap happened. Run §5 of that doc against this checkout
-> before building; it must report **11 `OK`**. If it does not, the integration
+> before building; it must report **21 `OK`**. If it does not, the integration
 > branch is incomplete and must be fixed first — do not build around it.
 
 ```powershell

--- a/docs/cef-build/build-patched-cef-windows.md
+++ b/docs/cef-build/build-patched-cef-windows.md
@@ -250,15 +250,27 @@ Compress-Archive -Path @(
 # answers from the enclosing Chromium checkout, returning CHROMIUM's HEAD. Take
 # the first candidate that is BOTH its own git root AND has the agentmuxai/cef
 # remote. Set $env:CEF_CLONE to override.
-$CefClone = $null
-foreach ($c in @($env:CEF_CLONE, "$HOME\cef-build\chromium_git\cef", "$HOME\cef-build\chromium\cef")) {
-  if (-not $c -or -not (Test-Path $c)) { continue }
-  $top = (git -C "$c" rev-parse --show-toplevel 2>$null)
-  if (-not $top -or (Resolve-Path $top).Path -ne (Resolve-Path $c).Path) { continue }
-  if (-not ((git -C "$c" remote -v 2>$null) -match 'agentmuxai/cef')) { continue }
-  $CefClone = $c; break
+# An explicit CEF_CLONE is a HARD requirement: validated, then used or fatal.
+# Folding it into the probe loop would `continue` past a wrong override and
+# silently record a DIFFERENT checkout's HEAD -- the same defect the bash
+# runbooks fix. Matches build-patched-libcef.md / build-patched-framework-macos.md.
+function Test-CefClone($p) {
+  if (-not $p -or -not (Test-Path $p)) { return $false }
+  $top = (git -C "$p" rev-parse --show-toplevel 2>$null)
+  if (-not $top -or (Resolve-Path $top).Path -ne (Resolve-Path $p).Path) { return $false }
+  return [bool]((git -C "$p" remote -v 2>$null) -match 'agentmuxai/cef')
 }
-if (-not $CefClone) { throw "No agentmuxai/cef clone found (a .git-less mirror does not count). Set CEF_CLONE." }
+
+$CefClone = $null
+if ($env:CEF_CLONE) {
+  if (Test-CefClone $env:CEF_CLONE) { $CefClone = $env:CEF_CLONE }
+  else { throw "CEF_CLONE=$($env:CEF_CLONE) is not an agentmuxai/cef git root." }
+} else {
+  foreach ($c in @("$HOME\cef-build\chromium_git\cef", "$HOME\cef-build\chromium\cef")) {
+    if (Test-CefClone $c) { $CefClone = $c; break }
+  }
+  if (-not $CefClone) { throw "No agentmuxai/cef clone found (a .git-less mirror does not count). Set CEF_CLONE." }
+}
 Write-Host "fork clone: $CefClone"
 
 # FULL sha: `gh release create --target` takes a branch or a full commit SHA.

--- a/docs/cef-build/build-patched-cef-windows.md
+++ b/docs/cef-build/build-patched-cef-windows.md
@@ -243,8 +243,25 @@ Compress-Archive -Path @(
 
 # Record the exact fork commit this artifact came from -- the only thing tying
 # the three platforms' tags together. See CEF_FORK_MAINTENANCE.md section 8 (P1).
+#
+# This MUST be the CEF fork clone, not the mirrored copy under chromium\src\cef.
+# The mirror is made with `robocopy /XD .git`, so it has no .git of its own --
+# and `git -C` on a directory with no .git silently WALKS UP and answers from the
+# enclosing Chromium checkout, returning CHROMIUM's HEAD. That SHA does not exist
+# in agentmuxai/cef, so --target and the notes would both be wrong, with no
+# error. The two asserts below make that impossible.
+$CefClone = if ($env:CEF_CLONE) { $env:CEF_CLONE } else { "$HOME\cef-build\chromium_git\cef" }
+
+$TopLevel = (git -C "$CefClone" rev-parse --show-toplevel 2>$null)
+if (-not $TopLevel -or (Resolve-Path $TopLevel).Path -ne (Resolve-Path $CefClone).Path) {
+  throw "$CefClone is not a git root; git would answer from the enclosing repo. Set CEF_CLONE."
+}
+if (-not ((git -C "$CefClone" remote -v 2>$null) -match 'agentmuxai/cef')) {
+  throw "$CefClone is not the agentmuxai/cef fork. Set CEF_CLONE."
+}
+
 # FULL sha: `gh release create --target` takes a branch or a full commit SHA.
-$CefForkSha = (git -C "$HOME\cef-build\chromium_git\cef" rev-parse HEAD)
+$CefForkSha = (git -C "$CefClone" rev-parse HEAD)
 # Refuse to publish a release with no provenance rather than one with an empty field.
 if (-not $CefForkSha) { throw "Refusing to publish without a recorded fork commit" }
 

--- a/docs/cef-build/build-patched-framework-macos.md
+++ b/docs/cef-build/build-patched-framework-macos.md
@@ -203,13 +203,17 @@ for _c in "${CEF_CLONE:-}" \
   git -C "$_c" remote -v 2>/dev/null | grep -q 'agentmuxai/cef' || continue
   CEF_CLONE="$_c"; break
 done
-[ -n "${CEF_CLONE:-}" ] || echo "FATAL: no agentmuxai/cef clone found (a .git-less mirror does not count). Set CEF_CLONE." >&2
 echo "fork clone: ${CEF_CLONE:-<none>}"
 
 # FULL sha: `gh release create --target` takes a branch or a full commit SHA.
-CEF_FORK_SHA=$(git -C "$CEF_CLONE" rev-parse HEAD)
-# Refuse to publish a release with no provenance rather than one with an empty
-# field -- an unattributable artifact is exactly what section 8 exists to prevent.
+#
+# The :? on CEF_CLONE is load-bearing, not decoration. `git -C "" rev-parse HEAD`
+# does NOT fail -- git treats an empty -C as "unchanged directory", exits 0, and
+# answers for the CURRENT directory, which by this point is inside the Chromium
+# checkout. An unmatched probe would then yield Chromium's HEAD: a real-looking
+# SHA, so a downstream emptiness check never fires. Failing at expansion time,
+# before git runs at all, is what removes that path.
+CEF_FORK_SHA=$(git -C "${CEF_CLONE:?FATAL: no agentmuxai/cef clone found (a .git-less mirror does not count); set CEF_CLONE}" rev-parse HEAD)
 : "${CEF_FORK_SHA:?refusing to publish without a recorded fork commit}"
 
 gh release create "cef-macos-arm64-${CEF_VERSION}${TAG_SUFFIX}" --repo agentmuxai/cef \

--- a/docs/cef-build/build-patched-framework-macos.md
+++ b/docs/cef-build/build-patched-framework-macos.md
@@ -29,7 +29,7 @@ The patches live in the same fork/branch as Linux:
   from a feature branch such as `agentmux/7778-drag-rightclick-and-transparency`:
   it may look newer and still be missing part of the carry-set, which is exactly
   how the 2026-07 transparency gap happened. Verify with §5 of
-  [CEF_FORK_MAINTENANCE.md](./CEF_FORK_MAINTENANCE.md) (expect **11 `OK`**)
+  [CEF_FORK_MAINTENANCE.md](./CEF_FORK_MAINTENANCE.md) (expect **21 `OK`**)
   before building; if it fails, fix the integration branch rather than building
   around it.
 - **Base:** Chromium 148 (CEF branch 7778)

--- a/docs/cef-build/build-patched-framework-macos.md
+++ b/docs/cef-build/build-patched-framework-macos.md
@@ -181,16 +181,18 @@ cd "$CEF_OUT"
 # adjust the CI extract step to `ditto -x -k`.
 tar -czf "cef-macos-arm64-${CEF_VERSION}${TAG_SUFFIX}.tar.gz" "Chromium Embedded Framework.framework"
 
-# Record the exact fork commit this artifact came from. This is the only thing
-# tying the three platforms' tags together -- the release job cross-checks just
-# the Chromium milestone, so two tags can agree on "148" and still come from
-# different fork commits with different carry-sets. See CEF_FORK_MAINTENANCE.md
-# section 8, practice P1.
-CEF_FORK_SHA=$(git -C ~/cef-build/chromium_git/cef rev-parse --short HEAD)
+# Record the exact fork commit this artifact came from -- the only thing tying
+# the three platforms' tags together. See CEF_FORK_MAINTENANCE.md section 8 (P1).
+# FULL sha: `gh release create --target` takes a branch or a full commit SHA.
+CEF_FORK_SHA=$(git -C ~/cef-build/chromium/chromium/src/cef rev-parse HEAD)
+# Refuse to publish a release with no provenance rather than one with an empty
+# field -- an unattributable artifact is exactly what section 8 exists to prevent.
+: "${CEF_FORK_SHA:?refusing to publish without a recorded fork commit}"
 
 gh release create "cef-macos-arm64-${CEF_VERSION}${TAG_SUFFIX}" --repo agentmuxai/cef \
+  --target "${CEF_FORK_SHA}" \
   --title "Patched CEF framework — macOS arm64 CEF ${CEF_VERSION}" \
-  --notes "BeginWindowDrag + drag-rightclick + transparency. Built from agentmuxai/cef ${CEF_FORK_SHA} (branch 7778). Unstripped (~547 MB); packager strips at bundle time." \
+  --notes "BeginWindowDrag + drag-rightclick + transparency. Built from agentmuxai/cef ${CEF_FORK_SHA:0:12} (branch 7778). Unstripped (~547 MB); packager strips at bundle time." \
   "cef-macos-arm64-${CEF_VERSION}${TAG_SUFFIX}.tar.gz"
 ```
 
@@ -205,7 +207,10 @@ release via `gh release list --json tagName --jq '[.[] | select(startswith(...))
 
 > ⚠️ **"Latest" here is not what you'd assume.** `gh release list`'s default
 > order is *not* reliably publish-time-descending on this fork — confirmed
-> 2026-07-28: every release created without an explicit `--target` picks up
+> 2026-07-28. **The release recipe above now passes `--target "${CEF_FORK_SHA}"`,
+> which addresses this at the source**; the verification below stays as a
+> belt-and-braces check, and remains necessary for the tags cut before that
+> change. Historically: every release created without an explicit `--target` picks up
 > `agentmuxai/cef`'s frozen default-branch HEAD commit date as its `created_at`
 > (not the actual `gh release create` call time), and `gh release list`
 > appears to sort by `created_at`. Net effect: a brand-new release can sort

--- a/docs/cef-build/build-patched-framework-macos.md
+++ b/docs/cef-build/build-patched-framework-macos.md
@@ -184,18 +184,27 @@ tar -czf "cef-macos-arm64-${CEF_VERSION}${TAG_SUFFIX}.tar.gz" "Chromium Embedded
 # Record the exact fork commit this artifact came from -- the only thing tying
 # the three platforms' tags together. See CEF_FORK_MAINTENANCE.md section 8 (P1).
 #
-# This MUST be the CEF fork clone, not the mirrored copy under chromium/src/cef.
-# The mirror is made with `rsync --exclude=.git` / `robocopy /XD .git`, so it has
-# no .git of its own -- and `git -C` on a directory with no .git silently WALKS
-# UP and answers from the enclosing Chromium checkout, returning CHROMIUM's HEAD.
-# That SHA does not exist in agentmuxai/cef, so --target and the notes would both
-# be wrong, with no error. The two asserts below make that impossible.
-CEF_CLONE="${CEF_CLONE:-$HOME/cef-build/chromium/chromium/src/cef}"
-
-[ "$(git -C "$CEF_CLONE" rev-parse --show-toplevel 2>/dev/null)" = "$(cd "$CEF_CLONE" && pwd -P)" ] \
-  || { echo "FATAL: $CEF_CLONE is not a git root; git would answer from the enclosing repo. Set CEF_CLONE." >&2; false; }
-git -C "$CEF_CLONE" remote -v 2>/dev/null | grep -q 'agentmuxai/cef' \
-  || { echo "FATAL: $CEF_CLONE is not the agentmuxai/cef fork. Set CEF_CLONE." >&2; false; }
+# Locate the fork clone rather than assuming a path. The mirrored copy under
+# chromium/src/cef is created with `rsync --exclude=.git`, so it has no .git of
+# its own -- and `git -C` on such a directory does not fail, it silently WALKS UP
+# and answers from the enclosing Chromium checkout, returning CHROMIUM's HEAD. A
+# SHA that does not exist in agentmuxai/cef would end up in --target and in the
+# notes, with no error. Layouts also differ: some trees clone the fork directly
+# at chromium/src/cef, others mirror into it from an outer clone.
+#
+# So: take the first candidate that is BOTH its own git root AND has the
+# agentmuxai/cef remote. Set CEF_CLONE to override.
+for _c in "${CEF_CLONE:-}" \
+          "$HOME/cef-build/chromium/chromium/src/cef" \
+          "$HOME/cef-build/chromium/cef" \
+          "$HOME/cef-build/chromium_git/cef"; do
+  [ -n "$_c" ] || continue
+  [ "$(git -C "$_c" rev-parse --show-toplevel 2>/dev/null)" = "$(cd "$_c" 2>/dev/null && pwd -P)" ] || continue
+  git -C "$_c" remote -v 2>/dev/null | grep -q 'agentmuxai/cef' || continue
+  CEF_CLONE="$_c"; break
+done
+[ -n "${CEF_CLONE:-}" ] || echo "FATAL: no agentmuxai/cef clone found (a .git-less mirror does not count). Set CEF_CLONE." >&2
+echo "fork clone: ${CEF_CLONE:-<none>}"
 
 # FULL sha: `gh release create --target` takes a branch or a full commit SHA.
 CEF_FORK_SHA=$(git -C "$CEF_CLONE" rev-parse HEAD)

--- a/docs/cef-build/build-patched-framework-macos.md
+++ b/docs/cef-build/build-patched-framework-macos.md
@@ -192,17 +192,26 @@ tar -czf "cef-macos-arm64-${CEF_VERSION}${TAG_SUFFIX}.tar.gz" "Chromium Embedded
 # notes, with no error. Layouts also differ: some trees clone the fork directly
 # at chromium/src/cef, others mirror into it from an outer clone.
 #
-# So: take the first candidate that is BOTH its own git root AND has the
-# agentmuxai/cef remote. Set CEF_CLONE to override.
-for _c in "${CEF_CLONE:-}" \
-          "$HOME/cef-build/chromium/chromium/src/cef" \
-          "$HOME/cef-build/chromium/cef" \
-          "$HOME/cef-build/chromium_git/cef"; do
-  [ -n "$_c" ] || continue
-  [ "$(git -C "$_c" rev-parse --show-toplevel 2>/dev/null)" = "$(cd "$_c" 2>/dev/null && pwd -P)" ] || continue
-  git -C "$_c" remote -v 2>/dev/null | grep -q 'agentmuxai/cef' || continue
-  CEF_CLONE="$_c"; break
-done
+# An explicit CEF_CLONE is a HARD requirement: validated, then used or fatal.
+# Falling through to a standard path when the override is wrong would record a
+# DIFFERENT checkout's HEAD -- a valid-looking but unrelated fork SHA -- and
+# look entirely successful.
+if [ -n "${CEF_CLONE:-}" ]; then
+  [ "$(git -C "$CEF_CLONE" rev-parse --show-toplevel 2>/dev/null)" = "$(cd "$CEF_CLONE" 2>/dev/null && pwd -P)" ] \
+    && git -C "$CEF_CLONE" remote -v 2>/dev/null | grep -q 'agentmuxai/cef' \
+    || { echo "FATAL: CEF_CLONE=$CEF_CLONE is not an agentmuxai/cef git root." >&2; CEF_CLONE=; }
+else
+  # No override: probe. First candidate that is BOTH its own git root AND has
+  # the agentmuxai/cef remote. A .git-less mirror is not a git root, so this
+  # rejects the case where `git -C` would walk up into the Chromium checkout.
+  for _c in "$HOME/cef-build/chromium/chromium/src/cef" \
+            "$HOME/cef-build/chromium/cef" \
+            "$HOME/cef-build/chromium_git/cef"; do
+    [ "$(git -C "$_c" rev-parse --show-toplevel 2>/dev/null)" = "$(cd "$_c" 2>/dev/null && pwd -P)" ] || continue
+    git -C "$_c" remote -v 2>/dev/null | grep -q 'agentmuxai/cef' || continue
+    CEF_CLONE="$_c"; break
+  done
+fi
 echo "fork clone: ${CEF_CLONE:-<none>}"
 
 # FULL sha: `gh release create --target` takes a branch or a full commit SHA.

--- a/docs/cef-build/build-patched-framework-macos.md
+++ b/docs/cef-build/build-patched-framework-macos.md
@@ -25,7 +25,13 @@ prerequisite for moving macOS onto the native drag path.
 
 The patches live in the same fork/branch as Linux:
 - **Repo:** https://github.com/agentmuxai/cef
-- **Branch:** `agentmux/7778-drag-rightclick-and-transparency`
+- **Branch:** `7778` — the **integration** branch for the milestone. Never build
+  from a feature branch such as `agentmux/7778-drag-rightclick-and-transparency`:
+  it may look newer and still be missing part of the carry-set, which is exactly
+  how the 2026-07 transparency gap happened. Verify with §5 of
+  [CEF_FORK_MAINTENANCE.md](./CEF_FORK_MAINTENANCE.md) (expect **11 `OK`**)
+  before building; if it fails, fix the integration branch rather than building
+  around it.
 - **Base:** Chromium 148 (CEF branch 7778)
 - **Rust binding:** `AgentU-asaf/cef-rs@agentmux/148-begin-window-drag` (pinned in
   `Cargo.toml` `[patch]`; the binding's `_cef_window_t` carries `begin_window_drag`
@@ -175,9 +181,16 @@ cd "$CEF_OUT"
 # adjust the CI extract step to `ditto -x -k`.
 tar -czf "cef-macos-arm64-${CEF_VERSION}${TAG_SUFFIX}.tar.gz" "Chromium Embedded Framework.framework"
 
+# Record the exact fork commit this artifact came from. This is the only thing
+# tying the three platforms' tags together -- the release job cross-checks just
+# the Chromium milestone, so two tags can agree on "148" and still come from
+# different fork commits with different carry-sets. See CEF_FORK_MAINTENANCE.md
+# section 8, practice P1.
+CEF_FORK_SHA=$(git -C ~/cef-build/chromium_git/cef rev-parse --short HEAD)
+
 gh release create "cef-macos-arm64-${CEF_VERSION}${TAG_SUFFIX}" --repo agentmuxai/cef \
   --title "Patched CEF framework — macOS arm64 CEF ${CEF_VERSION}" \
-  --notes "BeginWindowDrag + drag-rightclick + transparency. Branch: agentmux/7778-drag-rightclick-and-transparency. Unstripped (~547 MB); packager strips at bundle time." \
+  --notes "BeginWindowDrag + drag-rightclick + transparency. Built from agentmuxai/cef ${CEF_FORK_SHA} (branch 7778). Unstripped (~547 MB); packager strips at bundle time." \
   "cef-macos-arm64-${CEF_VERSION}${TAG_SUFFIX}.tar.gz"
 ```
 

--- a/docs/cef-build/build-patched-framework-macos.md
+++ b/docs/cef-build/build-patched-framework-macos.md
@@ -183,8 +183,22 @@ tar -czf "cef-macos-arm64-${CEF_VERSION}${TAG_SUFFIX}.tar.gz" "Chromium Embedded
 
 # Record the exact fork commit this artifact came from -- the only thing tying
 # the three platforms' tags together. See CEF_FORK_MAINTENANCE.md section 8 (P1).
+#
+# This MUST be the CEF fork clone, not the mirrored copy under chromium/src/cef.
+# The mirror is made with `rsync --exclude=.git` / `robocopy /XD .git`, so it has
+# no .git of its own -- and `git -C` on a directory with no .git silently WALKS
+# UP and answers from the enclosing Chromium checkout, returning CHROMIUM's HEAD.
+# That SHA does not exist in agentmuxai/cef, so --target and the notes would both
+# be wrong, with no error. The two asserts below make that impossible.
+CEF_CLONE="${CEF_CLONE:-$HOME/cef-build/chromium/chromium/src/cef}"
+
+[ "$(git -C "$CEF_CLONE" rev-parse --show-toplevel 2>/dev/null)" = "$(cd "$CEF_CLONE" && pwd -P)" ] \
+  || { echo "FATAL: $CEF_CLONE is not a git root; git would answer from the enclosing repo. Set CEF_CLONE." >&2; false; }
+git -C "$CEF_CLONE" remote -v 2>/dev/null | grep -q 'agentmuxai/cef' \
+  || { echo "FATAL: $CEF_CLONE is not the agentmuxai/cef fork. Set CEF_CLONE." >&2; false; }
+
 # FULL sha: `gh release create --target` takes a branch or a full commit SHA.
-CEF_FORK_SHA=$(git -C ~/cef-build/chromium/chromium/src/cef rev-parse HEAD)
+CEF_FORK_SHA=$(git -C "$CEF_CLONE" rev-parse HEAD)
 # Refuse to publish a release with no provenance rather than one with an empty
 # field -- an unattributable artifact is exactly what section 8 exists to prevent.
 : "${CEF_FORK_SHA:?refusing to publish without a recorded fork commit}"

--- a/docs/cef-build/build-patched-libcef.md
+++ b/docs/cef-build/build-patched-libcef.md
@@ -15,9 +15,15 @@
 
 Patches live in the AgentMux fork of CEF:
 - **Repo:** https://github.com/agentmuxai/cef (canonical) / https://github.com/a5af/cef (personal fork, kept in sync)
-- **Branch:** `agentmux/7778-drag-rightclick-and-transparency`
+- **Branch:** `7778` — the **integration** branch for the milestone. Never build
+  from a feature branch such as `agentmux/7778-drag-rightclick-and-transparency`:
+  it may look newer and still be missing part of the carry-set. Verify with §5 of
+  [CEF_FORK_MAINTENANCE.md](./CEF_FORK_MAINTENANCE.md) (expect **11 `OK`**) first.
 - **Base:** Chromium 148 (CEF branch 7778)
-- **HEAD:** `c87bca497` ("views: deferred top-level transparent bg + observer cleanup")
+- **HEAD:** do not hard-code one here. This previously pinned `c87bca497`, a
+  commit on the now-dead feature branch, which contradicts the branch above.
+  Capture the SHA at build time (`git rev-parse --short HEAD`) and record it in
+  the release notes — see CEF_FORK_MAINTENANCE.md §8 (P1).
 - **Rust binding:** `AgentU-asaf/cef-rs@agentmux/148-begin-window-drag` — adds `begin_window_drag` field to `_cef_window_t` in the linux_x86_64 binding
 - **Workspace patch in `Cargo.toml`:** `[patch.crates-io] cef-dll-sys = { git = "…AgentU-asaf/cef-rs", rev = "515b3ac5…" }`
 
@@ -232,9 +238,13 @@ tar -czf "cef-linux-x86_64-${CEF_VERSION}.tar.gz" \
   chrome_100_percent.pak chrome_200_percent.pak resources.pak \
   headless_command_resources.pak locales/
 
+# Record the exact fork commit this artifact came from -- the only thing tying
+# the three platforms' tags together. See CEF_FORK_MAINTENANCE.md section 8 (P1).
+CEF_FORK_SHA=$(git -C ~/cef-build/chromium_git/cef rev-parse --short HEAD)
+
 gh release create "cef-linux-x86_64-${CEF_VERSION}" --repo agentmuxai/cef \
   --title "Patched libcef.so — Linux x86_64 CEF ${CEF_VERSION}" \
-  --notes "BeginWindowDrag + right-click passthrough. Branch: agentmux/7778-drag-rightclick-and-transparency @ c87bca4" \
+  --notes "BeginWindowDrag + right-click passthrough. Built from agentmuxai/cef ${CEF_FORK_SHA} (branch 7778)." \
   "cef-linux-x86_64-${CEF_VERSION}.tar.gz"
 ```
 

--- a/docs/cef-build/build-patched-libcef.md
+++ b/docs/cef-build/build-patched-libcef.md
@@ -241,18 +241,27 @@ tar -czf "cef-linux-x86_64-${CEF_VERSION}.tar.gz" \
 # Record the exact fork commit this artifact came from -- the only thing tying
 # the three platforms' tags together. See CEF_FORK_MAINTENANCE.md section 8 (P1).
 #
-# This MUST be the CEF fork clone, not the mirrored copy under chromium/src/cef.
-# The mirror is made with `rsync --exclude=.git` / `robocopy /XD .git`, so it has
-# no .git of its own -- and `git -C` on a directory with no .git silently WALKS
-# UP and answers from the enclosing Chromium checkout, returning CHROMIUM's HEAD.
-# That SHA does not exist in agentmuxai/cef, so --target and the notes would both
-# be wrong, with no error. The two asserts below make that impossible.
-CEF_CLONE="${CEF_CLONE:-$HOME/cef-build/chromium_git/cef}"
-
-[ "$(git -C "$CEF_CLONE" rev-parse --show-toplevel 2>/dev/null)" = "$(cd "$CEF_CLONE" && pwd -P)" ] \
-  || { echo "FATAL: $CEF_CLONE is not a git root; git would answer from the enclosing repo. Set CEF_CLONE." >&2; false; }
-git -C "$CEF_CLONE" remote -v 2>/dev/null | grep -q 'agentmuxai/cef' \
-  || { echo "FATAL: $CEF_CLONE is not the agentmuxai/cef fork. Set CEF_CLONE." >&2; false; }
+# Locate the fork clone rather than assuming a path. The mirrored copy under
+# chromium/src/cef is created with `rsync --exclude=.git`, so it has no .git of
+# its own -- and `git -C` on such a directory does not fail, it silently WALKS UP
+# and answers from the enclosing Chromium checkout, returning CHROMIUM's HEAD. A
+# SHA that does not exist in agentmuxai/cef would end up in --target and in the
+# notes, with no error. Layouts also differ: some trees clone the fork directly
+# at chromium/src/cef, others mirror into it from an outer clone.
+#
+# So: take the first candidate that is BOTH its own git root AND has the
+# agentmuxai/cef remote. Set CEF_CLONE to override.
+for _c in "${CEF_CLONE:-}" \
+          "$HOME/cef-build/chromium/chromium/src/cef" \
+          "$HOME/cef-build/chromium/cef" \
+          "$HOME/cef-build/chromium_git/cef"; do
+  [ -n "$_c" ] || continue
+  [ "$(git -C "$_c" rev-parse --show-toplevel 2>/dev/null)" = "$(cd "$_c" 2>/dev/null && pwd -P)" ] || continue
+  git -C "$_c" remote -v 2>/dev/null | grep -q 'agentmuxai/cef' || continue
+  CEF_CLONE="$_c"; break
+done
+[ -n "${CEF_CLONE:-}" ] || echo "FATAL: no agentmuxai/cef clone found (a .git-less mirror does not count). Set CEF_CLONE." >&2
+echo "fork clone: ${CEF_CLONE:-<none>}"
 
 # FULL sha: `gh release create --target` takes a branch or a full commit SHA.
 CEF_FORK_SHA=$(git -C "$CEF_CLONE" rev-parse HEAD)

--- a/docs/cef-build/build-patched-libcef.md
+++ b/docs/cef-build/build-patched-libcef.md
@@ -240,11 +240,16 @@ tar -czf "cef-linux-x86_64-${CEF_VERSION}.tar.gz" \
 
 # Record the exact fork commit this artifact came from -- the only thing tying
 # the three platforms' tags together. See CEF_FORK_MAINTENANCE.md section 8 (P1).
-CEF_FORK_SHA=$(git -C ~/cef-build/chromium_git/cef rev-parse --short HEAD)
+# FULL sha: `gh release create --target` takes a branch or a full commit SHA.
+CEF_FORK_SHA=$(git -C ~/cef-build/chromium_git/cef rev-parse HEAD)
+# Refuse to publish a release with no provenance rather than one with an empty
+# field -- an unattributable artifact is exactly what section 8 exists to prevent.
+: "${CEF_FORK_SHA:?refusing to publish without a recorded fork commit}"
 
 gh release create "cef-linux-x86_64-${CEF_VERSION}" --repo agentmuxai/cef \
+  --target "${CEF_FORK_SHA}" \
   --title "Patched libcef.so — Linux x86_64 CEF ${CEF_VERSION}" \
-  --notes "BeginWindowDrag + right-click passthrough. Built from agentmuxai/cef ${CEF_FORK_SHA} (branch 7778)." \
+  --notes "BeginWindowDrag + right-click passthrough. Built from agentmuxai/cef ${CEF_FORK_SHA:0:12} (branch 7778)." \
   "cef-linux-x86_64-${CEF_VERSION}.tar.gz"
 ```
 

--- a/docs/cef-build/build-patched-libcef.md
+++ b/docs/cef-build/build-patched-libcef.md
@@ -260,13 +260,17 @@ for _c in "${CEF_CLONE:-}" \
   git -C "$_c" remote -v 2>/dev/null | grep -q 'agentmuxai/cef' || continue
   CEF_CLONE="$_c"; break
 done
-[ -n "${CEF_CLONE:-}" ] || echo "FATAL: no agentmuxai/cef clone found (a .git-less mirror does not count). Set CEF_CLONE." >&2
 echo "fork clone: ${CEF_CLONE:-<none>}"
 
 # FULL sha: `gh release create --target` takes a branch or a full commit SHA.
-CEF_FORK_SHA=$(git -C "$CEF_CLONE" rev-parse HEAD)
-# Refuse to publish a release with no provenance rather than one with an empty
-# field -- an unattributable artifact is exactly what section 8 exists to prevent.
+#
+# The :? on CEF_CLONE is load-bearing, not decoration. `git -C "" rev-parse HEAD`
+# does NOT fail -- git treats an empty -C as "unchanged directory", exits 0, and
+# answers for the CURRENT directory, which by this point is inside the Chromium
+# checkout. An unmatched probe would then yield Chromium's HEAD: a real-looking
+# SHA, so a downstream emptiness check never fires. Failing at expansion time,
+# before git runs at all, is what removes that path.
+CEF_FORK_SHA=$(git -C "${CEF_CLONE:?FATAL: no agentmuxai/cef clone found (a .git-less mirror does not count); set CEF_CLONE}" rev-parse HEAD)
 : "${CEF_FORK_SHA:?refusing to publish without a recorded fork commit}"
 
 gh release create "cef-linux-x86_64-${CEF_VERSION}" --repo agentmuxai/cef \

--- a/docs/cef-build/build-patched-libcef.md
+++ b/docs/cef-build/build-patched-libcef.md
@@ -62,11 +62,18 @@ python3 automate-git.py \
 
 ### 2. Switch to the AgentMux fork
 
+> **Build from the integration branch, never a feature branch.**
+> `docs/cef-build/CEF_FORK_MAINTENANCE.md` §4 (R3). A feature branch may look
+> newer and still be missing part of the carry-set — that is exactly how the
+> 2026-07 transparency gap happened. Run §5 of that doc against this checkout
+> before building; it must report **11 `OK`**. If it does not, the integration
+> branch is incomplete and must be fixed first — do not build around it.
+
 ```bash
 cd ~/cef-build/chromium_git/cef
 git remote add agentmuxai https://github.com/agentmuxai/cef.git
-git fetch agentmuxai agentmux/7778-drag-rightclick-and-transparency
-git checkout agentmuxai/agentmux/7778-drag-rightclick-and-transparency
+git fetch agentmuxai --prune
+git checkout agentmuxai/7778   # integration branch for the milestone
 
 # Mirror to the chromium-side cef checkout
 rsync -a --delete --exclude=.git ~/cef-build/chromium_git/cef/ ~/cef-build/chromium_git/chromium/src/cef/

--- a/docs/cef-build/build-patched-libcef.md
+++ b/docs/cef-build/build-patched-libcef.md
@@ -18,7 +18,7 @@ Patches live in the AgentMux fork of CEF:
 - **Branch:** `7778` — the **integration** branch for the milestone. Never build
   from a feature branch such as `agentmux/7778-drag-rightclick-and-transparency`:
   it may look newer and still be missing part of the carry-set. Verify with §5 of
-  [CEF_FORK_MAINTENANCE.md](./CEF_FORK_MAINTENANCE.md) (expect **11 `OK`**) first.
+  [CEF_FORK_MAINTENANCE.md](./CEF_FORK_MAINTENANCE.md) (expect **21 `OK`**) first.
 - **Base:** Chromium 148 (CEF branch 7778)
 - **HEAD:** do not hard-code one here. This previously pinned `c87bca497`, a
   commit on the now-dead feature branch, which contradicts the branch above.
@@ -72,7 +72,7 @@ python3 automate-git.py \
 > `docs/cef-build/CEF_FORK_MAINTENANCE.md` §4 (R3). A feature branch may look
 > newer and still be missing part of the carry-set — that is exactly how the
 > 2026-07 transparency gap happened. Run §5 of that doc against this checkout
-> before building; it must report **11 `OK`**. If it does not, the integration
+> before building; it must report **21 `OK`**. If it does not, the integration
 > branch is incomplete and must be fixed first — do not build around it.
 
 ```bash

--- a/docs/cef-build/build-patched-libcef.md
+++ b/docs/cef-build/build-patched-libcef.md
@@ -249,17 +249,26 @@ tar -czf "cef-linux-x86_64-${CEF_VERSION}.tar.gz" \
 # notes, with no error. Layouts also differ: some trees clone the fork directly
 # at chromium/src/cef, others mirror into it from an outer clone.
 #
-# So: take the first candidate that is BOTH its own git root AND has the
-# agentmuxai/cef remote. Set CEF_CLONE to override.
-for _c in "${CEF_CLONE:-}" \
-          "$HOME/cef-build/chromium/chromium/src/cef" \
-          "$HOME/cef-build/chromium/cef" \
-          "$HOME/cef-build/chromium_git/cef"; do
-  [ -n "$_c" ] || continue
-  [ "$(git -C "$_c" rev-parse --show-toplevel 2>/dev/null)" = "$(cd "$_c" 2>/dev/null && pwd -P)" ] || continue
-  git -C "$_c" remote -v 2>/dev/null | grep -q 'agentmuxai/cef' || continue
-  CEF_CLONE="$_c"; break
-done
+# An explicit CEF_CLONE is a HARD requirement: validated, then used or fatal.
+# Falling through to a standard path when the override is wrong would record a
+# DIFFERENT checkout's HEAD -- a valid-looking but unrelated fork SHA -- and
+# look entirely successful.
+if [ -n "${CEF_CLONE:-}" ]; then
+  [ "$(git -C "$CEF_CLONE" rev-parse --show-toplevel 2>/dev/null)" = "$(cd "$CEF_CLONE" 2>/dev/null && pwd -P)" ] \
+    && git -C "$CEF_CLONE" remote -v 2>/dev/null | grep -q 'agentmuxai/cef' \
+    || { echo "FATAL: CEF_CLONE=$CEF_CLONE is not an agentmuxai/cef git root." >&2; CEF_CLONE=; }
+else
+  # No override: probe. First candidate that is BOTH its own git root AND has
+  # the agentmuxai/cef remote. A .git-less mirror is not a git root, so this
+  # rejects the case where `git -C` would walk up into the Chromium checkout.
+  for _c in "$HOME/cef-build/chromium/chromium/src/cef" \
+            "$HOME/cef-build/chromium/cef" \
+            "$HOME/cef-build/chromium_git/cef"; do
+    [ "$(git -C "$_c" rev-parse --show-toplevel 2>/dev/null)" = "$(cd "$_c" 2>/dev/null && pwd -P)" ] || continue
+    git -C "$_c" remote -v 2>/dev/null | grep -q 'agentmuxai/cef' || continue
+    CEF_CLONE="$_c"; break
+  done
+fi
 echo "fork clone: ${CEF_CLONE:-<none>}"
 
 # FULL sha: `gh release create --target` takes a branch or a full commit SHA.

--- a/docs/cef-build/build-patched-libcef.md
+++ b/docs/cef-build/build-patched-libcef.md
@@ -240,8 +240,22 @@ tar -czf "cef-linux-x86_64-${CEF_VERSION}.tar.gz" \
 
 # Record the exact fork commit this artifact came from -- the only thing tying
 # the three platforms' tags together. See CEF_FORK_MAINTENANCE.md section 8 (P1).
+#
+# This MUST be the CEF fork clone, not the mirrored copy under chromium/src/cef.
+# The mirror is made with `rsync --exclude=.git` / `robocopy /XD .git`, so it has
+# no .git of its own -- and `git -C` on a directory with no .git silently WALKS
+# UP and answers from the enclosing Chromium checkout, returning CHROMIUM's HEAD.
+# That SHA does not exist in agentmuxai/cef, so --target and the notes would both
+# be wrong, with no error. The two asserts below make that impossible.
+CEF_CLONE="${CEF_CLONE:-$HOME/cef-build/chromium_git/cef}"
+
+[ "$(git -C "$CEF_CLONE" rev-parse --show-toplevel 2>/dev/null)" = "$(cd "$CEF_CLONE" && pwd -P)" ] \
+  || { echo "FATAL: $CEF_CLONE is not a git root; git would answer from the enclosing repo. Set CEF_CLONE." >&2; false; }
+git -C "$CEF_CLONE" remote -v 2>/dev/null | grep -q 'agentmuxai/cef' \
+  || { echo "FATAL: $CEF_CLONE is not the agentmuxai/cef fork. Set CEF_CLONE." >&2; false; }
+
 # FULL sha: `gh release create --target` takes a branch or a full commit SHA.
-CEF_FORK_SHA=$(git -C ~/cef-build/chromium_git/cef rev-parse HEAD)
+CEF_FORK_SHA=$(git -C "$CEF_CLONE" rev-parse HEAD)
 # Refuse to publish a release with no provenance rather than one with an empty
 # field -- an unattributable artifact is exactly what section 8 exists to prevent.
 : "${CEF_FORK_SHA:?refusing to publish without a recorded fork commit}"


### PR DESCRIPTION
## Why

We carry five AgentMux-specific changes on top of CEF and have **silently** lost pieces of that set twice. Neither failure produced an error, a conflict, or a failed build — you find out when a user reports a feature that used to work.

**Incident 1 (2026-07-01 → 2026-09-09).** The drag branch was merged into `fork/7778` via PR #3 on Jun 24, then kept receiving commits (PRs #4 and #5, Jul 1) that were never merged forward:

```
2720ba103 ──┬──► merged into fork/7778 as 2d7833dec (PR #3, Jun 24)
            │         └──► 5387e4974 (PR #7, Sep 8) ── fork/7778 tip
            │                                          has process_requirement, MISSING #4/#5
            └──► 7ba6b59f4 (PR #4, Jul 1) ──► 6c570e249 (PR #5, Jul 1) ── what SHIPPED
```

It cost nothing for two months because the July macOS framework was built from the drag branch tip directly. It bit when someone went to `fork/7778` for the P0 `process_requirement` fix — the obvious move, since that branch is the integration branch, is named for the Chromium version, and carried the newest commit. Building from it would have fixed the renderer crash-loop and regressed macOS window transparency at the same time.

**Incident 2 — found while writing this doc, still live.** The Chromium 152 port has already dropped the same work. `fork/agentmux/7977-drag-rightclick-and-transparency` ports `BeginWindowDrag`, `rwhv_background_opaque_check` and `views_caption_rightclick_passthrough`, but not the `blink_glue`/`mojom` half of transparency. Verified by identifier probe with the 7778 branch as positive control. **The 152 upgrade is currently set up to ship without transparency.**

## Root cause the doc names

Our changes live in **two layers with different mechanics**:

| | Layer A — Chromium-side patches | Layer B — libcef-side commits |
|---|---|---|
| Applied by | `patcher.py` at build time | nothing — just commits on a branch |
| Fails | loudly (`.rej`, non-zero exit) | **silently** — the tree still compiles |

Both incidents were Layer B. Nothing checks it, and the tree compiles fine without those commits because our additions are additive.

The 2026-07 gap is also a violation of a rule the repo already has in `CLAUDE.md` — *"Never reuse a branch after its PR is merged"* — which nobody had applied to the CEF fork.

## What's here

- `docs/cef-build/CEF_FORK_MAINTENANCE.md` — the standing practice: the two-layer model, the verified carry-set inventory (5 items, with per-platform scope), branch rules R1–R5, upgrade runbook, per-platform artifact verification, release-pinning practice P1–P3, checklists.
- `README.md` — the load-bearing half, so agents hit it without going looking.

## Verification

The doc's §5 block is **tested, not just written**. It reproduces both gaps independently and reports all-OK against a branch known to be complete:

| Branch | Result |
|---|---|
| `rebuild-7778-procreq-plus-transparency` (complete) | all 6 probes `OK` |
| `fork/7778` | `MISS rwhv_background_opaque_check`, `MISS transparency (blink_glue)`, `MISS transparency (mojom)` |
| `fork/agentmux/7977-drag-...` | `MISS transparency (blink_glue)` |

Testing it caught a real bug in my own script: written as `"$BR:libcef/..."` the shell eats the `:l` as a modifier and resolves `fork/7778ibcef/...`, producing a false MISS on the two probes that matter most. Fixed to `${BR}:` with a note explaining why, so it doesn't get "simplified" back.

Gates: `check-doc-status` ok (2 docs), `gen-docs-index --check` ok, `check-spec-citations` ok.

## Notes for the reviewer

- Docs only — no code paths touched.
- Platform scoping in the carry-set table was verified from the patch bodies, not assumed from names: `views_caption_rightclick_passthrough` is **Linux-only** (`window_event_filter_linux.cc`) despite the generic name.
- The `patcher.py --root-dir` trap is restated here rather than only in #3113, because the failure mode (applies **zero of 112** patches and builds anyway) is what makes the whole class of bug invisible.

## Follow-ups this does NOT do

1. **`fork/7778` is still incomplete upstream** — it has `process_requirement` but not the transparency commits. I merged them locally for the in-flight build; the fork itself still needs the merge. Wanted a decision before pushing to a shared repo.
2. **The 152 port needs the transparency half added** before that upgrade ships (#3103).
3. Suggested: have the release job assert all three pins resolve to the same `agentmuxai/cef` commit, which would make P1–P3 mechanical instead of convention.

<!-- agentmux:agent_id=clare -->