### PR TITLE
docs(armory): naming consolidation spec + consolidated memory status

### DIFF
--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -363,6 +363,7 @@ partial list.
 | [`SPEC_AGENT_ZOOM_PERSISTENCE_2026_06_22`](SPEC_AGENT_ZOOM_PERSISTENCE_2026_06_22.md) | Per-agent zoom persistence |
 | [`SPEC_ARMORY_DROP_HOST_CLI_CONFIG_BLOCK_2026_09_01`](SPEC_ARMORY_DROP_HOST_CLI_CONFIG_BLOCK_2026_09_01.md) | Spec: Drop the "Claude Code — host CLI config" block from Armory Global Memory |
 | [`SPEC_ARMORY_MEMORY_TAB_MERGE_2026_08_30`](SPEC_ARMORY_MEMORY_TAB_MERGE_2026_08_30.md) | Spec: Armory rail — merge "Global Memory" + "Personal Memory" into one "Memory" tab |
+| [`SPEC_ARMORY_NAMING_CONSOLIDATION_2026_09_09`](SPEC_ARMORY_NAMING_CONSOLIDATION_2026_09_09.md) | Spec: Armory Naming Consolidation — Bundle vs Memory |
 | [`SPEC_ARMORY_PERSONAL_MEMORY_AGENT_BLOCKS_2026_09_01`](SPEC_ARMORY_PERSONAL_MEMORY_AGENT_BLOCKS_2026_09_01.md) | Spec: Armory → Memory → Personal — browse by agent block, not a dropdown |
 | [`SPEC_ARMORY_PERSONAL_MEMORY_FILE_TILES_2026_09_04`](SPEC_ARMORY_PERSONAL_MEMORY_FILE_TILES_2026_09_04.md) | Spec: Armory → Memory → Personal — file tiles, not a dropdown |
 | [`SPEC_ARMORY_PERSONAL_MEMORY_FILTER_AND_SORT_2026_09_02`](SPEC_ARMORY_PERSONAL_MEMORY_FILTER_AND_SORT_2026_09_02.md) | Spec: find/filter and sort for Armory → Memory → Personal |

--- a/docs/specs/SPEC_ARMORY_NAMING_CONSOLIDATION_2026_09_09.md
+++ b/docs/specs/SPEC_ARMORY_NAMING_CONSOLIDATION_2026_09_09.md
@@ -12,8 +12,12 @@
 
 Two architectural questions are currently open and blocked on vocabulary:
 
-- ABF cannot round-trip memory (export never emits `components.memory`).
-- Curated memory is structurally empty for every agent and nothing surfaces it.
+- The agent-less `bundle.export` omits `components.memory` while the agent-scoped
+  `bundle.export_for_agent` includes it — whether that asymmetry is the intended
+  design or a gap is unclear from the code alone.
+- Curated memory is structurally empty for every agent, and while the Armory UI
+  shows the empty state, nothing at launch tells the operator the agent received
+  no `# Memory` section.
 
 Neither can be discussed precisely while one word denotes six different things.
 This spec fixes the vocabulary so those two can be reasoned about; it deliberately
@@ -146,8 +150,15 @@ Zero contract risk. Nothing user-visible, nothing persisted.
 
 **Mandatory file splits** — these hold both concepts and must be split, not renamed:
 - `backend/rpc_types/memory.rs` → `rpc_types/bundle.rs` + `rpc_types/native_memory.rs`
-- `server/agent_handlers/memory.rs` → `agent_handlers/bundle.rs` + `agent_handlers/native_memory.rs`
+  (19 `NativeMemory*` types live alongside the bundle types — verified)
 - `frontend/app/store/rpc-api/memory.ts` → `rpc-api/bundle.ts` (merging into the existing one) + `rpc-api/native-memory.ts`
+
+**Plain rename, NOT a split:**
+- `server/agent_handlers/memory.rs` → `agent_handlers/bundle.rs`. This file
+  registers only the bundle CRUD/system commands (plus the Claude config reader)
+  — zero native-memory references. Native-memory RPCs already live in
+  `server/native_memory_handlers.rs`, which stays untouched. Splitting this file
+  would create an empty or duplicate owner. (Codex P2 on #3131.)
 
 **Frontend** (names only, labels deferred to Phase 4):
 - `MemoryViewModel` → `BundleViewModel`; `MemoryManager` → `BundleManager`; `MemoryDraft`/`draftFromMemory`/`draftToWire` → `Bundle*`
@@ -230,8 +241,13 @@ Resolve §2.5: one table, one tab.
 
 ### Deferred — DB column renames (explicitly out of scope)
 
-`db_agent_definitions.memory_id`, `db_agents.default_memory_id`,
-`db_agent_instances.memory_id` all hold bundle ids (349 `memory_id` tokens).
+At schema v32, `db_agent_definitions` and `db_agent_instances` no longer exist —
+they were folded into `db_agents` (`migrations.rs:550`). The live columns holding
+bundle ids are **`db_agents.memory_id`** (`:578`) and **`db_agents.default_memory_id`**
+(`:639`) — 349 `memory_id` tokens across the crate. The `ALTER TABLE
+db_agent_definitions ADD COLUMN memory_id` at `:999` is a legacy adoption entry
+for the retired table, not a live schema. (An earlier draft named the retired
+tables; corrected per Codex P2 on #3131.)
 
 Deferred deliberately: `migrations.rs` has **no `RENAME COLUMN` precedent** —
 column changes are done by `ADD COLUMN` + backfill (`:991-1057`). Renaming would
@@ -295,10 +311,17 @@ The following are real requirements, agreed 2026-09-09, and deliberately kept
 out of this spec so that naming lands first. They belong together in one
 follow-on spec ("instruction and memory portability"):
 
-- **Export includes Memory.** A bundle export must carry the agent's native
-  memory. `components.memory` already exists as an ABF key and
-  `bundle.import_for_agent` already honours it — only the exporter never emits
-  it. Closes the round-trip gap.
+- **Export includes Memory — already implemented for the agent-scoped path.**
+  `bundle.export_for_agent` reads the agent's native-memory files and splices
+  `components.memory` plus the referenced files into the manifest
+  (`splice_memory_component`, `app_api/bundle.rs:439-468`; tested at `:2761`),
+  and `bundle.import_for_agent` consumes it. Only the agent-less `bundle.export`
+  omits memory, which is correct by design — a bundle detached from any agent has
+  no memory to carry. An earlier draft of this spec claimed export never emits
+  memory; that was wrong (Codex P2 on #3131). The remaining question for the
+  follow-on spec is narrower: whether the agent-less path should *warn* that
+  memory was not included, mirroring the import side's existing
+  `MEMORY_COMPONENT_IGNORED_WARNING`.
 - **Track Project Instructions.** Read, snapshot, version, and export the repo's
   own `CLAUDE.md`/`AGENTS.md`/etc. Read-only — never overwrite (§3).
 - **Memory location invariant.** Native memory must be written to one

--- a/docs/specs/SPEC_ARMORY_NAMING_CONSOLIDATION_2026_09_09.md
+++ b/docs/specs/SPEC_ARMORY_NAMING_CONSOLIDATION_2026_09_09.md
@@ -1,0 +1,335 @@
+# Spec: Armory Naming Consolidation — Bundle vs Memory
+
+**Status:** proposed — needs the §9 decisions before Phase 1 starts
+**Date:** 2026-09-09
+**Verified against:** `b65df28c2` (code, not spec prose)
+**Supersedes the naming proposal in:** `docs/status/STATUS_ARMORY_MEMORY_CONSOLIDATION_2026_09_09.md` §4, which was wrong — see §2.4
+**Related:** #2024 (tracking), `ARCHITECTURE_ARMORY_FOUNDATION_CONSOLIDATION_2026_08_19.md` §3.1/§3.4
+
+---
+
+## 1. Why this comes first
+
+Two architectural questions are currently open and blocked on vocabulary:
+
+- ABF cannot round-trip memory (export never emits `components.memory`).
+- Curated memory is structurally empty for every agent and nothing surfaces it.
+
+Neither can be discussed precisely while one word denotes six different things.
+This spec fixes the vocabulary so those two can be reasoned about; it deliberately
+does **not** attempt to solve either.
+
+## 2. The problem, stated precisely
+
+### 2.1 Six live terms for overlapping concepts
+
+`Memory` · `Bundle` · `ABF` · `Brain` · `Preset` · `Global Memory`
+
+### 2.2 The exhibit
+
+`agentmux-srv/src/server/app_api/mod.rs:757` — four vocabularies in eight lines:
+
+```rust
+pub(crate) async fn bundle_list_impl(state: &AppState) -> Result<Value, String> {
+    let memories = state.id_store.bundle_memory_list()...;   // storage: bundle_memory_*
+    let bundles: Vec<_> = memories.iter().map(...).collect(); // memories -> bundles
+    Ok(json!({ "bundles": bundles, "presets": bundles }))     // emitted under both keys
+}
+```
+
+A `bundle_*` function calls `bundle_memory_*` storage, binds it to `memories`,
+maps it to `bundles`, and serialises it as both `bundles` and `presets`.
+
+### 2.3 What each term actually refers to today
+
+| Term | Real referent | Verdict |
+|---|---|---|
+| Rust `struct Memory` (`memory_bundles.rs:25`) | a `db_bundles` row — a **Bundle** | misnamed |
+| "Global Memory" (UI) | `db_bundles` rows with `is_global=1` — **Bundles with a scope flag** | misnamed |
+| "Personal Memory" (UI) | `db_agent_native_memory` | **correct** |
+| `listmemories`/`getmemory`/`upsertmemory`/`deletememory`/… | operate on **Bundles** | misnamed |
+| "Brain" (`format_global_brain_block`, `reorderglobalbrain`, `global-brain-*`) | global **Bundles** | misnamed |
+| "Brain" (MCP schema gloss, `tool_schemas.rs:606/618/640`) | **native memory** | same word, opposite referent |
+| "Preset" (`presets` JSON key, `PresetList`/`PresetGet` MCP tools, `/api/v1/agent/preset/list`) | **Bundles** | retired in name only; still on the wire |
+| `memory_id` columns (349 tokens) | hold a **bundle id** | misnamed |
+
+### 2.4 Correction to the earlier proposal
+
+The status doc proposed "Global Memory → **Instructions**". That is wrong: a
+`db_bundles` row carries `instructions`, `instructions_by_provider`,
+`context_files`, `mcp_servers`, `skills`, `provider`, `model` — naming the
+container after one of seven payload fields would be a new inaccuracy. Global
+bundles are **Bundles with a scope flag**, not a distinct kind of thing.
+
+### 2.5 The same table is surfaced under two tabs
+
+Armory's rail is `Accounts | Memory | Skills | MCP Servers | ABF`
+(`armory-model.ts:36-42`). `db_bundles` appears in **two** of them:
+
+- **ABF** tab → `MemoryManager` (`view/memory/memory-manager.tsx`)
+- **Memory → Global** → `GlobalBrainManager` (`view/brain/global-brain-manager.tsx`)
+
+Both read `db_bundles` through the same `listmemories`/`upsertmemory` RPCs and
+both subscribe to `memories:changed`. Same table, two tabs, three component
+names, zero shared vocabulary.
+
+### 2.6 Two duplicate RPC surfaces over one storage layer
+
+`bundle.list/get/upsert/delete` and `listmemories/getmemory/upsertmemory/deletememory`
+both terminate in `Store::bundle_memory_*`. This is therefore a **consolidation**,
+not merely a rename — and the target names are already occupied by the surface we
+want to keep.
+
+## 3. Target vocabulary
+
+Exactly two nouns for these concepts, plus one for the format:
+
+- **Bundle** — a `db_bundles` row: the agent's instructions + context files + MCP
+  refs + skill refs + provider/model. Scope is expressed by **flags**, not by a
+  different noun: a bundle is *global* (applies to every agent), *system*
+  (AgentMux-owned, highest priority, implies global), or *agent-scoped*.
+- **Memory** — `db_agent_native_memory`: what an agent autonomously writes about
+  itself via `MemoryWrite`. Only this is memory.
+- **ABF (Armory Bundle Format)** — the portable *serialisation* of a Bundle. A
+  format, not a UI surface and not a synonym for Bundle.
+
+A third category the agent consumes, which AgentMux must be able to **read** but
+does not own:
+
+- **Project Instructions** — a project's own git-tracked instruction files that
+  the CLI reads natively: the root `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, etc.
+  These live in the repo, are versioned in git, and are hand-edited by humans.
+  AgentMux **tracks** them (read, snapshot, version, include in export) and never
+  writes them. `SPEC_CLAUDE_MD_OWNERSHIP_PROTECTION_2026_08_22.md` already
+  established the "never overwrite" half; the "track" half is new scope,
+  deferred to the follow-on spec in §8.
+
+This category is why `db_bundles` is empty in practice: the operator's real
+instructions live here, the CLI reads them directly, and the bundle system is
+bypassed. It is not a bug in bundles — it is a second source that was never
+brought under control.
+
+Retired entirely: **Brain**, **Preset**, **Global Memory** (as a noun for bundles).
+
+The distinction is worth preserving because it is behavioural, not cosmetic:
+**bundles are composed into the agent's startup file at spawn and are frozen for
+that session; memory is read live by the CLI.** A single collapsed name would
+hide that.
+
+## 4. What we are NOT renaming, and why
+
+This section is normative. Each of these is already correct under §3.
+
+| Surface | Why it stays |
+|---|---|
+| MCP tools `MemoryList/Read/Write/History/Diff/Revert` (`agentmux-mcp/src/tool_schemas.rs:596-664`) | native-memory-only; verified none touch `db_bundles`. Agent-facing — renaming breaks running agents for zero gain. |
+| WS RPC `agent:memory:*` (`commands.rs:561-568`), App API `memory.list/read/write` (`:430-432`) | native memory. Correct. |
+| Tables `db_agent_native_memory`, `db_agent_native_memory_versions` | correct. |
+| Rust `NativeMemory*` types, `native_memory_handlers.rs`, `agent_native_memory*.rs` | correct. |
+| Frontend `NativeMemoryManager`, `view/native-memory/*`, `AgentNativeMemoryModal`, `native-memory-history-model.ts` | correct. **Note:** an earlier draft wrongly flagged `NativeMemoryManager` as misnamed. It is not. |
+| `db_bundles` table name | already correct (renamed in Phase 4a). |
+| **ABF `components.*` keys** | `components.memory` is *correct* under §3 — it carries native memory. No key changes are needed, which is fortunate: §7.3 shows key renames would be silently lossy. |
+
+## 5. Phases
+
+Ordered by blast radius, cheapest and safest first. Each phase is independently
+shippable and independently revertible.
+
+### Phase 1 — internal names only (no wire, no schema, no UI text)
+
+Zero contract risk. Nothing user-visible, nothing persisted.
+
+**Rust** (`agentmux-srv`):
+- `backend/storage/memory_bundles.rs` → `bundles.rs`; module `memory_bundles` → `bundles` (24 path references across 10 files)
+- `struct Memory` → `struct Bundle` (159 bare-token occurrences across 31 files); both re-export paths (`storage/mod.rs:48`, `storage/store.rs:752`)
+- the 9 `Store::bundle_memory_*` methods → `Store::bundle_*` (148 occurrences across 13 files)
+
+**Mandatory file splits** — these hold both concepts and must be split, not renamed:
+- `backend/rpc_types/memory.rs` → `rpc_types/bundle.rs` + `rpc_types/native_memory.rs`
+- `server/agent_handlers/memory.rs` → `agent_handlers/bundle.rs` + `agent_handlers/native_memory.rs`
+- `frontend/app/store/rpc-api/memory.ts` → `rpc-api/bundle.ts` (merging into the existing one) + `rpc-api/native-memory.ts`
+
+**Frontend** (names only, labels deferred to Phase 4):
+- `MemoryViewModel` → `BundleViewModel`; `MemoryManager` → `BundleManager`; `MemoryDraft`/`draftFromMemory`/`draftToWire` → `Bundle*`
+- `AgentNewMemoryModalPanel` → `AgentNewBundleModalPanel` (its stylesheet is *already* `AgentNewBundleModal.scss` — a half-finished rename)
+- `gotypes.d.ts:481` `type Memory` → `type Bundle`
+
+**Generated bindings caveat:** renaming `CommandDeleteMemoryData`/`DeleteMemoryResult` regenerates `frontend/types/rpc/*.ts`. The old files must be `git rm`'d — `scripts/check-rpc-bindings.sh` uses `git status --porcelain -uall` and will not flag a stale leftover.
+
+### Phase 2 — retire "brain"
+
+238 occurrences across 27 files, but only **two live Rust callers** of
+`format_global_brain_block` (`app_api/agent_open.rs:778`, `editor_handlers.rs:85`),
+so the backend is cheap; the bulk (~185) is the frontend `view/brain/` directory.
+
+- `format_global_brain_block` → `format_global_bundle_block`
+- `view/brain/global-brain-model.ts` → folded into the bundle model (see Phase 4)
+- `global-brain.scss` (47 class names) → renamed with the component
+
+Once bundles stop using "brain", the MCP schema gloss ("your own native memory
+(brain) files") becomes unambiguous on its own and needs no change. Retiring the
+term on the bundle side is what resolves the collision.
+
+`reorderglobalbrain` is a wire name and belongs to Phase 3, not here.
+
+### Phase 3 — RPC consolidation (wire-breaking)
+
+Implements `ARCHITECTURE_ARMORY_FOUNDATION_CONSOLIDATION_2026_08_19.md` §3.4.
+
+Retire all seven bundle-operating `*memory` commands in favour of the existing
+`bundle.*` surface:
+
+| Retire | Replacement |
+|---|---|
+| `listmemories` | `bundle.list` |
+| `getmemory` | `bundle.get` |
+| `upsertmemory` | `bundle.upsert` |
+| `deletememory` | `bundle.delete` |
+| `reorderglobalbrain` | `bundle.reorder` *(new)* |
+| `upsertsystemmemory` | `bundle.upsert_system` *(new)* |
+| `deletesystemmemory` | `bundle.delete_system` *(new)* |
+
+Also: event `memories:changed` → `bundles:changed` (22 occurrences), and the
+`presets` alias key in `bundle_list_impl` — but **only after** the REST route
+`/api/v1/agent/preset/list` and the `PresetList`/`PresetGet` MCP tools are dealt
+with, since those are agent-facing and read `presets` (see §7.2).
+
+Only 2 of the 7 are currently `register_typed`/CI-gated; the other 5 are
+hand-maintained in `gotypes.d.ts`. Migrating them to `register_typed` requires
+`Bundle` to derive `ts_rs::TS` — which is the actual reason they were skipped
+(`agent_handlers/memory.rs:453-454`). **Recommendation:** derive `TS` on `Bundle`
+as part of this phase so all seven land typed and gated rather than perpetuating
+the split.
+
+`test/contract/rpc-contract.test.ts` currently baselines only `bundle.*` and
+`memory.*` — the seven retiring commands are absent from it, so it will not catch
+their removal. Add them to the baseline *before* removing them.
+
+### Phase 4 — UI consolidation (user-visible)
+
+Resolve §2.5: one table, one tab.
+
+- Fold **Memory → Global** into the **Bundles** tab as a scope filter
+  (`all | global | system | agent-scoped`), replacing `GlobalBrainManager`.
+- Rail becomes `Accounts | Bundles | Memory | Skills | MCP Servers`, where
+  **Memory** is now native memory only (today's "Personal") and **Bundles**
+  replaces today's "ABF" label.
+- ABF remains the name of the import/export format, surfaced on the Bundles tab's
+  import/export affordances — not as a tab name.
+- `MemorySubsection = "global" | "personal"` is persisted as block meta
+  (`armory-model.ts:50`, `:94`). Migrate it the same way `LegacyArmorySection`
+  already handles the retired `"native_memory"` value (`armory-model.ts:29`) —
+  precedent exists in the same file.
+- `MemoryViewModel.viewType = "memory"` is also a persisted key; CLAUDE.md
+  documents it as deliberately frozen. Either keep the wire value `"memory"` with
+  a renamed type, or migrate with the same legacy-value pattern. **Decision
+  needed (§9.3).**
+- `armory-view.test.tsx:116-130` asserts the exact rail labels, including negative
+  assertions that "Global Memory"/"Personal Memory" are absent. Update with the
+  labels.
+
+### Deferred — DB column renames (explicitly out of scope)
+
+`db_agent_definitions.memory_id`, `db_agents.default_memory_id`,
+`db_agent_instances.memory_id` all hold bundle ids (349 `memory_id` tokens).
+
+Deferred deliberately: `migrations.rs` has **no `RENAME COLUMN` precedent** —
+column changes are done by `ADD COLUMN` + backfill (`:991-1057`). Renaming would
+require add-column + backfill + read-both-for-a-release, or a table rebuild. The
+names are invisible to users and the payoff is small relative to the risk. Revisit
+only if a table rebuild is happening for another reason.
+
+## 6. Migration mechanics
+
+No table rename is required (`db_bundles` is already correct). For reference, the
+established mechanism — should a future phase need it — is
+`migrations.rs:365-380`:
+
+```rust
+const LEGACY_TABLE_RENAMES: &[(&str, &str)] = &[
+    ("db_memories", "db_memory_bundles"),   // :371
+    ("db_memory_bundles", "db_bundles"),    // :379  <- Phase 4a precedent
+];
+```
+
+Three properties of that precedent matter and must be preserved by anything that
+follows it:
+
+1. **Ordering is load-bearing.** Entries chain within one pass, so an ancient DB
+   migrates `db_memories → db_memory_bundles → db_bundles` in a single run.
+2. **Indexes must be dropped separately** (`LEGACY_INDEX_DROPS`, `:386-398`) —
+   `ALTER TABLE … RENAME` keeps index names, which then collide with the flat
+   `CREATE INDEX` DDL. Both the plain and shared-store (`idx_ss_*`) variants must
+   be listed.
+3. **Forward-only.** Old names remain as adoption entries permanently; there is
+   no down-migration.
+
+## 7. Risks
+
+### 7.1 Churn volume
+~150 `bundle_memory_*` + ~159 `Memory` + ~238 brain + ~184 frontend `Memory`
+tokens. Mostly mechanical, but large enough that Phase 1 should be one
+reviewable PR per language side rather than a single sweep.
+
+### 7.2 Agent-facing `preset` surface
+`PresetList`/`PresetGet` MCP tools and `/api/v1/agent/preset/list` still speak
+"preset" and read the `presets` key that `bundle_list_impl` emits for exactly
+that reason (`mod.rs:757` comment says so). Dropping the alias without retiring
+those first breaks running agents. Phase 3 must sequence this explicitly.
+
+### 7.3 ABF keys are silently lossy
+Import performs **no unknown-key warning and no version negotiation** —
+`$schema` is never parsed for dispatch, and `version` is only checked against
+`0.1.x`. Shape detection is structural. Renaming any `components.*` key would
+silently drop data from existing exported bundles. §4 keeps all keys unchanged,
+which sidesteps this entirely — but it constrains any future format work.
+
+### 7.4 Pre-existing exporter/importer version inconsistency
+The exporter emits `$schema: …/v0.2/…` while hardcoding `version: "0.1.0"`, and
+the importer warns on anything not `0.1.x`. Not caused by this spec, but any
+future version bump will trip it. Noted for whoever does ABF v0.3.
+
+## 8. Non-goals — deferred to a follow-on portability spec
+
+The following are real requirements, agreed 2026-09-09, and deliberately kept
+out of this spec so that naming lands first. They belong together in one
+follow-on spec ("instruction and memory portability"):
+
+- **Export includes Memory.** A bundle export must carry the agent's native
+  memory. `components.memory` already exists as an ABF key and
+  `bundle.import_for_agent` already honours it — only the exporter never emits
+  it. Closes the round-trip gap.
+- **Track Project Instructions.** Read, snapshot, version, and export the repo's
+  own `CLAUDE.md`/`AGENTS.md`/etc. Read-only — never overwrite (§3).
+- **Memory location invariant.** Native memory must be written to one
+  AgentMux-controlled location per agent. Extends the durability +
+  location-consistency invariant from `SPEC_NATIVE_MEMORY_DURABLE_SYNC_2026_08_07.md`.
+
+The unifying goal: tight control over everything an agent consumes as
+instructions or memory, including portability.
+
+Also out of scope here:
+
+- Fixing empty curated memory / adding a scaffold or emptiness indicator
+  (though §3's Project Instructions finding reframes what "empty" means).
+- Mid-session propagation of bundle edits to running agents.
+- The post-compaction digest decision.
+- Any change to what is *composed* into the startup file, or in what order.
+
+This spec changes names and surfaces only. Behaviour is intended to be
+bit-identical, and Phase 1–3 should produce no diff in `AGENTMUX_MEMORY.md` output
+for any existing agent.
+
+## 9. Decisions needed before Phase 1
+
+1. **Tab label** — is the Bundles tab called **"Bundles"** (honest, matches the
+   noun) or does it keep **"ABF"** (format-as-brand)? §5 assumes "Bundles" with
+   ABF reserved for import/export.
+2. **Phase 3 scope** — retire the `*memory` commands outright, or keep them as
+   deprecated aliases for one release? Outright is cleaner; aliases are safer if
+   anything outside this repo speaks that surface.
+3. **`viewType = "memory"`** — migrate the persisted value, or freeze the wire
+   value and rename only the type?
+4. **Sequencing** — Phases 1+2 are safe and could land immediately. Phase 3 (wire)
+   and Phase 4 (UI) are larger. Land 1+2 first and re-evaluate, or commit to all
+   four up front?

--- a/docs/status/STATUS_ARMORY_MEMORY_CONSOLIDATION_2026_09_09.md
+++ b/docs/status/STATUS_ARMORY_MEMORY_CONSOLIDATION_2026_09_09.md
@@ -1,0 +1,160 @@
+# Status: Armory Memory — Consolidated State and Naming Problem
+
+**Status:** open — four unresolved items (§4–§7), three of which need a product decision before more code lands
+**Date:** 2026-09-09
+**Verified against:** `b65df28c2` (code, not spec prose)
+**Tracking issue:** #2024 (consolidated there 2026-09-09)
+
+---
+
+## 1. Why this document exists
+
+Issue #2024 was last updated 2026-07-14 and predates roughly six weeks of shipped
+work. In that window the area has had commits landing almost daily, and the
+terminology used to describe it has drifted far enough from the code that
+discussing it accurately had become difficult.
+
+Two corrections to how this system was being described, both established by
+reading the code rather than the specs:
+
+1. It is **not** "two separate systems." Curated content and agent-written memory
+   are both **components of ABF** — `components.instructions` and
+   `components.memory` respectively (ABF v0.2 §2.3).
+2. Spec `Status:` fields in this area are **not trustworthy**. Nearly every
+   Armory/memory spec merged since 2026-08-30 still reads `Status: Proposed`
+   despite its PR having merged days later. Check `git log -- <spec>` instead.
+
+## 2. What exists today
+
+Three tiers, all surfaced under Armory → **Memory** (single tab with sub-nav
+since #2844, after having been split into two tabs in #2734):
+
+| Tier | Backing store | Author | Scope | How it reaches the model |
+|---|---|---|---|---|
+| System | `db_bundles` (system rows) | AgentMux itself | all agents | composed at spawn |
+| "Global Memory" | `db_bundles` (`is_global=1`) | the operator | all agents | AgentMux composes into `.claude/AGENTMUX_MEMORY.md` **at spawn only** |
+| "Personal Memory" | `db_agent_native_memory` + CLI memory dir | the agent, via `MemoryWrite` | one agent | the CLI reads it **natively and live**; AgentMux never injects it |
+
+The two operator-facing tiers differ in a way that is easy to miss and that users
+will feel: **operator content is frozen at spawn; agent memory is live.**
+
+### Shipped since #2024 was last updated
+
+Mandatory ABF (#2587), native-memory durable sync (#2459), version-controlled
+native memory (#2674) + retention/GC (#2728), Global Memory system tier (#2782),
+Global/Personal rename (#2734) then re-merge (#2844), blank-workdir fixes
+(#2901, #2926), per-agent-block browsing (#2917), filter/sort (#2929), reactive
+updates (#2932), tile-grid file picker (#3000), ABF v0.2 provider-override
+authoring UI (#3063).
+
+## 3. Items 2 and 3 of #2024 are resolved
+
+- **Item 3 (Bundle-as-container)** — shipped via
+  `SPEC_BUNDLE_AS_CONTAINER_V2_2026_08_17.md` / #2639, which added bundle-level
+  MCP + Skill references. Bundles are no longer "just instructions + context
+  files."
+- **Item 2 (Brain/Bundle tab decision)** — overtaken by events. The tabs were
+  split (#2734) and then re-merged into one Memory tab (#2844). The product call
+  happened implicitly; the item's "Brain tab" framing no longer matches the UI.
+
+## 4. Open item A — `memory` is overloaded four ways
+
+The word currently denotes all of:
+
+1. the Rust `Memory` struct — which is actually a **Bundle**
+   (`bundle_export.rs:7`: *"table/UI say 'Bundles', the type name predates the
+   rename"*);
+2. `db_bundles` rows, shown in the UI as **"Global Memory"**;
+3. `db_agent_native_memory`, shown in the UI as **"Personal Memory"**;
+4. the `bundle_memory_*` / `deletememory` RPC surface, which operates on
+   **bundles**, not memory.
+
+**ABF's own component names already draw the correct line** —
+`components.instructions` vs `components.memory`. The UI drifted from the format,
+not the other way round.
+
+### Proposed resolution (needs a decision, not yet actioned)
+
+Align the UI to ABF rather than inventing new vocabulary:
+
+- "Global Memory" → **Instructions** (it *is* instructions + context files)
+- "Personal Memory" → **Memory** (this is the only thing that is genuinely memory)
+- Rust `Memory` struct → **`Bundle`**
+
+**Keep the split.** The distinction is real — different author, and different
+update semantics (frozen at spawn vs. live). Collapsing the names would hide a
+behavioural difference users will hit. What is wrong is not that there are two
+things; it is that both are called "memory."
+
+**Rejected alternative: "Shared Memory"** for the global tier. It pairs better
+with "Personal" than "Global" does (ownership axis vs. reach axis), but `shared`
+already means something else here — `~/.agentmux/shared/providers/…` is
+host-level shared provider config — and it leaves the deeper problem (calling
+operator-authored instructions "memory") untouched.
+
+A smaller variant, if the full rename is unwanted: keep "Global/Personal" in the
+UI and rename only the Rust `Memory` struct → `Bundle`. That removes the worst of
+the ambiguity for maintainers without touching user-visible language.
+
+## 5. Open item B — ABF cannot round-trip memory
+
+`components.memory` is defined in ABF v0.2 §2.3, and the **import** side honours
+it via `bundle.import_for_agent` (plain `bundle.import` ignores it, emitting the
+`MEMORY_COMPONENT_IGNORED_WARNING` constant).
+
+But **`bundle_export.rs` never emits `components.memory`** — there are zero
+references to it in that file; export produces only `instructions` and `skills`.
+
+So an agent's memory can be **imported but never exported**. For a format whose
+stated purpose is portability, that is a real gap, and it is not tracked anywhere
+else.
+
+## 6. Open item C — curated memory is structurally empty (highest user impact)
+
+Per `SPEC_MEMORY_CARRYOVER_LOAD_AND_MANAGE_2026_09_05.md`, measured live
+2026-09-06:
+
+- `select count(*) from db_bundles where is_global=1` returns **0**.
+- The composed `.claude/AGENTMUX_MEMORY.md` is **byte-identical across agents**
+  (1089 bytes) with **no `# Memory` section at all**.
+
+The curated tier runs correctly and injects nothing. Nothing in the UI surfaces
+that emptiness, so it is indistinguishable from working. That spec calls fixing
+this the highest-value item in the area, and it is unimplemented.
+
+Two related threads from the same spec:
+
+- **Mid-session propagation** — editing Armory memory never reaches a running
+  agent (System A is written at spawn only). Open since
+  `TOKEN_TAX_ANALYSIS_2026_06_19.md`; explicitly out of scope there.
+- **Post-compaction digest** — originally requested by the repo owner, but the
+  spec's own measurements show memory *already* survives compaction, so it
+  recommends dropping the idea. Needs an explicit decision to close.
+
+## 7. Open item D — north-star vs. actual direction
+
+`ARCHITECTURE_ARMORY_FOUNDATION_CONSOLIDATION_2026_08_19.md` §3.4 wants the
+`listmemories` / `getmemory` / `upsertmemory` / `deletememory` /
+`reorderglobalbrain` surface **retired** in favour of `bundle.*`.
+
+PR #3115 (2026-09-08) did the opposite: it gave that surface generated TypeScript
+types and test coverage as part of the `register_typed` migration. That is
+reasonable work on its own terms, but it entrenches the surface the north-star
+document wants removed.
+
+§3.1–§3.6 of that document are otherwise unstarted as a program. Worth an
+explicit call on whether it is still the target architecture before more work
+lands in either direction. (The `Korp@claudius` agent-consolidation series —
+#3075/#3080/#3088/#3092/#3096, folding `db_agent_definitions`/`db_agent_instances`
+into `db_agents` — may be informal progress on §3.3, but that coordination is not
+documented anywhere.)
+
+## 8. Decisions needed
+
+1. **Naming** (§4) — full ABF alignment, the struct-rename-only variant, or leave as is.
+2. **Post-compaction digest** (§6) — build it, or accept the measurement and drop it.
+3. **North-star** (§7) — still the target, or superseded?
+
+§5 and §6's scaffold/visibility work do not need a decision, only prioritisation.
+Of the four, **§6 is the only one with user-facing impact today**; the rest are
+naming and architecture hygiene.

--- a/docs/status/STATUS_ARMORY_MEMORY_CONSOLIDATION_2026_09_09.md
+++ b/docs/status/STATUS_ARMORY_MEMORY_CONSOLIDATION_2026_09_09.md
@@ -96,18 +96,25 @@ A smaller variant, if the full rename is unwanted: keep "Global/Personal" in the
 UI and rename only the Rust `Memory` struct → `Bundle`. That removes the worst of
 the ambiguity for maintainers without touching user-visible language.
 
-## 5. Open item B — ABF cannot round-trip memory
+## 5. Open item B — memory export/import asymmetry (narrower than first stated)
 
-`components.memory` is defined in ABF v0.2 §2.3, and the **import** side honours
-it via `bundle.import_for_agent` (plain `bundle.import` ignores it, emitting the
-`MEMORY_COMPONENT_IGNORED_WARNING` constant).
+**Correction (Codex P2 on #3131):** an earlier draft of this section claimed ABF
+cannot round-trip memory because `bundle_export.rs` never emits
+`components.memory`. That was wrong. The file `bundle_export.rs` doesn't, but the
+**agent-scoped** export path does: `bundle.export_for_agent` reads the agent's
+native-memory files and splices `components.memory` plus the referenced files
+into the manifest (`splice_memory_component`, `app_api/bundle.rs:439-468`,
+tested at `:2761`). `bundle.import_for_agent` consumes it. **Memory round-trips
+correctly via the agent-scoped pair.**
 
-But **`bundle_export.rs` never emits `components.memory`** — there are zero
-references to it in that file; export produces only `instructions` and `skills`.
+What actually remains:
 
-So an agent's memory can be **imported but never exported**. For a format whose
-stated purpose is portability, that is a real gap, and it is not tracked anywhere
-else.
+- The agent-less `bundle.export` omits memory — correct by design (a bundle with
+  no agent has no memory) — but it does so **silently**, whereas the import side
+  emits an explicit `MEMORY_COMPONENT_IGNORED_WARNING` when it drops memory. The
+  export side has no equivalent. That asymmetry is the real open item.
+- Whether the *default* export affordance in the Armory UI uses the agent-scoped
+  or agent-less path, and whether a user would notice the difference.
 
 ## 6. Open item C — curated memory is structurally empty (highest user impact)
 
@@ -118,9 +125,22 @@ Per `SPEC_MEMORY_CARRYOVER_LOAD_AND_MANAGE_2026_09_05.md`, measured live
 - The composed `.claude/AGENTMUX_MEMORY.md` is **byte-identical across agents**
   (1089 bytes) with **no `# Memory` section at all**.
 
-The curated tier runs correctly and injects nothing. Nothing in the UI surfaces
-that emptiness, so it is indistinguishable from working. That spec calls fixing
-this the highest-value item in the area, and it is unimplemented.
+The curated tier runs correctly and injects nothing.
+
+**Correction (Codex P2 on #3131):** an earlier draft said "nothing in the UI
+surfaces that emptiness." That is wrong for the Armory: `GlobalBrainManager`
+renders `No global sections yet.`, offers `+ New section`, and shows `(empty)`
+in the combined preview (`global-brain-manager.tsx:327-388`). An operator who
+opens Armory → Memory → Global can see there is nothing there.
+
+The gap is narrower and sits on the **agent/launch side**, not the Armory side:
+at `agent.open` the composed startup file is written with no `# Memory` section
+and nothing tells the operator that this particular agent received no curated
+memory. An agent that "looks configured" in its own pane may have been launched
+with an empty curated tier, and the only way to discover that today is to go
+look in Armory. That launch-side visibility, plus a scaffold for new agents, is
+what `SPEC_MEMORY_CARRYOVER_LOAD_AND_MANAGE_2026_09_05.md` calls the
+highest-value item, and it is unimplemented.
 
 Two related threads from the same spec:
 

--- a/docs/status/STATUS_ARMORY_MEMORY_CONSOLIDATION_2026_09_09.md
+++ b/docs/status/STATUS_ARMORY_MEMORY_CONSOLIDATION_2026_09_09.md
@@ -1,6 +1,6 @@
 # Status: Armory Memory — Consolidated State and Naming Problem
 
-**Status:** open — four unresolved items (§4–§7), three of which need a product decision before more code lands
+**Status:** active — four unresolved items (§4–§7), three of which need a product decision before more code lands
 **Date:** 2026-09-09
 **Verified against:** `b65df28c2` (code, not spec prose)
 **Tracking issue:** #2024 (consolidated there 2026-09-09)


### PR DESCRIPTION
Two docs, both docs-only. Consolidates six weeks of Armory memory work that #2024 never caught up with, and formalises the naming fix that has to land before the open architectural questions can be discussed precisely.

## The finding

"memory" currently denotes **six** different things: Memory, Bundle, ABF, Brain, Preset, Global Memory. `bundle_list_impl` (`app_api/mod.rs:757`) uses four of them in eight lines:

```rust
let memories = state.id_store.bundle_memory_list()...   // bundle_memory_*
let bundles: Vec<_> = memories.iter()...                // memories → bundles
Ok(json!({ "bundles": bundles, "presets": bundles }))   // both keys
```

`db_bundles` is surfaced under **two** Armory tabs (ABF, and Memory → Global). `bundle.*` and the `listmemories` family are duplicate RPC surfaces over one storage method.

## Target vocabulary (spec §3)

| Name | What | AgentMux posture |
|---|---|---|
| **Bundle** | curated instructions + context + refs (`db_bundles`); scope is a *flag* (global/system/agent) | owns |
| **Memory** | what the agent learns (`db_agent_native_memory`) | mirrors + versions |
| **Project Instructions** | repo `CLAUDE.md`/`AGENTS.md`/… | **reads only**, never writes |
| **ABF** | the export format | — |

Retired: Brain, Preset, Global Memory.

## The spec corrects its own earlier draft

The status doc's §4 proposed "Global Memory → Instructions". That was wrong: a `db_bundles` row carries seven payload fields, so naming the container after one of them is a new inaccuracy. Global bundles are bundles with a scope flag. Recorded as a correction (§2.4) rather than silently revised.

## What is explicitly NOT renamed (§4, normative)

The `MemoryWrite/Read/History/…` MCP tools, `agent:memory:*`, `db_agent_native_memory*`, and all `NativeMemory*` code are **already correct** and agent-facing — renaming breaks running agents for nothing. ABF `components.*` keys are unchanged; `components.memory` is already right, and import has no unknown-key warning, so any key rename would silently drop data from bundles already exported.

## Phasing (§5)

By blast radius. Phases 1–2 (internal names, retire "brain") carry no contract risk. Phase 3 (retire `*memory` RPCs for `bundle.*`) is wire-breaking and must first retire the still-agent-facing `PresetList`/`PresetGet` MCP tools, which read the `presets` key. Phase 4 folds the two bundle tabs into one. DB column renames are deferred with a reason: `migrations.rs` has no `RENAME COLUMN` precedent.

Two traps the inventory surfaced: `test/contract/rpc-contract.test.ts` does not baseline the seven retiring commands, so it won't catch their removal — add them first. And `check-rpc-bindings.sh` uses `git status --porcelain -uall`, so stale generated bindings must be `git rm`'d or they pass silently.

## Follow-on, recorded not dropped (§8)

Three portability requirements agreed this session: export carries Memory (`components.memory` exists, import honours it, exporter just never emits it), Project Instructions are tracked read-only, and the memory-location invariant from `SPEC_NATIVE_MEMORY_DURABLE_SYNC`. Own spec, after naming lands.

<!-- agentmux:agent_id=agenta-07017 -->