### PR TITLE
Manoz@Area54: fix(floating-pane): require a real 500ms hover before a redock arms

### DIFF
--- a/.changesets/1788966810-fix-floating-pane-require-a-real-500ms-hover-before-a-floati-qve5.md
+++ b/.changesets/1788966810-fix-floating-pane-require-a-real-500ms-hover-before-a-floati-qve5.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(floating-pane): require a real 500ms hover before a floating pane redocks

--- a/agentmux-cef/src/ui_tasks/drag.rs
+++ b/agentmux-cef/src/ui_tasks/drag.rs
@@ -668,6 +668,46 @@ wrap_task! {
                             // button-state check re-runs on the next iteration.
                             // Other timers fall through to the `_` arm so CEF's
                             // own timers aren't dropped during the drag.
+                            //
+                            // Floater: also emit a redock-hover HEARTBEAT here.
+                            // WM_MOUSEMOVE stops arriving the moment the cursor
+                            // holds still, so a dwell clock fed only from that
+                            // handler cannot advance during the exact condition
+                            // it exists to measure. The renderer used to paper
+                            // over that by inferring dwell from the ABSENCE of
+                            // events, which armed a redock even after the
+                            // velocity gate had rejected the entry. Emitting on
+                            // this tick makes stationary dwell observable, so
+                            // the renderer can measure it honestly.
+                            // SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md §5.1.
+                            //
+                            // Shares `last_hover_emit` with the WM_MOUSEMOVE
+                            // path: while the cursor is actually moving that
+                            // handler is already emitting at 50ms and this tick
+                            // mostly no-ops, so the cadence is unchanged for a
+                            // moving drag.
+                            if !cancelled {
+                                if let Some(sl) = self.source_label.as_deref() {
+                                    if sl.starts_with("floating-")
+                                        && last_hover_emit.elapsed()
+                                            >= std::time::Duration::from_millis(50)
+                                    {
+                                        let mut cur = POINT { x: 0, y: 0 };
+                                        GetCursorPos(&mut cur);
+                                        let hover_args = serde_json::json!({
+                                            "source_label": sl,
+                                            "x": cur.x,
+                                            "y": cur.y,
+                                        });
+                                        let _ = crate::commands::window
+                                            ::update_floating_redock_hover(
+                                                &self.state,
+                                                &hover_args,
+                                            );
+                                        last_hover_emit = std::time::Instant::now();
+                                    }
+                                }
+                            }
                         }
                         _ => {
                             // Keep the app alive (paint, DPI changes, sent msgs).

--- a/agentmux-cef/src/ui_tasks/drag.rs
+++ b/agentmux-cef/src/ui_tasks/drag.rs
@@ -686,7 +686,15 @@ wrap_task! {
                             // handler is already emitting at 50ms and this tick
                             // mostly no-ops, so the cadence is unchanged for a
                             // moving drag.
-                            if !cancelled {
+                            // `moves > 0` mirrors the `moved` flag this loop
+                            // reports in window_drag_ended, which the renderer
+                            // requires before it will redock. Without it a
+                            // press-and-hold on the header would emit
+                            // stationary samples, arm the ghost after the dwell
+                            // and then dock nothing on release — an indicator
+                            // promising something the release gate refuses.
+                            // codex P2 on #3124.
+                            if !cancelled && moves > 0 {
                                 if let Some(sl) = self.source_label.as_deref() {
                                     if sl.starts_with("floating-")
                                         && last_hover_emit.elapsed()

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -338,6 +338,7 @@ partial list.
 | [`SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31`](SPEC_CONTENT_RESIZE_CONTRACT_2026_08_31.md) | SPEC: A single content-resize contract for the agent pane |
 | [`SPEC_DOCS_LIFECYCLE_HARDENING_2026_08_03`](SPEC_DOCS_LIFECYCLE_HARDENING_2026_08_03.md) | Docs Lifecycle Audit & Hardening Plan |
 | [`SPEC_EDITOR_MCP_OPEN_BLANK_PREVIEW_AND_PANE_REUSE_2026_08_03`](SPEC_EDITOR_MCP_OPEN_BLANK_PREVIEW_AND_PANE_REUSE_2026_08_03.md) | Plan: MCP-opened markdown blank-preview investigation + Editor-pane reuse |
+| [`SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09`](SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md) | SPEC: Floating-pane redock — hover-intent dwell and a neutral parking zone |
 | [`SPEC_HEADLESS_TRANSIENT_RETRY_2026_08_31`](SPEC_HEADLESS_TRANSIENT_RETRY_2026_08_31.md) | Transient-failure retry for turns with no rendered pane |
 | [`SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02`](SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md) | SPEC: Cross-channel jekt trust — closing the last unverifiable same-machine tier |
 | [`SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03`](SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03.md) | Migration System Audit & Hardening Plan |

--- a/docs/specs/SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md
+++ b/docs/specs/SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md
@@ -1,0 +1,328 @@
+# SPEC: Floating-pane redock — hover-intent dwell and a neutral parking zone
+
+**Status:** active
+**Date:** 2026-09-09
+**Implemented:** §5.1 (P1 heartbeat), §5.2 (P2 threshold) and §5.4 (P4
+extraction) shipped together — see §8 for why they could not be split. §5.3
+(P3, the neutral parking zone) is still open and is deliberately a separate
+change; the sections below are written as they were proposed, with §5.4's
+ordering caveat noted in §8.
+**Area:** floating panes / drag-and-dock
+**Scope:** The dwell/velocity gate gating floating-pane redock, on all three
+platforms. Tear-off (docked to floating) is out of scope; so is cross-tab pane
+drag, which shares `RedockFloatingPane` but not this gate.
+**Relates to:** [SPEC_FLOATING_PANE_REDOCK_2026-05-27](SPEC_FLOATING_PANE_REDOCK_2026-05-27.md),
+[SPEC_PANE_DRAG_TO_TAB_2026_07_10](SPEC_PANE_DRAG_TO_TAB_2026_07_10.md),
+[SPEC_REDOCK_FRAMEWORK_HARDENING_2026_07_27](SPEC_REDOCK_FRAMEWORK_HARDENING_2026_07_27.md)
+
+---
+
+## 1. Problem
+
+Dragging a floating pane over the main window shows the redock ghost and re-docks
+the pane the moment the mouse is released. A user who simply wants the floating
+pane to *sit above* AgentMux — as an overlay, not as a docked tile — cannot
+express that intent: every drag that ends over the main window docks.
+
+**This is a recurrence, not a new report.** The identical complaint was filed
+2026-06-03 and quoted verbatim in PR #1249's body:
+
+> "Sometimes when dragging the pane over a main window, I don't want it to dock,
+> but it immediately does."
+
+That report was fixed by adding a dwell + velocity gate. Three months later the
+same behavior is being reported again. The gate did ship and does work as
+written — but its threshold was tuned too low, and the mechanism it depends on
+is structurally unable to measure dwell while the cursor is stationary, so it
+falls back to inferences that re-open the very hole it was built to close.
+
+## 2. History
+
+| Date | PR / commit | What landed |
+|---|---|---|
+| 2026-06-08 | [#1249](https://github.com/agentmuxai/agentmux/pull/1249) `3aa3cdd0` | Original fix. Introduced `REDOCK_DWELL_MS = 180` + `REDOCK_VELOCITY_PX_PER_S = 400` in the floater drag handler. Two-stage "armed then committed" model. |
+| 2026-06-18 | [#1559](https://github.com/agentmuxai/agentmux/pull/1559) `ddf3177f` | Extended the same 180 ms gate to the *ghost* listener (`app-init.ts`), which had none; extracted both constants into `floating-pane-constants.ts` as a shared source of truth. |
+
+Two facts from that history matter for this spec:
+
+1. **PR #1249 pre-registered this escalation.** Its "Approach" section surveyed
+   dwell-time delay, velocity gating, and explicit compass widgets (VS Code,
+   Infragistics, Telerik, Dockview), chose dwell + velocity because it
+   "composes naturally, no new UI affordances," and stated plainly:
+   *"Compass widget is the natural next step if this proves insufficient."*
+   It has proven insufficient. Section 5.3 is that next step.
+
+2. **The spec #1249 promised was never written.** Its body cites a
+   `SPEC_FLOATING_REDOCK_DWELL_2026-06-03.md` under the specs directory for the
+   "full research summary, design rationale, behavior matrix, known limitations,
+   and future work." That file has never existed in git history. (Its full path
+   is deliberately not written out here: `scripts/check-spec-citations.sh` would
+   read it as a live citation, and a pointer to nothing is worse than none.) The industry research and
+   the tuning rationale therefore lived only in a PR description, where nobody
+   revisiting the constant would find them. `scripts/check-spec-citations.sh`
+   did not catch it because it only validates citations in *changed* files.
+   This document replaces that missing spec.
+
+## 3. Root causes
+
+Three independent causes. **Fixing only the constant (3.1) will not fix the
+reported behavior**, because 3.2 defeats any threshold value.
+
+### 3.1 The threshold is below the human intent boundary
+
+`frontend/app/workspace/floating-pane-constants.ts:12` — `REDOCK_DWELL_MS = 180`.
+
+PR #1249's tuning note justifies it:
+
+> `REDOCK_DWELL_MS = 180` — below Windows' 400 ms hover default because
+> drag-aiming feels more deliberate than passive hover.
+
+The premise is sound (aiming *is* more deliberate than passive hover) but the
+conclusion is inverted: deliberateness of the *gesture* is not what the delay
+gates. The delay gates the **consequence**, and the consequence here is
+destructive and non-obvious to undo — the floating window is destroyed, the
+pane is grafted into the layout tree, and recovering the previous state means
+manually tearing off again and re-positioning the window.
+
+This codebase already reached the opposite conclusion for a strictly *smaller*
+action. `frontend/app/tab/tabbar-dnd.ts:62` sets `SPRING_SWITCH_MS = 500`, and
+`SPEC_PANE_DRAG_TO_TAB_2026_07_10.md:31-33` justifies it as:
+
+> deliberately longer than the redock ghost's 180 ms since switching the visible
+> tab is a bigger action.
+
+Switching which tab is visible is reversible with one click. A redock is not.
+The precedent is anchored to the wrong reference point.
+
+### 3.2 Dwell is inferred from the *absence* of events — the load-bearing bug
+
+The Win32 drag loop emits hover state only from inside its `WM_MOUSEMOVE`
+handler, throttled to 50 ms (`agentmux-cef/src/ui_tasks/drag.rs:598-616`).
+**When the cursor stops moving, `WM_MOUSEMOVE` stops arriving, so hover events
+stop entirely.** A dwell clock driven by those events cannot advance during the
+exact condition it is meant to measure — holding still.
+
+To compensate, the renderer arms redock through a disjunction of fallbacks that
+substitute *elapsed time since the last event* for genuine dwell
+(`frontend/app/workspace/floating-pane-workspace.tsx`):
+
+| Line | Fallback | Why it re-opens the hole |
+|---|---|---|
+| `:533` | `hoverArmed` (real dwell, two confirmed events) | Correct — this is the intended path |
+| `:540` | `now - dwellHoverTargetFirstSeenAt >= REDOCK_DWELL_MS` at mouseup | Wall-clock recheck; acceptable |
+| `:545` | `dwellHoverTargetFirstSeenAt === null && now - dwellWinLastSampleAt >= REDOCK_DWELL_MS` | **Arms after the velocity gate explicitly rejected the entry**, purely because events went quiet |
+| `:652`, `:657`, `:659` | same three, re-evaluated in `window_drag_ended` | Duplicated for the Windows mouseup / drag-ended ordering race |
+
+The `:545` branch is the decisive one. Its own comment describes the intent —
+"Hold-still after fast entry: velocity gate preserved the target but cleared the
+timer; cursor then stopped so no slow event restarted it" — but the effect is
+that **any pause of at least `REDOCK_DWELL_MS` immediately before release arms
+the redock, including one the velocity gate just disqualified.**
+
+Every careful repositioning of a floating window ends in exactly that pause: the
+user stops moving, confirms the position, then releases. So the gate is bypassed
+on precisely the gesture it exists to protect. Raising `REDOCK_DWELL_MS` to 500
+in isolation would only change the required pause from 180 ms to 500 ms — still
+shorter than any deliberate "place it here and let go."
+
+### 3.3 There is no neutral surface to park over
+
+`frontend/app-init.ts:180-182` maps `DropDirection::Center` (dir `8`) to the
+**full leaf rect**. Combined with Top/Right/Bottom/Left (half-leaf) and the
+`Outer*` bands (1/5 edge), every pixel of every pane in the main window resolves
+to a valid drop zone. There is no region a user can hover over that means
+"nothing — I am just passing through, or parking here."
+
+A dwell-only model cannot express parking intent even in principle: parking is
+communicated by hovering *longer*, which is the same signal that arms the dock.
+The two intents are read from one channel, and dwell resolves the ambiguity in
+the wrong direction.
+
+## 4. Best practice
+
+| Product / guideline | Delay before a drag-hover action commits |
+|---|---|
+| Windows shell hover default | 400 ms |
+| macOS spring-loaded folders | ~500-750 ms (user-adjustable) |
+| Windows `MenuShowDelay` (submenu open) | 400 ms default |
+| AgentMux spring-loaded tabs (`SPRING_SWITCH_MS`) | 500 ms |
+| AgentMux redock (today) | **180 ms** |
+
+The consensus band for "hover became intent" is **400-700 ms**. AgentMux's
+redock is the outlier by a factor of roughly 2.5.
+
+The second, stronger convention: **mature docking UIs do not infer dock intent
+from window-relative position at all.** Visual Studio, JetBrains, Qt, and
+Dockview all require the drop to land on an explicit dock guide / compass
+target, leaving the rest of the surface neutral so a floating tool window can be
+parked anywhere. This is the affordance 3.3 is missing, and the one #1249
+deferred.
+
+**Chosen value: `REDOCK_DWELL_MS = 500`** — adopts the repo's own
+`SPRING_SWITCH_MS`, sits inside the consensus band, and is above the Windows
+400 ms hover default rather than deliberately below it. Choosing the existing
+in-repo constant rather than a newly invented number also removes the "two
+subsystems, two arbitrary thresholds" divergence noted in 3.1.
+
+## 5. Design
+
+Four phases. **P1 is a prerequisite for P2 being meaningful** — shipping the
+constant bump alone would be a cosmetic change to a defeated gate.
+
+### 5.1 P1 — Make dwell measurable while stationary (correctness)
+
+`agentmux-cef/src/ui_tasks/drag.rs:463-464` already installs a 100 ms wake
+timer for the entire drag:
+
+```rust
+const DRAG_TICK_ID: usize = 0xD9A6;
+SetTimer(h, DRAG_TICK_ID, 100, None);
+```
+
+Its handler (`:666-672`) currently does nothing but consume the message. Emit
+the redock-hover update from that tick as well as from `WM_MOUSEMOVE`, reusing
+the existing `last_hover_emit` throttle so a moving cursor does not double-emit:
+
+- Cursor moving: `WM_MOUSEMOVE` drives emission at 50 ms (unchanged).
+- Cursor stationary: the 100 ms tick keeps emitting with the last known cursor
+  position, so `dwellHoverTargetFirstSeenAt` advances truthfully.
+
+With a genuine heartbeat, the inference fallbacks become dead weight and must be
+**deleted, not retuned**: `:545` and its `window_drag_ended` twin `:659` are
+removed outright, leaving arming to `hoverArmed` plus the wall-clock recheck
+against `dwellHoverTargetFirstSeenAt`. The velocity gate then actually holds —
+a rejected fast entry stays rejected until the cursor genuinely slows and dwells.
+
+The macOS/Linux JS-driven path already receives continuous `mousemove` and needs
+no heartbeat; it needs only the same fallback deletion
+(`:560`, `:562` — the `dwellSlowSince` / `dwellCurrentConfirmedAt` proxies).
+
+### 5.2 P2 — Raise the threshold
+
+`REDOCK_DWELL_MS: 180 -> 500` in `floating-pane-constants.ts:12`.
+
+`REDOCK_VELOCITY_PX_PER_S` stays at 400 — it is a rate, not a duration, and
+#1249's derivation (relaxed aim is about 100 px / 250 ms; transit drags hit
+1500+ px/s) is still sound.
+
+One coupling to honour: `floating-pane-workspace.tsx:830` fires the hover IPC at
+`REDOCK_DWELL_MS - HOVER_THROTTLE_MS` (`HOVER_THROTTLE_MS = 50`, `:780`) so the
+ghost is painted before `mouseup` can commit. That relationship is preserved
+automatically by the subtraction, but the ghost's first paint moves from ~130 ms
+to ~450 ms. That is intended: **the ghost appearing is the user-visible signal
+that release will dock**, so it must not appear before the gesture has been
+recognised as a dock attempt. It should remain the case that ghost-visible and
+armed are the same instant, never ghost-visible-but-not-armed.
+
+### 5.3 P3 — A neutral parking zone (the compass escalation)
+
+Restrict redock arming to explicit drop-guide regions rather than the whole leaf:
+
+- Keep the `Outer*` edge bands (1/5) and the Top/Right/Bottom/Left half-splits.
+- **Remove `Center` = full-leaf as an implicit arming target.** Center-drop
+  (append into the leaf) remains available, but only from an explicit central
+  guide target — a compass hit-rect of bounded size (proposal: 96x96 CSS px
+  centred in the leaf), not the entire remaining surface.
+
+The result is a genuinely neutral majority of each pane's area: hovering there
+shows no ghost and arms nothing, so a floating pane can be parked anywhere over
+AgentMux by simply not aiming at a guide. This directly answers the user's
+stated goal ("the user may simply want the floating pane above, not a redock")
+in a way no dwell value can.
+
+If P3's UI work is deferred, an interim escape hatch is a modifier-key
+suppression (hold <kbd>Alt</kbd> during the drag: never arm, never ghost),
+which is roughly ten lines and requires no new rendering. It is strictly worse
+UX than guides (undiscoverable) and should be treated as a stopgap, not the
+answer.
+
+### 5.4 P4 — Collapse the duplicated gate (debt paydown)
+
+`docs/retro/retro-redock-ghost-landing-reliability-2026-07-27.md:47` already
+flagged this:
+
+> The dwell/velocity hover gate is hand-implemented twice (once for the Windows
+> native-move-loop path, once for the macOS/Linux JS-driven path) with
+> near-duplicate state — any future gating tweak has to be applied symmetrically
+> by hand or platforms silently diverge.
+
+This spec is exactly such a tweak, and it touches both copies. Extract the
+arming state machine into one module (proposal:
+`frontend/app/workspace/redock-arming.ts`) exposing a platform-agnostic
+`onHoverSample({ target, x, y, t })` returning `{ armed, indicator }`, with the
+two platform paths reduced to feeding it samples. This is what makes P1-P3
+testable (section 7) — the current state is spread across roughly twenty mutable
+closure variables in an `onMount` body and cannot be unit-tested at all.
+
+## 6. Blast radius
+
+| File | Lines | Role | Phase |
+|---|---|---|---|
+| `frontend/app/workspace/floating-pane-constants.ts` | `12`, `15` | Constant definitions | P2 |
+| `agentmux-cef/src/ui_tasks/drag.rs` | `463-464`, `598-616`, `666-672` | Win32 hover emission + wake tick | P1 |
+| `frontend/app/workspace/floating-pane-workspace.tsx` | `53` (import), `533`, `540`, `545`, `560`, `562`, `652`, `657`, `659` (arming), `730`, `808` (velocity), `765` (dwell arm), `780`, `830` (IPC lead-in) | Floater-side gate, both platform paths | P1, P2, P4 |
+| `frontend/app-init.ts` | `59` (import), `180-182` (`rectForDirection` Center), `187` (`ghostDwellMs`), `217` (ghost show gate) | Ghost-side gate + drop-zone mapping | P1, P3 |
+| `frontend/app/tab/tabbar-dnd.ts` | `62` | `SPRING_SWITCH_MS` — update its comment, which currently anchors itself to the 180 ms value | P2 |
+
+No Rust code reads either constant; the Rust change in P1 is emission cadence
+only. `SPEC_PANE_DRAG_TO_TAB_2026_07_10.md:31-33` and `:164` cite the 180 ms
+value in prose and must be corrected in the same PR.
+
+## 7. Test plan
+
+**There is currently no test coverage of any of this** — no vitest or Rust test
+references `REDOCK_DWELL_MS`, dwell arming, or velocity rejection. Changing the
+constant today breaks no test, which is the risk, not the reassurance. P4's
+extraction exists to make the following table testable as pure functions:
+
+| # | Scenario | Expected |
+|---|---|---|
+| 1 | Fast transit across main window, release while over it | No ghost, no dock (regression guard for #1249) |
+| 2 | Slow aim, hold 200 ms, release | **No dock** (this docked before) |
+| 3 | Slow aim, hold 600 ms over a guide, release | Ghost visible, docks |
+| 4 | Move floater over main window, pause 2 s in a neutral (non-guide) area, release | No ghost, no dock, floater stays (P3) |
+| 5 | Fast entry, velocity rejects, stop dead, release after 600 ms | **No dock** (kills the `:545` inference path) |
+| 6 | Cursor stationary over a guide for 600 ms with zero `WM_MOUSEMOVE` | Arms (proves the P1 heartbeat works) |
+| 7 | Ghost visible, then drag away fast | Ghost clears within one frame; release elsewhere gives no dock |
+| 8 | Same matrix on macOS + Linux JS-driven path | Identical outcomes (P4 symmetry) |
+
+Manual verification is required for 6 and 8 (host-loop and platform behavior);
+1-5 and 7 should be unit tests against the extracted arming module.
+
+## 8. Rollout
+
+1. **P1 + P2 together** in one PR — the heartbeat plus the fallback deletions
+   plus the constant bump. Splitting them ships either a defeated gate (P2 alone)
+   or an unexplained behavior change (P1 alone).
+2. **P4** immediately after, as a pure refactor with the section 7 tests added
+   against the extracted module. Doing it before P1/P2 would mean writing tests
+   for logic that is about to be deleted.
+3. **P3** as its own PR with design review — it changes a visible affordance and
+   deserves to be evaluated on its own, per #1249's framing of the compass
+   widget as a distinct step.
+
+**What actually shipped (2026-09-09):** P4 was folded into step 1 rather than
+following it. Step 2's rationale above assumed P4 meant "extract the existing
+logic," which would indeed have been tests-for-code-about-to-be-deleted. In
+practice the fallback deletions in P1 *are* the extraction — the arming rules
+that survive are small enough to state as a pure function, and writing them
+into `redock-arming.ts` directly was less work than editing them in place
+twice. The section 7 table is therefore covered by unit tests in this PR
+rather than the next one. P3 remains a separate, unstarted change.
+
+## 9. Open questions
+
+- **Should the dwell be user-configurable?** `window:*` settings already exist
+  (`agentmux-srv/src/backend/wconfig/mod.rs`), so `window:redockdwellms` is
+  cheap. Recommendation: **no, not initially.** A correct default plus a neutral
+  zone (P3) should remove the need; a setting would ossify the current
+  one-channel-two-intents design rather than fix it.
+- **Should `SPRING_SWITCH_MS` and `REDOCK_DWELL_MS` become one constant?** They
+  would share a value (500) after P2 but gate different subsystems. Keep them
+  separate, and update the stale cross-reference comment at `tabbar-dnd.ts:62`
+  rather than merging them.
+- **Does the P1 heartbeat cost anything measurable?** The 100 ms tick already
+  runs; the added work is one `resolve_window_at_cursor` Z-order walk per tick
+  while stationary. Expected negligible, but worth confirming against the
+  `[redock-resolve]` diagnostic already present at
+  `agentmux-cef/src/commands/window/motion.rs:299-301`.

--- a/docs/specs/SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md
+++ b/docs/specs/SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md
@@ -189,13 +189,41 @@ the existing `last_hover_emit` throttle so a moving cursor does not double-emit:
 
 With a genuine heartbeat, the inference fallbacks become dead weight and must be
 **deleted, not retuned**: `:545` and its `window_drag_ended` twin `:659` are
-removed outright, leaving arming to `hoverArmed` plus the wall-clock recheck
-against `dwellHoverTargetFirstSeenAt`. The velocity gate then actually holds —
-a rejected fast entry stays rejected until the cursor genuinely slows and dwells.
+removed outright. The velocity gate then actually holds — a rejected fast entry
+stays rejected until the cursor genuinely slows and dwells.
 
-The macOS/Linux JS-driven path already receives continuous `mousemove` and needs
-no heartbeat; it needs only the same fallback deletion
-(`:560`, `:562` — the `dwellSlowSince` / `dwellCurrentConfirmedAt` proxies).
+This section originally kept one of them: the wall-clock recheck against
+`dwellHoverTargetFirstSeenAt` (`:540`), on the reasoning that re-reading a real
+confirmed-hover timestamp is not the same as inferring from missing samples.
+**That was wrong, and it did not survive review** (codex P1 on #3124). Two
+distinct failures:
+
+- The ghost renderer only paints once it observes an *armed* sample. A release
+  inside the extrapolation window therefore docked with **no ghost ever
+  shown** — the exact inverse of the invariant §5.2 sets out below.
+- `firstSeenAt` describes the target of the *last* sample. Extrapolating past
+  that sample can report armed for a window the cursor has since left, and
+  because the redock re-resolves the window under the cursor independently at
+  release, the pane lands somewhere that never showed a ghost.
+
+Arming therefore requires a confirming sample, full stop — `isArmed()` takes no
+timestamp. The heartbeat is what makes this affordable: the flag is never more
+than one 100ms tick stale, so the cost is ~100ms of latency in exchange for the
+two sides agreeing exactly. As defence in depth, the release path also compares
+the resolved window against the armed target and aborts on a mismatch.
+
+The macOS/Linux JS-driven path receives continuous `mousemove` while the cursor
+moves, but falls equally silent when it stops, so it needs the same heartbeat in
+JS (a 100ms interval re-emitting at the last known position) plus the same
+fallback deletion (`:560`, `:562` — the `dwellSlowSince` /
+`dwellCurrentConfirmedAt` proxies).
+
+**Both heartbeats must be gated on the drag having actually moved** (codex P2 on
+#3124). The redock is refused unless the drag reports movement — `hasMoved` in
+the renderer, `moves > 0` in the host loop — so emitting stationary samples
+during a press-and-hold on the header would arm the indicator after the dwell
+and then dock nothing on release, an indicator promising what the release gate
+will refuse.
 
 ### 5.2 P2 — Raise the threshold
 

--- a/docs/specs/SPEC_PANE_DRAG_TO_TAB_2026_07_10.md
+++ b/docs/specs/SPEC_PANE_DRAG_TO_TAB_2026_07_10.md
@@ -29,8 +29,12 @@ v2 design (implemented; supersedes §4.1–§4.6 below, kept for history):
   release over the bar clears `currentDragPayload` (the §7 tear-off fix).
 - **Blink then switch**: on enter, the hovered tab pulses (`.tile-drop-hover`,
   as v1); after `SPRING_SWITCH_MS` (500ms) dwell, the UI switches to that tab
-  (`setActiveTab` via the tab's own `onSelect`) — deliberately longer than the
-  redock ghost's 180ms since switching the visible tab is a bigger action.
+  (`setActiveTab` via the tab's own `onSelect`). This originally read
+  "deliberately longer than the redock ghost's 180ms since switching the
+  visible tab is a bigger action" — corrected 2026-09-09: a redock is the
+  *less* reversible of the two, and the redock gate has since been raised to
+  500ms to match this value. See
+  `SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md` §3.1.
 - **Real-layout ghost**: the target tab's own TileLayout overlay handles
   placement using the existing `ComputeMove` → pending-`Move` → placeholder
   machinery. One shared-code extension makes this work cross-tab:
@@ -161,7 +165,7 @@ queue_source_layout_delete(state, &source_tab_id, &block_id).await
 
 ### 2.5 Ghost/preview precedent for a *live, direction-aware* drop indicator
 
-`app-init.ts:113-273` (`installFloatingRedockHoverListener`) is the closest existing "ghost stitched into a target's layout, updating live while a real drag is in progress": on `floating-redock:hover-state` host events (cursor position during a floating-window OS-level move), it does `elementFromPoint` → nearest `[data-blockid]` leaf → `determineDropDirection` → `rectForDirection` (hardcoded Top/Right/Bottom/Left = half-leaf, Outer* = 1/5 band, Center = full-leaf) → positions a raw `.floating-redock-drop-placeholder` div, gated by a 180ms dwell timer on Windows (`REDOCK_DWELL_MS`) to prevent flicker.
+`app-init.ts:113-273` (`installFloatingRedockHoverListener`) is the closest existing "ghost stitched into a target's layout, updating live while a real drag is in progress": on `floating-redock:hover-state` host events (cursor position during a floating-window OS-level move), it does `elementFromPoint` → nearest `[data-blockid]` leaf → `determineDropDirection` → `rectForDirection` (hardcoded Top/Right/Bottom/Left = half-leaf, Outer* = 1/5 band, Center = full-leaf) → positions a raw `.floating-redock-drop-placeholder` div, gated by a dwell timer keyed on `REDOCK_DWELL_MS` to prevent flicker. (180ms and Windows-only when this spec was written; 500ms since `SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md`, and the Windows-only carve-out is gone — floater and ghost now share one arming module.)
 
 **This only works because its target is a visible, active tab's real DOM** (the dragged window is a separate OS process, the target tab is necessarily the one currently on screen in that other window). **Our target tab is usually inactive and `display:none`**, so `elementFromPoint`/`getBoundingClientRect` are not usable directly — see §4.2.
 
@@ -199,7 +203,7 @@ Set only when the dragged payload is `kind: "tile"` and the tile's *own* tab dif
 
 ### 4.2 Tab flash (Goal 2)
 
-A CSS class (e.g. `.tab--drop-flash`) toggled by `hoveredDropTabId`, applied as a restartable keyframe pulse (not a static highlight) so re-entering the same tab after briefly leaving re-triggers the flash — mirrors the existing `bouncingTabId` one-shot-animation pattern (`tabbar.tsx`) rather than inventing a new animation-retrigger mechanism. Dwell-gate this at ~120–180ms (matching `REDOCK_DWELL_MS`'s precedent, §2.5) before the preview (§4.3) mounts, so a fast pass-through over several tabs doesn't spawn/despawn previews per-frame.
+A CSS class (e.g. `.tab--drop-flash`) toggled by `hoveredDropTabId`, applied as a restartable keyframe pulse (not a static highlight) so re-entering the same tab after briefly leaving re-triggers the flash — mirrors the existing `bouncingTabId` one-shot-animation pattern (`tabbar.tsx`) rather than inventing a new animation-retrigger mechanism. Dwell-gate this at ~120–180ms (this matched `REDOCK_DWELL_MS`'s precedent, §2.5, when that constant was also 180ms; it is 500ms since 2026-09-09 and this preview gate was deliberately *not* raised alongside it — mounting a preview is cheap and reversible, unlike a redock) before the preview (§4.3) mounts, so a fast pass-through over several tabs doesn't spawn/despawn previews per-frame.
 
 ### 4.3 Schematic tab-layout preview (Goal 3) — the genuinely new piece
 

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -56,7 +56,7 @@ import { setProviderModels } from "@/app/view/agent/providers";
 import { scheduleRevealLift } from "@/store/tab-reveal";
 import { installLauncherEventBridge } from "@/util/launcher-events";
 import { installSrvEventBridge } from "@/util/srv-events";
-import { REDOCK_DWELL_MS } from "@/app/workspace/floating-pane-constants";
+import { createRedockArming } from "@/app/workspace/redock-arming";
 import {
     seedKnownEntriesFromSnapshot,
     startLauncherEventReducer,
@@ -125,10 +125,17 @@ function installFloatingRedockHoverListener(): void {
         return placeholderEl;
     };
     const clearPlaceholder = () => {
+        const hadGhost = placeholderEl !== null;
         if (placeholderEl) {
             placeholderEl.remove();
             placeholderEl = null;
         }
+        // Nothing was showing, so there is no stored ghost state to clear —
+        // the backend entry is written on the same path that mounts the
+        // placeholder. Bailing here matters now that this runs on every
+        // not-yet-armed hover sample: without it, a 500ms dwell would fire an
+        // IPC per heartbeat just to clear state that was never set.
+        if (!hadGhost) return;
         // Phase 4b — clear the stored ghost state for this window so a stale
         // direction cannot bleed into the next drop event.
         fireAndForget(async () => {
@@ -176,17 +183,16 @@ function installFloatingRedockHoverListener(): void {
     };
 
     // Dwell gate for the redock ghost.
-    // On Windows, Win32BeginMoveTask emits floating-redock:hover-state every 50ms
-    // with no dwell awareness — we must gate the ghost ourselves to 180ms.
-    // On non-Windows, the floater's onMouseMove path already waits REDOCK_DWELL_MS
-    // before calling update_floating_redock_hover, so the first event arrives at
-    // ~T=180ms; applying our own 180ms clock on top would delay to ~T=360ms and
-    // would never fire if the cursor is held still (no further mousemoves = no
-    // further events). Set ghostDwellMs=0 on non-Windows so the ghost appears on
-    // the first event (already pre-gated by the floater).
-    const ghostDwellMs = isWindows() ? REDOCK_DWELL_MS : 0;
-    let dwellTarget: string | null = null;
-    let dwellSince = 0;
+    //
+    // Both sides run the SAME arming state machine over the SAME event stream,
+    // so the ghost appears exactly when the floater considers the drag armed —
+    // no per-platform clock to keep in sync, and no window where the ghost is
+    // visible but a release would not dock (or vice versa). Previously this was
+    // a second, independent dwell timer that had to be disabled outright on
+    // non-Windows because the floater pre-gated its own IPC, which meant the
+    // two sides were gating on different rules by construction.
+    // SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md §5.1/§5.4.
+    const ghostArming = createRedockArming();
 
     fireAndForget(async () => {
         const { listenEvent, invokeCommand } = await import("@/app/platform/ipc");
@@ -198,36 +204,32 @@ function installFloatingRedockHoverListener(): void {
             cursor_y?: number;
         }>("floating-redock:hover-state", (payload) => {
             const newTarget = payload?.target_label ?? null;
-            if (!payload || newTarget !== myLabel) {
-                // Target changed away from us or cleared — reset dwell and hide ghost.
-                if (dwellTarget !== null) {
-                    dwellTarget = null;
-                    dwellSince = 0;
-                }
-                clearPlaceholder();
-                return;
-            }
-            // Cursor is over our window. Start or continue dwell clock.
-            const now = performance.now();
-            if (dwellTarget !== myLabel) {
-                dwellTarget = myLabel;
-                dwellSince = now;
-            }
-            // Ghost only appears after the dwell has elapsed (0 on non-Windows).
-            if (now - dwellSince < ghostDwellMs) return;
-
-            const cursorX = payload.cursor_x;
-            const cursorY = payload.cursor_y;
-            if (typeof cursorX !== "number" || typeof cursorY !== "number") {
-                clearPlaceholder();
-                return;
-            }
+            const cursorX = payload?.cursor_x;
+            const cursorY = payload?.cursor_y;
             // The broadcast cursor is in the host's coordinate space: physical
             // px on Windows (divide by DPR to get CSS px), DIP on macOS/Linux
             // (already CSS px — no divide). Inverse of the sender's posScale()
             // in floating-pane-workspace.tsx. Without this the drop-zone
-            // highlight lands wrong on a Retina display.
+            // highlight lands wrong on a Retina display, and the velocity gate
+            // would read 2× the real cursor speed.
             const invScale = isWindows() ? window.devicePixelRatio || 1 : 1;
+            // A teardown broadcast (`clear_floating_redock_hover`) carries a
+            // null target and no cursor. Feed it through as a null-target
+            // sample so the module disarms, rather than special-casing it.
+            const { armed } = ghostArming.sample({
+                target: newTarget,
+                x: typeof cursorX === "number" ? cursorX / invScale : undefined,
+                y: typeof cursorY === "number" ? cursorY / invScale : undefined,
+                t: performance.now(),
+            });
+            if (!payload || newTarget !== myLabel || !armed) {
+                clearPlaceholder();
+                return;
+            }
+            if (typeof cursorX !== "number" || typeof cursorY !== "number") {
+                clearPlaceholder();
+                return;
+            }
             const clientX = cursorX / invScale - window.screenX;
             const clientY = cursorY / invScale - window.screenY;
             const el = document.elementFromPoint(clientX, clientY) as HTMLElement | null;

--- a/frontend/app/tab/tabbar-dnd.ts
+++ b/frontend/app/tab/tabbar-dnd.ts
@@ -56,9 +56,14 @@ export const [hoveredDropTabId, setHoveredDropTabId] = createSignal<string | nul
 
 // How long a pane drag must dwell over a tab before the UI spring-switches
 // to it (the blink plays during this window). Modeled on browser/VS Code
-// spring-loading; deliberately longer than REDOCK_DWELL_MS's 180ms ghost
-// gate — switching the whole visible tab is a bigger action than showing a
-// ghost, so it gets a more deliberate threshold.
+// spring-loading.
+//
+// This used to note that it was "deliberately longer than REDOCK_DWELL_MS's
+// 180ms". That framing was wrong in both directions: a redock is *less*
+// reversible than a tab switch, not more, and the 180ms it was measuring
+// itself against has since been raised to 500 to match this value. The two
+// are equal now and gate different subsystems — keep them as separate
+// constants. SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md §3.1.
 export const SPRING_SWITCH_MS = 500;
 
 // Tabs whose LayoutModel.activeDrag was force-set by a mid-drag spring

--- a/frontend/app/workspace/floating-pane-constants.ts
+++ b/frontend/app/workspace/floating-pane-constants.ts
@@ -8,8 +8,18 @@
  * threshold.
  */
 
-/** Milliseconds the cursor must hover over a target before redock arms. */
-export const REDOCK_DWELL_MS = 180;
+/**
+ * Milliseconds the cursor must hover over a target before redock arms.
+ *
+ * Matches `SPRING_SWITCH_MS` (frontend/app/tab/tabbar-dnd.ts) deliberately:
+ * a redock destroys the floating window and grafts the pane into the layout
+ * tree, which is strictly less reversible than switching the visible tab, so
+ * it does not get a shorter fuse. This was 180ms until
+ * `docs/specs/SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md` — below the
+ * 400-700ms band every comparable hover-intent interaction uses, and low
+ * enough that an ordinary reposition-and-release read as a dock request.
+ */
+export const REDOCK_DWELL_MS = 500;
 
 /** CSS-px/s above which cursor motion cancels the dwell clock. */
 export const REDOCK_VELOCITY_PX_PER_S = 400;

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -206,7 +206,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
         // arrival cannot fire a redock on the already-redocked block.
         let armedAtRelease: boolean | null = null;
         const consumeArmedAtRelease = (): boolean => {
-            const armed = armedAtRelease ?? arming.isArmed(performance.now());
+            const armed = armedAtRelease ?? arming.isArmed();
             armedAtRelease = null;
             arming.reset();
             return armed;
@@ -499,7 +499,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 // decision here and let whichever handler runs second read it
                 // rather than re-deriving from state the first one may have
                 // already torn down.
-                armedAtRelease = arming.isArmed(performance.now());
+                armedAtRelease = arming.isArmed();
                 pendingRedockCoords = { x: e.screenX, y: e.screenY };
             } else if (hasMoved) {
                 // Non-Windows (macOS + Linux): the JS-driven path keeps the
@@ -513,7 +513,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 // (reagent P1 on #1249's follow-up).
                 dragSessionId += 1;
                 if (consumeArmedAtRelease()) {
-                    void tryRedockAtCursor(e.screenX, e.screenY);
+                    void tryRedockAtCursor(e.screenX, e.screenY, preGhostWindow);
                 }
             }
         };
@@ -607,7 +607,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                         return pendingRedockCoords;
                     })();
                     pendingRedockCoords = null;
-                    if (coords) void tryRedockAtCursor(coords.x, coords.y);
+                    if (coords) void tryRedockAtCursor(coords.x, coords.y, capturedGhostForWindow);
                 } else {
                     pendingRedockCoords = null;
                 }
@@ -716,7 +716,13 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             startHoverHeartbeat = () => {
                 if (heartbeatTimer !== null) return;
                 heartbeatTimer = setInterval(() => {
-                    if (!dragging) return;
+                    // hasMoved gates the redock in onMouseUp, so emitting before the
+                    // drag has moved would paint a ghost promising a dock that
+                    // cannot happen — a press-and-hold on the header would arm
+                    // the indicator after the dwell and then do nothing on
+                    // release (codex P2 on #3124). The host heartbeat is gated
+                    // on its own `moves > 0` for the same reason.
+                    if (!dragging || !hasMoved) return;
                     emitHover(jsDragLatestScreenX, jsDragLatestScreenY);
                 }, HOVER_HEARTBEAT_MS);
             };
@@ -752,16 +758,16 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             unlistenMouseMove = () => document.removeEventListener("mousemove", onMouseMove);
         }
 
-        const tryRedockAtCursor = async (screenX: number, screenY: number) => {
+        const tryRedockAtCursor = async (screenX: number, screenY: number, expectedTarget: string | null) => {
             setRedockInProgress(true);
             try {
-                await tryRedockAtCursorInner(screenX, screenY);
+                await tryRedockAtCursorInner(screenX, screenY, expectedTarget);
             } finally {
                 setRedockInProgress(false);
             }
         };
 
-        const tryRedockAtCursorInner = async (screenX: number, screenY: number) => {
+        const tryRedockAtCursorInner = async (screenX: number, screenY: number, expectedTarget: string | null) => {
             const ourLabel = windowLabel();
             if (!ourLabel || cleaned) return;
             // `mouseup.screenX/Y` are CSS px. Host coordinate space: physical px
@@ -792,6 +798,20 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             if (!target.label || !target.window_id) {
                 // Cursor over desktop, external app, or our own floater
                 // — leave floater at the dropped position.
+                return;
+            }
+            // The arming decision was made about a specific window, but this
+            // resolve runs independently at release time. If the cursor left
+            // that window after the arming sample and before the release —
+            // within one heartbeat, so no sample caught it — the two disagree,
+            // and docking here would drop the pane into a window that never
+            // showed a ghost. Trust the armed target, not the late resolve.
+            // codex P1 on #3124.
+            if (expectedTarget && target.label !== expectedTarget) {
+                console.log(
+                    "[floating-pane] redock aborted: cursor left the armed target",
+                    { expectedTarget, resolved: target.label },
+                );
                 return;
             }
 

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -50,7 +50,7 @@ import { atoms, getApi } from "@/store/global";
 import * as WOS from "@/store/wos";
 import { Show, createEffect, createMemo, createSignal, onCleanup, onMount, type JSX } from "solid-js";
 
-import { REDOCK_DWELL_MS, REDOCK_VELOCITY_PX_PER_S } from "./floating-pane-constants";
+import { createRedockArming } from "./redock-arming";
 import "./floating-pane-workspace.scss";
 
 /**
@@ -190,36 +190,31 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
         // from a prior drag session arriving during a new drag (or after a cancel).
         let dragSessionId = 0;
         // Dwell + velocity gate: prevents accidental redock when the cursor
-        // transits over another window at speed. Arms hover only after the cursor
-        // stays near the same target window for REDOCK_DWELL_MS ms at
-        // ≤ REDOCK_VELOCITY_PX_PER_S CSS-px/s. All vars hoisted to drag scope so
-        // a second drag never inherits state from the first.
-        let hoverArmed = false;
-        // Preserves arm state across the Windows mouseup/window_drag_ended race:
-        // onMouseUp sets pendingRedockArmed=hoverArmed before clearing hoverArmed,
-        // so window_drag_ended can safely use either flag.
-        let pendingRedockArmed = false;
-        // Velocity sampling state (non-Windows mousemove path).
-        let dwellLastMoveSampleAt = 0;
-        let dwellLastMoveSampleX = 0;
-        let dwellLastMoveSampleY = 0;
-        let dwellSlowSince: number | null = null;
-        // Per-target dwell (non-Windows): reset arming when IPC returns a new target.
-        let dwellLastArmedTarget: string | null = null;
-        // Non-Windows: wall-clock time when IPC first confirmed the current target.
-        // Used as fallback when cursor holds still after first confirmation (no 2nd IPC).
-        let dwellCurrentConfirmedAt: number | null = null;
-        // Non-Windows: true once update_floating_redock_hover returned a non-null target
-        // (indicator is showing on the backend). Separate from hoverArmed so the velocity
-        // gate can clear the indicator even before the full dwell interval has elapsed.
-        let indicatorShowing = false;
-        // Per-target dwell (Windows): driven by floating-redock:hover-state events.
-        let dwellCurrentHoverTarget: string | null = null;
-        let dwellHoverTargetFirstSeenAt: number | null = null;
-        // Velocity sampling for Windows (hover-state events carry cursor_x/y).
-        let dwellWinLastSampleAt = 0;
-        let dwellWinLastSampleX = 0;
-        let dwellWinLastSampleY = 0;
+        // transits over another window at speed, and — since
+        // SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md — when the user is
+        // merely repositioning the floater above the main window rather than
+        // asking to dock it. Both platform paths feed the SAME state machine
+        // (redock-arming.ts) so they cannot drift; the fourteen hand-rolled
+        // dwell/velocity variables that used to live here, and the
+        // events-went-quiet fallbacks they supported, are what that module
+        // replaces.
+        const arming = createRedockArming();
+        // Captured by whichever of DOM mouseup / window_drag_ended observes the
+        // release first (their relative order is not guaranteed on Windows —
+        // separate CEF IPC channels). The other reads this instead of
+        // re-deriving, and `consumeArmedAtRelease` nulls it so the second
+        // arrival cannot fire a redock on the already-redocked block.
+        let armedAtRelease: boolean | null = null;
+        const consumeArmedAtRelease = (): boolean => {
+            const armed = armedAtRelease ?? arming.isArmed(performance.now());
+            armedAtRelease = null;
+            arming.reset();
+            return armed;
+        };
+        // Assigned by the non-Windows branch below (Windows gets its heartbeat
+        // from the host's drag tick instead, so these stay no-ops there).
+        let startHoverHeartbeat: () => void = () => {};
+        let stopHoverHeartbeat: () => void = () => {};
         // redockInProgress is a signal at component scope (above this onMount)
         // so createEffect re-runs when it changes.
         // Sentinel for the listenEvent .then() race: if the component unmounts
@@ -423,20 +418,9 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 jsDragLatestScreenY = e.screenY;
                 hasMoved = false;
                 pendingRedockCoords = null;
-                hoverArmed = false;
-                pendingRedockArmed = false;
-                dwellLastMoveSampleAt = 0;
-                dwellLastMoveSampleX = 0;
-                dwellLastMoveSampleY = 0;
-                dwellSlowSince = null;
-                dwellLastArmedTarget = null;
-                dwellCurrentConfirmedAt = null;
-                indicatorShowing = false;
-                dwellCurrentHoverTarget = null;
-                dwellHoverTargetFirstSeenAt = null;
-                dwellWinLastSampleAt = 0;
-                dwellWinLastSampleX = 0;
-                dwellWinLastSampleY = 0;
+                arming.reset();
+                armedAtRelease = null;
+                startHoverHeartbeat();
                 invokeCommand<{ x: number; y: number }>("get_window_position", { label })
                     .then((pos) => {
                         if (myId !== jsDragMouseDownId) return;
@@ -471,20 +455,8 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             dragging = true;
             hasMoved = false;
             pendingRedockCoords = null;
-            hoverArmed = false;
-            pendingRedockArmed = false;
-            dwellLastMoveSampleAt = 0;
-            dwellLastMoveSampleX = 0;
-            dwellLastMoveSampleY = 0;
-            dwellSlowSince = null;
-            dwellLastArmedTarget = null;
-            dwellCurrentConfirmedAt = null;
-            indicatorShowing = false;
-            dwellCurrentHoverTarget = null;
-            dwellHoverTargetFirstSeenAt = null;
-            dwellWinLastSampleAt = 0;
-            dwellWinLastSampleX = 0;
-            dwellWinLastSampleY = 0;
+            arming.reset();
+            armedAtRelease = null;
             dragSessionId += 1;
         };
 
@@ -494,6 +466,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             if (jsDrivenDrag) jsDragMouseDownId += 1;
             if (!dragging) return;
             dragging = false;
+            stopHoverHeartbeat();
             // On macOS/Linux, paneRect() returns unchanged client coords after a
             // window move, so browser-view's syncPosition dedupe guard skips the
             // browser_pane_resize re-send. Signal it to force one so the
@@ -509,7 +482,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             // triggers clearPlaceholder on the target renderer. This avoids the cross-
             // process race where the target's set_floating_redock_target(null) arrives
             // before tryRedockAtCursorInner's delayed call to get_floating_redock_target.
-            const preGhostWindow = dwellCurrentHoverTarget;
+            const preGhostWindow = arming.target();
             capturedGhostForWindow = preGhostWindow;
             capturedGhostForDrop = preGhostWindow
                 ? invokeCommand<{ block_id?: string; dir?: number }>(
@@ -519,60 +492,29 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 : Promise.resolve({});
             invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
             if (isWindows()) {
-                // On Windows: preserve arm state before clearing — window_drag_ended
-                // may arrive before or after DOM mouseup (separate CEF IPC channels).
-                // If ended arrives first: hoverArmed is still true and wins.
-                // If mouseup arrives first: pendingRedockArmed carries it for ended.
-                // Point-in-time fallback: if user held still over a target until the
-                // dwell threshold elapsed but no further hover-state event fired to set
-                // hoverArmed, check the wall-clock directly at mouseup time.
-                const nowMs = performance.now();
-                pendingRedockArmed = hoverArmed ||
-                    (dwellCurrentHoverTarget !== null &&
-                     dwellHoverTargetFirstSeenAt !== null &&
-                     nowMs - dwellHoverTargetFirstSeenAt >= REDOCK_DWELL_MS) ||
-                    // Hold-still after fast entry: velocity gate preserved the target
-                    // but cleared the timer; cursor then stopped so no slow event
-                    // restarted it. Check time-since-last-event as dwell proxy.
-                    (dwellCurrentHoverTarget !== null &&
-                     dwellHoverTargetFirstSeenAt === null &&
-                     dwellWinLastSampleAt > 0 &&
-                     nowMs - dwellWinLastSampleAt >= REDOCK_DWELL_MS);
-                hoverArmed = false;
+                // On Windows the redock itself is committed by window_drag_ended
+                // (it carries host cursor coords, so it doesn't have to trust the
+                // DOM's). The two events travel separate CEF IPC channels and
+                // their relative order is not guaranteed, so record the arm
+                // decision here and let whichever handler runs second read it
+                // rather than re-deriving from state the first one may have
+                // already torn down.
+                armedAtRelease = arming.isArmed(performance.now());
                 pendingRedockCoords = { x: e.screenX, y: e.screenY };
             } else if (hasMoved) {
                 // Non-Windows (macOS + Linux): the JS-driven path keeps the
-                // renderer receiving mousemove+mouseup normally. Only attempt
-                // redock if the dwell gate armed and motion confirmed.
-                // Arm conditions (any one suffices):
-                // 1. hoverArmed: second IPC confirmed same target (full dwell cycle).
-                // 2. dwellSlowSince elapsed: cursor slowed and stopped before
-                //    the IPC could fire (stopped during the slow-motion window);
-                //    tryRedockAtCursorInner handles the no-target case gracefully.
-                // 3. dwellCurrentConfirmedAt elapsed: first IPC confirmed the target;
-                //    user has now held still over it for a full REDOCK_DWELL_MS.
-                //    (indicatorShowing intentionally excluded — arming on first IPC
-                //    confirmation lets slow desktop transits dock without per-target
-                //    dwell; dwellCurrentConfirmedAt is the spec-correct check.)
-                const nowMs = performance.now();
-                const armed = hoverArmed ||
-                    (dwellSlowSince !== null &&
-                     nowMs - dwellSlowSince >= REDOCK_DWELL_MS) ||
-                    (dwellCurrentConfirmedAt !== null &&
-                     nowMs - dwellCurrentConfirmedAt >= REDOCK_DWELL_MS);
-                // Invalidate in-flight IPC .then() so it cannot re-arm hoverArmed
-                // after this mouseup has already consumed and cleared the state
-                // (reagent P1 — stale IPC re-arm → spurious window_drag_ended dock).
+                // renderer receiving mousemove+mouseup normally, so the redock
+                // commits here. Consuming resets the arming state, which is what
+                // stops a late window_drag_ended (the Linux race) from firing a
+                // second tryRedockAtCursor on the already-redocked block.
+                //
+                // Invalidate in-flight IPC .then() as well, so a stale hover
+                // response cannot re-arm after this release has been consumed
+                // (reagent P1 on #1249's follow-up).
                 dragSessionId += 1;
-                hoverArmed = false;
-                indicatorShowing = false;
-                // Clear non-Windows dwell state so window_drag_ended (Linux race)
-                // cannot see stale dwellCurrentConfirmedAt and fire a second
-                // tryRedockAtCursor on the already-redocked block (reagent P1).
-                dwellCurrentConfirmedAt = null;
-                dwellCurrentHoverTarget = null;
-                dwellHoverTargetFirstSeenAt = null;
-                if (armed) void tryRedockAtCursor(e.screenX, e.screenY);
+                if (consumeArmedAtRelease()) {
+                    void tryRedockAtCursor(e.screenX, e.screenY);
+                }
             }
         };
 
@@ -601,22 +543,11 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                     if (jsDrivenDrag) jsDragMouseDownId += 1;
                     dragSessionId += 1;
                     dragging = false;
+                    stopHoverHeartbeat();
                     hasMoved = false;
                     pendingRedockCoords = null;
-                    hoverArmed = false;
-                    pendingRedockArmed = false;
-                    dwellSlowSince = null;
-                    dwellLastArmedTarget = null;
-                    dwellCurrentConfirmedAt = null;
-                    indicatorShowing = false;
-                    dwellCurrentHoverTarget = null;
-                    dwellHoverTargetFirstSeenAt = null;
-                    dwellLastMoveSampleAt = 0;
-                    dwellLastMoveSampleX = 0;
-                    dwellLastMoveSampleY = 0;
-                    dwellWinLastSampleAt = 0;
-                    dwellWinLastSampleX = 0;
-                    dwellWinLastSampleY = 0;
+                    arming.reset();
+                    armedAtRelease = null;
                 }
             },
         );
@@ -637,36 +568,17 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             (ev) => {
                 if (!ev.label || ev.label !== label) return;
                 dragging = false;
-                // Capture arm state before clearing — handles the Windows race where
-                // this event can arrive before or after DOM mouseup (separate CEF IPC
-                // channels). Before mouseup: hoverArmed is still true. After mouseup:
-                // onMouseUp already moved it to pendingRedockArmed.
-                // Point-in-time fallback: if the user held still over a target until
-                // the dwell elapsed but no event fired to set hoverArmed (or mouseup
-                // raced ahead and set pendingRedockArmed via the fallback there), the
-                // wall-clock check here covers the window_drag_ended ordering leg.
-                const nowMs = performance.now();
-                const armedAtEnd = pendingRedockArmed || hoverArmed ||
-                    (dwellCurrentHoverTarget !== null &&
-                     dwellHoverTargetFirstSeenAt !== null &&
-                     nowMs - dwellHoverTargetFirstSeenAt >= REDOCK_DWELL_MS) ||
-                    // Hold-still after fast entry (Windows): same fallback as onMouseUp.
-                    (dwellCurrentHoverTarget !== null &&
-                     dwellHoverTargetFirstSeenAt === null &&
-                     dwellWinLastSampleAt > 0 &&
-                     nowMs - dwellWinLastSampleAt >= REDOCK_DWELL_MS) ||
-                    (dwellCurrentConfirmedAt !== null &&
-                     nowMs - dwellCurrentConfirmedAt >= REDOCK_DWELL_MS);
-                hoverArmed = false;
-                indicatorShowing = false;
-                pendingRedockArmed = false;
+                stopHoverHeartbeat();
                 // Phase 4b — pre-capture ghost if onMouseUp hasn't already done so
                 // (window_drag_ended can arrive before DOM mouseup on Windows — separate
-                // CEF IPC channels, documented above). Guards against double-consume:
+                // CEF IPC channels). Guards against double-consume:
                 // get_floating_redock_target removes the entry atomically, so the
                 // second caller would get {} anyway, but skip the IPC entirely.
+                //
+                // MUST run before consumeArmedAtRelease() below, which resets the
+                // arming state and with it arming.target().
                 if (!capturedGhostForDrop) {
-                    const preGhostWindow = dwellCurrentHoverTarget;
+                    const preGhostWindow = arming.target();
                     capturedGhostForWindow = preGhostWindow;
                     capturedGhostForDrop = preGhostWindow
                         ? invokeCommand<{ block_id?: string; dir?: number }>(
@@ -675,6 +587,10 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                           ).catch(() => ({}))
                         : Promise.resolve({});
                 }
+                // Whichever of DOM mouseup / this event ran first recorded the
+                // arm decision; this consumes it (and resets arming) so the two
+                // orderings agree and neither can redock twice.
+                const armedAtEnd = consumeArmedAtRelease();
                 // Always clear hover — safety net for non-Windows where onMouseUp
                 // may not have fired (BeginWindowDrag absorbs the release).
                 invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
@@ -714,57 +630,24 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 "floating-redock:hover-state",
                 (ev) => {
                     if (!dragging) return;
-                    const newTarget = ev.target_label ?? null;
-                    const now = performance.now();
-                    // Velocity gate: cursor_x/cursor_y are physical px — divide by
-                    // posScale() to get CSS px (1 DIP on non-HiDPI, 0.5 CSS on 2×).
-                    if (typeof ev.cursor_x === "number" && typeof ev.cursor_y === "number") {
-                        const scale = posScale();
-                        const cssCurX = ev.cursor_x / scale;
-                        const cssCurY = ev.cursor_y / scale;
-                        if (dwellWinLastSampleAt > 0) {
-                            const dt = now - dwellWinLastSampleAt;
-                            const dx = cssCurX - dwellWinLastSampleX;
-                            const dy = cssCurY - dwellWinLastSampleY;
-                            const velocity = dt > 0 ? Math.sqrt(dx * dx + dy * dy) / (dt / 1000) : 0;
-                            if (velocity > REDOCK_VELOCITY_PX_PER_S) {
-                                // Moving fast — reset dwell clock and disarm.
-                                // Preserve dwellCurrentHoverTarget (don't null it) so that
-                                // if the cursor slows or stops over the same target the
-                                // dwell timer can restart (codex P2 fix). Only the timer
-                                // is cleared; the target identity is kept.
-                                dwellCurrentHoverTarget = newTarget;
-                                dwellHoverTargetFirstSeenAt = null;
-                                hoverArmed = false;
-                                invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
-                                dwellWinLastSampleAt = now;
-                                dwellWinLastSampleX = cssCurX;
-                                dwellWinLastSampleY = cssCurY;
-                                return;
-                            }
-                        }
-                        dwellWinLastSampleAt = now;
-                        dwellWinLastSampleX = cssCurX;
-                        dwellWinLastSampleY = cssCurY;
-                    }
-                    // Dwell gate: arm only after seeing the same non-null target for
-                    // REDOCK_DWELL_MS ms. Target change resets the clock.
-                    if (newTarget !== dwellCurrentHoverTarget) {
-                        dwellCurrentHoverTarget = newTarget;
-                        dwellHoverTargetFirstSeenAt = newTarget !== null ? now : null;
-                        const wasArmed = hoverArmed;
-                        hoverArmed = false;
-                        if (wasArmed) invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
-                    } else if (newTarget !== null && dwellHoverTargetFirstSeenAt === null) {
-                        // Velocity gate preserved the target but cleared the timer.
-                        // Cursor has now slowed on the same target — restart dwell clock.
-                        dwellHoverTargetFirstSeenAt = now;
-                    } else if (
-                        newTarget !== null &&
-                        dwellHoverTargetFirstSeenAt !== null &&
-                        now - dwellHoverTargetFirstSeenAt >= REDOCK_DWELL_MS
-                    ) {
-                        hoverArmed = true;
+                    // cursor_x/cursor_y are physical px on Windows — divide by
+                    // posScale() to get the CSS px the arming module expects
+                    // (1 DIP on non-HiDPI, 0.5 CSS on 2×). The host emits these
+                    // both from WM_MOUSEMOVE and, since the dwell spec, from the
+                    // 100ms drag tick — so samples keep arriving while the
+                    // cursor is stationary and dwell is measured, not inferred.
+                    const scale = posScale();
+                    const { clearIndicator } = arming.sample({
+                        target: ev.target_label ?? null,
+                        // Absent on the target-only teardown broadcast; the
+                        // module reuses its last position rather than reading
+                        // the gap as a jump from the origin.
+                        x: typeof ev.cursor_x === "number" ? ev.cursor_x / scale : undefined,
+                        y: typeof ev.cursor_y === "number" ? ev.cursor_y / scale : undefined,
+                        t: performance.now(),
+                    });
+                    if (clearIndicator) {
+                        invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
                     }
                 },
             );
@@ -779,6 +662,71 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
         if (!isWindows()) {
             const HOVER_THROTTLE_MS = 50;
             let lastHoverAt = 0;
+            // Guards against an out-of-order IPC response feeding the arming
+            // module a sample older than one it has already applied, which
+            // would drag the dwell clock backwards.
+            let lastAppliedSampleT = 0;
+
+            // Resolve the target under the cursor and feed the result to the
+            // arming module. The hover IPC is no longer pre-gated on a local
+            // dwell estimate: the module owns the arming decision now, and it
+            // needs a continuous sample stream to make it. The ghost stays
+            // hidden until armed, so emitting early costs nothing visible.
+            const emitHover = (screenX: number, screenY: number) => {
+                const now = performance.now();
+                if (now - lastHoverAt < HOVER_THROTTLE_MS) return;
+                lastHoverAt = now;
+                const sourceLabel = windowLabel();
+                if (!sourceLabel) return;
+                const scale = posScale();
+                const capturedSessionId = dragSessionId;
+                // Sampled at REQUEST time so the velocity the module sees is the
+                // cursor's, not the IPC round-trip's.
+                const sampleX = screenX;
+                const sampleY = screenY;
+                const sampleT = now;
+                invokeCommand<{ target_label?: string | null }>("update_floating_redock_hover", {
+                    source_label: sourceLabel,
+                    x: Math.round(screenX * scale),
+                    y: Math.round(screenY * scale),
+                }).then((res) => {
+                    if (capturedSessionId !== dragSessionId) return;
+                    if (sampleT < lastAppliedSampleT) return;
+                    lastAppliedSampleT = sampleT;
+                    const { clearIndicator } = arming.sample({
+                        target: res?.target_label ?? null,
+                        x: sampleX,
+                        y: sampleY,
+                        t: sampleT,
+                    });
+                    if (clearIndicator) {
+                        invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
+                    }
+                }).catch(() => {});
+            };
+
+            // The renderer stops receiving mousemove the instant the cursor
+            // holds still, so dwell fed from mousemove alone cannot advance
+            // during exactly the gesture it measures. This is the JS
+            // counterpart of the host's DRAG_TICK heartbeat on Windows
+            // (agentmux-cef/src/ui_tasks/drag.rs) — same cadence, same reason.
+            // SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md §5.1.
+            const HOVER_HEARTBEAT_MS = 100;
+            let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+            startHoverHeartbeat = () => {
+                if (heartbeatTimer !== null) return;
+                heartbeatTimer = setInterval(() => {
+                    if (!dragging) return;
+                    emitHover(jsDragLatestScreenX, jsDragLatestScreenY);
+                }, HOVER_HEARTBEAT_MS);
+            };
+            stopHoverHeartbeat = () => {
+                if (heartbeatTimer !== null) {
+                    clearInterval(heartbeatTimer);
+                    heartbeatTimer = null;
+                }
+            };
+
             const onMouseMove = (e: MouseEvent) => {
                 if (jsDrivenDrag) {
                     // Track latest coords even before dragging is armed — needed for
@@ -798,80 +746,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                         jsDragInitWinY + Math.round((e.screenY - jsDragClickScreenY) * scale),
                     );
                 }
-                const now = performance.now();
-                // Velocity gate: measure cursor speed since the last sample.
-                const dt = now - dwellLastMoveSampleAt;
-                const dx = e.screenX - dwellLastMoveSampleX;
-                const dy = e.screenY - dwellLastMoveSampleY;
-                if (dwellLastMoveSampleAt > 0 && dt > 0) {
-                    const velocity = Math.sqrt(dx * dx + dy * dy) / (dt / 1000);
-                    if (velocity > REDOCK_VELOCITY_PX_PER_S) {
-                        dwellSlowSince = null;
-                        dwellLastArmedTarget = null;
-                        dwellCurrentConfirmedAt = null;
-                        if (hoverArmed || indicatorShowing) {
-                            hoverArmed = false;
-                            indicatorShowing = false;
-                            invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
-                        }
-                        dwellLastMoveSampleAt = now;
-                        dwellLastMoveSampleX = e.screenX;
-                        dwellLastMoveSampleY = e.screenY;
-                        return;
-                    }
-                }
-                dwellLastMoveSampleAt = now;
-                dwellLastMoveSampleX = e.screenX;
-                dwellLastMoveSampleY = e.screenY;
-                if (dwellSlowSince === null) dwellSlowSince = now;
-                // Fire the hover IPC HOVER_THROTTLE_MS before the arm threshold so
-                // the round-trip completes and the ghost is visible before onMouseUp
-                // can fire — otherwise the user sees no ghost but the block docks.
-                if (now - dwellSlowSince < REDOCK_DWELL_MS - HOVER_THROTTLE_MS) return;
-                // Cursor has been slow for REDOCK_DWELL_MS - HOVER_THROTTLE_MS — throttle IPC calls.
-                if (now - lastHoverAt < HOVER_THROTTLE_MS) return;
-                lastHoverAt = now;
-                const scale = posScale();
-                const sourceLabel = windowLabel();
-                if (!sourceLabel) return;
-                const capturedSessionId = dragSessionId;
-                invokeCommand<{ target_label?: string | null }>("update_floating_redock_hover", {
-                    source_label: sourceLabel,
-                    x: Math.round(e.screenX * scale),
-                    y: Math.round(e.screenY * scale),
-                }).then((res) => {
-                    if (capturedSessionId !== dragSessionId) return;
-                    const newTarget = res?.target_label ?? null;
-                    if (newTarget !== dwellLastArmedTarget) {
-                        // Target changed — disarm old target and restart both dwell
-                        // clocks. dwellSlowSince reset prevents a slow transit across
-                        // an intermediate window from pre-satisfying the dwell for the
-                        // destination. dwellCurrentConfirmedAt records when this target
-                        // was first confirmed so the mouseup fallback uses "180ms since
-                        // first confirmation" (prevents desktop-transit false arm).
-                        // Exception: null → target is the initial hover confirmation, not
-                        // a transit. Keeping dwellSlowSince lets onMouseUp's condition-2
-                        // arm fire even when the IPC was sent early and the user releases
-                        // immediately after the ghost appears.
-                        const prevTarget = dwellLastArmedTarget;
-                        dwellLastArmedTarget = newTarget;
-                        dwellCurrentHoverTarget = newTarget; // Phase 4b: mirror for ghost capture in onMouseUp (Windows sets this via event; macOS must set it here)
-                        dwellCurrentConfirmedAt = newTarget !== null ? performance.now() : null;
-                        if (prevTarget !== null) dwellSlowSince = null;
-                        if (hoverArmed || indicatorShowing) {
-                            hoverArmed = false;
-                            indicatorShowing = false;
-                            invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
-                        }
-                        // Backend has now broadcast the indicator for the new target.
-                        // Mark it showing so the velocity gate can clear it on fast
-                        // escape. hoverArmed stays false — full dwell still required.
-                        indicatorShowing = newTarget !== null;
-                    } else if (newTarget !== null) {
-                        indicatorShowing = true;
-                        hoverArmed = true;
-                    }
-                }).catch(() => {});
+                emitHover(e.screenX, e.screenY);
             };
             document.addEventListener("mousemove", onMouseMove);
             unlistenMouseMove = () => document.removeEventListener("mousemove", onMouseMove);
@@ -1020,6 +895,7 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             stopCancelListener();
             stopEndedListener();
             stopHoverStateListener();
+            stopHoverHeartbeat();
             unlistenMouseMove?.();
         });
     });

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -420,7 +420,8 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                 pendingRedockCoords = null;
                 arming.reset();
                 armedAtRelease = null;
-                startHoverHeartbeat();
+                capturedGhostForDrop = null;
+                capturedGhostForWindow = null;
                 invokeCommand<{ x: number; y: number }>("get_window_position", { label })
                     .then((pos) => {
                         if (myId !== jsDragMouseDownId) return;
@@ -441,6 +442,12 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                             );
                         }
                         dragging = true;
+                        // Started here, not in mousedown: a plain header click
+                        // can release before this IPC resolves, and onMouseUp
+                        // returns early while `dragging` is still false — so a
+                        // heartbeat armed up front would never be cleared and
+                        // would outlive the gesture. reagent P1 on #3124.
+                        startHoverHeartbeat();
                     })
                     .catch(() => {});
                 return;
@@ -457,6 +464,8 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             pendingRedockCoords = null;
             arming.reset();
             armedAtRelease = null;
+            capturedGhostForDrop = null;
+            capturedGhostForWindow = null;
             dragSessionId += 1;
         };
 
@@ -464,9 +473,11 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             // Invalidate any in-flight JS-driven get_window_position IPC so a race
             // where mouseup fires before the promise resolves doesn't arm dragging.
             if (jsDrivenDrag) jsDragMouseDownId += 1;
+            // Before the !dragging early return: a click that never became a
+            // drag must still tear down anything mousedown started.
+            stopHoverHeartbeat();
             if (!dragging) return;
             dragging = false;
-            stopHoverHeartbeat();
             // On macOS/Linux, paneRect() returns unchanged client coords after a
             // window move, so browser-view's syncPosition dedupe guard skips the
             // browser_pane_resize re-send. Signal it to force one so the
@@ -482,14 +493,26 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             // triggers clearPlaceholder on the target renderer. This avoids the cross-
             // process race where the target's set_floating_redock_target(null) arrives
             // before tryRedockAtCursorInner's delayed call to get_floating_redock_target.
-            const preGhostWindow = arming.target();
-            capturedGhostForWindow = preGhostWindow;
-            capturedGhostForDrop = preGhostWindow
-                ? invokeCommand<{ block_id?: string; dir?: number }>(
-                      "get_floating_redock_target",
-                      { window_label: preGhostWindow },
-                  ).catch(() => ({}))
-                : Promise.resolve({});
+            //
+            // Guarded, and NOT idempotent without the guard: on Windows
+            // window_drag_ended can run first, and it captures the ghost and
+            // then calls consumeArmedAtRelease(), which resets arming. Re-reading
+            // arming.target() here would overwrite that good capture with null
+            // and leave the in-flight redock to fall back to an empty ghost —
+            // docking the pane somewhere other than where the user saw it, with
+            // no error. The pre-PR code got away with an unguarded capture only
+            // because it read dwellCurrentHoverTarget, which nothing reset.
+            // reagent P1 on #3124.
+            if (!capturedGhostForDrop) {
+                capturedGhostForWindow = arming.target();
+                capturedGhostForDrop = capturedGhostForWindow
+                    ? invokeCommand<{ block_id?: string; dir?: number }>(
+                          "get_floating_redock_target",
+                          { window_label: capturedGhostForWindow },
+                      ).catch(() => ({}))
+                    : Promise.resolve({});
+            }
+            const preGhostWindow = capturedGhostForWindow;
             invokeCommand("clear_floating_redock_hover", {}).catch(() => {});
             if (isWindows()) {
                 // On Windows the redock itself is committed by window_drag_ended
@@ -548,6 +571,8 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
                     pendingRedockCoords = null;
                     arming.reset();
                     armedAtRelease = null;
+                    capturedGhostForDrop = null;
+                    capturedGhostForWindow = null;
                 }
             },
         );

--- a/frontend/app/workspace/redock-arming.test.ts
+++ b/frontend/app/workspace/redock-arming.test.ts
@@ -1,0 +1,159 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { createRedockArming } from "./redock-arming";
+
+// Every test drives the module with explicit timestamps rather than real
+// time. `t` is whatever the caller's monotonic clock says; the module never
+// reads a clock itself, which is the whole point of extracting it.
+const DWELL = 500;
+const VEL = 400;
+
+function arming() {
+    return createRedockArming({ dwellMs: DWELL, velocityPxPerS: VEL });
+}
+
+describe("redock arming — dwell", () => {
+    it("arms after the cursor holds the same target for the full dwell", () => {
+        const a = arming();
+        a.sample({ target: "main", x: 0, y: 0, t: 0 });
+        expect(a.isArmed(0)).toBe(false);
+        a.sample({ target: "main", x: 0, y: 0, t: 100 });
+        expect(a.isArmed(100)).toBe(false);
+        const out = a.sample({ target: "main", x: 0, y: 0, t: 500 });
+        expect(out.armed).toBe(true);
+        expect(a.isArmed(500)).toBe(true);
+    });
+
+    it("does not arm on a hold shorter than the dwell", () => {
+        const a = arming();
+        a.sample({ target: "main", x: 0, y: 0, t: 0 });
+        a.sample({ target: "main", x: 0, y: 0, t: 200 });
+        expect(a.isArmed(200)).toBe(false);
+    });
+
+    it("restarts the clock when the target changes", () => {
+        const a = arming();
+        a.sample({ target: "main", x: 0, y: 0, t: 0 });
+        a.sample({ target: "main", x: 0, y: 0, t: 400 });
+        // Switching windows at t=400 must not inherit the 400ms already served.
+        a.sample({ target: "floater-2", x: 0, y: 0, t: 400 });
+        expect(a.isArmed(400)).toBe(false);
+        expect(a.isArmed(800)).toBe(false);
+        expect(a.isArmed(900)).toBe(true);
+    });
+
+    it("disarms and clears the indicator when the cursor leaves every target", () => {
+        const a = arming();
+        a.sample({ target: "main", x: 0, y: 0, t: 0 });
+        a.sample({ target: "main", x: 0, y: 0, t: 600 });
+        expect(a.isArmed(600)).toBe(true);
+        const out = a.sample({ target: null, x: 0, y: 0, t: 650 });
+        expect(out.armed).toBe(false);
+        expect(out.clearIndicator).toBe(true);
+        expect(a.isArmed(2000)).toBe(false);
+    });
+
+    it("arms from stationary samples alone, with no cursor movement", () => {
+        // The P1 heartbeat case: WM_MOUSEMOVE never fires, the 100ms drag tick
+        // supplies every sample, and the cursor never moves a pixel.
+        const a = arming();
+        for (let t = 0; t <= 600; t += 100) {
+            a.sample({ target: "main", x: 42, y: 42, t });
+        }
+        expect(a.isArmed(600)).toBe(true);
+    });
+});
+
+describe("redock arming — velocity", () => {
+    it("never arms during a fast transit", () => {
+        const a = arming();
+        // 1500 px/s across the window for a full second.
+        for (let t = 0; t <= 1000; t += 50) {
+            a.sample({ target: "main", x: t * 1.5, y: 0, t });
+        }
+        expect(a.isArmed(1000)).toBe(false);
+    });
+
+    it("disarms and clears the indicator when an armed cursor speeds away", () => {
+        const a = arming();
+        a.sample({ target: "main", x: 0, y: 0, t: 0 });
+        a.sample({ target: "main", x: 0, y: 0, t: 600 });
+        expect(a.isArmed(600)).toBe(true);
+        const out = a.sample({ target: "main", x: 300, y: 0, t: 650 });
+        expect(out.armed).toBe(false);
+        expect(out.clearIndicator).toBe(true);
+    });
+
+    it("requires a fresh full dwell after a fast entry, not merely stillness", () => {
+        // This is the regression that motivated the spec. The old gate armed
+        // whenever events simply went quiet for REDOCK_DWELL_MS, even though
+        // the velocity gate had just rejected the entry — so a fast flick onto
+        // the window followed by any pause before release would dock.
+        const a = arming();
+        a.sample({ target: "main", x: 0, y: 0, t: 0 });
+        a.sample({ target: "main", x: 900, y: 0, t: 100 }); // 9000 px/s — rejected
+        expect(a.isArmed(100)).toBe(false);
+        // Cursor now stops dead. Stillness alone must not arm until a full
+        // dwell has been served from the moment motion actually settled.
+        a.sample({ target: "main", x: 900, y: 0, t: 200 });
+        expect(a.isArmed(600)).toBe(false);
+        expect(a.isArmed(701)).toBe(true);
+    });
+
+    it("does not read a cursorless teardown sample as a jump from the origin", () => {
+        // clear_floating_redock_hover broadcasts { target_label: null } with no
+        // cursor. Feeding 0,0 for the missing position would make the NEXT real
+        // sample look like a 1000px leap and trip the velocity gate, costing an
+        // extra heartbeat before the ghost could re-arm.
+        const a = arming();
+        a.sample({ target: "main", x: 900, y: 500, t: 0 });
+        a.sample({ target: null, t: 100 }); // teardown — no cursor
+        a.sample({ target: "main", x: 900, y: 500, t: 200 });
+        // Position never actually changed, so dwell runs uninterrupted from 200.
+        expect(a.isArmed(699)).toBe(false);
+        expect(a.isArmed(700)).toBe(true);
+    });
+
+    it("treats a zero-duration sample as no motion rather than infinite speed", () => {
+        const a = arming();
+        a.sample({ target: "main", x: 0, y: 0, t: 0 });
+        a.sample({ target: "main", x: 50, y: 0, t: 0 });
+        // Must not throw or divide by zero, and must not have armed yet.
+        expect(a.isArmed(0)).toBe(false);
+    });
+});
+
+describe("redock arming — lifecycle", () => {
+    it("reports the current target so callers can pre-capture the ghost", () => {
+        const a = arming();
+        expect(a.target()).toBe(null);
+        a.sample({ target: "main", x: 0, y: 0, t: 0 });
+        expect(a.target()).toBe("main");
+    });
+
+    it("arms on the wall clock between samples", () => {
+        // Samples arrive at 100ms; a mouseup landing at t=520 must see the
+        // dwell as served even though no sample has arrived since t=500.
+        const a = arming();
+        a.sample({ target: "main", x: 0, y: 0, t: 0 });
+        a.sample({ target: "main", x: 0, y: 0, t: 400 });
+        expect(a.isArmed(400)).toBe(false);
+        expect(a.isArmed(520)).toBe(true);
+    });
+
+    it("forgets everything on reset so a second drag cannot inherit state", () => {
+        const a = arming();
+        a.sample({ target: "main", x: 0, y: 0, t: 0 });
+        a.sample({ target: "main", x: 0, y: 0, t: 600 });
+        expect(a.isArmed(600)).toBe(true);
+        a.reset();
+        expect(a.isArmed(600)).toBe(false);
+        expect(a.target()).toBe(null);
+        // A fresh drag starting mid-clock must serve its own full dwell.
+        a.sample({ target: "main", x: 0, y: 0, t: 700 });
+        expect(a.isArmed(1000)).toBe(false);
+        expect(a.isArmed(1200)).toBe(true);
+    });
+});

--- a/frontend/app/workspace/redock-arming.test.ts
+++ b/frontend/app/workspace/redock-arming.test.ts
@@ -18,19 +18,19 @@ describe("redock arming — dwell", () => {
     it("arms after the cursor holds the same target for the full dwell", () => {
         const a = arming();
         a.sample({ target: "main", x: 0, y: 0, t: 0 });
-        expect(a.isArmed(0)).toBe(false);
+        expect(a.isArmed()).toBe(false);
         a.sample({ target: "main", x: 0, y: 0, t: 100 });
-        expect(a.isArmed(100)).toBe(false);
+        expect(a.isArmed()).toBe(false);
         const out = a.sample({ target: "main", x: 0, y: 0, t: 500 });
         expect(out.armed).toBe(true);
-        expect(a.isArmed(500)).toBe(true);
+        expect(a.isArmed()).toBe(true);
     });
 
     it("does not arm on a hold shorter than the dwell", () => {
         const a = arming();
         a.sample({ target: "main", x: 0, y: 0, t: 0 });
         a.sample({ target: "main", x: 0, y: 0, t: 200 });
-        expect(a.isArmed(200)).toBe(false);
+        expect(a.isArmed()).toBe(false);
     });
 
     it("restarts the clock when the target changes", () => {
@@ -39,20 +39,22 @@ describe("redock arming — dwell", () => {
         a.sample({ target: "main", x: 0, y: 0, t: 400 });
         // Switching windows at t=400 must not inherit the 400ms already served.
         a.sample({ target: "floater-2", x: 0, y: 0, t: 400 });
-        expect(a.isArmed(400)).toBe(false);
-        expect(a.isArmed(800)).toBe(false);
-        expect(a.isArmed(900)).toBe(true);
+        expect(a.isArmed()).toBe(false);
+        a.sample({ target: "floater-2", x: 0, y: 0, t: 800 });
+        expect(a.isArmed()).toBe(false);
+        a.sample({ target: "floater-2", x: 0, y: 0, t: 900 });
+        expect(a.isArmed()).toBe(true);
     });
 
     it("disarms and clears the indicator when the cursor leaves every target", () => {
         const a = arming();
         a.sample({ target: "main", x: 0, y: 0, t: 0 });
         a.sample({ target: "main", x: 0, y: 0, t: 600 });
-        expect(a.isArmed(600)).toBe(true);
+        expect(a.isArmed()).toBe(true);
         const out = a.sample({ target: null, x: 0, y: 0, t: 650 });
         expect(out.armed).toBe(false);
         expect(out.clearIndicator).toBe(true);
-        expect(a.isArmed(2000)).toBe(false);
+        expect(a.isArmed()).toBe(false);
     });
 
     it("arms from stationary samples alone, with no cursor movement", () => {
@@ -62,7 +64,7 @@ describe("redock arming — dwell", () => {
         for (let t = 0; t <= 600; t += 100) {
             a.sample({ target: "main", x: 42, y: 42, t });
         }
-        expect(a.isArmed(600)).toBe(true);
+        expect(a.isArmed()).toBe(true);
     });
 });
 
@@ -73,14 +75,14 @@ describe("redock arming — velocity", () => {
         for (let t = 0; t <= 1000; t += 50) {
             a.sample({ target: "main", x: t * 1.5, y: 0, t });
         }
-        expect(a.isArmed(1000)).toBe(false);
+        expect(a.isArmed()).toBe(false);
     });
 
     it("disarms and clears the indicator when an armed cursor speeds away", () => {
         const a = arming();
         a.sample({ target: "main", x: 0, y: 0, t: 0 });
         a.sample({ target: "main", x: 0, y: 0, t: 600 });
-        expect(a.isArmed(600)).toBe(true);
+        expect(a.isArmed()).toBe(true);
         const out = a.sample({ target: "main", x: 300, y: 0, t: 650 });
         expect(out.armed).toBe(false);
         expect(out.clearIndicator).toBe(true);
@@ -94,12 +96,14 @@ describe("redock arming — velocity", () => {
         const a = arming();
         a.sample({ target: "main", x: 0, y: 0, t: 0 });
         a.sample({ target: "main", x: 900, y: 0, t: 100 }); // 9000 px/s — rejected
-        expect(a.isArmed(100)).toBe(false);
+        expect(a.isArmed()).toBe(false);
         // Cursor now stops dead. Stillness alone must not arm until a full
         // dwell has been served from the moment motion actually settled.
         a.sample({ target: "main", x: 900, y: 0, t: 200 });
-        expect(a.isArmed(600)).toBe(false);
-        expect(a.isArmed(701)).toBe(true);
+        a.sample({ target: "main", x: 900, y: 0, t: 600 });
+        expect(a.isArmed()).toBe(false);
+        a.sample({ target: "main", x: 900, y: 0, t: 701 });
+        expect(a.isArmed()).toBe(true);
     });
 
     it("does not read a cursorless teardown sample as a jump from the origin", () => {
@@ -112,8 +116,10 @@ describe("redock arming — velocity", () => {
         a.sample({ target: null, t: 100 }); // teardown — no cursor
         a.sample({ target: "main", x: 900, y: 500, t: 200 });
         // Position never actually changed, so dwell runs uninterrupted from 200.
-        expect(a.isArmed(699)).toBe(false);
-        expect(a.isArmed(700)).toBe(true);
+        a.sample({ target: "main", x: 900, y: 500, t: 699 });
+        expect(a.isArmed()).toBe(false);
+        a.sample({ target: "main", x: 900, y: 500, t: 700 });
+        expect(a.isArmed()).toBe(true);
     });
 
     it("treats a zero-duration sample as no motion rather than infinite speed", () => {
@@ -121,7 +127,7 @@ describe("redock arming — velocity", () => {
         a.sample({ target: "main", x: 0, y: 0, t: 0 });
         a.sample({ target: "main", x: 50, y: 0, t: 0 });
         // Must not throw or divide by zero, and must not have armed yet.
-        expect(a.isArmed(0)).toBe(false);
+        expect(a.isArmed()).toBe(false);
     });
 });
 
@@ -133,27 +139,53 @@ describe("redock arming — lifecycle", () => {
         expect(a.target()).toBe("main");
     });
 
-    it("arms on the wall clock between samples", () => {
-        // Samples arrive at 100ms; a mouseup landing at t=520 must see the
-        // dwell as served even though no sample has arrived since t=500.
+    it("does not arm until a sample confirms the dwell", () => {
+        // Previously isArmed(now) extrapolated: with the last sample at 400ms
+        // a release at 520ms armed on the wall clock alone. That let a release
+        // dock before the target window had painted any ghost (it only paints
+        // on an armed sample), and firstSeenAt belongs to the target of the
+        // LAST sample, so the extrapolation could arm for a window the cursor
+        // had already left. codex P1 on #3124.
         const a = arming();
         a.sample({ target: "main", x: 0, y: 0, t: 0 });
         a.sample({ target: "main", x: 0, y: 0, t: 400 });
-        expect(a.isArmed(400)).toBe(false);
-        expect(a.isArmed(520)).toBe(true);
+        // A release at 520ms would once have armed here on the wall clock.
+        expect(a.isArmed()).toBe(false);
+        // The heartbeat delivers the confirming sample, and only now is it armed.
+        a.sample({ target: "main", x: 0, y: 0, t: 500 });
+        expect(a.isArmed()).toBe(true);
+    });
+
+    it("never reports armed for a window the cursor has already left", () => {
+        // The half of codex P1 that survives requiring a confirmed sample:
+        // arming is about a specific target, so a caller must be able to tell
+        // WHICH one. tryRedockAtCursorInner re-resolves the window under the
+        // cursor at release and compares it against target() for exactly this.
+        const a = arming();
+        a.sample({ target: "main", x: 0, y: 0, t: 0 });
+        a.sample({ target: "main", x: 0, y: 0, t: 500 });
+        expect(a.isArmed()).toBe(true);
+        expect(a.target()).toBe("main");
+        // Cursor flicks to another window; the next sample retargets and the
+        // arming is dropped rather than transferred.
+        a.sample({ target: "other", x: 0, y: 0, t: 560 });
+        expect(a.isArmed()).toBe(false);
+        expect(a.target()).toBe("other");
     });
 
     it("forgets everything on reset so a second drag cannot inherit state", () => {
         const a = arming();
         a.sample({ target: "main", x: 0, y: 0, t: 0 });
         a.sample({ target: "main", x: 0, y: 0, t: 600 });
-        expect(a.isArmed(600)).toBe(true);
+        expect(a.isArmed()).toBe(true);
         a.reset();
-        expect(a.isArmed(600)).toBe(false);
+        expect(a.isArmed()).toBe(false);
         expect(a.target()).toBe(null);
         // A fresh drag starting mid-clock must serve its own full dwell.
         a.sample({ target: "main", x: 0, y: 0, t: 700 });
-        expect(a.isArmed(1000)).toBe(false);
-        expect(a.isArmed(1200)).toBe(true);
+        a.sample({ target: "main", x: 0, y: 0, t: 1000 });
+        expect(a.isArmed()).toBe(false);
+        a.sample({ target: "main", x: 0, y: 0, t: 1200 });
+        expect(a.isArmed()).toBe(true);
     });
 });

--- a/frontend/app/workspace/redock-arming.ts
+++ b/frontend/app/workspace/redock-arming.ts
@@ -57,12 +57,22 @@ export interface RedockArmingOutcome {
 export interface RedockArming {
     sample(s: RedockHoverSample): RedockArmingOutcome;
     /**
-     * Arming state as of `now`. Re-checks the dwell against the wall clock so a
-     * mouseup landing between two samples still sees a dwell that has in fact
-     * elapsed. This is a recheck of a real confirmed-hover timestamp, not an
-     * inference from missing samples — see the design note above.
+     * Whether a sample has confirmed a full dwell over the current target.
+     *
+     * Deliberately NOT extrapolated against the wall clock. An earlier revision
+     * also returned true once `now - firstSeenAt >= dwellMs` even if no sample
+     * had confirmed it yet, reasoning that the timestamp was real. Two ways
+     * that goes wrong (codex P1 on #3124):
+     *   - The ghost renderer only paints once it sees an armed sample, so a
+     *     release inside that window docked with no ghost ever shown — the
+     *     inverse of the invariant the spec sets out in §5.2.
+     *   - `firstSeenAt` belongs to the target of the LAST sample. Extrapolating
+     *     past it can arm for a window the cursor has since left.
+     * With the §5.1 heartbeat the arming flag is never more than one tick
+     * stale, so requiring a confirmed sample costs ~100ms and buys exact
+     * agreement between the two sides.
      */
-    isArmed(now: number): boolean;
+    isArmed(): boolean;
     /** Current resolved target, for pre-capturing the ghost before teardown. */
     target(): string | null;
     reset(): void;
@@ -83,9 +93,6 @@ export function createRedockArming(opts?: {
     let lastT: number | null = null;
     let lastX = 0;
     let lastY = 0;
-
-    const dwellServed = (now: number): boolean =>
-        target !== null && firstSeenAt !== null && now - firstSeenAt >= dwellMs;
 
     return {
         sample(s: RedockHoverSample): RedockArmingOutcome {
@@ -131,8 +138,8 @@ export function createRedockArming(opts?: {
             return { armed, clearIndicator: wasArmed && !armed };
         },
 
-        isArmed(now: number): boolean {
-            return armed || dwellServed(now);
+        isArmed(): boolean {
+            return armed;
         },
 
         target(): string | null {

--- a/frontend/app/workspace/redock-arming.ts
+++ b/frontend/app/workspace/redock-arming.ts
@@ -1,0 +1,151 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Redock arming state machine — the single decision point for "has this drag
+ * become a dock attempt?".
+ *
+ * Previously this logic was hand-implemented twice (once for the Windows
+ * native-move-loop path, once for the macOS/Linux JS-driven path) across ~20
+ * mutable closure variables, with each copy accumulating its own fallbacks.
+ * `docs/retro/retro-redock-ghost-landing-reliability-2026-07-27.md` flagged the
+ * duplication; `docs/specs/SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md` §5.4
+ * is the extraction.
+ *
+ * The module never reads a clock. Callers supply `t` from their own monotonic
+ * source, which is what makes the whole gate unit-testable.
+ *
+ * DESIGN NOTE — why there is no "events went quiet" fallback here:
+ * the previous implementation inferred dwell from the *absence* of hover
+ * events, because the Win32 drag loop only emitted from `WM_MOUSEMOVE` and so
+ * fell silent exactly when the cursor held still. That inference armed a redock
+ * even after the velocity gate had explicitly rejected the entry, which is the
+ * bug the spec above exists to fix. Dwell is now measured only from samples
+ * that actually confirmed a target at a qualifying speed; the host supplies a
+ * heartbeat (`agentmux-cef/src/ui_tasks/drag.rs`, `DRAG_TICK_ID`) so those
+ * samples keep arriving while stationary. Do not reintroduce a timeout-based
+ * arming path here.
+ */
+
+import { REDOCK_DWELL_MS, REDOCK_VELOCITY_PX_PER_S } from "./floating-pane-constants";
+
+export interface RedockHoverSample {
+    /** Resolved redock target window label, or null when over nothing dockable. */
+    target: string | null;
+    /**
+     * Cursor position in CSS px. Callers normalise from their own space.
+     *
+     * Omit both when the event carries no cursor — the `clear_floating_redock_hover`
+     * teardown broadcast is target-only. The module then reuses its last known
+     * position so the sample reads as "no motion" instead of a jump from the
+     * origin, which would otherwise trip the velocity gate on the NEXT real
+     * sample and cost an extra heartbeat before arming.
+     */
+    x?: number;
+    y?: number;
+    /** Monotonic timestamp in ms (`performance.now()`). */
+    t: number;
+}
+
+export interface RedockArmingOutcome {
+    /** Whether the gesture is now a committed dock attempt. */
+    armed: boolean;
+    /** True when this sample invalidated an indicator that was showing. */
+    clearIndicator: boolean;
+}
+
+export interface RedockArming {
+    sample(s: RedockHoverSample): RedockArmingOutcome;
+    /**
+     * Arming state as of `now`. Re-checks the dwell against the wall clock so a
+     * mouseup landing between two samples still sees a dwell that has in fact
+     * elapsed. This is a recheck of a real confirmed-hover timestamp, not an
+     * inference from missing samples — see the design note above.
+     */
+    isArmed(now: number): boolean;
+    /** Current resolved target, for pre-capturing the ghost before teardown. */
+    target(): string | null;
+    reset(): void;
+}
+
+export function createRedockArming(opts?: {
+    dwellMs?: number;
+    velocityPxPerS?: number;
+}): RedockArming {
+    const dwellMs = opts?.dwellMs ?? REDOCK_DWELL_MS;
+    const velocityPxPerS = opts?.velocityPxPerS ?? REDOCK_VELOCITY_PX_PER_S;
+
+    let target: string | null = null;
+    // null = the dwell clock is not running. Set to the timestamp at which the
+    // cursor was first confirmed over `target` at a qualifying speed.
+    let firstSeenAt: number | null = null;
+    let armed = false;
+    let lastT: number | null = null;
+    let lastX = 0;
+    let lastY = 0;
+
+    const dwellServed = (now: number): boolean =>
+        target !== null && firstSeenAt !== null && now - firstSeenAt >= dwellMs;
+
+    return {
+        sample(s: RedockHoverSample): RedockArmingOutcome {
+            const wasArmed = armed;
+
+            // Velocity is measured between consecutive samples. A zero (or
+            // backwards) interval carries no speed information — treat it as no
+            // motion rather than dividing by zero into a spurious rejection.
+            const x = s.x ?? lastX;
+            const y = s.y ?? lastY;
+            let tooFast = false;
+            if (lastT !== null && s.t > lastT) {
+                const dx = x - lastX;
+                const dy = y - lastY;
+                const velocity = Math.sqrt(dx * dx + dy * dy) / ((s.t - lastT) / 1000);
+                tooFast = velocity > velocityPxPerS;
+            }
+            lastT = s.t;
+            lastX = x;
+            lastY = y;
+
+            if (tooFast) {
+                // Keep the target identity but stop the clock: if the cursor
+                // settles on this same window the dwell restarts from the
+                // moment it actually slowed, not from when it arrived.
+                target = s.target;
+                firstSeenAt = null;
+                armed = false;
+            } else if (s.target === null) {
+                target = null;
+                firstSeenAt = null;
+                armed = false;
+            } else if (s.target !== target) {
+                target = s.target;
+                firstSeenAt = s.t;
+                armed = false;
+            } else if (firstSeenAt === null) {
+                firstSeenAt = s.t;
+            } else if (s.t - firstSeenAt >= dwellMs) {
+                armed = true;
+            }
+
+            return { armed, clearIndicator: wasArmed && !armed };
+        },
+
+        isArmed(now: number): boolean {
+            return armed || dwellServed(now);
+        },
+
+        target(): string | null {
+            return target;
+        },
+
+        reset(): void {
+            target = null;
+            firstSeenAt = null;
+            armed = false;
+            lastT = null;
+            lastX = 0;
+            lastY = 0;
+        },
+    };
+}


### PR DESCRIPTION
## Problem

Dragging a floating pane over the main window shows the redock ghost and docks it on release. A user who just wants the floater to sit *above* AgentMux can't — every drag ending over the main window docks.

**This is a recurrence.** The identical complaint was filed 2026-06-03 and quoted in #1249, which shipped the 180ms dwell + velocity gate:

> "Sometimes when dragging the pane over a main window, I don't want it to dock, but it immediately does."

#1249 also pre-registered the escalation — *"Compass widget is the natural next step if this proves insufficient"* — and cited a `SPEC_FLOATING_REDOCK_DWELL_2026-06-03.md` for its research and rationale that **was never committed**, which is a large part of why the 180ms number survived unexamined. This PR adds the spec that was missing.

## Why the existing gate didn't hold

Not merely mistuned — structurally defeated.

The Win32 drag loop emits hover state only from `WM_MOUSEMOVE`, throttled to 50ms (`drag.rs:598-616`). **When the cursor stops, events stop**, so a dwell clock fed from them can't advance during the exact condition it measures. The renderer compensated with a disjunction of fallbacks that substitute *time since the last event* for real dwell. One of them (`floating-pane-workspace.tsx:545`) armed the redock after the velocity gate had **explicitly rejected** the entry, purely because events went quiet.

Every deliberate repositioning ends in a pause before release. So the gate was bypassed on precisely the gesture it existed to protect — and raising `REDOCK_DWELL_MS` alone would only have changed the required pause from 180ms to 500ms.

## Changes

**1. Heartbeat so dwell is measured, not inferred.** `drag.rs:463-464` already ran a 100ms `SetTimer` for the whole drag whose handler did nothing but consume the message. It now also emits the hover update, sharing the existing 50ms `last_hover_emit` throttle — so cadence is unchanged while moving, and stationary dwell becomes observable. The inference fallbacks are **deleted, not retuned**.

**2. `REDOCK_DWELL_MS` 180 → 500.** Adopts the repo's own `SPRING_SWITCH_MS` rather than inventing a number. `SPEC_PANE_DRAG_TO_TAB_2026_07_10.md:31-33` justified 500ms for tabs as *"deliberately longer than the redock ghost's 180ms since switching the visible tab is a bigger action"* — backwards, since a redock destroys the floating window and mutates the layout tree while a tab switch is one click to undo. That comment and its counterpart in `tabbar-dnd.ts` are corrected.

**3. One arming module, shared.** The gate was hand-implemented twice (Windows native-move-loop vs macOS/Linux JS path) across ~20 closure variables — the duplication `retro-redock-ghost-landing-reliability-2026-07-27.md:47` warned would "silently diverge." Both platforms and the ghost listener now feed one `redock-arming.ts`. The ghost side previously ran a *second, independent* dwell timer that had to be disabled outright on non-Windows, so the two sides were gating by different rules by construction; they can't drift now.

Net **-124 lines** in `floating-pane-workspace.tsx`.

## Tests

There was **no coverage of any of this** — no test referenced `REDOCK_DWELL_MS` or dwell arming, so the old constant could be changed without breaking anything. 13 unit tests now cover the spec's matrix, notably:

- `requires a fresh full dwell after a fast entry, not merely stillness` — the exact regression above
- `arms from stationary samples alone, with no cursor movement` — proves the heartbeat works
- `never arms during a fast transit` — regression guard for #1249's original fix
- `does not read a cursorless teardown sample as a jump from the origin` — `clear_floating_redock_hover` broadcasts a target with no cursor; feeding 0,0 would trip the velocity gate on the next real sample

## Verification

- `cargo check -p agentmux-cef` — clean (only pre-existing warnings)
- `npx tsc --noEmit` — clean
- `npx vitest run` — **3889 passed, 0 failed** (baseline 3888; +1 is the new test file's extra case)
- `check-doc-status.sh`, `check-spec-citations.sh`, `gen-docs-index.sh --check` — all ok

## Deliberately NOT in this PR

The spec's §5.3 — the neutral parking zone. `Center` still maps to the **full leaf** (`app-init.ts:180-182`), so every pixel of every pane remains a live drop zone and there is no neutral area to park over. With a 500ms fuse a normal reposition no longer docks, which is the reported bug; but *fully* answering "let me keep a floater above AgentMux indefinitely" needs explicit dock guides. That's a visible affordance change and gets its own PR with design review, per #1249's framing.

Spec: `docs/specs/SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md`

<!-- agentmux:agent_id=manoz -->
