### PR TITLE
refactor(block): BlockFrame_Header/EndIcons take a reactive blockId accessor

### DIFF
--- a/.changesets/1788997373-refactor-block-blockframe-header-endicons-take-a-reactive-bl-iiw9.md
+++ b/.changesets/1788997373-refactor-block-blockframe-header-endicons-take-a-reactive-bl-iiw9.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(block): BlockFrame_Header/EndIcons take a reactive blockId accessor

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -27,7 +27,7 @@ import { NodeModel } from "@/layout/index";
 import * as util from "@/util/util";
 import { computeBgStyleFromMeta } from "@/util/waveutil";
 import clsx from "clsx";
-import type { JSX } from "solid-js";
+import type { Accessor, JSX } from "solid-js";
 import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { CopyButton } from "../element/copybutton";
 import { detectAgentColor, detectAgentFromEnv, detectAgentTextColor, getEffectiveTitle, isUsableFocusRingColor } from "./autotitle";
@@ -223,6 +223,13 @@ function EndIcons(props: {
     /** View key from `blockData.meta.view`, used to render a context-aware
      *  tooltip on the per-pane mic button (e.g. "Speak into this terminal"). */
     blockView?: string;
+    /** The currently active blockId, reactive — NOT `nodeModel.blockId`
+     *  (frozen for this component's mount lifetime, see NodeModel.blockId's
+     *  own doc comment). Every existing caller passes
+     *  `() => nodeModel.blockId`, a behavior-preserving trivial wrapper; a
+     *  hoisted pane-chrome caller can instead pass `nodeModel.activeBlockId`
+     *  to track a switch without remounting this component. */
+    blockId: Accessor<string>;
 }): JSX.Element {
     // createMemo so blockAtom reads inside endIconButtons() are tracked and
     // the button array re-evaluates when the agent loads/unloads.
@@ -262,7 +269,7 @@ function EndIcons(props: {
                 Terminal keeps the header mic unchanged. */}
             <Show when={props.viewModel?.voiceHandle && props.blockView !== "agent"}>
                 <MicButton
-                    blockId={props.nodeModel.blockId}
+                    blockId={props.blockId()}
                     handle={props.viewModel.voiceHandle!()}
                     paneTitle={
                         props.blockView === "term"
@@ -294,7 +301,7 @@ function EndIcons(props: {
                         disabled={magnifyDisabled()}
                     />
                 }>
-                    <FloatingMaximizeButton label={floatingLabel()!} blockId={props.nodeModel.blockId} />
+                    <FloatingMaximizeButton label={floatingLabel()!} blockId={props.blockId()} />
                 </Show>
             }>
                 <IconButton decl={{
@@ -309,8 +316,17 @@ function EndIcons(props: {
     );
 }
 
-function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.SignalAtom<boolean>; error?: Error }): JSX.Element {
-    const [blockData] = WOS.useWaveObjectValue<Block>(WOS.makeORef("block", props.nodeModel.blockId));
+function BlockFrame_Header(
+    props: BlockFrameProps & { changeConnModalAtom: util.SignalAtom<boolean>; error?: Error; blockId: Accessor<string> }
+): JSX.Element {
+    // `getWaveObjectAtom`-in-a-memo, not `useWaveObjectValue`: the latter
+    // ref-counts through onCleanup tied to THIS component's mount, and never
+    // re-subscribes if `props.blockId()` later points at a different oref —
+    // exactly the leak a hoisted, switch-surviving chrome caller would hit.
+    // `getWaveObjectAtom` has no such lifecycle coupling; calling it fresh
+    // inside a memo that re-runs when blockId changes correctly re-points at
+    // live data with no leak (frontend/app/store/wos.ts).
+    const blockData = createMemo(() => WOS.getWaveObjectAtom<Block>(WOS.makeORef("block", props.blockId()))());
     const showBlockIds = getSettingsKeyAtom("blockheader:showblockids")();
     const preIconButton = util.useAtomValueSafe(props.viewModel?.preIconButton);
     const manageConnection = util.useAtomValueSafe(props.viewModel?.manageConnection);
@@ -500,7 +516,7 @@ function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.
                     <ViewNameEditor name={viewName()} onSave={(v) => void props.viewModel.setViewName(v)} />
                 </Show>
                 <Show when={showBlockIds}>
-                    <div class="block-frame-blockid">[{props.nodeModel.blockId.substring(0, 8)}]</div>
+                    <div class="block-frame-blockid">[{props.blockId().substring(0, 8)}]</div>
                 </Show>
             </div>
             <Show when={manageConnection}>
@@ -530,6 +546,7 @@ function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.
                     nodeModel={props.nodeModel}
                     onContextMenu={onContextMenu}
                     blockView={blockData()?.meta?.view}
+                    blockId={props.blockId}
                 />
             </div>
         </div>
@@ -855,11 +872,21 @@ function BlockFrame_Default_Component(props: BlockFrameProps): JSX.Element {
         innerStyle = computeBgStyleFromMeta(customBg);
     }
     const previewElem = <div class="block-frame-preview">{viewIconElem}</div>;
+    // Trivial wrapper — behavior-preserving today. A hoisted pane-chrome
+    // caller (PR 3) will pass nodeModel.activeBlockId instead, to track a
+    // switch without this header remounting.
+    const headerBlockId: Accessor<string> = () => nodeModel.blockId;
     const headerElem = (
-        <BlockFrame_Header {...props} connBtnRef={connBtnRef} changeConnModalAtom={changeConnModalAtom} />
+        <BlockFrame_Header {...props} connBtnRef={connBtnRef} changeConnModalAtom={changeConnModalAtom} blockId={headerBlockId} />
     );
     const headerElemNoView = (
-        <BlockFrame_Header {...props} connBtnRef={connBtnRef} changeConnModalAtom={changeConnModalAtom} viewModel={null} />
+        <BlockFrame_Header
+            {...props}
+            connBtnRef={connBtnRef}
+            changeConnModalAtom={changeConnModalAtom}
+            viewModel={null}
+            blockId={headerBlockId}
+        />
     );
 
     // Body right-click handler. `browserCtx` is only ever passed by the


### PR DESCRIPTION
## Summary
- PR 2 of 3 for the agent-pane header/tab-strip flash fix
  (`docs/specs/SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md`).
  Independent of PR #3132 (PR 1) — touches disjoint files, can merge in
  either order.
- `BlockFrame_Header` and `EndIcons` now take an explicit
  `blockId: Accessor<string>` prop alongside the existing `nodeModel`,
  instead of reading `nodeModel.blockId` directly. Every existing call
  site passes a trivial `() => nodeModel.blockId` wrapper —
  behavior-preserving everywhere already in use.
- `BlockFrame_Header`'s block-data lookup switches from
  `WOS.useWaveObjectValue` (ref-counted via `onCleanup` tied to this
  component's mount, never re-subscribes if the oref changes later) to a
  `getWaveObjectAtom` call inside a `createMemo` keyed on `blockId()` (no
  such lifecycle coupling — safe to call fresh with a changing oref).
- `nodeModel` stays unchanged for everything genuinely leaf-scoped
  (focus/magnify/minimize/close) — only block-identity reads move to the
  new accessor.
- This alone changes nothing on screen; it's mechanical prep so a future
  hoisted pane-chrome caller (PR 3) can pass `nodeModel.activeBlockId`
  instead of the trivial wrapper, to track an active-member switch
  without this header remounting.

## Test plan
- [x] `npx vitest run` — full suite, 3890 passing / 3 skipped, no
      regressions.
- [x] `npx tsc -p tsconfig.json --noEmit` — clean.
- [ ] No dedicated test file exists for `blockframe.tsx`; behavior
      preservation here relies on the mechanical nature of the change
      (every read-site swap is a like-for-like accessor call) plus the
      full suite passing. Manual visual verification is deferred to PR 3,
      where this plumbing actually gets used by a switch-surviving chrome
      layer.

<!-- agentmux:agent_id=camper -->