### PR TITLE
Manoz@Area54: fix(floating-pane): add drop guides so a floating pane can be parked

### DIFF
--- a/.changesets/1788975019-fix-floating-pane-add-drop-guides-so-a-floating-pane-can-be--tzu0.md
+++ b/.changesets/1788975019-fix-floating-pane-add-drop-guides-so-a-floating-pane-can-be--tzu0.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(floating-pane): add drop guides so a floating pane can be parked over the window

--- a/docs/specs/SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md
+++ b/docs/specs/SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md
@@ -2,11 +2,9 @@
 
 **Status:** active
 **Date:** 2026-09-09
-**Implemented:** §5.1 (P1 heartbeat), §5.2 (P2 threshold) and §5.4 (P4
-extraction) shipped together — see §8 for why they could not be split. §5.3
-(P3, the neutral parking zone) is still open and is deliberately a separate
-change; the sections below are written as they were proposed, with §5.4's
-ordering caveat noted in §8.
+**Implemented:** all four phases. §5.1 (heartbeat), §5.2 (500ms threshold) and
+§5.4 (extraction) shipped together in #3124; §5.3 (the neutral parking zone) in
+the follow-up. §8 records how the rollout went versus the plan.
 **Area:** floating panes / drag-and-dock
 **Scope:** The dwell/velocity gate gating floating-pane redock, on all three
 platforms. Tear-off (docked to floating) is out of scope; so is cross-tab pane
@@ -127,11 +125,24 @@ shorter than any deliberate "place it here and let go."
 
 ### 3.3 There is no neutral surface to park over
 
-`frontend/app-init.ts:180-182` maps `DropDirection::Center` (dir `8`) to the
-**full leaf rect**. Combined with Top/Right/Bottom/Left (half-leaf) and the
-`Outer*` bands (1/5 edge), every pixel of every pane in the main window resolves
-to a valid drop zone. There is no region a user can hover over that means
-"nothing — I am just passing through, or parking here."
+`determineDropDirection` (`frontend/layout/lib/utils.ts:15`) partitions the
+**entire leaf**: a centre fifth returns `Center`, the diagonals split the rest
+into four quadrants, and proximity to an edge promotes each to its `Outer*`
+variant. Every pixel resolves to some direction — only the exact diagonals
+return `undefined`. `app-init.ts` runs that helper for the redock ghost, so
+every pixel of every pane in the main window is a valid drop zone, and there is
+no region a user can hover over that means "nothing — I am just passing through,
+or parking here."
+
+That total partition is *correct* for the caller it was written for. An
+in-window tile drag is already a committed move; the only open question is
+where the pane lands, so leaving part of the leaf undefined would just be a dead
+zone. A floating pane is the case the helper was never designed for: "leave it
+floating" is a legitimate outcome, and a total partition cannot express it.
+
+(An earlier revision of this section blamed `rectForDirection` mapping `Center`
+to the full leaf rect. That is a real behaviour but it is the *drawn ghost*, not
+the hit region, and it is not why parking is impossible.)
 
 A dwell-only model cannot express parking intent even in principle: parking is
 communicated by hovering *longer*, which is the same signal that arms the dock.
@@ -244,25 +255,46 @@ armed are the same instant, never ghost-visible-but-not-armed.
 
 ### 5.3 P3 — A neutral parking zone (the compass escalation)
 
-Restrict redock arming to explicit drop-guide regions rather than the whole leaf:
+Resolve the redock direction from explicit drop guides rather than from a total
+partition of the leaf. `determineDropDirection` is left untouched — it is shared
+with the in-window tile drag, where partitioning everything is correct — and the
+redock path gets its own geometry in `frontend/app/workspace/redock-guides.ts`.
 
-- Keep the `Outer*` edge bands (1/5) and the Top/Right/Bottom/Left half-splits.
-- **Remove `Center` = full-leaf as an implicit arming target.** Center-drop
-  (append into the leaf) remains available, but only from an explicit central
-  guide target — a compass hit-rect of bounded size (proposal: 96x96 CSS px
-  centred in the leaf), not the entire remaining surface.
+Per hovered leaf, in fixed CSS px (a guide is a target the user aims at, so it
+should not grow with the pane the way the old fractional bands did — those were
+a third of a large pane each):
 
-The result is a genuinely neutral majority of each pane's area: hovering there
-shows no ghost and arms nothing, so a floating pane can be parked anywhere over
-AgentMux by simply not aiming at a guide. This directly answers the user's
-stated goal ("the user may simply want the floating pane above, not a redock")
-in a way no dwell value can.
+- a **plus-shaped compass** of five 44px cells at the leaf's centre — `Center`
+  plus the four half-splits — with the diagonal corners left neutral;
+- a **24px band** along each of the four leaf edges, giving the `Outer*` narrow
+  splits.
 
-If P3's UI work is deferred, an interim escape hatch is a modifier-key
-suppression (hold <kbd>Alt</kbd> during the drag: never arm, never ghost),
-which is roughly ten lines and requires no new rendering. It is strictly worse
-UX than guides (undiscoverable) and should be treated as a stopgap, not the
-answer.
+Both are clamped on small panes so they cannot meet in the middle, and the
+compass is hit-tested first so a clamped layout can never make the centre of a
+pane mean `OuterLeft`. **All nine `DropDirection` values stay reachable, so this
+removes no capability** — `Outer*` differs from its inner counterpart only by
+split fraction (0.2 vs 0.5, `layout_helpers.rs:124`), not by axis or target.
+
+Everything else is parking area — on a typical pane, comfortably the majority of
+its surface. Hovering there keeps the guides visible (that is how the user sees
+where docking *is* possible) but previews nothing and records no target.
+
+The guides render only once the dwell has armed, so a fast transit never paints
+them. They are the affordance that was missing: with a total partition there was
+nothing to show, because there was nowhere the answer was "no".
+
+**The release path must change too**, or the guides are cosmetic: an absent
+ghost previously fell back to `queue_target_layout_insert` (append), which is
+what made every pixel a drop zone in the first place. It now leaves the pane
+floating. That is only sound *because* of §5.2's dwell — 500ms is many hover
+events, so a guide the user was genuinely aiming at has certainly recorded
+itself, and an absent ghost is a real answer rather than a race. P3 depends on
+P1/P2 having shipped first; it would have been unsafe on its own.
+
+A modifier-key suppression (hold <kbd>Alt</kbd> to never arm) was considered as
+a cheaper stopgap and rejected: undiscoverable, and it answers a different
+question ("suppress this drag") than the one the guides answer ("where, if
+anywhere, does this land").
 
 ### 5.4 P4 — Collapse the duplicated gate (debt paydown)
 
@@ -336,7 +368,20 @@ practice the fallback deletions in P1 *are* the extraction — the arming rules
 that survive are small enough to state as a pure function, and writing them
 into `redock-arming.ts` directly was less work than editing them in place
 twice. The section 7 table is therefore covered by unit tests in this PR
-rather than the next one. P3 remains a separate, unstarted change.
+rather than the next one.
+
+P3 did ship as its own change, as planned, and the ordering turned out to be
+load-bearing rather than merely tidy: it replaces the append fallback with
+"leave the pane floating", which is only a safe reading of an absent ghost
+because P2's 500ms dwell guarantees a genuinely-aimed guide has had many hover
+events in which to record itself. Shipping P3 first — against the old 180ms
+gate, or against the pre-P1 arming that inferred dwell from event absence —
+would have turned races into silent failures to dock.
+
+Step 3 also anticipated design review on P3 because it changes a visible
+affordance. What made that cheap in the end was that the affordance was
+strictly additive: the guides are new UI, but every `DropDirection` they can
+produce already existed and the server-side mapping was untouched.
 
 ## 9. Open questions
 

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -57,6 +57,8 @@ import { scheduleRevealLift } from "@/store/tab-reveal";
 import { installLauncherEventBridge } from "@/util/launcher-events";
 import { installSrvEventBridge } from "@/util/srv-events";
 import { createRedockArming } from "@/app/workspace/redock-arming";
+import { guideRectsForLeaf, hitTestGuides, type GuideRect } from "@/app/workspace/redock-guides";
+import { DropDirection } from "@/layout/lib/types";
 import {
     seedKnownEntriesFromSnapshot,
     startLauncherEventReducer,
@@ -97,19 +99,21 @@ const RPC_TIMEOUT = 5_000; // 5 seconds for individual RPC calls
  *      `window.screenX/Y`, same pattern as `tabbar.tsx`).
  *   2. `document.elementFromPoint(clientX, clientY)` → walk to the
  *      nearest `[data-blockid]` ancestor.
- *   3. Run `determineDropDirection` (from `@/layout/lib/utils`) on
- *      the cursor's position within the leaf — same helper as
- *      within-window pane drag — to classify the drop as
- *      Center / Top / Right / Bottom / Left (and Outer variants).
- *   4. Render a singleton overlay div positioned over the
- *      half/quadrant/full-leaf that maps to that direction (e.g. Top
- *      → top half of leaf; Center → full leaf; OuterRight → right
- *      fifth of leaf).
+ *   3. Render that leaf's drop guides (`redock-guides.ts`) and hit-test
+ *      the cursor against them — a plus-shaped compass of five cells at
+ *      the leaf's centre plus a thin band along each edge, covering all
+ *      nine `DropDirection` values.
+ *   4. On a hit, render a singleton overlay div over the
+ *      half/strip/full-leaf that maps to that direction, and record the
+ *      direction for the floater to pass to `RedockFloatingPane`.
  *
- * The block STILL lands as a sibling in the target tab's layout for
- * MVP (backend ignores the direction). Phase 4b will wire the
- * direction through `RedockFloatingPane` so the block lands in the
- * exact slot the user previewed.
+ * A cursor between the guides hits nothing: the guides stay visible but
+ * no slot is previewed and no target is recorded, so releasing there
+ * leaves the pane floating. That parking area is the whole point — this
+ * used to run `determineDropDirection`, which partitions the entire leaf
+ * (correct for an in-window tile drag, which is already a committed
+ * move) and therefore made every pixel of the window a drop zone.
+ * SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md §5.3.
  */
 function installFloatingRedockHoverListener(): void {
     const myLabel =
@@ -124,6 +128,47 @@ function installFloatingRedockHoverListener(): void {
         }
         return placeholderEl;
     };
+    // Drop guides for the leaf under the cursor. Kept separate from the
+    // placeholder: the guides stay up while the cursor wanders the parking
+    // area (they are how the user sees where docking *is* possible), whereas
+    // the placeholder only previews an actual landing.
+    let guideEls: HTMLDivElement[] = [];
+    let guidesKey = "";
+
+    const clearGuides = () => {
+        if (guideEls.length === 0) return;
+        for (const el of guideEls) el.remove();
+        guideEls = [];
+        guidesKey = "";
+    };
+
+    // `key` identifies the leaf AND its geometry, so the guides are rebuilt
+    // when the cursor moves to a different pane or the layout resizes under
+    // it, but not on every hover event for a stationary cursor.
+    const renderGuides = (guides: GuideRect[], key: string) => {
+        if (guidesKey === key) return;
+        clearGuides();
+        for (const g of guides) {
+            const el = document.createElement("div");
+            el.className = "floating-redock-guide";
+            el.dataset.dir = String(g.dir);
+            el.style.top = `${g.top}px`;
+            el.style.left = `${g.left}px`;
+            el.style.width = `${g.width}px`;
+            el.style.height = `${g.height}px`;
+            document.body.appendChild(el);
+            guideEls.push(el);
+        }
+        guidesKey = key;
+    };
+
+    const highlightGuide = (dir: DropDirection | null) => {
+        const active = dir === null ? null : String(dir);
+        for (const el of guideEls) {
+            el.classList.toggle("is-active", el.dataset.dir === active);
+        }
+    };
+
     const clearPlaceholder = () => {
         const hadGhost = placeholderEl !== null;
         if (placeholderEl) {
@@ -196,7 +241,6 @@ function installFloatingRedockHoverListener(): void {
 
     fireAndForget(async () => {
         const { listenEvent, invokeCommand } = await import("@/app/platform/ipc");
-        const { determineDropDirection } = await import("@/layout/lib/utils");
         await listenEvent<{
             target_label: string | null;
             source_label?: string;
@@ -224,10 +268,12 @@ function installFloatingRedockHoverListener(): void {
             });
             if (!payload || newTarget !== myLabel || !armed) {
                 clearPlaceholder();
+                clearGuides();
                 return;
             }
             if (typeof cursorX !== "number" || typeof cursorY !== "number") {
                 clearPlaceholder();
+                clearGuides();
                 return;
             }
             const clientX = cursorX / invScale - window.screenX;
@@ -236,19 +282,31 @@ function installFloatingRedockHoverListener(): void {
             const leafEl = el?.closest("[data-blockid]") as HTMLElement | null;
             if (!leafEl) {
                 clearPlaceholder();
+                clearGuides();
                 return;
             }
             const leafRect = leafEl.getBoundingClientRect();
-            const dir = determineDropDirection(
-                {
-                    width: leafRect.width,
-                    height: leafRect.height,
-                    left: leafRect.left,
-                    top: leafRect.top,
-                },
-                { x: clientX, y: clientY },
+            // Guides, not `determineDropDirection`: that partitions the entire
+            // leaf, which is right for an in-window tile drag (already a
+            // committed move) but leaves a floater nowhere to express "stay
+            // floating". See redock-guides.ts.
+            const guides = guideRectsForLeaf({
+                top: leafRect.top,
+                left: leafRect.left,
+                width: leafRect.width,
+                height: leafRect.height,
+            });
+            renderGuides(
+                guides,
+                `${leafEl.dataset.blockid}:${Math.round(leafRect.left)}:${Math.round(leafRect.top)}:${Math.round(leafRect.width)}:${Math.round(leafRect.height)}`,
             );
-            if (dir === undefined) {
+            const dir = hitTestGuides(guides, clientX, clientY);
+            highlightGuide(dir);
+            if (dir === null) {
+                // Parking area. Guides stay up so the user can see where
+                // docking is possible; nothing is previewed, and the cleared
+                // target below is what makes the release leave the pane
+                // floating rather than falling back to an append.
                 clearPlaceholder();
                 return;
             }

--- a/frontend/app/app.scss
+++ b/frontend/app/app.scss
@@ -61,6 +61,27 @@ body {
     transition: top 120ms ease-out, left 120ms ease-out, width 120ms ease-out, height 120ms ease-out;
 }
 
+// Redock drop guides — the explicit targets a dragged floater must be aimed
+// at. They appear on the pane under the cursor once the dwell has armed, and
+// exist so that everything *between* them reads as "leave this floating":
+// before they existed the whole pane was a drop zone and a floater could not
+// be parked over AgentMux at all.
+// SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md §5.3.
+.floating-redock-guide {
+    position: fixed;
+    pointer-events: none;
+    z-index: 9998; // under the placeholder, which previews the actual landing
+    border: 1px solid rgba(from var(--accent-color) r g b / 0.5);
+    border-radius: 4px;
+    background-color: rgba(from var(--accent-color) r g b / 0.08);
+    transition: background-color 90ms ease-out, border-color 90ms ease-out;
+
+    &.is-active {
+        border-color: var(--accent-color);
+        background-color: rgba(from var(--accent-color) r g b / 0.3);
+    }
+}
+
 a.plain-link {
     color: var(--secondary-text-color);
 }

--- a/frontend/app/workspace/floating-pane-workspace.tsx
+++ b/frontend/app/workspace/floating-pane-workspace.tsx
@@ -893,16 +893,32 @@ function FloatingPaneWorkspaceElem(): JSX.Element {
             }
 
             // Phase 4b — use the ghost pre-captured in onMouseUp (before
-            // clear_floating_redock_hover cleared it). If the resolved target
-            // window differs from the captured window, fall back to empty ghost
-            // (InsertNode path). Clear after consuming so a subsequent drag
-            // can't accidentally reuse stale state.
+            // clear_floating_redock_hover cleared it). Clear after consuming so
+            // a subsequent drag can't accidentally reuse stale state.
             const ghost =
                 capturedGhostForDrop != null && capturedGhostForWindow === target.label
                     ? await capturedGhostForDrop
                     : {};
             capturedGhostForDrop = null;
             capturedGhostForWindow = null;
+
+            // No ghost means the cursor was in the parking area — over the
+            // window, but not aimed at any drop guide — so the user's intent
+            // was to leave the pane floating above it. Bail rather than fall
+            // back to an append, which is what used to make every pixel of the
+            // window a drop zone.
+            //
+            // This is only safe to read as intent because the 500ms dwell has
+            // already elapsed by the time we get here: a guide the user was
+            // actually aiming at has had many hover events in which to record
+            // itself, so an absent ghost is a real answer and not a race.
+            // SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md §5.3.
+            if (!ghost.block_id) {
+                console.log(
+                    "[floating-pane] release in the parking area — leaving the pane floating",
+                );
+                return false;
+            }
 
             try {
                 await WorkspaceService.RedockFloatingPane(

--- a/frontend/app/workspace/redock-guides.test.ts
+++ b/frontend/app/workspace/redock-guides.test.ts
@@ -1,0 +1,123 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { DropDirection } from "@/layout/lib/types";
+import { guideRectsForLeaf, hitTestGuides } from "./redock-guides";
+
+// A comfortably large leaf, so nothing is clamped.
+const LEAF = { top: 100, left: 200, width: 800, height: 600 };
+
+function hit(x: number, y: number, leaf = LEAF): DropDirection | null {
+    return hitTestGuides(guideRectsForLeaf(leaf), x, y);
+}
+
+const centerX = LEAF.left + LEAF.width / 2;
+const centerY = LEAF.top + LEAF.height / 2;
+
+describe("redock guides — the parking zone", () => {
+    it("leaves the bulk of the leaf neutral so a floater can be parked", () => {
+        // Halfway between the compass cluster and the edge band, on each axis.
+        expect(hit(LEAF.left + 150, centerY)).toBe(null);
+        expect(hit(LEAF.left + LEAF.width - 150, centerY)).toBe(null);
+        expect(hit(centerX, LEAF.top + 120)).toBe(null);
+        expect(hit(centerX, LEAF.top + LEAF.height - 120)).toBe(null);
+        // Diagonally out from the compass, well clear of every band.
+        expect(hit(LEAF.left + 200, LEAF.top + 160)).toBe(null);
+    });
+
+    it("measures the neutral area as the clear majority of the leaf", () => {
+        // Guard against a future tweak quietly eating the parking area: sample
+        // the leaf on a grid and require most of it to hit nothing.
+        const guides = guideRectsForLeaf(LEAF);
+        let neutral = 0;
+        let total = 0;
+        for (let x = LEAF.left; x < LEAF.left + LEAF.width; x += 10) {
+            for (let y = LEAF.top; y < LEAF.top + LEAF.height; y += 10) {
+                total++;
+                if (hitTestGuides(guides, x, y) === null) neutral++;
+            }
+        }
+        expect(neutral / total).toBeGreaterThan(0.6);
+    });
+
+    it("reports nothing for a point outside the leaf entirely", () => {
+        expect(hit(LEAF.left - 5, centerY)).toBe(null);
+        expect(hit(centerX, LEAF.top + LEAF.height + 5)).toBe(null);
+    });
+});
+
+describe("redock guides — the compass", () => {
+    it("maps the centre cell to Center", () => {
+        expect(hit(centerX, centerY)).toBe(DropDirection.Center);
+    });
+
+    it("maps the four cells around the centre to the half-splits", () => {
+        const guides = guideRectsForLeaf(LEAF);
+        const cell = guides.find((g) => g.dir === DropDirection.Center)!;
+        const step = cell.height + 4; // one cell plus the gap
+        expect(hitTestGuides(guides, centerX, centerY - step)).toBe(DropDirection.Top);
+        expect(hitTestGuides(guides, centerX, centerY + step)).toBe(DropDirection.Bottom);
+        expect(hitTestGuides(guides, centerX - step, centerY)).toBe(DropDirection.Left);
+        expect(hitTestGuides(guides, centerX + step, centerY)).toBe(DropDirection.Right);
+    });
+
+    it("leaves the diagonal corners of the cluster neutral", () => {
+        // The compass is a plus, not a 3x3 block — corners are parking area.
+        const guides = guideRectsForLeaf(LEAF);
+        const cell = guides.find((g) => g.dir === DropDirection.Center)!;
+        const step = cell.height + 4;
+        expect(hitTestGuides(guides, centerX - step, centerY - step)).toBe(null);
+        expect(hitTestGuides(guides, centerX + step, centerY + step)).toBe(null);
+    });
+});
+
+describe("redock guides — the edge bands", () => {
+    it("maps each edge strip to its Outer direction", () => {
+        expect(hit(centerX, LEAF.top + 2)).toBe(DropDirection.OuterTop);
+        expect(hit(centerX, LEAF.top + LEAF.height - 2)).toBe(DropDirection.OuterBottom);
+        expect(hit(LEAF.left + 2, centerY)).toBe(DropDirection.OuterLeft);
+        expect(hit(LEAF.left + LEAF.width - 2, centerY)).toBe(DropDirection.OuterRight);
+    });
+
+    it("keeps every direction reachable, so nothing is lost versus the old mapping", () => {
+        const reachable = new Set(guideRectsForLeaf(LEAF).map((g) => g.dir));
+        expect(reachable).toEqual(
+            new Set([
+                DropDirection.Top,
+                DropDirection.Right,
+                DropDirection.Bottom,
+                DropDirection.Left,
+                DropDirection.OuterTop,
+                DropDirection.OuterRight,
+                DropDirection.OuterBottom,
+                DropDirection.OuterLeft,
+                DropDirection.Center,
+            ]),
+        );
+    });
+});
+
+describe("redock guides — small leaves", () => {
+    it("still fits a usable compass in a small pane without overlapping guides", () => {
+        const small = { top: 0, left: 0, width: 200, height: 160 };
+        const guides = guideRectsForLeaf(small);
+        // Every guide must lie inside the leaf.
+        for (const g of guides) {
+            expect(g.left).toBeGreaterThanOrEqual(small.left);
+            expect(g.top).toBeGreaterThanOrEqual(small.top);
+            expect(g.left + g.width).toBeLessThanOrEqual(small.left + small.width);
+            expect(g.top + g.height).toBeLessThanOrEqual(small.top + small.height);
+        }
+        // And the centre must still resolve to Center rather than a band.
+        expect(hitTestGuides(guides, 100, 80)).toBe(DropDirection.Center);
+    });
+
+    it("prefers the compass over an edge band where a tiny leaf makes them meet", () => {
+        // Ordering guarantee: the compass is hit-tested first, so a clamped
+        // layout can never make the centre of a pane mean OuterLeft.
+        const tiny = { top: 0, left: 0, width: 90, height: 90 };
+        const guides = guideRectsForLeaf(tiny);
+        expect(hitTestGuides(guides, 45, 45)).toBe(DropDirection.Center);
+    });
+});

--- a/frontend/app/workspace/redock-guides.ts
+++ b/frontend/app/workspace/redock-guides.ts
@@ -1,0 +1,129 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Redock drop guides — the explicit targets a floating pane must be aimed at
+ * before it will dock, and the neutral area around them where it will not.
+ *
+ * WHY THIS EXISTS, rather than reusing `determineDropDirection`:
+ * that function partitions the WHOLE leaf — every pixel resolves to some
+ * direction, by design, because an in-window tile drag is already a committed
+ * move and only has to decide where. A floating pane is different: "leave it
+ * floating above the window" is a legitimate outcome, and with a total
+ * partition there is nowhere to express it. That is why a floater could not be
+ * parked over AgentMux no matter how the dwell was tuned — the dwell decides
+ * *when* the drag becomes a dock, but something has to decide *whether*.
+ * See `docs/specs/SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md` §3.3/§5.3.
+ *
+ * `determineDropDirection` is deliberately left alone: it is shared with the
+ * in-window tile drag, where a total partition is the correct behaviour.
+ *
+ * Layout, per hovered leaf:
+ *   - a plus-shaped compass of five cells at the centre (Center + the four
+ *     half-splits), and
+ *   - a thin band along each of the four edges (the Outer* narrow splits).
+ * Everything else — including the diagonal corners of the compass — is
+ * parking area. All nine `DropDirection` values stay reachable, so this
+ * removes no capability.
+ */
+
+import { DropDirection } from "@/layout/lib/types";
+
+export interface LeafBox {
+    top: number;
+    left: number;
+    width: number;
+    height: number;
+}
+
+export interface GuideRect extends LeafBox {
+    dir: DropDirection;
+}
+
+/** Edge in CSS px. Deliberately a fixed size, not a fraction of the leaf: a
+ *  guide is a UI target the user aims at, and targets should not grow with the
+ *  pane. The old fractional bands were a third of a large pane each. */
+const EDGE_BAND = 24;
+/** One compass cell, CSS px. */
+const CELL = 44;
+/** Space between compass cells, CSS px. */
+const GAP = 4;
+
+/**
+ * Guides for one leaf, in the same client-CSS-px space as the leaf rect.
+ *
+ * Compass cells come first: `hitTestGuides` returns the first match, so on a
+ * leaf small enough that the clamped compass meets the clamped edge bands, the
+ * centre still means Center rather than an edge split.
+ */
+export function guideRectsForLeaf(leaf: LeafBox): GuideRect[] {
+    const shortest = Math.min(leaf.width, leaf.height);
+    // Clamp both features so they stay inside a small pane and never meet in
+    // the middle. A third of the shortest side leaves room for the neutral
+    // ring at any size the layout can actually produce.
+    const cell = Math.max(8, Math.min(CELL, (shortest - 2 * GAP) / 3 - 2));
+    const band = Math.max(4, Math.min(EDGE_BAND, shortest / 6));
+
+    const midX = leaf.left + leaf.width / 2;
+    const midY = leaf.top + leaf.height / 2;
+    const step = cell + GAP;
+    const half = cell / 2;
+
+    const cellAt = (dir: DropDirection, cx: number, cy: number): GuideRect => ({
+        dir,
+        left: cx - half,
+        top: cy - half,
+        width: cell,
+        height: cell,
+    });
+
+    return [
+        cellAt(DropDirection.Center, midX, midY),
+        cellAt(DropDirection.Top, midX, midY - step),
+        cellAt(DropDirection.Bottom, midX, midY + step),
+        cellAt(DropDirection.Left, midX - step, midY),
+        cellAt(DropDirection.Right, midX + step, midY),
+        {
+            dir: DropDirection.OuterTop,
+            left: leaf.left,
+            top: leaf.top,
+            width: leaf.width,
+            height: band,
+        },
+        {
+            dir: DropDirection.OuterBottom,
+            left: leaf.left,
+            top: leaf.top + leaf.height - band,
+            width: leaf.width,
+            height: band,
+        },
+        {
+            dir: DropDirection.OuterLeft,
+            left: leaf.left,
+            top: leaf.top,
+            width: band,
+            height: leaf.height,
+        },
+        {
+            dir: DropDirection.OuterRight,
+            left: leaf.left + leaf.width - band,
+            top: leaf.top,
+            width: band,
+            height: leaf.height,
+        },
+    ];
+}
+
+/** The guide under this point, or null when the cursor is in parking area. */
+export function hitTestGuides(
+    guides: GuideRect[],
+    x: number,
+    y: number,
+): DropDirection | null {
+    for (const g of guides) {
+        if (x >= g.left && x <= g.left + g.width && y >= g.top && y <= g.top + g.height) {
+            return g.dir;
+        }
+    }
+    return null;
+}


### PR DESCRIPTION
## Problem

#3124 made a redock require a deliberate 500ms hover, so an ordinary reposition-and-release no longer docks. But a long enough hover **anywhere** over the main window still docked, because every pixel of every pane was a drop zone — there was nowhere the answer could be *"leave this floating"*. That was the remaining half of the original report ("the user may simply want the floating pane above, not a redock") and it was called out as still-open in #3124.

## Cause

`determineDropDirection` (`frontend/layout/lib/utils.ts:15`) partitions the **entire leaf**: a centre fifth returns `Center`, the diagonals split the rest into quadrants, edge proximity promotes each to its `Outer*` variant. Only the exact diagonals return `undefined`.

That is *correct* for the caller it was written for. An in-window tile drag is already a committed move — the only open question is where the pane lands, so an undefined region would just be a dead zone. A floating pane is the case the helper was never designed for: "stay floating" is a legitimate outcome, and a total partition cannot express it.

So `determineDropDirection` is **left untouched** (still shared with the tile drag), and the redock path gets its own geometry.

## Change

**`frontend/app/workspace/redock-guides.ts`** — per hovered leaf, in fixed CSS px:

- a **plus-shaped compass** of five 44px cells at the leaf centre — `Center` plus the four half-splits — diagonal corners left neutral;
- a **24px band** along each of the four leaf edges — the `Outer*` narrow splits.

Fixed sizes, not fractions: a guide is a target you aim at, and it shouldn't grow with the pane the way the old bands did (a third of a large pane each). Both clamp on small panes so they can't meet in the middle, and the compass is hit-tested first so a clamped layout can never make a pane's centre mean `OuterLeft`.

**All nine `DropDirection` values stay reachable, so no capability is removed** — `Outer*` differs from its inner counterpart only by split fraction (0.2 vs 0.5, `layout_helpers.rs:124`), not by axis or target.

Everything else is parking area — comfortably the majority of a typical pane.

**The guides are rendered** in the target window once the dwell arms (so a fast transit never paints them) and stay up while the cursor wanders the neutral area. That's the affordance that was missing: with a total partition there was nothing to show, because there was nowhere the answer was "no".

**The release path changes with them, or they'd be cosmetic.** An absent ghost previously fell back to `queue_target_layout_insert` (append) — which is precisely what made every pixel a drop zone. It now leaves the pane floating.

## Why this had to come after #3124

Reading an absent ghost as "the user wants it to stay floating" is only sound **because** of the 500ms dwell: a guide the user was genuinely aiming at has had many hover events in which to record itself, so an absent ghost is a real answer rather than a race. Against the old 180ms gate — or against the pre-#3124 arming that inferred dwell from event *absence* — this same change would have turned races into silent failures to dock.

## Tests

10 unit tests on the geometry, including:

- `measures the neutral area as the clear majority of the leaf` — samples the leaf on a grid and asserts >60% hits nothing, so a later tweak can't quietly eat the parking area
- `keeps every direction reachable, so nothing is lost versus the old mapping`
- `prefers the compass over an edge band where a tiny leaf makes them meet`
- `leaves the diagonal corners of the cluster neutral`

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — **3900 passed, 0 failed** (3890 before, +10 new)
- Doc gates green

## Not verified

I have not exercised this in a running app — the guide rendering and hit-testing are covered by unit tests on the geometry and by tsc, but the actual on-screen appearance, the guide sizing against real pane sizes, and the cross-process timing of guides appearing in the target window have not been observed live. Worth a manual pass before release: tear a pane off, drag it back, confirm the guides appear after the dwell, that aiming at one previews the right slot, and that releasing between them leaves the floater alone.

Spec: `docs/specs/SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md` §5.3 (also corrects §3.3, which had attributed the missing parking area to `rectForDirection` rather than to `determineDropDirection`).

<!-- agentmux:agent_id=manoz -->
