### PR TITLE
Manoz@Area54: fix(floating-pane): retune the redock dwell to 300ms

### DIFF
--- a/.changesets/1788991931-fix-floating-pane-retune-the-redock-dwell-to-300ms-o36m.md
+++ b/.changesets/1788991931-fix-floating-pane-retune-the-redock-dwell-to-300ms-o36m.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(floating-pane): retune the redock dwell to 300ms

--- a/docs/specs/SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md
+++ b/docs/specs/SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md
@@ -146,7 +146,8 @@ the wrong direction.
 | macOS spring-loaded folders | ~500-750 ms (user-adjustable) |
 | Windows `MenuShowDelay` (submenu open) | 400 ms default |
 | AgentMux spring-loaded tabs (`SPRING_SWITCH_MS`) | 500 ms |
-| AgentMux redock (today) | **180 ms** |
+| AgentMux redock (before this spec) | **180 ms** |
+| AgentMux redock (now) | **300 ms** — see the retune note below |
 
 The consensus band for "hover became intent" is **400-700 ms**. AgentMux's
 redock is the outlier by a factor of roughly 2.5.
@@ -163,6 +164,23 @@ deferred.
 400 ms hover default rather than deliberately below it. Choosing the existing
 in-repo constant rather than a newly invented number also removes the "two
 subsystems, two arbitrary thresholds" divergence noted in 3.1.
+
+> **Retuned to 300 ms (2026-09-09, after use).** 500 ms was noticeably sluggish
+> in the hand. This is a deliberate step below the published band, and the band
+> is the reason to be careful rather than a reason not to: those figures
+> describe *passive* hover, where the user has not declared any intent yet. A
+> floater drag is already a committed gesture — only the destination is open —
+> so the threshold is separating "aiming here" from "passing through", not
+> "meant anything at all" from "meant nothing".
+>
+> 300 ms is not a partial return to the original 180 ms bug. That failure was
+> mechanical rather than numeric: dwell was inferred from the *absence* of hover
+> events, so any pause armed a redock even after the velocity gate had rejected
+> the entry (§3.2). With dwell measured from confirmed samples, 300 ms of
+> genuine stillness is a real signal in a way 180 ms never was.
+>
+> Everything else about the interaction is unchanged — this is a threshold
+> change only.
 
 ## 5. Design
 
@@ -227,7 +245,8 @@ will refuse.
 
 ### 5.2 P2 — Raise the threshold
 
-`REDOCK_DWELL_MS: 180 -> 500` in `floating-pane-constants.ts:12`.
+`REDOCK_DWELL_MS: 180 -> 500` in `floating-pane-constants.ts:12`, retuned to
+300 after use — see the note at the end of section 4.
 
 `REDOCK_VELOCITY_PX_PER_S` stays at 400 — it is a rate, not a duration, and
 #1249's derivation (relaxed aim is about 100 px / 250 ms; transit drags hit

--- a/docs/specs/SPEC_PANE_DRAG_TO_TAB_2026_07_10.md
+++ b/docs/specs/SPEC_PANE_DRAG_TO_TAB_2026_07_10.md
@@ -32,8 +32,9 @@ v2 design (implemented; supersedes §4.1–§4.6 below, kept for history):
   (`setActiveTab` via the tab's own `onSelect`). This originally read
   "deliberately longer than the redock ghost's 180ms since switching the
   visible tab is a bigger action" — corrected 2026-09-09: a redock is the
-  *less* reversible of the two, and the redock gate has since been raised to
-  500ms to match this value. See
+  *less* reversible of the two, and the redock gate has since moved
+  independently of this constant (180ms -> 500ms -> 300ms, the last on how it
+  felt in use). Do not treat the two as pinned together. See
   `SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md` §3.1.
 - **Real-layout ghost**: the target tab's own TileLayout overlay handles
   placement using the existing `ComputeMove` → pending-`Move` → placeholder
@@ -165,7 +166,7 @@ queue_source_layout_delete(state, &source_tab_id, &block_id).await
 
 ### 2.5 Ghost/preview precedent for a *live, direction-aware* drop indicator
 
-`app-init.ts:113-273` (`installFloatingRedockHoverListener`) is the closest existing "ghost stitched into a target's layout, updating live while a real drag is in progress": on `floating-redock:hover-state` host events (cursor position during a floating-window OS-level move), it does `elementFromPoint` → nearest `[data-blockid]` leaf → `determineDropDirection` → `rectForDirection` (hardcoded Top/Right/Bottom/Left = half-leaf, Outer* = 1/5 band, Center = full-leaf) → positions a raw `.floating-redock-drop-placeholder` div, gated by a dwell timer keyed on `REDOCK_DWELL_MS` to prevent flicker. (180ms and Windows-only when this spec was written; 500ms since `SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md`, and the Windows-only carve-out is gone — floater and ghost now share one arming module.)
+`app-init.ts:113-273` (`installFloatingRedockHoverListener`) is the closest existing "ghost stitched into a target's layout, updating live while a real drag is in progress": on `floating-redock:hover-state` host events (cursor position during a floating-window OS-level move), it does `elementFromPoint` → nearest `[data-blockid]` leaf → `determineDropDirection` → `rectForDirection` (hardcoded Top/Right/Bottom/Left = half-leaf, Outer* = 1/5 band, Center = full-leaf) → positions a raw `.floating-redock-drop-placeholder` div, gated by a dwell timer keyed on `REDOCK_DWELL_MS` to prevent flicker. (180ms and Windows-only when this spec was written. `SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md` raised it — to 500ms, then 300ms on how it felt in use — and removed the Windows-only carve-out; floater and ghost now share one arming module. Read the constant rather than any figure quoted here.)
 
 **This only works because its target is a visible, active tab's real DOM** (the dragged window is a separate OS process, the target tab is necessarily the one currently on screen in that other window). **Our target tab is usually inactive and `display:none`**, so `elementFromPoint`/`getBoundingClientRect` are not usable directly — see §4.2.
 
@@ -203,7 +204,7 @@ Set only when the dragged payload is `kind: "tile"` and the tile's *own* tab dif
 
 ### 4.2 Tab flash (Goal 2)
 
-A CSS class (e.g. `.tab--drop-flash`) toggled by `hoveredDropTabId`, applied as a restartable keyframe pulse (not a static highlight) so re-entering the same tab after briefly leaving re-triggers the flash — mirrors the existing `bouncingTabId` one-shot-animation pattern (`tabbar.tsx`) rather than inventing a new animation-retrigger mechanism. Dwell-gate this at ~120–180ms (this matched `REDOCK_DWELL_MS`'s precedent, §2.5, when that constant was also 180ms; it is 500ms since 2026-09-09 and this preview gate was deliberately *not* raised alongside it — mounting a preview is cheap and reversible, unlike a redock) before the preview (§4.3) mounts, so a fast pass-through over several tabs doesn't spawn/despawn previews per-frame.
+A CSS class (e.g. `.tab--drop-flash`) toggled by `hoveredDropTabId`, applied as a restartable keyframe pulse (not a static highlight) so re-entering the same tab after briefly leaving re-triggers the flash — mirrors the existing `bouncingTabId` one-shot-animation pattern (`tabbar.tsx`) rather than inventing a new animation-retrigger mechanism. Dwell-gate this at ~120–180ms (this matched `REDOCK_DWELL_MS`'s precedent, §2.5, when that constant was also 180ms; it has since moved independently, to 500ms and then 300ms on 2026-09-09, and this preview gate was deliberately *not* moved alongside it — mounting a preview is cheap and reversible, unlike a redock) before the preview (§4.3) mounts, so a fast pass-through over several tabs doesn't spawn/despawn previews per-frame.
 
 ### 4.3 Schematic tab-layout preview (Goal 3) — the genuinely new piece
 

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -133,8 +133,10 @@ function installFloatingRedockHoverListener(): void {
         // Nothing was showing, so there is no stored ghost state to clear —
         // the backend entry is written on the same path that mounts the
         // placeholder. Bailing here matters now that this runs on every
-        // not-yet-armed hover sample: without it, a 500ms dwell would fire an
-        // IPC per heartbeat just to clear state that was never set.
+        // not-yet-armed hover sample: without it, the whole dwell would fire
+        // an IPC per heartbeat just to clear state that was never set.
+        // (Deliberately does not name the threshold — REDOCK_DWELL_MS is the
+        // single source of truth and has already moved twice.)
         if (!hadGhost) return;
         // Phase 4b — clear the stored ghost state for this window so a stale
         // direction cannot bleed into the next drop event.

--- a/frontend/app/tab/tabbar-dnd.ts
+++ b/frontend/app/tab/tabbar-dnd.ts
@@ -59,11 +59,12 @@ export const [hoveredDropTabId, setHoveredDropTabId] = createSignal<string | nul
 // spring-loading.
 //
 // This used to note that it was "deliberately longer than REDOCK_DWELL_MS's
-// 180ms". That framing was wrong in both directions: a redock is *less*
-// reversible than a tab switch, not more, and the 180ms it was measuring
-// itself against has since been raised to 500 to match this value. The two
-// are equal now and gate different subsystems — keep them as separate
-// constants. SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md §3.1.
+// 180ms" on the grounds that a tab switch is the bigger action. That framing
+// was wrong — a redock is the *less* reversible of the two — so do not read
+// the current ordering as endorsing it. REDOCK_DWELL_MS has since moved
+// independently (180 -> 500 -> 300, the last on how it felt in use); the two
+// gate different subsystems and are deliberately separate constants.
+// SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md §3.1.
 export const SPRING_SWITCH_MS = 500;
 
 // Tabs whose LayoutModel.activeDrag was force-set by a mid-drag spring

--- a/frontend/app/workspace/floating-pane-constants.ts
+++ b/frontend/app/workspace/floating-pane-constants.ts
@@ -11,15 +11,25 @@
 /**
  * Milliseconds the cursor must hover over a target before redock arms.
  *
- * Matches `SPRING_SWITCH_MS` (frontend/app/tab/tabbar-dnd.ts) deliberately:
- * a redock destroys the floating window and grafts the pane into the layout
- * tree, which is strictly less reversible than switching the visible tab, so
- * it does not get a shorter fuse. This was 180ms until
- * `docs/specs/SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md` — below the
- * 400-700ms band every comparable hover-intent interaction uses, and low
- * enough that an ordinary reposition-and-release read as a dock request.
+ * 180ms originally, which was too short: an ordinary reposition-and-release
+ * read as a dock request. Raised to 500ms by
+ * `docs/specs/SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md` to sit inside the
+ * 400-700ms band comparable hover-intent interactions use, and to match
+ * `SPRING_SWITCH_MS` (frontend/app/tab/tabbar-dnd.ts).
+ *
+ * Lowered to 300ms after using it: 500ms was noticeably sluggish in the hand,
+ * and the argument for it was desk research, not experience. That is a
+ * deliberate step below the published band — the band describes *passive*
+ * hover, where the user has not yet declared intent, whereas a floater drag is
+ * already a committed gesture and only the destination is in question.
+ *
+ * 300ms is not a partial return to the 180ms bug. That failure was mostly
+ * mechanical rather than numeric: dwell was inferred from the ABSENCE of hover
+ * events, so a pause of any kind armed a redock even after the velocity gate
+ * had rejected the entry. Dwell is now measured from confirmed samples (§5.1),
+ * so 300ms of genuine stillness is a real signal in a way 180ms never was.
  */
-export const REDOCK_DWELL_MS = 500;
+export const REDOCK_DWELL_MS = 300;
 
 /** CSS-px/s above which cursor motion cancels the dwell clock. */
 export const REDOCK_VELOCITY_PX_PER_S = 400;


### PR DESCRIPTION
## What

`REDOCK_DWELL_MS: 500 -> 300`. Nothing else changes — no behavioural or UI change, same interaction as #3124 shipped.

## Why

500ms was noticeably sluggish in use. The case for it was desk research — the 400–700ms band comparable hover-intent interactions use, plus matching `SPRING_SWITCH_MS` — and actually using it beats that.

This is a deliberate step below the published band, and the band is a reason to be careful rather than a reason not to: those figures describe **passive** hover, where the user hasn't declared any intent yet. A floater drag is already a committed gesture and only the destination is open, so this threshold separates *"aiming here"* from *"passing through"*, not *"meant something"* from *"meant nothing"*.

## This is not a partial return to the 180ms bug

Worth stating explicitly, since 300 sits close to the value that failed. That failure was **mechanical, not numeric**: dwell was inferred from the *absence* of hover events, so any pause armed a redock even after the velocity gate had explicitly rejected the entry (spec §3.2). Since #3124 the host emits a heartbeat and dwell is measured from confirmed samples — so 300ms of genuine stillness is a real signal in a way 180ms never was. Raising the number was never the part of #3124 that did the work.

## Also in here

`tabbar-dnd.ts`'s comment asserted the two constants were equal, which this makes false — corrected, no code change. The spec records the retune and the reasoning so the value doesn't get "restored" later by someone reading only the original rationale.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run frontend/app/workspace/` — 14 passed
- No test pins the constant (the arming tests inject their own `dwellMs`), so nothing needed updating

## Context

Supersedes the approach in #3126, which I closed unmerged — the drop guides there were a misunderstanding of scope on my part, not something wanted. The parking-zone work in the spec (§5.3) stays open and unstarted.

Spec: `docs/specs/SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md` §4

<!-- agentmux:agent_id=manoz -->
