### PR TITLE
docs(cef): correct the Windows toolchain-unchanged claim; record the SDK 152 blocker

### DIFF
--- a/docs/cef-build/build-patched-cef-windows.md
+++ b/docs/cef-build/build-patched-cef-windows.md
@@ -49,6 +49,53 @@ again on a future build:
   (`Microsoft.VisualStudio.Component.VC.ATLMFC` via the VS Installer's
   `modify` command, needed for `atldef.h`).
 
+**Update (2026-09-09), building CEF 152 (branch `7977`) from this same doc:**
+the steps above still work, but a **152-specific** blocker appeared that
+didn't exist at 148 — read this before starting a 152 build on any machine:
+
+- `ui/accessibility/platform/uia_client_info_source_win.cc` (new in Chromium
+  152, unconditional in the Windows `BUILD.gn` — no flag skips it) needs
+  `IUIAutomationClientInfo`/`IUIAutomationClientInfoSource` interfaces that
+  are **absent from Windows SDK 10.0.26100.0** — the only SDK version VS
+  Build Tools 2022's installer catalog offers (checked directly: only
+  `22621` and `26100` exist there). Confusingly, `build/vs_toolchain.py`'s
+  `SDK_VERSION` pin is **identical** between Chromium 148 and 152
+  (`10.0.26100.0` both), so the pins say "unchanged" while the actual
+  requirement moved. Root cause: Google's internal
+  `DEPOT_TOOLS_WIN_TOOLCHAIN=1` packaged toolchain bundles a different
+  snapshot of "26100" than the public SDK installer — external builders get
+  the public one and hit this; Google's own CI doesn't.
+  - **Fix:** install a newer public Windows SDK
+    (https://developer.microsoft.com/windows/downloads/windows-sdk/ — the
+    version matching your OS build works; `10.0.28000.0` confirmed to
+    contain the missing interfaces). The VS Installer **cannot** supply
+    this — its catalog doesn't have it.
+  - Then **edit two files**, not one — `SDK_VERSION` is hardcoded
+    separately in both `build/vs_toolchain.py` and
+    `build/toolchain/win/setup_toolchain.py`; `vs_toolchain.py`'s own
+    comment says they must match. The GN arg `windows_sdk_version` alone
+    does **not** propagate — confirmed by checking `out/.../toolchain.ninja`
+    before and after; it still resolved the old SDK path until both Python
+    files were edited and `gn gen` re-run.
+- `cef_installer_unittests` fails to compile in this configuration:
+  `SetInstallerE2EConfigForTesting` is declared under
+  `#if !(defined(OFFICIAL_BUILD) && defined(NDEBUG))` but its own unittest
+  calls it unconditionally — an upstream CEF bug in official+release
+  builds, unrelated to any AgentMux patch or the SDK issue above. **Build
+  `libcef.dll` directly** (`ninja -C out/Release_GN_x64 libcef.dll`) rather
+  than the top-level `cef` target — `ninja -t query libcef.dll` confirms it
+  does not depend on the test binary.
+- **Verifying `BeginWindowDrag` landed:** do NOT `strings`/grep the built
+  DLL for the function name — struct/vtable function-pointer fields are not
+  named exports and never appear as a bare string in a release binary
+  (confirmed: even definitely-present sibling fields like
+  `SetDraggableRegions` return zero hits this way). Check the actual
+  generated wrapper source instead —
+  `cef/libcef_dll/cpptoc/views/window_cpptoc.cc` should have
+  `GetStruct()->begin_window_drag = window_begin_window_drag_<N>` where
+  `<N>` matches the current `/*--cef(added=N)--*/` annotation on
+  `CefWindow::BeginWindowDrag()` in `include/views/cef_window.h`.
+
 ---
 
 ## Prerequisites

--- a/docs/cef-build/build-patched-cef-windows.md
+++ b/docs/cef-build/build-patched-cef-windows.md
@@ -50,8 +50,27 @@ again on a future build:
   `modify` command, needed for `atldef.h`).
 
 **Update (2026-09-09), building CEF 152 (branch `7977`) from this same doc:**
-the steps above still work, but a **152-specific** blocker appeared that
-didn't exist at 148 — read this before starting a 152 build on any machine:
+the steps below now use `$CefBranch` (Codex review on PR #3130: an earlier
+revision left every numbered step hardcoded to `7778`, so following the doc
+for "152" silently built 148 instead). Set `$CefBranch = "7977"` in step 1.
+
+**Branch-topology gap this also caught and fixed:** unlike `7778` — where
+patches are merged directly into the milestone branch itself, so checking it
+out gets you everything — `7977` was, until this fix, still the bare
+upstream mirror. The 152 patch work existed only on two separate feature
+branches (`agentmux/7977-process-requirement`,
+`agentmux/7977-drag-rightclick-and-transparency`) that had never been merged
+together. Checking out bare `7977` per this doc's own "integration branch,
+never a feature branch" guidance would have built **zero patches** —
+silently, since none of them are load-bearing for compilation (they only
+change behavior, not build success). Fixed by merging both feature branches
+into `7977` directly (one `patch.cfg` conflict — both branches append at the
+same anchor; resolved by keeping both entries). `7977` is now a genuine
+integration branch, same model as `7778`. Verified via the API post-push:
+all three `patch.cfg`-registered patches present, `BeginWindowDrag` present.
+
+A **152-specific** build blocker also appeared that didn't exist at 148 —
+read this before starting a 152 build on any machine:
 
 - `ui/accessibility/platform/uia_client_info_source_win.cc` (new in Chromium
   152, unconditional in the Windows `BUILD.gn` — no flag skips it) needs
@@ -146,6 +165,14 @@ didn't exist at 148 — read this before starting a 152 build on any machine:
 $env:DEPOT_TOOLS_WIN_TOOLCHAIN = "0"
 $env:PATH = "C:\depot_tools;$env:PATH"
 
+# The ONE place the target CEF branch is set. 7778 = Chromium 148 (current
+# canonical). Set to 7977 for a Chromium 152 build (Codex review on PR #3130:
+# an earlier revision of this doc's 152 addendum left every step below
+# hardcoded to 7778, so following the doc literally still built 148). Every
+# subsequent step in this doc reads $CefBranch -- do not hardcode 7778/7977
+# again below this line.
+$CefBranch = "7778"
+
 New-Item -ItemType Directory -Force -Path "$HOME\cef-build" | Out-Null
 Set-Location "$HOME\cef-build"
 
@@ -156,7 +183,7 @@ Invoke-WebRequest -Uri "https://bitbucket.org/chromiumembedded/cef/raw/master/to
 # First sync (downloads chromium ~99 GB, takes hours)
 python3 automate-git.py `
   --download-dir="$(Get-Location)" `
-  --branch=7778 `
+  --branch=$CefBranch `
   --no-distrib `
   --no-build
 ```
@@ -177,7 +204,7 @@ Windows uses this branch despite not needing its patches.
 Set-Location "$HOME\cef-build\chromium_git\cef"
 git remote add agentmuxai https://github.com/agentmuxai/cef.git
 git fetch agentmuxai --prune
-git checkout agentmuxai/7778   # integration branch for the milestone
+git checkout agentmuxai/$CefBranch   # integration branch for the milestone
 
 # Mirror to the chromium-side cef checkout
 robocopy "$HOME\cef-build\chromium_git\cef" "$HOME\cef-build\chromium_git\chromium\src\cef" /MIR /XD .git
@@ -245,7 +272,21 @@ pressure on the first run:
 
 ```powershell
 Set-Location "$HOME\cef-build\chromium_git\chromium\src"
-ninja -j 20 -l 28 -C out\Release_GN_x64 cef
+# NOT the top-level "cef" target — that also builds cef_installer_unittests,
+# which fails to compile in this configuration (Codex review on PR #3130:
+# an earlier revision of this doc only mentioned the workaround in the intro
+# note above, while this actual step still said "cef" — so a reader would
+# still hit the failure after hours of compilation). SetInstallerE2EConfigForTesting
+# is declared under #if !(OFFICIAL_BUILD && NDEBUG) but its own unittest calls
+# it unconditionally -- an upstream CEF bug in official+release builds,
+# unrelated to any AgentMux patch. libcef.dll does not depend on that test
+# binary (confirmed: `ninja -t query libcef.dll` does not list it).
+ninja -j 20 -l 28 -C out\Release_GN_x64 libcef.dll
+
+# cefsimple is NOT pulled in by the libcef.dll target above (it depends on
+# the library, not the reverse -- Codex P2 on PR #3130). Build it separately
+# before step 6, or that verification step fails with "file not found":
+ninja -j 20 -l 28 -C out\Release_GN_x64 cefsimple
 ```
 
 Expect ~3-6 hours on first build with a cold build cache. If ninja OOMs
@@ -257,8 +298,8 @@ walking away entirely on an unverified job count.
 ### 6. Verify it boots
 
 ```powershell
-Set-Location "$HOME\cef-build\chromium_git\cef\tests"
-out\Release_GN_x64\cefsimple.exe --url=https://example.com
+Set-Location "$HOME\cef-build\chromium_git\chromium\src\out\Release_GN_x64"
+.\cefsimple.exe --url=https://example.com
 ```
 
 A window with example.com proves the libcef.dll is functional.
@@ -328,7 +369,7 @@ if (-not $CefForkSha) { throw "Refusing to publish without a recorded fork commi
 gh release create "cef-windows-x86_64-$CefVersion" --repo agentmuxai/cef `
   --target "$CefForkSha" `
   --title "Codec-enabled CEF -- Windows x86_64 CEF $CefVersion" `
-  --notes "proprietary_codecs + HEVC/AC3/EAC3/Dolby Vision. Built from agentmuxai/cef $($CefForkSha.Substring(0,12)) (branch 7778; patches inert on Windows -- built for codec flags only)." `
+  --notes "proprietary_codecs + HEVC/AC3/EAC3/Dolby Vision. Built from agentmuxai/cef $($CefForkSha.Substring(0,12)) (branch $CefBranch; patches inert on Windows -- built for codec flags only)." `
   "cef-windows-x86_64-$CefVersion.zip"
 ```
 

--- a/docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md
+++ b/docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md
@@ -26,7 +26,7 @@ one shipped-binary gap (§5).
 | Do the four carried patches still apply / are any now upstream? | Inventory was **wrong in two places** — see §2. `BeginWindowDrag` is still not upstream at 152. |
 | Does `cef-rs`/`cef-dll-sys` have a 152-compatible crate? | **Yes** — `cef 152.0.0+152.0.5`, published 2026-09-07. |
 | Is `begin_window_drag` in its generated bindings? | **No** — same as 148, so the binding fork is still required. |
-| Have the build toolchain requirements moved? | **Windows: no. Linux: no.** macOS: unconfirmed, see §4. |
+| Have the build toolchain requirements moved? | **Corrected 2026-09-09** — Windows: *pins* say no, but a real 152 build hit a hard blocker the pins don't show (§4). Linux: no (unverified by an actual build). macOS: unconfirmed. |
 | Go / no-go on targeting 152 directly? | **Go.** #1/#2/#3 verified vs real 152 source; #4's Chromium-side file verified and its CEF-side cascade ported (§5b). 16 of 18 CEF files byte-identical upstream; the 2 drifted merged cleanly. **Phase B 18/18 ported, nothing built.** macOS Xcode pin deferred to Phase D. |
 
 **A separate finding, not about 152:** patch #1 (the macOS -67030 renderer
@@ -196,6 +196,29 @@ So Windows and Linux need no toolchain change for this upgrade. **macOS is
 unverified**, not verified-as-fine — confirm it at Phase D build time on the
 actual machine rather than trusting this table for that row.
 
+> **Correction (2026-09-09, from an actual Windows 152 build on claudius).**
+> "Windows: unchanged" above is true about the *pins* and was **wrong about
+> buildability**. A real build failed at 22,219/59,112 targets:
+> `ui/accessibility/platform/uia_client_info_source_win.cc` (new in Chromium
+> 152, unconditional in the Windows `BUILD.gn`) needs
+> `IUIAutomationClientInfo{,Source}` interfaces **absent from Windows SDK
+> 10.0.26100.0** — the exact SDK `vs_toolchain.py`'s `TOOLCHAIN_HASH`/
+> `SDK_VERSION` checks above confirmed unchanged, and the only SDK VS Build
+> Tools 2022's installer catalog offers. Google's internal
+> `DEPOT_TOOLS_WIN_TOOLCHAIN=1` toolchain bundles a different snapshot of
+> "26100" than the public installer, so this only bites external builders.
+> **Fixed** by installing a newer public SDK (`10.0.28000.0`) and editing
+> `SDK_VERSION` in *both* `build/vs_toolchain.py` and
+> `build/toolchain/win/setup_toolchain.py` — the GN arg alone doesn't
+> propagate. Full detail: `docs/cef-build/build-patched-cef-windows.md`'s
+> 2026-09-09 update. **Lesson repeated a third time in this same recon
+> effort** (after the API-annotation bug and the invalid `strings`-based
+> symbol check): comparing version pins is not a substitute for actually
+> compiling. Treat every "unchanged" toolchain claim in this table as
+> "unchanged in the numbers checked," not "confirmed buildable," until an
+> actual build says otherwise — which is now true for Windows but still not
+> for Linux.
+
 ---
 
 ## 5. The shipped-binary gap — corrected
@@ -338,7 +361,9 @@ compile". Phase D is the first thing that will actually exercise it.
 recon makes 152 harder than assumed, and the patch work turned out cheaper:
 
 - the binding exists and is current;
-- Windows/Linux toolchains are unchanged;
+- Windows/Linux toolchain *pins* are unchanged, though Windows needed a newer
+  public SDK than those pins implied to actually build (§4 correction) —
+  resolved, not a blocker, but real;
 - the patch set did not grow.
 
 It did not get materially *cheaper* either — the hope in §2 that upstream might

--- a/docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md
+++ b/docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md
@@ -6,15 +6,19 @@
 source-side fix shipped (`agentmuxai/cef` PR #7, merged 2026-09-08), **Patches #1/#2/#3 are verified against real 152
 source** (§2.4/§2.5). **Patch #4's five-commit CEF-side cascade is now ported**
 (§5b) — its Chromium-side file applies cleanly and the cascade merged cleanly
-onto 7977, but **none of it is compile-verified**. Also deferred: the macOS
+onto 7977. **Windows is now compile-verified** (below); macOS/Linux are not.
+Also deferred: the macOS
 hermetic Xcode pin (§4), a Phase D build-time check. **Phase B's port is
-COMPLETE — 18 of 18 files** (§5b). Nothing is built. This is the Phase A output that
+COMPLETE — 18 of 18 files** (§5b), and **compiled successfully on Windows**
+(`libcef.dll` built and boot-verified 2026-09-09, see the toolchain correction
+below) — macOS and Linux remain unbuilt. This is the Phase A output that
 `docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md` §4 gates on.
 **Verdict:** **Go** on §3's "straight to 152" decision — the *milestone target*
 is sound: nothing found makes 152 harder, and 16 of the 18 fork-modified CEF
 files are byte-identical upstream. **This is not a statement that the port is
-compile-verified** — Phase B is 18/18 ported (§5b), but nothing has been built
-(§2.4, §5b). Also corrects two errors in the spec's patch inventory, and records
+compile-verified on all platforms** — Phase B is 18/18 ported (§5b) and
+**Windows has actually been built and boots** (2026-09-09); macOS and Linux
+have not (§2.4, §5b). Also corrects two errors in the spec's patch inventory, and records
 one shipped-binary gap (§5).
 
 ---
@@ -27,7 +31,7 @@ one shipped-binary gap (§5).
 | Does `cef-rs`/`cef-dll-sys` have a 152-compatible crate? | **Yes** — `cef 152.0.0+152.0.5`, published 2026-09-07. |
 | Is `begin_window_drag` in its generated bindings? | **No** — same as 148, so the binding fork is still required. |
 | Have the build toolchain requirements moved? | **Corrected 2026-09-09** — Windows: *pins* say no, but a real 152 build hit a hard blocker the pins don't show (§4). Linux: no (unverified by an actual build). macOS: unconfirmed. |
-| Go / no-go on targeting 152 directly? | **Go.** #1/#2/#3 verified vs real 152 source; #4's Chromium-side file verified and its CEF-side cascade ported (§5b). 16 of 18 CEF files byte-identical upstream; the 2 drifted merged cleanly. **Phase B 18/18 ported, nothing built.** macOS Xcode pin deferred to Phase D. |
+| Go / no-go on targeting 152 directly? | **Go.** #1/#2/#3 verified vs real 152 source; #4's Chromium-side file verified and its CEF-side cascade ported (§5b). 16 of 18 CEF files byte-identical upstream; the 2 drifted merged cleanly. **Phase B 18/18 ported. Windows built and boot-verified 2026-09-09; macOS/Linux not built.** macOS Xcode pin deferred to Phase D. |
 
 **A separate finding, not about 152:** patch #1 (the macOS -67030 renderer
 crash fix) was never registered in `patch/patch.cfg`, so no build on any
@@ -114,13 +118,17 @@ because it edits CEF's *own* sources rather than Chromium's.
 **Read this table narrowly.** It reports per-*file* apply results, not
 per-*patch* completeness. Patch #3 is fully covered by its one Chromium file.
 **Patch #4 is not** — it also carries a five-commit CEF-side transparency
-cascade that this table does **not** cover and that is **not** verified; see the
-caveat below and §5b. Patch #1 is in §2.5.
+cascade that this table does **not** cover. That cascade **has since compiled
+successfully** as part of the Windows build (2026-09-09, §5b) — but compiling
+is not the same claim as "the transparency effect works correctly at
+runtime," which was never tested (the boot check only confirmed a plain page
+navigates, not a transparent-window use case). See the caveat below and §5b.
+Patch #1 is in §2.5.
 
 | Patch | Target(s) | Method | Result |
 |---|---|---|---|
 | #3 `views_caption_rightclick_passthrough` | `ui/views/widget/desktop_aura/window_event_filter_linux.cc` | real `git apply -p0` vs Chromium 152 | **applies cleanly** |
-| #4 — ⚠️ `rwhv_background_opaque_check` **only** (this is *one part of* patch #4, **not** patch #4) | `content/browser/renderer_host/render_widget_host_view_base.cc` | real `git apply -p0` vs Chromium 152 | **that file applies cleanly** — patch #4 overall is **NOT verified** (§5b) |
+| #4 — ⚠️ `rwhv_background_opaque_check` **only** (this is *one part of* patch #4, **not** patch #4) | `content/browser/renderer_host/render_widget_host_view_base.cc` | real `git apply -p0` vs Chromium 152 | **that file applies cleanly.** The rest of patch #4 (CEF-side cascade) has since **compiled** on Windows (§5b) but its runtime behavior is untested — treat as "compiles," not "works." |
 | #2 `BeginWindowDrag` | `include/views/cef_window.h`, `libcef/browser/views/window_impl.{cc,h}` | `cmp` upstream 7778 vs 7977 | **all three byte-identical** → port is mechanical |
 
 Patch #2's result is the notable one: **upstream CEF did not touch any of its
@@ -134,9 +142,11 @@ contains no `BeginWindowDrag` reference on either side and is **not** part of it
 
 > **Caveat on patch #4 (Codex, PR #3095).** The row above covers only patch #4's
 > single *Chromium-side* file. Patch #4's transparency cascade is five coupled
-> **CEF-side** commits as well; those are part of the 18-file surface in §5b and
-> are ported (§5b) but **not compile-verified**. Treat #1/#2/#3 as
-> apply-verified and #4's cascade as ported-only.
+> **CEF-side** commits as well; those are part of the 18-file surface in §5b
+> and have since **compiled successfully on Windows** (§5b, 2026-09-09) — not
+> yet on macOS/Linux, and never functionally exercised at runtime on any
+> platform. Treat #1/#2/#3 as apply-verified, #4's cascade as
+> Windows-compile-verified but functionally untested.
 
 **Consequence: most of the patch surface costs little to move to 152** — 16 of
 18 fork-modified CEF files are byte-identical upstream, so they copy rather than
@@ -299,59 +309,79 @@ Recorded so the next person doesn't repeat it.
 
 ---
 
-## 5b. Phase B — patch port to 7977 (COMPLETE, 18/18 — not built)
+## 5b. Phase B — patch port to 7977 (COMPLETE, 18/18 — Windows built)
 
-> **Scope correction (2026-09-08, Codex review on PR #3095).** An earlier
-> revision said "all four patches are ported" and §2.4 said all four were
-> "verified." **Both over-claimed patch #4.** Patch #4 is not the single
-> `rwhv_background_opaque_check.patch` file I tested — per
-> `SPEC_CEF_148_LINUX_FORWARD_PORT_2026_06_04.md` §3 it is **five tightly
-> coupled CEF-side commits** (WebContents propagation, RWHView update, a
-> `WebContentsObserver` for renderer swaps, keeping it alive across process
-> swaps, deferred top-level transparent background) which that spec says
-> "should be ported as a unit."
->
-> Measured properly: **18 hand-written CEF source files** differ between
-> upstream 7778 and the fork's shipped source. **I ported 3.**
+> **History, in order, each correcting the last:** (1) 2026-09-08, claimed
+> "all four ported" after testing one file of patch #4 — wrong, Codex caught
+> it on PR #3095; corrected to 3/18 measured properly. (2) 2026-09-09,
+> completed the remaining 15 files via real per-file 3-way merges (18/18,
+> below). (3) 2026-09-09, built and boot-verified on Windows (§ below).
+> Kept all three states visible rather than collapsing straight to the
+> current one — this doc's own recurring failure mode has been updating a
+> conclusion and leaving the reasoning behind it stale.
 
-### Actual porting surface
+### Actual porting surface — 18/18 ported
 
 | | Count | Meaning |
 |---|---|---|
 | Fork-modified CEF source files | **18** | `libcef/**` + `include/{views,internal}/**`, excluding generated `capi`/`libcef_dll` |
 | Byte-identical upstream 7778 ↔ 7977 | **16** | mechanical copy — correct by construction |
-| **Drifted, need real forward-porting** | **2** | `include/internal/cef_types.h`, `libcef/renderer/render_manager.cc` |
-| Ported so far | **3** | `include/views/cef_window.h`, `libcef/browser/views/window_impl.{cc,h}` |
+| Drifted, forward-ported via real 3-way merge | **2** | `include/internal/cef_types.h`, `libcef/renderer/render_manager.cc` — merged cleanly, zero conflicts, because our changes and upstream's occupy different regions of each file |
+| **Ported, total** | **18/18** | |
 
-The *shape* of the earlier conclusion survives — most of the port is mechanical
-because upstream barely touched this surface in four milestones — but "done" was
-wrong, and the two drifted files need a checkout to merge and compile-check.
+Most of the port really was mechanical, because upstream barely touched this
+surface across four milestones — but note the two drifted files include
+`render_manager.cc`, which is patch #4's *renderer-side* transparency
+cascade half. Its earlier "not verified" status (§2.4) is now **compiled**,
+not just ported — see the Windows build below.
 
-### Branch layout (mirrors the 7778 lineage)
+### Branch layout — `7977` is now a real integration branch
 
 | Branch | Contents |
 |---|---|
-| `7977` | upstream mirror (CEF 152 / Chromium 152.0.7977.83) |
+| `7977` | **integration branch** (was the bare upstream mirror until 2026-09-09 — see the merge below) |
 | `agentmux/7977-process-requirement` | patch #1, registered in `patch.cfg` |
-| `agentmux/7977-drag-rightclick-and-transparency` | patch #2's three source files; patches #3 and #4 with both registered in `patch.cfg` |
+| `agentmux/7977-drag-rightclick-and-transparency` | patch #2's three source files; patches #3 and #4, both registered in `patch.cfg` |
 
-Note 152's `patch.cfg` tail differs from 148's (it ends with
-`chrome_browser_extensions_background`, not `chrome_browser_task_manager`), so
-insertion points are not copyable between milestones.
+**Gap found and fixed, 2026-09-09.** Unlike `7778` — where patches are merged
+directly into the milestone branch, so checking it out gets everything —
+`7977` was, until this fix, still the bare upstream mirror (`0` ahead/behind
+`chromiumembedded/cef`). The two feature branches above existed but had never
+been merged into it. Checking out bare `7977` per this repo's own "always
+build from the integration branch" convention would have silently built
+**zero of the four patches** — caught while fixing a Codex finding on
+PR #3130 about the build doc's 152 instructions. Fixed by merging both
+feature branches into `7977` directly (one conflict — both branches append to
+`patch.cfg`'s tail at the same anchor; resolved by keeping both entries).
+Verified post-push via the API: all three `patch.cfg` entries present,
+`BeginWindowDrag` present.
 
-**A registration gap was found and deliberately not carried forward.** Patch #4
-(`rwhv_background_opaque_check`) is registered on
+**A registration gap was also found and deliberately not carried forward.**
+Patch #4 (`rwhv_background_opaque_check`) is registered on
 `agentmux/7778-drag-rightclick-and-transparency` — the branch the shipped
-binaries were actually built from — but **not** on the `7778` integration
-branch. So a port done "from `7778`" would have silently dropped it. It is
-registered on the 152 branch. This is the same divergence noted in §5.1: the
-build branch and the integration branch are 4 ahead / 2 behind each other, and
-they do not contain the same patch set.
+148 binaries were actually built from — but **not** on the `7778` integration
+branch. A port done "from `7778`" would have silently dropped it; it's
+registered on the 152 branch instead. Same divergence as §5.1: the 148 build
+branch and its integration branch are 4 ahead / 2 behind each other and do
+not contain the same patch set.
 
-**Complete, but still unbuilt.** All 18 files are ported. Phase B is
-source-only; nothing is compiled or tested, and `agentmuxai/cef` has no CI —
-so "ported" here means "merges cleanly and is registered", **not** "known to
-compile". Phase D is the first thing that will actually exercise it.
+### Windows: built and boot-verified, 2026-09-09
+
+`libcef.dll` compiled from the completed `7977` integration branch —
+305,693,184 bytes, zero compile/link errors (after two build-environment
+fixes unrelated to the port itself: a Windows SDK version gap and an
+unrelated upstream CEF test-suite bug, both in §4/the build doc). Boot-tested
+via `cefsimple.exe`: real top-level window, `MainWindowTitle = "Example
+Domain"` after navigating — genuine render, not just process launch.
+
+**What this does and doesn't establish:** the port *compiles* on Windows,
+including patch #4's CEF-side cascade. It does **not** establish that the
+cascade's actual transparency behavior is correct at runtime — that was
+never exercised (the boot test loads an opaque page). It also says nothing
+about macOS or Linux, which remain unbuilt and may still hit compile issues
+this pass didn't surface — Windows never routes through patches #2/#3/#4
+functionally in the first place (§2.1-§2.3), so a clean Windows compile is
+weaker evidence for those platforms than it looks.
 
 ---
 

--- a/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
+++ b/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
@@ -11,14 +11,19 @@ genuinely drifted** (`include/internal/cef_types.h`,
 `libcef/renderer/render_manager.cc`). Open: the macOS hermetic Xcode pin
 (Phase D build-time check). **Patch #4's five coupled CEF-side commits are now
 ported** (Codex correctly flagged on #3095 that test-applying only its one
-Chromium-side file didn't verify it) — ported via clean 3-way merge, but **not
-compile-verified**. **Phase B's port is COMPLETE — all 18 of 18
-files**, done as real per-file 3-way merges (base=upstream 7778, ours=fork,
-theirs=upstream 7977); all merged clean, zero conflicts. Both files that had
-drifted merged cleanly because our changes and upstream's sit in different
-regions. Branches `7977`, `agentmux/7977-process-requirement`,
-`agentmux/7977-drag-rightclick-and-transparency`. **Phases C–G not started;
-nothing is built or tested — `agentmuxai/cef` has no CI.** The
+Chromium-side file didn't verify it) — ported via clean 3-way merge, and has
+since **compiled on Windows** (2026-09-09; macOS/Linux not built, and no
+platform has functionally exercised the transparency behavior). **Phase B's
+port is COMPLETE — all 18 of 18 files**, done as real per-file 3-way merges
+(base=upstream 7778, ours=fork, theirs=upstream 7977); all merged clean, zero
+conflicts. Both files that had drifted merged cleanly because our changes and
+upstream's sit in different regions. Branch `7977` is now a genuine
+integration branch (was the bare upstream mirror until 2026-09-09 — both
+feature branches, `agentmux/7977-process-requirement` and
+`agentmux/7977-drag-rightclick-and-transparency`, are merged into it).
+**Phases C/E/F/G not started; Windows built (`libcef.dll`, boot-verified);
+macOS/Linux not built — `agentmuxai/cef` has no CI, so this is the only
+compile signal that exists.** The
 recon **corrects two errors in §2's patch table** (marked inline below), makes
 §4's Phase E work different from what's written there (see the callout in that
 section — the un-pinned-CEF finding it describes was closed by #3086/#3085/#3089),
@@ -94,7 +99,8 @@ Plus **build flags, not patches** — version-controlled in *this* repo, not the
 > 7778 and 7977. **Patch #4's CEF-side cascade is now ported** (it was the
 > gap behind the earlier "partially verified" note): the five coupled commits
 > live across `libcef/`, including `render_manager.cc`'s renderer half, and all
-> merged cleanly onto 7977. Ported ≠ built: still unverified by compilation.
+> merged cleanly onto 7977, and has since compiled successfully on Windows
+> (2026-09-09) — not yet on macOS/Linux, and never functionally exercised.
 > See the report's §2.4/§2.5/§5b.
 
 ---
@@ -119,18 +125,19 @@ Output: `docs/reports/REPORT_CEF_UPGRADE_PHASE_A_RECON_2026_09_08.md`.
 **Verdict: go on the 152 target** — nothing found makes it harder, and 16 of the
 18 fork-modified CEF files are byte-identical upstream. **Not a readiness
 statement:** patches #1/#2/#3 are verified against real 152 source, **#4 only
-#4's Chromium-side file verified and its CEF-side cascade ported but not
-compile-verified. Phase B is **18/18 files ported**. The
+#4's Chromium-side file verified and its CEF-side cascade compiled on Windows
+(2026-09-09). Phase B is **18/18 files ported, Windows built**. The
 macOS hermetic Xcode pin also remains unconfirmed — a Phase D build-time check.
 See the report's §2.4/§2.5/§5b.
 Answers to the three tasks below:
 (1) patch inventory corrected — see §2's callout; `BeginWindowDrag` confirmed
 still not upstream at 152, so nothing was deleted. **Patches #1/#2/#3 are
 verified against real 152 source** (#1/#3 by real `git apply -p0`; #2's three
-target files `cmp`-identical between 7778 and 7977). **Patch #4 is only
-ported in full** — its Chromium-side file applies cleanly and its CEF-side
-cascade merged cleanly onto 7977, though the cascade is not compile-verified —
-report §2.4/§2.5/§5b. (2) **yes**,
+target files `cmp`-identical between 7778 and 7977). **Patch #4 is fully
+ported and Windows-compiled** — its Chromium-side file applies cleanly and its
+CEF-side cascade, merged cleanly onto 7977, has since compiled successfully as
+part of the 2026-09-09 Windows build (functional/runtime behavior untested on
+any platform) — report §2.4/§2.5/§5b. (2) **yes**,
 `cef 152.0.0+152.0.5` is published; `begin_window_drag` is **not** in it, so
 the binding fork is still needed. (3) Windows and Linux toolchain pins are
 **unchanged** between the two Chromium tags; macOS's Xcode pin is
@@ -144,9 +151,13 @@ byte-identical so they copied rather than ported. The **2 genuinely drifted
 files** (`include/internal/cef_types.h`, `libcef/renderer/render_manager.cc`)
 merged cleanly via 3-way merge — our changes and upstream's sit in different
 regions — and patch #4's five-commit CEF-side cascade is ported with them.
-**None of it is compile-verified.** A registration gap on `7778` (patch #4 registered only on
+**All of it has since compiled on Windows** (2026-09-09); macOS/Linux remain
+unbuilt. A registration gap on `7778` (patch #4 registered only on
 the build branch, not the integration branch) was found and not carried forward.
-**Nothing is built — Phase D is the gate, and Phase B must finish first.**
+`7977` itself had the same class of gap — it was still the bare upstream
+mirror, with both patch branches unmerged into it, until this same pass
+merged them (§5b of the report has the full account). **Windows is built;
+macOS/Linux are the remaining Phase D gate.**
 
 *(original task list, for reference)*
 1. Diff each of the four patches against upstream 7977; determine which are now upstream, which apply cleanly, which need real porting.


### PR DESCRIPTION
## Summary

Windows CEF 152 build on claudius (tracked on #3108) surfaced a real blocker
and, with it, a wrong claim in the Phase A recon report.

## The claim, and why it was wrong

The report said "Windows toolchain: unchanged between 148 and 152," based on
comparing `TOOLCHAIN_HASH`, `MSVS_VERSIONS`, and `SDK_VERSION` — all
identical across the two Chromium tags. **True about the pins, wrong about
buildability.**

A real build failed at 22,219/59,112 targets:
`ui/accessibility/platform/uia_client_info_source_win.cc` (new in Chromium
152, unconditional in the Windows `BUILD.gn`) needs
`IUIAutomationClientInfo{,Source}` interfaces **absent from Windows SDK
10.0.26100.0** — the exact SDK version the pins say is unchanged, and the
only one VS Build Tools 2022's installer catalog offers.

Root cause: Google's internal `DEPOT_TOOLS_WIN_TOOLCHAIN=1` packaged
toolchain bundles a different snapshot of "26100" than the public SDK
installer. External builders get the public one and hit this; Google's own
CI doesn't, so the pin never had to move.

## The fix

Install a newer public Windows SDK
(`10.0.28000.0` confirmed to contain the missing interfaces), then edit
**two** files — `SDK_VERSION` is hardcoded separately in
`build/vs_toolchain.py` and `build/toolchain/win/setup_toolchain.py`, and
the former's own comment says they must match. The GN arg
`windows_sdk_version` alone does **not** propagate — confirmed by checking
`toolchain.ninja` before and after.

## Also recorded

- An unrelated upstream CEF bug: `cef_installer_unittests` fails to compile
  in official+release builds (`SetInstallerE2EConfigForTesting` guarded by
  `#if !(OFFICIAL_BUILD && NDEBUG)` but called unconditionally by its own
  test). Workaround: build the `libcef.dll` ninja target directly — its
  dependency graph doesn't include the test binary.
- The correct way to verify `BeginWindowDrag` landed: **not** `strings` on
  the binary (struct/vtable function-pointer fields aren't named exports and
  never appear as bare strings — confirmed against a known-present sibling
  field, which also returned zero hits). Check the generated wrapper source
  instead.

## The pattern, named explicitly

This is the **third** time in this recon effort that comparing version pins
passed where actually compiling failed — after the API-annotation bug (fixed
in a prior commit) and the invalid `strings`-based symbol check just now.
Recorded in the report as a correction with the original claim quoted, not
silently edited, same as the two prior corrections on this effort.

## Verification

- Doc-status and spec-citation gates pass locally.
- The SDK fix itself is verified by an actual successful build:
  `libcef.dll` compiled clean (305,693,184 bytes) and boot-tested via
  `cefsimple.exe` (`MainWindowTitle = "Example Domain"` after navigating,
  confirming real render, not just process launch).

<!-- agentmux:agent_id=agent5 -->