### PR TITLE
fix(agent): stop the pane header/tab-strip flash on Agent <-> History switch

### DIFF
--- a/.changesets/1789000090-fix-agent-stop-the-pane-header-tab-strip-flash-when-switchin-u0r3.md
+++ b/.changesets/1789000090-fix-agent-stop-the-pane-header-tab-strip-flash-when-switchin-u0r3.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent): stop the pane header/tab-strip flash when switching Agent <-> History tabs

--- a/frontend/app/block/block.tsx
+++ b/frontend/app/block/block.tsx
@@ -39,7 +39,14 @@ import { useSubagentBackfillGate } from "@/app/view/agent/hooks/useSubagentBackf
 // overlay and picker-fade, AgentPicker's own overlay).
 const READY_GATE_FADE_MS = 200;
 
-function makeViewModel(blockId: string, blockView: string, nodeModel: NodeModel): ViewModel {
+/**
+ * Applies the view-type migration/rename redirects below. Exported so
+ * `pane-leaf-chrome.tsx` can apply the identical rules when deciding
+ * whether a stack member's EFFECTIVE view is "agent" — e.g. a still-live
+ * "forge" block must route through the same redirect `makeViewModel`
+ * itself applies, not just a raw `meta.view === "agent"` check.
+ */
+export function resolveEffectiveViewType(blockView: string): string {
     // Migration shims:
     //   * v0.33.197: forge was folded into the agent pane; redirect old
     //     "forge" blocks to "agent" so they keep rendering.
@@ -61,6 +68,11 @@ function makeViewModel(blockId: string, blockView: string, nodeModel: NodeModel)
     if (effectiveView === "forge") effectiveView = "agent";
     if (effectiveView === "workflows") effectiveView = "drone";
     if (effectiveView === "trust") effectiveView = "armory";
+    return effectiveView;
+}
+
+function makeViewModel(blockId: string, blockView: string, nodeModel: NodeModel): ViewModel {
+    const effectiveView = resolveEffectiveViewType(blockView);
     const ctor = getBlockViewClass(effectiveView);
     if (ctor != null) {
         return new ctor(blockId, nodeModel as any);
@@ -291,9 +303,23 @@ function Block(props: BlockProps): JSX.Element {
             registerBlockComponentModel(props.nodeModel.blockId, registeredBcm);
         }
         setViewModel(vm);
+        // See NodeModel.activeViewModel/setActiveViewModel's own doc
+        // comments (layout/lib/types.ts) — hoisted pane chrome's only live
+        // pointer to a callable ViewModel, since the global registry
+        // doesn't survive this component's own dispose-on-unmount. Owner
+        // matches the SAME object identity `unregisterBlockComponentModel`
+        // below would be called with, so an adopting (not creating) mount's
+        // eventual cleanup correctly no-ops instead of clobbering the
+        // creating mount's still-live registration.
+        props.nodeModel.setActiveViewModel?.(vm, registeredBcm ?? bcm);
     });
 
     onCleanup(() => {
+        // Owner is `registeredBcm` here too (not `registeredBcm ?? bcm`) —
+        // an adopting mount never created its own registration object, so
+        // this correctly no-ops for it instead of clearing the creating
+        // mount's still-live activeViewModel out from under it.
+        props.nodeModel.setActiveViewModel?.(null, registeredBcm);
         if (registeredBcm) {
             unregisterBlockComponentModel(props.nodeModel.blockId, registeredBcm);
         }

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -1056,4 +1056,4 @@ function BlockFrame(props: BlockFrameProps): JSX.Element {
     );
 }
 
-export { BlockFrame, NumActiveConnColors };
+export { BlockFrame, BlockFrame_Header, NumActiveConnColors };

--- a/frontend/app/block/blocktypes.ts
+++ b/frontend/app/block/blocktypes.ts
@@ -13,6 +13,10 @@ export interface BlockNodeModel {
     innerRect?: Accessor<{ width: string; height: string }>;
     onClose?: () => void;
     focusNode: () => void;
+    /** See the real `NodeModel.hasEverBeenMultiMember`'s doc comment
+     *  (frontend/layout/lib/types.ts) — this is the same field, narrowed to
+     *  this leaner interface for `ViewModel` constructors. */
+    hasEverBeenMultiMember?: Accessor<boolean>;
 }
 
 export type FullBlockProps = {

--- a/frontend/app/block/blockutil.tsx
+++ b/frontend/app/block/blockutil.tsx
@@ -6,7 +6,7 @@ import { getConnStatusAtom } from "@/app/store/global";
 import * as util from "@/util/util";
 import clsx from "clsx";
 import type { JSX } from "solid-js";
-import { createMemo, createSignal } from "solid-js";
+import { createMemo, createSignal, Show } from "solid-js";
 import dotsUrl from "../asset/dots-anim-4.svg?url";
 
 const colorRegex = /^((#[0-9a-f]{6,8})|([a-z]+))$/;
@@ -86,24 +86,26 @@ export function computeConnColorNum(connStatus: ConnStatus): number {
     return connColorNum;
 }
 
-export function ConnectionButton({ connection, changeConnModalAtom, ref }: ConnectionButtonProps): JSX.Element {
-    const [connModalOpen, setConnModalOpen] = createSignal(changeConnModalAtom());
-    const isLocal = util.isBlank(connection);
-    const connStatusAtom = getConnStatusAtom(connection);
-    const connStatus = createMemo(() => connStatusAtom());
-    let showDisconnectedSlash = false;
+export function ConnectionButton(props: ConnectionButtonProps): JSX.Element {
+    // Reads `props.connection` reactively throughout (never destructured) —
+    // codex P2 on PR #3134: destructuring it once, like the previous
+    // version of this component did, freezes `isLocal`/`connStatusAtom` at
+    // whatever `connection` was on first mount. That was harmless as long
+    // as every blockId change forced a remount (the header's own remount
+    // boundary), but a hoisted, switch-surviving header
+    // (SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md) can now change
+    // which block's `connection` this same mounted instance should reflect
+    // without remounting at all.
+    const [connModalOpen, setConnModalOpen] = createSignal(props.changeConnModalAtom());
+    const isLocal = createMemo(() => util.isBlank(props.connection));
+    const connStatus = createMemo(() => getConnStatusAtom(props.connection)());
     const connColorNum = createMemo(() => computeConnColorNum(connStatus()));
     const color = createMemo(() => `var(--conn-icon-color-${connColorNum()})`);
     const clickHandler = function () {
-        changeConnModalAtom._set(true);
+        props.changeConnModalAtom._set(true);
         setConnModalOpen(true);
     };
-    let titleText = null;
     let shouldSpin = false;
-
-    if (isLocal) {
-        return null;
-    }
 
     const getConnIcon = (): JSX.Element => {
         const cs = connStatus();
@@ -125,7 +127,7 @@ export function ConnectionButton({ connection, changeConnModalAtom, ref }: Conne
 
     const getTitleText = (): string => {
         const cs = connStatus();
-        if (isLocal) return "Connected to Local Machine";
+        const connection = props.connection;
         if (cs?.status == "connecting") return "Connecting to " + connection;
         if (cs?.status == "error") {
             let t = "Error connecting to " + connection;
@@ -138,26 +140,32 @@ export function ConnectionButton({ connection, changeConnModalAtom, ref }: Conne
 
     const getShowDisconnectedSlash = (): boolean => {
         const cs = connStatus();
-        if (isLocal) return false;
         return cs?.status == "error" || !cs?.connected;
     };
 
     return (
-        <div ref={(el) => { if (ref) ref.current = el; }} class={clsx("connection-button")} onClick={clickHandler} title={getTitleText()}>
-            <span class={clsx("fa-stack connection-icon-box", shouldSpin ? "fa-spin" : null)}>
-                {getConnIcon()}
-                <i
-                    class="fa-slash fa-solid fa-stack-1x"
-                    style={{
-                        color: color(),
-                        "margin-right": "2px",
-                        "text-shadow": "0 1px black, 0 1.5px black",
-                        opacity: getShowDisconnectedSlash() ? 1 : 0,
-                    }}
-                />
-            </span>
-            {isLocal ? null : <div class="connection-name ellipsis">{connection}</div>}
-        </div>
+        <Show when={!isLocal()}>
+            <div
+                ref={(el) => { if (props.ref) props.ref.current = el; }}
+                class={clsx("connection-button")}
+                onClick={clickHandler}
+                title={getTitleText()}
+            >
+                <span class={clsx("fa-stack connection-icon-box", shouldSpin ? "fa-spin" : null)}>
+                    {getConnIcon()}
+                    <i
+                        class="fa-slash fa-solid fa-stack-1x"
+                        style={{
+                            color: color(),
+                            "margin-right": "2px",
+                            "text-shadow": "0 1px black, 0 1.5px black",
+                            opacity: getShowDisconnectedSlash() ? 1 : 0,
+                        }}
+                    />
+                </span>
+                <div class="connection-name ellipsis">{props.connection}</div>
+            </div>
+        </Show>
     );
 }
 

--- a/frontend/app/tab/pane-leaf-chrome.test.tsx
+++ b/frontend/app/tab/pane-leaf-chrome.test.tsx
@@ -1,0 +1,174 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for the leaf-level chrome-hoisting router
+ * (SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md).
+ *
+ * The acceptance criterion that actually proves the fix, not just "looks
+ * right": mount, capture the hoisted chrome's own DOM element reference,
+ * drive a switch (the active member changes), and assert `===` on that
+ * reference afterward — while the switch-scoped content DOES get a fresh
+ * element, proving the inner remount boundary is doing the work the outer
+ * one used to.
+ */
+
+import { cleanup, render, screen } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { NodeModel } from "@/layout/index";
+
+// Hoisted mocks — factories run before imports, so the real Block/
+// resolveEffectiveViewType and the real WOS store are replaced with
+// controllable test doubles before pane-leaf-chrome.tsx (which imports
+// both) is ever loaded.
+vi.mock("@/app/block/block", () => ({
+    Block: (props: { nodeModel: NodeModel; preview: boolean }) => (
+        <div data-testid={`block-${props.nodeModel.blockId}`}>{props.nodeModel.blockId}</div>
+    ),
+    // Identity — the real migration/rename redirect logic (forge->agent
+    // etc.) is exercised by block.tsx's own consumer, makeViewModel; here
+    // the test drives the effective view type directly via block meta.
+    resolveEffectiveViewType: (v: string) => v,
+}));
+
+const blockMetaSignals = new Map<string, ReturnType<typeof createSignal<{ meta?: { view?: string } }>>>();
+function setBlockView(blockId: string, view: string | undefined) {
+    if (!blockMetaSignals.has(blockId)) {
+        blockMetaSignals.set(blockId, createSignal<{ meta?: { view?: string } }>({ meta: { view } }));
+    } else {
+        blockMetaSignals.get(blockId)![1]({ meta: { view } });
+    }
+}
+
+vi.mock("@/app/store/global", () => ({
+    WOS: {
+        makeORef: (_otype: string, oid: string) => oid,
+        getWaveObjectAtom: (oid: string) => {
+            if (!blockMetaSignals.has(oid)) {
+                blockMetaSignals.set(oid, createSignal<{ meta?: { view?: string } }>({ meta: {} }));
+            }
+            return blockMetaSignals.get(oid)![0];
+        },
+    },
+}));
+
+async function loadPaneLeafChrome() {
+    const mod = await import("./pane-leaf-chrome");
+    return mod.PaneLeafChrome;
+}
+
+/** Minimal fake NodeModel — only the fields PaneLeafChrome itself reads. */
+function makeFakeNodeModel(overrides?: {
+    activeBlockId?: () => string;
+    hasEverBeenMultiMember?: () => boolean;
+    activeViewModel?: () => ViewModel | null;
+}): NodeModel {
+    return {
+        blockId: "b1",
+        nodeId: "node-1",
+        activeBlockId: overrides?.activeBlockId ?? (() => "b1"),
+        hasEverBeenMultiMember: overrides?.hasEverBeenMultiMember ?? (() => false),
+        activeViewModel: overrides?.activeViewModel ?? (() => null),
+    } as unknown as NodeModel;
+}
+
+function fakeChromeViewModel(testId: string): ViewModel {
+    return {
+        viewType: "agent",
+        viewComponent: null as any,
+        renderPaneChrome: (_nodeModel: NodeModel, content: any) => (
+            <div data-testid={testId}>
+                <div data-testid="chrome-header">chrome</div>
+                {content}
+            </div>
+        ),
+    } as unknown as ViewModel;
+}
+
+afterEach(() => {
+    cleanup();
+    blockMetaSignals.clear();
+});
+
+describe("PaneLeafChrome — passthrough (not hoisted)", () => {
+    it("renders the block directly, with no chrome wrapper, when the leaf has never been multi-member", async () => {
+        setBlockView("b1", "agent");
+        const nodeModel = makeFakeNodeModel({ hasEverBeenMultiMember: () => false });
+        const PaneLeafChrome = await loadPaneLeafChrome();
+
+        render(() => <PaneLeafChrome nodeModel={nodeModel} />);
+
+        expect(screen.getByTestId("block-b1")).toBeInTheDocument();
+        expect(screen.queryByTestId("chrome-header")).toBeNull();
+    });
+
+    it("renders the block directly when hasEverBeenMultiMember is true but the effective view type isn't agent", async () => {
+        setBlockView("b1", "term");
+        const nodeModel = makeFakeNodeModel({
+            hasEverBeenMultiMember: () => true,
+            activeViewModel: () => fakeChromeViewModel("chrome-root"),
+        });
+        const PaneLeafChrome = await loadPaneLeafChrome();
+
+        render(() => <PaneLeafChrome nodeModel={nodeModel} />);
+
+        expect(screen.getByTestId("block-b1")).toBeInTheDocument();
+        expect(screen.queryByTestId("chrome-header")).toBeNull();
+    });
+});
+
+describe("PaneLeafChrome — hoisted", () => {
+    it("wraps the block in the active ViewModel's renderPaneChrome once multi-member and view type is agent", async () => {
+        setBlockView("b1", "agent");
+        const nodeModel = makeFakeNodeModel({
+            hasEverBeenMultiMember: () => true,
+            activeViewModel: () => fakeChromeViewModel("chrome-root"),
+        });
+        const PaneLeafChrome = await loadPaneLeafChrome();
+
+        render(() => <PaneLeafChrome nodeModel={nodeModel} />);
+
+        expect(screen.getByTestId("chrome-root")).toBeInTheDocument();
+        expect(screen.getByTestId("chrome-header")).toBeInTheDocument();
+        // Content still renders, now NESTED inside chrome.
+        expect(screen.getByTestId("chrome-root").contains(screen.getByTestId("block-b1"))).toBe(true);
+    });
+
+    // The acceptance criterion: chrome's own DOM node survives a switch
+    // (same reference, not just equal-looking markup), while the
+    // switch-scoped block content gets a genuinely fresh element — proving
+    // the inner remount boundary is what updates displayed content now,
+    // not a full teardown of the chrome around it.
+    it("keeps the SAME chrome DOM node across a switch, while the block content remounts", async () => {
+        setBlockView("b1", "agent");
+        setBlockView("b2", "agent");
+        const [activeBlockId, setActiveBlockId] = createSignal("b1");
+        const nodeModel = makeFakeNodeModel({
+            activeBlockId,
+            hasEverBeenMultiMember: () => true,
+            activeViewModel: () => fakeChromeViewModel("chrome-root"),
+        });
+        const PaneLeafChrome = await loadPaneLeafChrome();
+
+        render(() => <PaneLeafChrome nodeModel={nodeModel} />);
+
+        const chromeBefore = screen.getByTestId("chrome-root");
+        const headerBefore = screen.getByTestId("chrome-header");
+        const blockBefore = screen.getByTestId("block-b1");
+
+        setActiveBlockId("b2");
+
+        const chromeAfter = screen.getByTestId("chrome-root");
+        const headerAfter = screen.getByTestId("chrome-header");
+        expect(chromeAfter).toBe(chromeBefore); // same DOM node — chrome did NOT remount
+        expect(headerAfter).toBe(headerBefore);
+
+        // The old member's block element is gone; a fresh one for the new
+        // active member takes its place — this IS the mechanism that
+        // updates displayed content now.
+        expect(screen.queryByTestId("block-b1")).toBeNull();
+        const blockAfter = screen.getByTestId("block-b2");
+        expect(blockAfter).not.toBe(blockBefore);
+    });
+});

--- a/frontend/app/tab/pane-leaf-chrome.test.tsx
+++ b/frontend/app/tab/pane-leaf-chrome.test.tsx
@@ -14,18 +14,57 @@
  */
 
 import { cleanup, render, screen } from "@solidjs/testing-library";
-import { createSignal } from "solid-js";
+import { createEffect, createSignal, onCleanup } from "solid-js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { NodeModel } from "@/layout/index";
+
+// Module-level, reset in afterEach — read by the mocked Block below (via a
+// live binding, not a snapshot: the factory body runs lazily on every
+// mount, so it always sees whatever this currently points at) and by
+// tests, to count how many times renderPaneChrome actually fires.
+let renderPaneChromeCallCount = { count: 0 };
 
 // Hoisted mocks — factories run before imports, so the real Block/
 // resolveEffectiveViewType and the real WOS store are replaced with
 // controllable test doubles before pane-leaf-chrome.tsx (which imports
 // both) is ever loaded.
+//
+// This fake Block deliberately reproduces block.tsx's REAL
+// setActiveViewModel timing, not just its end state — ReAgent P1 on this
+// PR: an earlier version of this mock never called setActiveViewModel at
+// all, so activeViewModel() was driven directly by the test and never
+// exercised the null blip a real switch produces (block.tsx's onCleanup
+// clears the OLD member's vm SYNCHRONOUSLY, during the <Key>'s own
+// reconciliation; the createEffect that sets the NEW member's vm is
+// DEFERRED to the next effects flush) — the exact gap that let a
+// re-invocation bug ship undetected. Matching that timing here is what
+// makes the "does not re-invoke renderPaneChrome" test below meaningful.
 vi.mock("@/app/block/block", () => ({
-    Block: (props: { nodeModel: NodeModel; preview: boolean }) => (
-        <div data-testid={`block-${props.nodeModel.blockId}`}>{props.nodeModel.blockId}</div>
-    ),
+    Block: (props: { nodeModel: NodeModel; preview: boolean }) => {
+        const owner = {};
+        createEffect(() => {
+            (props.nodeModel as any).setActiveViewModel?.(
+                {
+                    viewType: "agent",
+                    viewComponent: null,
+                    renderPaneChrome: (_nodeModel: NodeModel, content: any) => {
+                        renderPaneChromeCallCount.count++;
+                        return (
+                            <div data-testid="chrome-root">
+                                <div data-testid="chrome-header">chrome</div>
+                                {content}
+                            </div>
+                        );
+                    },
+                } as unknown as ViewModel,
+                owner,
+            );
+        });
+        onCleanup(() => {
+            (props.nodeModel as any).setActiveViewModel?.(null, owner);
+        });
+        return <div data-testid={`block-${props.nodeModel.blockId}`}>{props.nodeModel.blockId}</div>;
+    },
     // Identity — the real migration/rename redirect logic (forge->agent
     // etc.) is exercised by block.tsx's own consumer, makeViewModel; here
     // the test drives the effective view type directly via block meta.
@@ -58,7 +97,9 @@ async function loadPaneLeafChrome() {
     return mod.PaneLeafChrome;
 }
 
-/** Minimal fake NodeModel — only the fields PaneLeafChrome itself reads. */
+/** Minimal fake NodeModel — only the fields PaneLeafChrome itself reads.
+ *  `activeViewModel` is a plain, externally-set accessor here — fine for
+ *  tests that don't drive a real Block mount/unmount switch. */
 function makeFakeNodeModel(overrides?: {
     activeBlockId?: () => string;
     hasEverBeenMultiMember?: () => boolean;
@@ -86,9 +127,38 @@ function fakeChromeViewModel(testId: string): ViewModel {
     } as unknown as ViewModel;
 }
 
+/** A NodeModel with a REAL, owner-checked activeViewModel/setActiveViewModel
+ *  signal pair — mirroring layoutNodeModels.ts's actual implementation —
+ *  so the mocked Block above (which drives it via createEffect/onCleanup,
+ *  exactly like real block.tsx) produces the real null-blip timing on
+ *  every switch. */
+function makeRealisticNodeModel(overrides?: { activeBlockId?: () => string }): NodeModel {
+    let owner: object | null = null;
+    const [activeViewModelSig, setActiveViewModelSig] = createSignal<ViewModel | null>(null);
+    const setActiveViewModel = (vm: ViewModel | null, o: object) => {
+        if (vm === null) {
+            if (owner !== o) return;
+            owner = null;
+            setActiveViewModelSig(null);
+            return;
+        }
+        owner = o;
+        setActiveViewModelSig(() => vm);
+    };
+    return {
+        blockId: "b1",
+        nodeId: "node-1",
+        activeBlockId: overrides?.activeBlockId ?? (() => "b1"),
+        hasEverBeenMultiMember: () => true,
+        activeViewModel: activeViewModelSig,
+        setActiveViewModel,
+    } as unknown as NodeModel;
+}
+
 afterEach(() => {
     cleanup();
     blockMetaSignals.clear();
+    renderPaneChromeCallCount = { count: 0 };
 });
 
 describe("PaneLeafChrome — passthrough (not hoisted)", () => {
@@ -139,16 +209,15 @@ describe("PaneLeafChrome — hoisted", () => {
     // (same reference, not just equal-looking markup), while the
     // switch-scoped block content gets a genuinely fresh element — proving
     // the inner remount boundary is what updates displayed content now,
-    // not a full teardown of the chrome around it.
+    // not a full teardown of the chrome around it. Uses the REALISTIC
+    // node model (real activeViewModel signal, driven by the mocked
+    // Block's own createEffect/onCleanup) so this actually exercises the
+    // null-blip timing a real switch produces.
     it("keeps the SAME chrome DOM node across a switch, while the block content remounts", async () => {
         setBlockView("b1", "agent");
         setBlockView("b2", "agent");
         const [activeBlockId, setActiveBlockId] = createSignal("b1");
-        const nodeModel = makeFakeNodeModel({
-            activeBlockId,
-            hasEverBeenMultiMember: () => true,
-            activeViewModel: () => fakeChromeViewModel("chrome-root"),
-        });
+        const nodeModel = makeRealisticNodeModel({ activeBlockId });
         const PaneLeafChrome = await loadPaneLeafChrome();
 
         render(() => <PaneLeafChrome nodeModel={nodeModel} />);
@@ -170,5 +239,35 @@ describe("PaneLeafChrome — hoisted", () => {
         expect(screen.queryByTestId("block-b1")).toBeNull();
         const blockAfter = screen.getByTestId("block-b2");
         expect(blockAfter).not.toBe(blockBefore);
+    });
+
+    // ReAgent P1 on this PR, the direct regression test for the exact bug
+    // found: NodeModel.activeViewModel() genuinely blips through `null` on
+    // EVERY switch (see the mocked Block's own comment above for why), and
+    // a naive `<Show when={nodeModel.activeViewModel()}>` callback form
+    // would treat that as a fresh falsy->truthy edge and re-invoke
+    // renderPaneChrome — mounting a BRAND NEW AgentPaneChrome each time.
+    // This asserts the call count directly, the strongest form of the
+    // claim: not just "the DOM node happens to look the same" but "chrome
+    // was genuinely constructed exactly once," across three switches.
+    it("invokes renderPaneChrome exactly once per leaf, never again on later switches", async () => {
+        setBlockView("b1", "agent");
+        setBlockView("b2", "agent");
+        setBlockView("b3", "agent");
+        const [activeBlockId, setActiveBlockId] = createSignal("b1");
+        const nodeModel = makeRealisticNodeModel({ activeBlockId });
+        const PaneLeafChrome = await loadPaneLeafChrome();
+
+        render(() => <PaneLeafChrome nodeModel={nodeModel} />);
+        expect(renderPaneChromeCallCount.count).toBe(1);
+
+        setActiveBlockId("b2");
+        expect(renderPaneChromeCallCount.count).toBe(1); // NOT 2
+
+        setActiveBlockId("b3");
+        expect(renderPaneChromeCallCount.count).toBe(1); // NOT 3
+
+        setActiveBlockId("b1");
+        expect(renderPaneChromeCallCount.count).toBe(1); // switching back doesn't re-invoke either
     });
 });

--- a/frontend/app/tab/pane-leaf-chrome.tsx
+++ b/frontend/app/tab/pane-leaf-chrome.tsx
@@ -72,14 +72,43 @@ export function PaneLeafChrome(props: { nodeModel: NodeModel }): JSX.Element {
         () => (nodeModel.hasEverBeenMultiMember?.() ?? false) && effectiveViewType() === "agent"
     );
 
+    // ReAgent P1, confirmed by an empirical repro before trusting it:
+    // `NodeModel.activeViewModel()` genuinely blips through `null` on
+    // EVERY switch, not just the first hoist. `block.tsx`'s `onCleanup`
+    // (clearing the OLD member's vm) runs synchronously during the inner
+    // `<Key>`'s reconciliation; the `createEffect` that sets the NEW
+    // member's vm is deferred to the next effects flush. A naive
+    // `<Show when={nodeModel.activeViewModel()}>` callback form looks safe
+    // (`<Show>` only re-runs its child function on a falsy->truthy edge),
+    // but that real null blip IS such an edge every time, so it would
+    // re-invoke `renderPaneChrome` — mounting a BRAND NEW `AgentPaneChrome`
+    // on every switch and reproducing the exact flash this file exists to
+    // eliminate. Fixed by latching the FIRST non-null vm ever observed
+    // into a plain closure variable: once captured, this memo's OWN return
+    // value stops changing (same object reference) regardless of how
+    // `activeViewModel()` fluctuates underneath, so Solid's default `===`
+    // memo comparison means no consumer — including `<Show>` below — ever
+    // observes a falsy value again after the first real capture. Renders
+    // via whichever vm happened to be active at that FIRST hoist and never
+    // re-derives afterward — the same "frozen after first hoist" identity
+    // `anchorBlockId` (agent-model.ts's own `renderPaneChrome` closure)
+    // already assumes.
+    let latchedChromeVm: ViewModel | null = null;
+    const chromeVm = createMemo(() => {
+        if (!latchedChromeVm) {
+            latchedChromeVm = nodeModel.activeViewModel?.() ?? null;
+        }
+        return latchedChromeVm;
+    });
+
     return (
         <Show when={hoisted()} fallback={content}>
-            {/* Guards only the brief same-flush null window between one
-                member's <Block> unmounting and the next one's mounting
-                (NodeModel.activeViewModel's own doc comment, types.ts) —
-                does NOT itself unmount the outer chrome, which is gated
-                only by `hoisted()` above and never flips back to false. */}
-            <Show when={nodeModel.activeViewModel?.()}>
+            {/* Guards only the leaf's own first-hoist window, before any
+                ViewModel has been observed yet — does NOT itself unmount
+                the outer chrome once mounted, since `chromeVm()` (above)
+                never returns to a falsy value after its first real
+                capture. */}
+            <Show when={chromeVm()}>
                 {(vm) => vm().renderPaneChrome!(nodeModel, content)}
             </Show>
         </Show>

--- a/frontend/app/tab/pane-leaf-chrome.tsx
+++ b/frontend/app/tab/pane-leaf-chrome.tsx
@@ -1,0 +1,87 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Block, resolveEffectiveViewType } from "@/app/block/block";
+import { WOS } from "@/app/store/global";
+import type { NodeModel } from "@/layout/index";
+import { Key } from "@solid-primitives/keyed";
+import { createMemo, Show, type JSX } from "solid-js";
+
+/**
+ * Router `tabcontent.tsx` renders instead of `<Block>` directly — the
+ * leaf-level entry point for the pane-tab-switch chrome-stability fix
+ * (`docs/specs/SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md`).
+ *
+ * ALWAYS renders a per-active-member, `<Key>`-scoped `<Block>` — the inner
+ * remount boundary `layoutStack.ts`'s own header comment refers to. This
+ * alone is what updates displayed content on a switch now that the OUTER,
+ * whole-leaf remount (`tilelayout-shared.tsx`'s `DisplayNodesWrapper`) no
+ * longer does — for every view type, uniformly, including one that never
+ * hoists chrome at all: the end result (`<Block>` remounts on every switch)
+ * is byte-for-byte identical to what the old outer-leaf-key mechanism
+ * produced, just driven from a narrower boundary.
+ *
+ * When the active member's EFFECTIVE view type (`resolveEffectiveViewType`
+ * — the same migration/rename redirects `block.tsx`'s own `makeViewModel`
+ * applies, so a still-live "forge" block routes through this too) is
+ * `"agent"` AND this leaf's stack has ever had 2+ members
+ * (`NodeModel.hasEverBeenMultiMember`), wraps that `<Block>` in the
+ * currently-active `ViewModel`'s own `renderPaneChrome` — a stable outer
+ * shell (tab strip, progress-bar slot) that survives every subsequent
+ * switch, instead of `BlockFrame`'s own per-switch-remounting header.
+ * Every other case (another view type, or an agent pane that's never gone
+ * multi-member) falls through to the bare `content` below — zero behavior
+ * change for those, matching what `<Block>` alone already did.
+ */
+export function PaneLeafChrome(props: { nodeModel: NodeModel }): JSX.Element {
+    const nodeModel = props.nodeModel;
+    const activeBlockId = () => nodeModel.activeBlockId?.() ?? nodeModel.blockId;
+
+    // Block-scoped NodeModel wrapper for the inner, per-activation <Block>
+    // mount. The LEAF's own NodeModel.blockId is frozen — captured once,
+    // never re-derived (see that field's own doc comment in types.ts) —
+    // and, now that layoutStack.ts no longer disposes this NodeModel on a
+    // switch, would show the SAME member forever if passed straight into
+    // <Block>. Reconstructed (new object identity) exactly when
+    // activeBlockId() changes — i.e. exactly when the <Key> below remounts
+    // anyway — so nothing ever observes a wrapper whose .blockId doesn't
+    // match its own <Block> mount's lifetime, satisfying
+    // NodeModel.blockId's "one instance, one immutable blockId" contract
+    // at this narrower, per-activation granularity. Every other NodeModel
+    // field (focus/magnify/minimize/close/etc.) delegates straight through
+    // to the real, leaf-level nodeModel via the spread — those stay
+    // leaf-scoped, unaffected by which member is active.
+    const scopedNodeModel = createMemo<NodeModel>(() => ({ ...nodeModel, blockId: activeBlockId() }));
+
+    const content = (
+        <Key each={[scopedNodeModel()]} by={(nm) => nm.blockId}>
+            {(nm) => <Block nodeModel={nm()} preview={false} />}
+        </Key>
+    );
+
+    // Effective view type of the ACTIVE member, reactive — getWaveObjectAtom
+    // inside a memo, not useWaveObjectValue, the same reactive-oref pattern
+    // PR #3134 established for BlockFrame_Header (frontend/app/store/wos.ts's
+    // own doc comments explain why: useWaveObjectValue's onCleanup-ref-count
+    // is tied to THIS component's mount, and never re-subscribes if the
+    // oref it was called with later changes).
+    const activeBlockData = createMemo(() => WOS.getWaveObjectAtom<Block>(WOS.makeORef("block", activeBlockId()))());
+    const effectiveViewType = createMemo(() => resolveEffectiveViewType(activeBlockData()?.meta?.view ?? ""));
+
+    const hoisted = createMemo(
+        () => (nodeModel.hasEverBeenMultiMember?.() ?? false) && effectiveViewType() === "agent"
+    );
+
+    return (
+        <Show when={hoisted()} fallback={content}>
+            {/* Guards only the brief same-flush null window between one
+                member's <Block> unmounting and the next one's mounting
+                (NodeModel.activeViewModel's own doc comment, types.ts) —
+                does NOT itself unmount the outer chrome, which is gated
+                only by `hoisted()` above and never flips back to false. */}
+            <Show when={nodeModel.activeViewModel?.()}>
+                {(vm) => vm().renderPaneChrome!(nodeModel, content)}
+            </Show>
+        </Show>
+    );
+}

--- a/frontend/app/tab/tabcontent.tsx
+++ b/frontend/app/tab/tabcontent.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Block } from "@/app/block/block";
+import { PaneLeafChrome } from "@/app/tab/pane-leaf-chrome";
 import { ContextMenuModel } from "@/app/store/contextmenu";
 import { ModalLayer } from "@/element/ModalLayer";
 import { CenteredDiv } from "@/element/quickelems";
@@ -40,9 +41,13 @@ function TabContent(props: { tabId: string }): JSX.Element {
 
     const tileLayoutContents = createMemo<TileLayoutContents>(() => {
         const renderContent: ContentRenderer = (nodeModel: NodeModel) => {
-            return <Block nodeModel={nodeModel} preview={false} />;
+            return <PaneLeafChrome nodeModel={nodeModel} />;
         };
 
+        // Deliberately plain <Block>, not <PaneLeafChrome> — a drag-preview
+        // thumbnail has no interactive tab strip to hoist (it's a static
+        // snapshot, never switched), so routing it through the chrome
+        // decision would be pure overhead for no behavior change.
         const renderPreview: PreviewRenderer = (nodeModel: NodeModel) => {
             return <Block nodeModel={nodeModel} preview={true} />;
         };

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -1,14 +1,16 @@
 // Copyright 2024-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createSignal, createEffect, onCleanup } from "solid-js";
+import { createComponent, createSignal, createEffect, onCleanup } from "solid-js";
+import type { JSX } from "solid-js";
 import { BlockNodeModel } from "@/app/block/blocktypes";
+import type { NodeModel } from "@/layout/index";
 import type { PaneVoiceHandle } from "@/app/hook/useVoiceInput";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { atoms, getApi, WOS } from "@/app/store/global";
 import { SignalAtom } from "@/util/util";
-import { AgentViewWrapper } from "./agent-view";
+import { AgentBlockContent, AgentPaneChrome } from "./agent-view";
 import { buildAgentPaneIcon } from "./components/AgentPaneIcon";
 import { PROVIDERS, resolveProviderAlias } from "./providers";
 import { resolveVendorEnvOverride } from "./providers/vendor-env";
@@ -39,6 +41,23 @@ export class AgentViewModel implements ViewModel {
     viewText: () => string | HeaderElem[];
     viewComponent: ViewComponent;
     noPadding: () => boolean;
+    noHeader: () => boolean;
+    renderPaneChrome: (nodeModel: NodeModel, content: JSX.Element) => JSX.Element;
+    setProgressBarMount: (el: HTMLDivElement | null) => void;
+    /** NOT part of the shared `ViewModel` contract — `AgentBlockContent`
+     *  reads this directly off its own concrete `AgentViewModel` instance
+     *  to know where to portal the marching-ants progress bar. Populated
+     *  externally by whichever `AgentPaneChrome` instance is currently
+     *  hoisted (via `setProgressBarMount`, tracking `NodeModel.activeViewModel()`
+     *  reactively) — `null` until chrome has mounted and called it at
+     *  least once. */
+    progressBarMount: () => HTMLDivElement | null;
+    /** NOT part of the shared `ViewModel` contract — same bridging pattern
+     *  as `progressBarMount`/`setProgressBarMount` above, for
+     *  `AgentBlockContent`'s picker-host strip-clearance padding
+     *  (agent-view.tsx's own comment on that style binding explains why). */
+    tabStripVisible: () => boolean;
+    setTabStripVisible: (visible: boolean) => void;
     endIconButtons: () => IconButtonDecl[];
     nodejsError: string | null = null;
 
@@ -68,7 +87,26 @@ export class AgentViewModel implements ViewModel {
         this.blockId = blockId;
         this.nodeModel = nodeModel;
         this.blockAtom = WOS.getWaveObjectAtom<Block>(`block:${blockId}`);
-        this.viewComponent = AgentViewWrapper as any;
+        this.viewComponent = AgentBlockContent as any;
+        // createComponent (not a plain `AgentPaneChrome({...})` call) —
+        // this file is a plain .ts, so it can't use JSX's `<AgentPaneChrome>`
+        // syntax, but a bare function call would run AgentPaneChrome's own
+        // createEffect/onCleanup/createSignal calls in whatever reactive
+        // scope happens to be ambient at THIS constructor call (wrong —
+        // ties chrome's disposal to whichever effect first constructed this
+        // one vm instance, not to chrome's own actual mount/unmount in the
+        // DOM). createComponent is the JSX-free equivalent of what
+        // `<AgentPaneChrome .../>` compiles to; pane-leaf-chrome.tsx (a real
+        // .tsx file) is what actually establishes the owning scope, since
+        // that's where this returned JSX.Element gets inserted into the tree.
+        this.renderPaneChrome = (leafNodeModel: NodeModel, content: JSX.Element): JSX.Element =>
+            createComponent(AgentPaneChrome, { anchorBlockId: this.blockId, nodeModel: leafNodeModel, children: content });
+        const [progressBarMountSig, setProgressBarMountSig] = createSignal<HTMLDivElement | null>(null);
+        this.progressBarMount = progressBarMountSig;
+        this.setProgressBarMount = (el: HTMLDivElement | null) => setProgressBarMountSig(el);
+        const [tabStripVisibleSig, setTabStripVisibleSig] = createSignal(false);
+        this.tabStripVisible = tabStripVisibleSig;
+        this.setTabStripVisible = (visible: boolean) => setTabStripVisibleSig(visible);
 
         // Flash signal: set true briefly when the activity summary changes to a
         // new non-empty value. Compare to previous so unrelated meta writes
@@ -137,6 +175,13 @@ export class AgentViewModel implements ViewModel {
             return elems;
         };
         this.noPadding = () => true;
+        // Once this leaf's stack has ever had 2+ members, the header comes
+        // from AgentPaneChrome's own renderPaneChrome (hoisted, mounted
+        // once, survives every switch) instead of BlockFrame's inline one —
+        // never flips back even if the stack later shrinks to 1 member. See
+        // NodeModel.hasEverBeenMultiMember's own doc comment
+        // (layout/lib/types.ts) for why this must be monotonic.
+        this.noHeader = () => this.nodeModel.hasEverBeenMultiMember?.() ?? false;
         this.setViewName = async (name: string) => {
             if (!name.trim()) return;
             const oref = WOS.makeORef("block", this.blockId);

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -12,6 +12,7 @@ import { atoms, getApi, WOS } from "@/app/store/global";
 import { SignalAtom } from "@/util/util";
 import { AgentBlockContent, AgentPaneChrome } from "./agent-view";
 import { buildAgentPaneIcon } from "./components/AgentPaneIcon";
+import { useAgentDefinitions } from "./components/AgentPicker";
 import { PROVIDERS, resolveProviderAlias } from "./providers";
 import { resolveVendorEnvOverride } from "./providers/vendor-env";
 import { Logger } from "@/util/logger";
@@ -58,6 +59,16 @@ export class AgentViewModel implements ViewModel {
      *  (agent-view.tsx's own comment on that style binding explains why). */
     tabStripVisible: () => boolean;
     setTabStripVisible: (visible: boolean) => void;
+    /** NOT part of the shared `ViewModel` contract. ReAgent P2 on
+     *  SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md's PR: owned here
+     *  (one `useAgentDefinitions()` subscription per ViewModel instance,
+     *  matching the granularity content was already reconstructed at) so
+     *  both `AgentBlockContent` (via `model.agentDefinitions`) and
+     *  `AgentPaneChrome` (via `nodeModel.activeViewModel()?.agentDefinitions`)
+     *  read the SAME list instead of each independently calling the hook —
+     *  the exact redundant-RPC-plus-subscription pattern this file's own
+     *  header comment (reagent P2 on PR #2488) already warns against. */
+    agentDefinitions: () => AgentDefinition[];
     endIconButtons: () => IconButtonDecl[];
     nodejsError: string | null = null;
 
@@ -107,6 +118,7 @@ export class AgentViewModel implements ViewModel {
         const [tabStripVisibleSig, setTabStripVisibleSig] = createSignal(false);
         this.tabStripVisible = tabStripVisibleSig;
         this.setTabStripVisible = (visible: boolean) => setTabStripVisibleSig(visible);
+        this.agentDefinitions = useAgentDefinitions()[0];
 
         // Flash signal: set true briefly when the activity summary changes to a
         // new non-empty value. Compare to previous so unrelated meta writes

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -33,10 +33,21 @@
 @use "styles/loading-overlay";
 @use "styles/picker-fade";
 
-// Wrapper stack for the pane-level tab strip (AgentViewWrapper): strip on
-// top, content region filling the remainder. ModalLayer's mount is a plain
-// 100%-height box, so without this the strip's height ADDS to
-// .agent-view's height:100% and the composer gets clipped off the bottom.
+// Wrapper stack for the pane-level tab strip (AgentPaneChrome, agent-view.tsx):
+// strip on top, content region filling the remainder. Owned by chrome, not
+// content — AgentPaneChrome renders this OUTSIDE the switch-scoped <Block>
+// it wraps (content is `props.children`, rendered inside
+// .agent-pane-stack-content below, as `.block`/BlockFrame's own wrapper),
+// so this box's height:100%/width:100% must fill whatever container the
+// tile layout positions AgentPaneChrome's own root into — previously that
+// was `.block-content` (this box lived INSIDE the leaf's single BlockFrame
+// wrapper); now it's the tile's own leaf slot directly, one level higher,
+// since AgentPaneChrome only mounts once this leaf's stack has ever had 2+
+// members (SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md) — for
+// every other case `.block`/BlockFrame is still the outermost element,
+// unaffected. Regardless of which container it fills, without this
+// wrapper the strip's height ADDS to `.agent-view`'s height:100% and the
+// composer gets clipped off the bottom.
 .agent-pane-stack {
     display: flex;
     flex-direction: column;
@@ -217,9 +228,12 @@
 // now starts flush at the very top of the pane, with no reserved gap
 // between it and the pane header above.
 //
-// AgentPresentationView (deep inside .agent-pane-stack-content, itself
-// BELOW the tab strip in DOM order) portals .agent-pane-progress-bar into
-// this slot — see AgentViewWrapper's progressBarSlot signal and
+// AgentPresentationView (nested inside the switch-scoped <Block> chrome
+// wraps, itself BELOW the tab strip in DOM order) portals
+// .agent-pane-progress-bar into this slot — bridged through the active
+// AgentViewModel's progressBarMount/setProgressBarMount (agent-model.ts),
+// since chrome (which owns this slot) and content are separate component
+// trees as of SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md. See
 // SPEC_AGENT_PANE_PROGRESS_BAR_ABOVE_TAB_STRIP_2026_08_10.md. No CSS-only
 // fix reaches across that boundary: every ancestor between
 // .agent-pane-stack-content and here clips overflow before an
@@ -243,7 +257,7 @@
 // === Marching-ants Progress Bar ===
 // Fills its slot above — no zoom-compensation math needed here (unlike
 // its previous home nested inside .agent-view), since this slot lives in
-// AgentViewWrapper's tree, outside .agent-view's per-pane `zoom` CSS
+// AgentPaneChrome's tree, outside .agent-view's per-pane `zoom` CSS
 // property entirely, alongside the tab strip and other unzoomed pane
 // chrome. Colors via color-mix() so every theme inherits without
 // hardcoded hex.

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -45,6 +45,8 @@ import { makeWindowFocusSignal } from "@/app/window/window-focus";
 import { ConfirmModal } from "@/element/modal";
 import { useModalLayer } from "@/element/modal-layer";
 import { ModalLayer } from "@/element/ModalLayer";
+import { ErrorBoundary } from "@/element/errorboundary";
+import { BlockFrame_Header } from "@/app/block/blockframe";
 import {
     closeBlockInStack,
     getLayoutModelForStaticTab,
@@ -56,7 +58,7 @@ import { findNode } from "@/layout/lib/layoutNode";
 import { holdLeafRevealGate, scheduleLeafRevealLift } from "@/app/store/tab-reveal";
 import { getTrail } from "@/log/render-trail";
 import { writeText as clipboardWriteText } from "@/util/clipboard";
-import { sleep } from "@/util/util";
+import { createSignalAtom, sleep } from "@/util/util";
 import { createEffect, createMemo, createSignal, on, onCleanup, onMount, Show, untrack, type Accessor, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
 import { earliestLiveAttachedStartMs } from "./activity/attached-task";
@@ -375,6 +377,42 @@ export const AgentPaneChrome = (props: {
     const agentId = () => activeBlockData()?.meta?.["agentId"];
     const isHistoryTab = () => !!activeBlockData()?.meta?.[HISTORY_TAB_FOR_META_KEY];
 
+    // Codex P1 on this PR: noHeader (agent-model.ts) suppresses
+    // BlockFrame's own inline header once hoisted, but nothing was
+    // rendering a REPLACEMENT — losing the pane's title, Stash, and
+    // minimize/magnify/close controls permanently the moment a leaf's
+    // stack first went multi-member. BlockFrame_Header (exported from
+    // blockframe.tsx specifically for this — see PR #3134's own doc
+    // comments) is reused directly here rather than reimplemented, reading
+    // the reactive `activeBlockId` accessor above instead of a frozen
+    // `nodeModel.blockId`. `changeConnModalAtom`/`connBtnRef` are inert
+    // stand-ins, not wired to any real modal state: AgentViewModel never
+    // sets `manageConnection`, so BlockFrame_Header's own connection-button
+    // branch never renders for an agent pane regardless.
+    const changeConnModalAtom = createSignalAtom(false);
+    const connBtnRef: { current: HTMLDivElement | null } = { current: null };
+    const activeViewModelOrUndefined = () => nodeModel.activeViewModel?.() ?? undefined;
+    const headerElem = (
+        <BlockFrame_Header
+            nodeModel={nodeModel}
+            viewModel={activeViewModelOrUndefined()}
+            preview={false}
+            blockId={activeBlockId}
+            connBtnRef={connBtnRef}
+            changeConnModalAtom={changeConnModalAtom}
+        />
+    );
+    const headerElemNoView = (
+        <BlockFrame_Header
+            nodeModel={nodeModel}
+            viewModel={null}
+            preview={false}
+            blockId={activeBlockId}
+            connBtnRef={connBtnRef}
+            changeConnModalAtom={changeConnModalAtom}
+        />
+    );
+
     // In-pane tabs — rendered here (not inside AgentBlockContent) so the
     // strip stays visible whether the active member is a launched
     // conversation OR a blank/picker tab (AgentPicker, no agentId yet).
@@ -675,7 +713,28 @@ export const AgentPaneChrome = (props: {
         // to float over the right box. See agent-view.scss's own comments
         // on `.agent-pane-stack`/`.agent-pane-stack-content` for the full
         // positioning chain this depends on.
-        <div class="agent-pane-stack">
+        //
+        // data-blockid={activeBlockId()} — codex P1 on this PR: the CEF
+        // browser API (agentmux-cef/src/browser_api/routes.rs) resolves an
+        // agent's own pane for UIQuery/UIClick/screenshot-clip via a plain
+        // `document.querySelector('[data-blockid="<id>"]')`, then scopes to
+        // THAT element's subtree. Only the nested, switch-scoped <Block>
+        // (content, below) carries this attribute otherwise — chrome
+        // (tab strip, header) lives outside that subtree once hoisted, so
+        // an agent's own self-targeting UIQuery/UIClick could no longer
+        // find its own tab strip or header. Duplicating the same attribute
+        // (same value, when this pane IS the active member) on this outer,
+        // persistent root fixes it: `querySelector` returns the FIRST match
+        // in document order, and this element precedes the nested one, so
+        // it resolves to the wider root that actually contains everything.
+        <div class="agent-pane-stack" data-blockid={activeBlockId()}>
+            {/* Replacement for BlockFrame's own inline header, suppressed
+                by AgentViewModel.noHeader once hoisted — see that field's
+                own doc comment and headerElem's, above. Same
+                ErrorBoundary-isolation pattern BlockFrame_Default_Component
+                itself uses (blockframe.tsx) so a broken header computation
+                blanks only the header, not the whole pane. */}
+            <ErrorBoundary fallback={headerElemNoView}>{headerElem}</ErrorBoundary>
             {/* Progress bar's own overlay strip — floats above the tab
                 strip, never reserving layout space (SPEC_AGENT_PANE_
                 PROGRESS_BAR_OVERLAY_NO_GAP_2026_08_25.md). Empty div; its

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -50,6 +50,7 @@ import {
     getLayoutModelForStaticTab,
     pushBlockOntoStack,
     setActiveBlockInStack,
+    type NodeModel,
 } from "@/layout/index";
 import { holdLeafRevealGate, scheduleLeafRevealLift } from "@/app/store/tab-reveal";
 import { getTrail } from "@/log/render-trail";
@@ -126,9 +127,9 @@ import { useAgentStream } from "./useAgentStream";
 // rendered state (this text is not our own trusted output; it's shell-command
 // output the user chose to run).
 // Matches BrainSpinner.scss's own `.is-fading` opacity transition duration —
-// the AgentPicker->AgentPresentationView cross-fade (AgentViewWrapper, below)
-// reuses the same visual timing so the two fades feel like one brand moment
-// rather than two differently-tuned animations back to back.
+// the AgentPicker->AgentPresentationView cross-fade (AgentBlockContent,
+// below) reuses the same visual timing so the two fades feel like one brand
+// moment rather than two differently-tuned animations back to back.
 const PICKER_FADE_OUT_MS = 200;
 
 const ANSI_SEQUENCE_RE = new RegExp(
@@ -155,21 +156,27 @@ const sanitizeLogTextForTerminal = (text: string): string => {
 };
 
 /**
- * Top-level wrapper — switches between agent picker and presentation view.
+ * Content half of the agent pane — becomes `AgentViewModel.viewComponent`.
+ * Switches between the agent picker and the live presentation view (or the
+ * read-only history reader). Constructed fresh per stack member, exactly
+ * like every other `viewComponent` — the "one instance, one immutable
+ * blockId for its lifetime" `ViewModel` contract is unchanged here.
  *
- * The pane-scope `<ModalLayer>` wrap lives HERE (not inside
- * AgentPresentationView) because the launch picker — which uses
- * `useModalLayer()` to open the launch / install / new-bundle /
- * create-from-template modals — runs in the fallback branch BEFORE
- * an agentId exists. If the layer wrapped only the presentation
- * view, every first-launch / template-launch call site would resolve
- * `useModalLayer()` to the outer tab-scope layer and the modal would
- * inert the whole tab instead of just this pane. Wrapping at the
- * wrapper covers both the pre-launch picker AND the post-launch
- * presentation view, so the pane-scope lock holds across the entire
- * pane lifecycle. SPEC_LAUNCH_MODAL_PANE_SCOPE_2026_05_25.md.
+ * The pane-scope `<ModalLayer>` wrap lives HERE, not in `AgentPaneChrome` —
+ * `AgentPaneChrome` only mounts once this leaf's stack has ever had 2+
+ * members (`NodeModel.hasEverBeenMultiMember`), but the launch picker
+ * (`useModalLayer()`, opened before any agentId exists) must work on the
+ * ordinary, never-stacked pane too — the overwhelmingly common case. If the
+ * layer instead wrapped only chrome, most panes would have no pane-scope
+ * modal layer at all and every first-launch/template-launch call site would
+ * resolve `useModalLayer()` to the outer tab-scope layer, inerting the
+ * whole tab instead of just this pane. Wrapping here covers both the
+ * pre-launch picker AND the post-launch presentation view, and (once
+ * `AgentPaneChrome` does mount) sits inside it, so the pane-scope lock
+ * still holds across the entire pane lifecycle either way.
+ * SPEC_LAUNCH_MODAL_PANE_SCOPE_2026_05_25.md.
  */
-export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Element => {
+export const AgentBlockContent = ({ model }: { model: AgentViewModel }): JSX.Element => {
     const block = model.blockAtom;
     const agentId = () => block()?.meta?.["agentId"];
     // A block opened as a read-only history reader (openOrFocusHistoryTab)
@@ -237,19 +244,122 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
         }
     });
 
-    // Portal target for the marching-ants progress bar (below) — the bar's
-    // own working-state/turn-phase reads live inside AgentPresentationView
-    // (deep in .agent-pane-stack-content, BELOW the tab strip in DOM order),
-    // but it needs to render visually in its own row between the tab strip
-    // and the content, which no CSS trick can reach across that boundary
-    // (.agent-pane-stack-content's containing-block ancestors all clip
-    // overflow before it could escape upward). A signal (not a plain ref
-    // variable) so <Portal>'s mount prop — read reactively by
-    // AgentPresentationView on its own first render — never races the ref
-    // callback that sets it just above in JSX order.
-    const [progressBarSlot, setProgressBarSlot] = createSignal<HTMLDivElement>();
+    const [agentDefinitions] = useAgentDefinitions();
 
-    // In-pane tabs — rendered here (not inside AgentPresentationView) so the
+    return (
+        <ModalLayer scope="pane">
+            <Show
+                when={isHistoryTab()}
+                fallback={
+                    <>
+                        <Show when={agentId()}>
+                            <AgentPresentationView
+                                model={model}
+                                agentId={agentId()}
+                                agentDefinitions={agentDefinitions}
+                                progressBarMount={model.progressBarMount}
+                            />
+                        </Show>
+                        {/* Cross-fades out on top of AgentPresentationView
+                            once agentId() is set, instead of the two Shows
+                            above hard-swapping instantly — see
+                            pickerVisible/pickerFadingOut above.
+                            SPEC_PANE_BLOCK_STACK_MOUNT_FLICKER_2026_08_22.md §2.3. */}
+                        <Show when={pickerVisible()}>
+                            <div
+                                class="agent-picker-host"
+                                // Strip clearance — mirrors chrome's own
+                                // tab-strip-visibility state
+                                // (AgentPaneChrome writes it via
+                                // model.setTabStripVisible, the same
+                                // bridging pattern as progressBarMount,
+                                // since chrome and content are now separate
+                                // trees). The floating strip still
+                                // physically overlaps this box (it's
+                                // position:absolute within the same
+                                // .agent-pane-stack-content containing
+                                // block content's own .block wrapper is a
+                                // normal-flow child of), even though
+                                // they're no longer DOM siblings.
+                                style={{
+                                    "--pane-tab-strip-reserve": model.tabStripVisible()
+                                        ? "var(--pane-tab-strip-height, 28px)"
+                                        : "0px",
+                                }}
+                                classList={{
+                                    // Applied the instant agentId() is set
+                                    // (same render as AgentPresentationView
+                                    // appearing) so this never sits in
+                                    // normal flow alongside it, even for
+                                    // one frame.
+                                    "is-overlay": !!agentId(),
+                                    "is-fading": pickerFadingOut(),
+                                    "is-reduced-motion": atoms.prefersReducedMotionAtom(),
+                                }}
+                            >
+                                <AgentPicker model={model} />
+                            </div>
+                        </Show>
+                    </>
+                }
+            >
+                {/* No progressBarMount here — a history tab is a read-only
+                    reader with no live turn/working state of its own, so
+                    there's nothing for a progress bar to represent. */}
+                <AgentHistoryTabView model={model} />
+            </Show>
+        </ModalLayer>
+    );
+};
+
+AgentBlockContent.displayName = "AgentBlockContent";
+
+/**
+ * Chrome half of the agent pane — the tab strip and progress-bar slot,
+ * rendered via `AgentViewModel.renderPaneChrome` once this leaf's stack has
+ * ever had 2+ members (`NodeModel.hasEverBeenMultiMember`), wrapping
+ * whichever `AgentBlockContent` instance is currently the active stack
+ * member's own switch-scoped `<Block>` (`content` prop, supplied by
+ * `pane-leaf-chrome.tsx`). Unlike `AgentBlockContent`, this component is
+ * constructed ONCE per leaf and stays mounted across every subsequent
+ * switch — that persistence is the entire point of this file's split
+ * (`SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md`).
+ *
+ * `anchorBlockId` is the blockId of whichever stack member's `ViewModel`
+ * FIRST called `renderPaneChrome` (i.e. the 1→2-member transition) — frozen
+ * for this component's entire lifetime, the same "one instance, one
+ * immutable blockId" contract every other `ViewModel`/`NodeModel` consumer
+ * already follows. This remains a valid anchor for `getNodeByBlockId`
+ * lookups forever after: `anchorBlockId` stays a DORMANT stack member (even
+ * once no longer active) unless the user explicitly closes that specific
+ * tab, and `getNodeByBlockId` matches on `blockStack.includes(blockId)`,
+ * not just the active member.
+ */
+export const AgentPaneChrome = (props: {
+    anchorBlockId: string;
+    nodeModel: NodeModel;
+    children: JSX.Element;
+}): JSX.Element => {
+    const layoutModel = getLayoutModelForStaticTab();
+    const nodeModel = props.nodeModel;
+    const anchorBlockId = props.anchorBlockId;
+
+    // Reads the SAME reactive field `pane-leaf-chrome.tsx`'s inner `<Key>`
+    // is keyed on — see NodeModel.activeBlockId's own doc comment
+    // (layout/lib/types.ts).
+    const activeBlockId = () => nodeModel.activeBlockId?.() ?? anchorBlockId;
+
+    // Block-scoped reads (agentId/isHistoryTab/zoom) must track the
+    // CURRENTLY ACTIVE member, not `anchorBlockId` (frozen to whichever
+    // ViewModel instance first rendered this chrome) — getWaveObjectAtom
+    // inside a memo, not useWaveObjectValue, the same reactive-oref pattern
+    // PR #3134 already established for BlockFrame_Header
+    // (frontend/app/store/wos.ts's own doc comments explain why).
+    const activeBlockData = createMemo(() => WOS.getWaveObjectAtom<Block>(WOS.makeORef("block", activeBlockId()))());
+    const agentId = () => activeBlockData()?.meta?.["agentId"];
+    const isHistoryTab = () => !!activeBlockData()?.meta?.[HISTORY_TAB_FOR_META_KEY];
+
+    // In-pane tabs — rendered here (not inside AgentBlockContent) so the
     // strip stays visible whether the active member is a launched
     // conversation OR a blank/picker tab (AgentPicker, no agentId yet).
     // Previously the strip lived only in AgentPresentationView and was
@@ -267,11 +377,9 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
     //    that are open in ANOTHER top-level pane (Phase 3/4) — kept as
     //    additional pills, deduped against the stack by blockId, so
     //    cross-pane fork-switching keeps working.
-    const layoutModel = getLayoutModelForStaticTab();
-    const [agentDefinitions] = useAgentDefinitions();
     const [openDefinitions] = useOpenDefinitionMap();
     const forks = useForkSet({
-        definitions: agentDefinitions,
+        definitions: useAgentDefinitions()[0],
         openBlockByDef: openDefinitions,
         activeDefinitionId: () => agentId() ?? "",
     });
@@ -298,13 +406,14 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
     // SetMetaCommand round-trip (term.tsx's titleOverrides precedent).
     const [titleOverrides, setTitleOverrides] = createSignal<Record<string, string>>({});
     const labelForBlock = (id: string): PaneTab => {
-        // The currently-mounted member reads its own reactive block meta;
-        // every other (dormant) stack member isn't mounted here — read its
+        // The currently ACTIVE member reads its own reactive block meta
+        // (activeBlockData, already memoized above); every other (dormant)
+        // stack member isn't the active read target — read its
         // last-persisted meta directly, same as term.tsx's termTabs does.
-        const meta = id === model.blockId ? block()?.meta : WOS.getObjectValue<Block>(WOS.makeORef("block", id))?.meta;
+        const meta = id === activeBlockId() ? activeBlockData()?.meta : WOS.getObjectValue<Block>(WOS.makeORef("block", id))?.meta;
         const definitionId = meta?.["agentId"] as string | undefined;
-        const isHistoryTab = !!meta?.[HISTORY_TAB_FOR_META_KEY];
-        if (isHistoryTab) {
+        const isHistoryTabFlag = !!meta?.[HISTORY_TAB_FOR_META_KEY];
+        if (isHistoryTabFlag) {
             // Deliberately ignores titleOverrides/agentName — a history
             // tab is never user-renamed (see PaneTab.isHistoryTab) and
             // must read distinctly from its live sibling, which carries
@@ -318,8 +427,8 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
         // Reactive dependency: re-derive whenever ANY layout mutation
         // happens (matches term.tsx's termTabs).
         layoutModel.localTreeStateAtom();
-        const node = layoutModel.getNodeByBlockId(model.blockId);
-        const stack = node?.data?.blockStack?.length ? node.data.blockStack : [model.blockId];
+        const node = layoutModel.getNodeByBlockId(anchorBlockId);
+        const stack = node?.data?.blockStack?.length ? node.data.blockStack : [anchorBlockId];
         return stack.map(labelForBlock);
     });
     const combinedTabs = createMemo<PaneTab[]>(() => {
@@ -345,25 +454,17 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
             isHistoryTab: isHistoryTab(),
         }),
     );
-    const activeBlockId = createMemo(() => {
-        layoutModel.localTreeStateAtom();
-        return layoutModel.getNodeByBlockId(model.blockId)?.data?.activeBlockId ?? model.blockId;
-    });
     // Per-pane zoom for the tab strip itself — mirrors
     // AgentPresentationView's own zoomFactor memo (term:zoom block meta +
-    // clamp, further down this file) but keyed off activeBlockId() rather
-    // than model.blockId: this component renders the tab strip for the
-    // whole stack, so the strip's zoom must track whichever tab is
-    // actually active, not the pane's own root block — the two diverge
-    // once more than one tab/fork is open. Independent read of the same
-    // live meta key labelForBlock (above) already reads for non-active
-    // stack members — not a shared computation with
-    // AgentPresentationView's own memo, which lives in a child component
-    // out of scope here (SPEC_PANE_TAB_STRIP_CHROME_ZOOM_AND_SCROLL_CLEARANCE_2026_08_12.md §A.3).
+    // clamp, further down this file). Simply activeBlockData()?.meta now —
+    // this component renders the tab strip for the whole stack, and
+    // activeBlockData is already keyed off activeBlockId(), so it already
+    // tracks whichever tab is actually active rather than the anchor's own
+    // original block. Not a shared computation with AgentPresentationView's
+    // own memo, which lives in a child component out of scope here
+    // (SPEC_PANE_TAB_STRIP_CHROME_ZOOM_AND_SCROLL_CLEARANCE_2026_08_12.md §A.3).
     const tabStripZoomFactor = createMemo(() => {
-        const id = activeBlockId();
-        const meta = id === model.blockId ? block()?.meta : WOS.getObjectValue<Block>(WOS.makeORef("block", id))?.meta;
-        const z = meta?.["term:zoom"];
+        const z = activeBlockData()?.meta?.["term:zoom"];
         if (z == null || typeof z !== "number" || isNaN(z)) return 1.0;
         return Math.max(0.5, Math.min(2.0, z));
     });
@@ -374,18 +475,20 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
     // picker's "Switch to existing" flow already does.
     const handleTabSwitch = (targetBlockId: string) => {
         if (targetBlockId === activeBlockId()) return;
-        const node = layoutModel.getNodeByBlockId(model.blockId);
+        const node = layoutModel.getNodeByBlockId(anchorBlockId);
         if (!node) return;
-        const stack = node.data?.blockStack?.length ? node.data.blockStack : [model.blockId];
+        const stack = node.data?.blockStack?.length ? node.data.blockStack : [anchorBlockId];
         if (stack.includes(targetBlockId)) {
-            // Switching to an ALREADY-OPEN pill forces the same remount as
-            // creating a new one — layoutStack.ts's setActiveBlockInStack
-            // evicts the NodeModel just like pushBlockOntoStack does.
-            // Codex's review of PR #2761 caught that this path (unlike
-            // create-new) had no reveal gate at all.
-            const gen = holdLeafRevealGate(node.id);
+            // No reveal gate: reaching this branch at all requires
+            // node.data.blockStack.length > 1 (otherwise `stack` above is
+            // just [anchorBlockId], and targetBlockId !== activeBlockId()
+            // already ruled out targetBlockId === anchorBlockId) — the
+            // exact same precondition NodeModel.hasEverBeenMultiMember()
+            // latches on. AgentPaneChrome only exists in the DOM at all
+            // once that's true, so by the time a human can click a second
+            // pill, chrome is already hoisted and stable by construction.
+            // See SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md.
             setActiveBlockInStack(layoutModel, node.id, targetBlockId);
-            scheduleLeafRevealLift(node.id, gen);
         } else {
             refocusNode(targetBlockId);
         }
@@ -399,7 +502,7 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
     // pane's own stack. No modal, no implicit fork of the current
     // conversation.
     const handleNewAgentTab = async (): Promise<void> => {
-        const initialNode = layoutModel.getNodeByBlockId(model.blockId);
+        const initialNode = layoutModel.getNodeByBlockId(anchorBlockId);
         if (!initialNode) return;
         // Hide this pane while the new tab settles — pane.open's RPC round
         // trip plus pushBlockOntoStack's forced remount (layoutStack.ts's
@@ -430,7 +533,7 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
             // reference. If it's gone, the skip_placement block we just
             // created has nowhere to attach to; delete it instead of leaving
             // an orphaned, unreachable block behind.
-            const node = layoutModel.getNodeByBlockId(model.blockId);
+            const node = layoutModel.getNodeByBlockId(anchorBlockId);
             if (!node) {
                 await ObjectService.DeleteBlock(paneOpenResult.block_id).catch(() => {});
                 return;
@@ -449,29 +552,21 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
     // that block; last member closes the pane), for a cross-pane fork tab
     // it's that other pane (same semantics apply there). closeBlockInStack
     // guards against a blockId that isn't a member, so a stale tab entry
-    // can't close the wrong thing. Gated the same as handleTabSwitch, and
-    // ONLY when targetBlockId is the resolved node's own active member
-    // (reagent's follow-up review of PR #2761: gating unconditionally hides
-    // the leaf's real, unchanging content for the close+settle window when
-    // closing a background tab, since gatingNodeIds() hides the whole node
-    // regardless of whether a remount is actually about to happen) —
-    // popping the ACTIVE member out of a multi-member stack reassigns
-    // activeBlockId and evicts the NodeModel, the identical forced-remount
-    // pattern as switching; popping a background member changes nothing
-    // visible. Note: `node` here may be a different pane than this
-    // component's own (the cross-pane fork tab case), so this checks the
-    // resolved node's own activeBlockId, not this pane's activeBlockId().
+    // can't close the wrong thing. Note: `node` here may be a different
+    // pane than this component's own (the cross-pane fork tab case).
+    //
+    // No reveal gate on either branch — same reasoning as handleTabSwitch:
+    // this is only ever reachable for a resolved node whose blockStack
+    // already had >=2 members (closeBlockInStack's own stack.length<=1
+    // check delegates to a full closeNode otherwise, a different, already
+    // ungated path), which is the same precondition
+    // NodeModel.hasEverBeenMultiMember() latches on — that node's own
+    // AgentPaneChrome (if this is an agent pane) is already hoisted and
+    // stable by construction. See SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md.
     const handleTabClose = (targetBlockId: string) => {
         const node = layoutModel.getNodeByBlockId(targetBlockId);
         if (!node) return;
-        if (node.data?.activeBlockId !== targetBlockId) {
-            void closeBlockInStack(layoutModel, node.id, targetBlockId);
-            return;
-        }
-        const gen = holdLeafRevealGate(node.id);
-        void closeBlockInStack(layoutModel, node.id, targetBlockId).finally(() => {
-            scheduleLeafRevealLift(node.id, gen);
-        });
+        void closeBlockInStack(layoutModel, node.id, targetBlockId);
     };
     // Double-click a tab to rename it (only meaningful once it has launched
     // an agent — a still-blank picker tab has nothing to rename). TWO writes
@@ -525,130 +620,104 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
         }).catch(() => {});
     };
 
+    // Progress-bar mount handoff — bridges chrome's own DOM slot to
+    // whichever AgentViewModel is CURRENTLY active (nodeModel.activeViewModel(),
+    // see that field's own doc comment in types.ts for why this can't read
+    // the global block-component registry). onCleanup inside the effect
+    // clears the OLD vm's mount target before the NEW one is set, whenever
+    // the active vm changes — the same idiom NodeModel's own
+    // activeViewModel/setActiveViewModel wiring in block.tsx uses.
+    const [slotEl, setSlotEl] = createSignal<HTMLDivElement | null>(null);
+    createEffect(() => {
+        const vm = nodeModel.activeViewModel?.() as AgentViewModel | null;
+        const el = slotEl();
+        vm?.setProgressBarMount?.(el);
+        onCleanup(() => {
+            vm?.setProgressBarMount?.(null);
+        });
+    });
+    // Same bridging pattern for the tab-strip-visibility flag AgentBlockContent's
+    // picker-host reads for its own strip-clearance padding (see that
+    // component's own comment) — chrome and content are separate trees now,
+    // so this can no longer be a plain shared local `showTabStrip()` read.
+    createEffect(() => {
+        const vm = nodeModel.activeViewModel?.() as AgentViewModel | null;
+        const visible = showTabStrip();
+        vm?.setTabStripVisible?.(visible);
+        onCleanup(() => {
+            vm?.setTabStripVisible?.(false);
+        });
+    });
+
     return (
-        <ModalLayer scope="pane">
-            {/* Flex-column stack: strip on top, content filling the rest.
-                Required because ModalLayer's mount is a plain 100%-height
-                box, NOT a flex column — without this wrapper the strip's
-                own height ADDS to `.agent-view`'s height:100%, overflowing
-                the pane and clipping the composer off the bottom (found
-                live 2026-08-09: "agent pane has no text input"). */}
-            <div class="agent-pane-stack">
-                {/* Progress bar's own overlay strip — floats above the tab
-                    strip, never reserving layout space (SPEC_AGENT_PANE_
-                    PROGRESS_BAR_OVERLAY_NO_GAP_2026_08_25.md). Empty div;
-                    its only content is whatever AgentPresentationView
-                    portals into it below. Positioned in agent-view.scss
-                    (.agent-pane-progress-bar-slot). */}
-                <div class="agent-pane-progress-bar-slot" ref={(el) => setProgressBarSlot(el)} />
-                <div class="agent-pane-stack-content">
-                    {/* Tab strip floats over the content instead of
-                        reserving its own row (SPEC_AGENT_PANE_TAB_STRIP_
-                        OVERLAY_2026_08_10.md) — with a single conversation
-                        open, the strip is exactly the "+" button's own
-                        28×28px box (shrink-to-fit + hidden-until-2nd-tab,
-                        SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md),
-                        so the conversation renders, and can be scrolled,
-                        underneath the rest of this row — unobstructed except
-                        for wherever a real tab or the "+" actually sits. The
-                        tab pill itself stays hidden until there's something to
-                        switch BETWEEN (see visibleTabs above), and on a FRESH
-                        pane — picker showing, no agent launched yet — the
-                        whole strip (including its "+") is gone rather than
-                        floating a lone button over the picker. The "+" comes
-                        back the moment the pane is a real conversation; see
-                        shouldShowTabStrip for why a 2nd blank tab still keeps
-                        the strip up. */}
-                    <Show when={showTabStrip()}>
-                        <PaneTabStrip
-                            tabs={visibleTabs()}
-                            activeId={activeBlockId()}
-                            zoomFactor={tabStripZoomFactor}
-                            getId={(t) => t.blockId}
-                            getLabel={(t) => t.label}
-                            onActivate={handleTabSwitch}
-                            onClose={handleTabClose}
-                            onTabDoubleClick={(t) => t.definitionId && setRenamingBlockId(t.blockId)}
-                            renderLabel={(t) =>
-                                renamingBlockId() === t.blockId && t.definitionId ? (
-                                    <PaneTabRenameInput
-                                        initialValue={t.label}
-                                        onConfirm={(title) => void handleTabRenameConfirm(t, title)}
-                                        onCancel={() => setRenamingBlockId(null)}
-                                    />
-                                ) : (
-                                    <span class="pane-tab-label">{t.label}</span>
-                                )
-                            }
-                            onAdd={() => void handleNewAgentTab()}
-                            addTitle="New agent"
-                        />
-                    </Show>
-                    <Show
-                        when={isHistoryTab()}
-                        fallback={
-                            <>
-                                <Show when={agentId()}>
-                                    <AgentPresentationView
-                                        model={model}
-                                        agentId={agentId()}
-                                        agentDefinitions={agentDefinitions}
-                                        progressBarMount={progressBarSlot}
-                                    />
-                                </Show>
-                                {/* Cross-fades out on top of AgentPresentationView
-                                    once agentId() is set, instead of the two
-                                    Shows above hard-swapping instantly — see
-                                    pickerVisible/pickerFadingOut above.
-                                    SPEC_PANE_BLOCK_STACK_MOUNT_FLICKER_2026_08_22.md §2.3. */}
-                                <Show when={pickerVisible()}>
-                                    <div
-                                        class="agent-picker-host"
-                                        // Strip clearance, inherited by
-                                        // `.agent-picker`'s padding-top (see
-                                        // _picker.scss). The strip floats over
-                                        // the content, so the picker pads
-                                        // itself out of the way — but on a
-                                        // fresh pane the strip isn't rendered
-                                        // at all (shouldShowTabStrip), and
-                                        // reserving its height there is pure
-                                        // dead space above "My Agents".
-                                        style={{
-                                            "--pane-tab-strip-reserve": showTabStrip()
-                                                ? "var(--pane-tab-strip-height, 28px)"
-                                                : "0px",
-                                        }}
-                                        classList={{
-                                            // Applied the instant agentId()
-                                            // is set (same render as
-                                            // AgentPresentationView
-                                            // appearing) so this never sits
-                                            // in normal flow alongside it,
-                                            // even for one frame.
-                                            "is-overlay": !!agentId(),
-                                            "is-fading": pickerFadingOut(),
-                                            "is-reduced-motion": atoms.prefersReducedMotionAtom(),
-                                        }}
-                                    >
-                                        <AgentPicker model={model} />
-                                    </div>
-                                </Show>
-                            </>
+        // Flex-column stack: strip on top, content filling the rest.
+        // `.agent-pane-stack-content`'s own containing-block role (relative
+        // positioning) is what `> .pane-tab-strip`'s `position: absolute;
+        // top: 0` resolves against — `content` (the switch-scoped `<Block>`,
+        // itself `.block`/`BlockFrame`'s own wrapper) must render as ITS
+        // direct sibling here, not merely "somewhere below," for the strip
+        // to float over the right box. See agent-view.scss's own comments
+        // on `.agent-pane-stack`/`.agent-pane-stack-content` for the full
+        // positioning chain this depends on.
+        <div class="agent-pane-stack">
+            {/* Progress bar's own overlay strip — floats above the tab
+                strip, never reserving layout space (SPEC_AGENT_PANE_
+                PROGRESS_BAR_OVERLAY_NO_GAP_2026_08_25.md). Empty div; its
+                only content is whatever the active AgentPresentationView
+                portals into it via progressBarMount above. Positioned in
+                agent-view.scss (.agent-pane-progress-bar-slot). */}
+            <div class="agent-pane-progress-bar-slot" ref={(el) => setSlotEl(el)} />
+            <div class="agent-pane-stack-content">
+                {/* Tab strip floats over the content instead of reserving
+                    its own row (SPEC_AGENT_PANE_TAB_STRIP_OVERLAY_2026_08_10.md)
+                    — with a single conversation open, the strip is exactly
+                    the "+" button's own 28×28px box (shrink-to-fit +
+                    hidden-until-2nd-tab, SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md),
+                    so the conversation renders, and can be scrolled,
+                    underneath the rest of this row — unobstructed except
+                    for wherever a real tab or the "+" actually sits. The
+                    tab pill itself stays hidden until there's something to
+                    switch BETWEEN (see visibleTabs above); AgentPaneChrome
+                    itself doesn't mount at all until hasEverBeenMultiMember(),
+                    so the "fresh pane, no strip at all" case (picker
+                    showing, no agent launched yet) is simply the passthrough
+                    branch in pane-leaf-chrome.tsx, not a state this
+                    component needs to represent. The "+" comes back the
+                    moment the pane is a real conversation; see
+                    shouldShowTabStrip for why a 2nd blank tab still keeps
+                    the strip up. */}
+                <Show when={showTabStrip()}>
+                    <PaneTabStrip
+                        tabs={visibleTabs()}
+                        activeId={activeBlockId()}
+                        zoomFactor={tabStripZoomFactor}
+                        getId={(t) => t.blockId}
+                        getLabel={(t) => t.label}
+                        onActivate={handleTabSwitch}
+                        onClose={handleTabClose}
+                        onTabDoubleClick={(t) => t.definitionId && setRenamingBlockId(t.blockId)}
+                        renderLabel={(t) =>
+                            renamingBlockId() === t.blockId && t.definitionId ? (
+                                <PaneTabRenameInput
+                                    initialValue={t.label}
+                                    onConfirm={(title) => void handleTabRenameConfirm(t, title)}
+                                    onCancel={() => setRenamingBlockId(null)}
+                                />
+                            ) : (
+                                <span class="pane-tab-label">{t.label}</span>
+                            )
                         }
-                    >
-                        {/* No progressBarMount here — a history tab is a
-                            read-only reader with no live turn/working state
-                            of its own, so there's nothing for a progress
-                            bar to represent. */}
-                        <AgentHistoryTabView model={model} />
-                    </Show>
-                </div>
+                        onAdd={() => void handleNewAgentTab()}
+                        addTitle="New agent"
+                    />
+                </Show>
+                {props.children}
             </div>
-        </ModalLayer>
+        </div>
     );
 };
 
-AgentViewWrapper.displayName = "AgentViewWrapper";
+AgentPaneChrome.displayName = "AgentPaneChrome";
 
 // Launch flow lives in `flows/launch-flow.ts` — Step 2 of
 // docs/specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md.
@@ -667,10 +736,13 @@ const AgentPresentationView = ({
      *  this component is always co-mounted with the wrapper (reagent P2 on
      *  PR #2488). */
     agentDefinitions: () => AgentDefinition[];
-    /** DOM node (owned by AgentViewWrapper, between the tab strip and the
-     *  content) the marching-ants progress bar portals into — see the
-     *  signal's own doc comment in AgentViewWrapper. undefined only for the
-     *  ref-not-yet-assigned instant on first mount. */
+    /** DOM node (owned by AgentPaneChrome, between the tab strip and the
+     *  content) the marching-ants progress bar portals into — bridged
+     *  through this AgentViewModel instance via
+     *  progressBarMount/setProgressBarMount (see those fields' own doc
+     *  comments in agent-model.ts) since chrome and content are separate
+     *  component trees now. undefined/null before chrome has mounted and
+     *  called setProgressBarMount at least once. */
     progressBarMount: () => HTMLDivElement | undefined;
 }): JSX.Element => {
     const block = model.blockAtom;
@@ -688,11 +760,13 @@ const AgentPresentationView = ({
     // the current AgentDefinition object for identity/memory modal requests.
     const currentAgent = createMemo(() => agentDefinitions().find((a) => a.id === agentId));
 
-    // Fork tab strip + in-pane "+" tab logic moved up to AgentViewWrapper
+    // Fork tab strip + in-pane "+" tab logic lives in AgentPaneChrome
     // (SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md §4.3 follow-up,
-    // 2026-08-09) so the strip stays visible even when the pane's active
-    // member is a blank/picker tab with no agentId yet — see that
-    // component's comment for the full rationale.
+    // 2026-08-09, moved out of this component by
+    // SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md) so the strip
+    // stays visible even when the pane's active member is a blank/picker
+    // tab with no agentId yet — see that component's comment for the full
+    // rationale.
 
     // Wire the pane-scoped modal callback into the model so the single
     // title-bar "Stash" (backpack) icon can open the unified tabbed
@@ -925,8 +999,8 @@ const AgentPresentationView = ({
     // Pass the agent definition id so the snapshot fast-path reads from the
     // agent-anchored zone (`agent:<defId>:current`) rather than the
     // per-block zone. `agentId` here is the AgentDefinition slug/UUID —
-    // a non-empty string is guaranteed at this point by the `Show
-    // when={agentId()}` gate in AgentViewWrapper above.
+    // a non-empty string is guaranteed at this point by AgentBlockContent's
+    // own `Show when={agentId()}` gate around this component.
     // Bridged callback: AgentDocumentView registers viewState.markHistoryReady
     // here on mount (before any async history work starts), so
     // useHistoryPagination can signal "history done" into the viewState
@@ -2249,10 +2323,10 @@ const AgentPresentationView = ({
     };
 
     return (
-        // Pane-scope `<ModalLayer>` lives in AgentViewWrapper (above)
-        // so it covers BOTH this presentation view AND the picker
-        // fallback. Anything in this subtree that calls
-        // `useModalLayer()` resolves to that outer pane-scope layer.
+        // Pane-scope `<ModalLayer>` lives in AgentBlockContent (this
+        // component's own parent) so it covers BOTH this presentation view
+        // AND the picker fallback. Anything in this subtree that calls
+        // `useModalLayer()` resolves to that pane-scope layer.
         <div
             ref={rootRef}
             class="agent-view agent-view--presentation"
@@ -2275,15 +2349,18 @@ const AgentPresentationView = ({
             {/* Gradient progress bar — 3px, marching-ants shimmer while
                 working, hidden at rest. Colors derived from --accent-color
                 via color-mix() so it adapts to all themes. Portaled into a
-                slot AgentViewWrapper owns, between the tab strip and the
-                content (its own row, never overlapping either) — this
-                component's state (turnPhase, launch activity) is what
-                drives it, but .agent-view (this component's own root,
-                nested inside .agent-pane-stack-content, itself BELOW the
-                tab strip in DOM order) can't reach a position above the
-                tab strip through CSS alone; every ancestor between here and
-                there clips overflow before an absolutely-positioned escape
-                could ever become visible. See
+                slot AgentPaneChrome owns, between the tab strip and the
+                content (its own row, never overlapping either), bridged
+                through this AgentViewModel instance's progressBarMount
+                signal — see that field's own doc comment (agent-model.ts)
+                for why chrome and content, now separate component trees,
+                need that indirection. This component's state (turnPhase,
+                launch activity) is what drives the bar, but .agent-view
+                (this component's own root, nested inside .agent-pane-stack-content,
+                itself BELOW the tab strip in DOM order) can't reach a
+                position above the tab strip through CSS alone; every
+                ancestor between here and there clips overflow before an
+                absolutely-positioned escape could ever become visible. See
                 SPEC_AGENT_PANE_STATUS_GRADIENT_2026_06_14.md §4 and
                 SPEC_AGENT_PANE_PROGRESS_BAR_ABOVE_TAB_STRIP_2026_08_10.md.
                 Renders nothing until the slot ref is assigned (one frame,
@@ -2310,7 +2387,7 @@ const AgentPresentationView = ({
                 driven by AgentViewModel.viewName / viewIcon / endIconButtons.
                 See SPEC_AGENT_PANE_FOLLOWUPS item #8. */}
 
-            {/* Tab strip now lives in AgentViewWrapper — see its comment. */}
+            {/* Tab strip now lives in AgentPaneChrome — see its comment. */}
 
             {/* This component only ever represents the live view now —
                 Agent History is a separate pane tab (AgentHistoryTabView),

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -75,7 +75,7 @@ import { AgentDecisionPanel } from "./components/AgentDecisionPanel";
 import { AgentDisconnectedBanner } from "./components/AgentDisconnectedBanner";
 import { AgentAuthPanel, AgentDocumentView } from "./components/AgentDocumentView";
 import { AgentFooter, AgentWorkingRow } from "./components/AgentFooter";
-import { AgentPicker, useAgentDefinitions, useOpenDefinitionMap } from "./components/AgentPicker";
+import { AgentPicker, useOpenDefinitionMap } from "./components/AgentPicker";
 import { AgentQuestionPanel } from "./components/AgentQuestionPanel";
 import { AgentSearchBar } from "./components/AgentSearchBar";
 import { AgentShellSubblock } from "./components/AgentShellSubblock";
@@ -247,7 +247,13 @@ export const AgentBlockContent = ({ model }: { model: AgentViewModel }): JSX.Ele
         }
     });
 
-    const [agentDefinitions] = useAgentDefinitions();
+    // ReAgent P2 on SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md's
+    // PR: owned by the model (one useAgentDefinitions() subscription per
+    // ViewModel instance) instead of a fresh call here, so AgentPaneChrome
+    // can read the SAME list via nodeModel.activeViewModel() instead of
+    // independently subscribing a second time — see AgentViewModel.agentDefinitions'
+    // own doc comment (agent-model.ts).
+    const agentDefinitions = model.agentDefinitions;
 
     return (
         <ModalLayer scope="pane">
@@ -439,8 +445,13 @@ export const AgentPaneChrome = (props: {
     //    additional pills, deduped against the stack by blockId, so
     //    cross-pane fork-switching keeps working.
     const [openDefinitions] = useOpenDefinitionMap();
+    // ReAgent P2: reads the active ViewModel's OWN agentDefinitions
+    // (agent-model.ts) instead of calling useAgentDefinitions() again here
+    // — that would be a second, independent RPC + agents:changed
+    // subscription for the same pane, on top of the one AgentBlockContent
+    // already owns.
     const forks = useForkSet({
-        definitions: useAgentDefinitions()[0],
+        definitions: () => (nodeModel.activeViewModel?.() as AgentViewModel | null)?.agentDefinitions?.() ?? [],
         openBlockByDef: openDefinitions,
         activeDefinitionId: () => agentId() ?? "",
     });

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -388,7 +388,14 @@ export const AgentPaneChrome = (props: {
     // `nodeModel.blockId`. `changeConnModalAtom`/`connBtnRef` are inert
     // stand-ins, not wired to any real modal state: AgentViewModel never
     // sets `manageConnection`, so BlockFrame_Header's own connection-button
-    // branch never renders for an agent pane regardless.
+    // branch never renders for an agent pane regardless. This is dead code
+    // waiting to matter, not truly inert forever (ReAgent, this PR): if a
+    // future caller ever sets `manageConnection` on an AgentViewModel, the
+    // button would render but silently do nothing, since these stand-ins
+    // aren't wired to real per-block modal state. Wire a real
+    // `changeConnModalAtom` (mirroring `useBlockAtom` keyed on
+    // `activeBlockId()`) at that point — don't assume this comment alone
+    // will be noticed.
     const changeConnModalAtom = createSignalAtom(false);
     const connBtnRef: { current: HTMLDivElement | null } = { current: null };
     const activeViewModelOrUndefined = () => nodeModel.activeViewModel?.() ?? undefined;

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -52,6 +52,7 @@ import {
     setActiveBlockInStack,
     type NodeModel,
 } from "@/layout/index";
+import { findNode } from "@/layout/lib/layoutNode";
 import { holdLeafRevealGate, scheduleLeafRevealLift } from "@/app/store/tab-reveal";
 import { getTrail } from "@/log/render-trail";
 import { writeText as clipboardWriteText } from "@/util/clipboard";
@@ -329,11 +330,15 @@ AgentBlockContent.displayName = "AgentBlockContent";
  * FIRST called `renderPaneChrome` (i.e. the 1→2-member transition) — frozen
  * for this component's entire lifetime, the same "one instance, one
  * immutable blockId" contract every other `ViewModel`/`NodeModel` consumer
- * already follows. This remains a valid anchor for `getNodeByBlockId`
- * lookups forever after: `anchorBlockId` stays a DORMANT stack member (even
- * once no longer active) unless the user explicitly closes that specific
- * tab, and `getNodeByBlockId` matches on `blockStack.includes(blockId)`,
- * not just the active member.
+ * already follows. It is NOT used to resolve the owning `LayoutNode`,
+ * though — ReAgent P0 on this PR: `anchorBlockId` can itself be closed by
+ * the user (removed from `blockStack` by `closeBlockInStack`'s `filter`),
+ * and `hasEverBeenMultiMember` is monotonic, so `AgentPaneChrome` never
+ * unmounts to recover — a `getNodeByBlockId(anchorBlockId)` lookup that
+ * outlives that tab's closure would return `null` forever after, breaking
+ * the whole tab strip. Node resolution uses `nodeModel.nodeId` instead
+ * (`getOwnNode`, below) — the leaf's own id, stable regardless of which
+ * stack members come and go.
  */
 export const AgentPaneChrome = (props: {
     anchorBlockId: string;
@@ -343,6 +348,17 @@ export const AgentPaneChrome = (props: {
     const layoutModel = getLayoutModelForStaticTab();
     const nodeModel = props.nodeModel;
     const anchorBlockId = props.anchorBlockId;
+
+    // ReAgent P0 on this PR: resolving the owning node via
+    // layoutModel.getNodeByBlockId(anchorBlockId) — anchorBlockId's own
+    // originating tab — breaks permanently the moment the user closes THAT
+    // specific tab: closeBlockInStack removes a closed member from
+    // blockStack via filter, so getNodeByBlockId(anchorBlockId) would
+    // return null forever after (hasEverBeenMultiMember is monotonic, so
+    // AgentPaneChrome never unmounts to recover). The leaf's own nodeId
+    // (NodeModel.nodeId) is stable regardless of which stack members come
+    // and go — resolve on that instead, everywhere in this component.
+    const getOwnNode = () => findNode(layoutModel.treeState.rootNode, nodeModel.nodeId);
 
     // Reads the SAME reactive field `pane-leaf-chrome.tsx`'s inner `<Key>`
     // is keyed on — see NodeModel.activeBlockId's own doc comment
@@ -427,8 +443,8 @@ export const AgentPaneChrome = (props: {
         // Reactive dependency: re-derive whenever ANY layout mutation
         // happens (matches term.tsx's termTabs).
         layoutModel.localTreeStateAtom();
-        const node = layoutModel.getNodeByBlockId(anchorBlockId);
-        const stack = node?.data?.blockStack?.length ? node.data.blockStack : [anchorBlockId];
+        const node = getOwnNode();
+        const stack = node?.data?.blockStack?.length ? node.data.blockStack : [activeBlockId()];
         return stack.map(labelForBlock);
     });
     const combinedTabs = createMemo<PaneTab[]>(() => {
@@ -475,14 +491,14 @@ export const AgentPaneChrome = (props: {
     // picker's "Switch to existing" flow already does.
     const handleTabSwitch = (targetBlockId: string) => {
         if (targetBlockId === activeBlockId()) return;
-        const node = layoutModel.getNodeByBlockId(anchorBlockId);
+        const node = getOwnNode();
         if (!node) return;
-        const stack = node.data?.blockStack?.length ? node.data.blockStack : [anchorBlockId];
+        const stack = node.data?.blockStack?.length ? node.data.blockStack : [activeBlockId()];
         if (stack.includes(targetBlockId)) {
             // No reveal gate: reaching this branch at all requires
             // node.data.blockStack.length > 1 (otherwise `stack` above is
-            // just [anchorBlockId], and targetBlockId !== activeBlockId()
-            // already ruled out targetBlockId === anchorBlockId) — the
+            // just [activeBlockId()], and targetBlockId !== activeBlockId()
+            // already ruled out targetBlockId matching it) — the
             // exact same precondition NodeModel.hasEverBeenMultiMember()
             // latches on. AgentPaneChrome only exists in the DOM at all
             // once that's true, so by the time a human can click a second
@@ -502,7 +518,7 @@ export const AgentPaneChrome = (props: {
     // pane's own stack. No modal, no implicit fork of the current
     // conversation.
     const handleNewAgentTab = async (): Promise<void> => {
-        const initialNode = layoutModel.getNodeByBlockId(anchorBlockId);
+        const initialNode = getOwnNode();
         if (!initialNode) return;
         // Hide this pane while the new tab settles — pane.open's RPC round
         // trip plus pushBlockOntoStack's forced remount (layoutStack.ts's
@@ -533,7 +549,7 @@ export const AgentPaneChrome = (props: {
             // reference. If it's gone, the skip_placement block we just
             // created has nowhere to attach to; delete it instead of leaving
             // an orphaned, unreachable block behind.
-            const node = layoutModel.getNodeByBlockId(anchorBlockId);
+            const node = getOwnNode();
             if (!node) {
                 await ObjectService.DeleteBlock(paneOpenResult.block_id).catch(() => {});
                 return;

--- a/frontend/layout/lib/layoutNodeModels.ts
+++ b/frontend/layout/lib/layoutNodeModels.ts
@@ -4,7 +4,7 @@
 import { createSignalAtom, fireAndForget } from "@/util/util";
 import { findNode } from "./layoutNode";
 import type { Properties as CSSProperties } from "csstype";
-import { createMemo, createRoot } from "solid-js";
+import { createEffect, createMemo, createRoot, createSignal } from "solid-js";
 import { LayoutNode, LayoutNodeAdditionalProps, NodeModel } from "./types";
 import type { LayoutModel } from "./layoutModel";
 
@@ -66,6 +66,31 @@ export function getNodeModel(model: LayoutModel, node: LayoutNode): NodeModel {
                     if (addlProps.hasOwnProperty(nodeid)) return addlProps[nodeid];
                     return undefined;
                 });
+                // Monotonic — see NodeModel.hasEverBeenMultiMember's own doc
+                // comment (types.ts) for why this never resets to false.
+                const [everMultiMember, setEverMultiMember] = createSignal(false);
+                createEffect(() => {
+                    model.localTreeStateAtom();
+                    const current = findNode(model.treeState.rootNode, nodeid);
+                    if (!everMultiMember() && (current?.data?.blockStack?.length ?? 0) > 1) {
+                        setEverMultiMember(true);
+                    }
+                });
+                // Owner-checked the same way unregisterBlockComponentModel
+                // is (block-component-registry.ts) — see
+                // NodeModel.setActiveViewModel's own doc comment (types.ts).
+                let activeViewModelOwner: object | null = null;
+                const [activeViewModelSig, setActiveViewModelSig] = createSignal<ViewModel | null>(null);
+                const setActiveViewModel = (vm: ViewModel | null, owner: object) => {
+                    if (vm === null) {
+                        if (activeViewModelOwner !== owner) return; // stale cleanup — a newer mount already owns this
+                        activeViewModelOwner = null;
+                        setActiveViewModelSig(null);
+                        return;
+                    }
+                    activeViewModelOwner = owner;
+                    setActiveViewModelSig(() => vm);
+                };
                 model.nodeModelDisposers.set(nodeid, disposeThisNodeModel);
                 model.nodeModels.set(nodeid, {
                 additionalProps: addlPropsAtom,
@@ -103,6 +128,9 @@ export function getNodeModel(model: LayoutModel, node: LayoutNode): NodeModel {
                     const current = findNode(model.treeState.rootNode, nodeid);
                     return current?.data?.activeBlockId || current?.data?.blockId || blockId;
                 }),
+                hasEverBeenMultiMember: everMultiMember,
+                activeViewModel: activeViewModelSig,
+                setActiveViewModel,
                 blockNum: createMemo(() => model.leafOrder().findIndex((leafEntry) => leafEntry.nodeid === nodeid) + 1),
                 isFocused: createMemo(() => {
                     const treeState = model.localTreeStateAtom();

--- a/frontend/layout/lib/layoutStack.ts
+++ b/frontend/layout/lib/layoutStack.ts
@@ -16,30 +16,29 @@
  * branch already uses (`layoutMagnify.ts`) for payload-only changes that
  * don't need `treeReducer`'s balance/validation machinery.
  *
- * Every mutation here still evicts the target node's cached `NodeModel` (via
- * `disposeNodeModel`, `layoutNodeModels.ts`) on an active-member change —
- * this is CURRENTLY required, not optional. `activeKeyFor`
- * (`layoutNodeModels.ts`) still includes `activeBlockId` in a stacked leaf's
- * key for exactly this reason: `TabContent`/`Block` render
- * `nodeModel.blockId` as a plain, frozen field with no remount boundary of
- * their own, so this outer, whole-leaf remount is the ONLY mechanism that
- * updates the displayed block content after a switch
- * (`SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md` documents the
- * narrower replacement — a `pane-leaf-chrome.tsx` inner remount boundary —
- * but it does not exist yet; PR #3132 tried shipping the key change and this
- * disposal removal ahead of it and ReAgent/Codex correctly caught the
- * resulting regression: switching a stack leaves the old block displayed,
- * and closing the active member can leave the deleted block displayed).
- * Do not remove these `disposeNodeModel` calls until that inner boundary
- * lands in the SAME deployable change.
+ * NONE of these mutators dispose the leaf's cached `NodeModel` on an
+ * active-member change anymore, as of `pane-leaf-chrome.tsx`
+ * (`SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md`). PR #3132 tried
+ * shipping that removal ahead of the replacement mechanism and ReAgent/Codex
+ * correctly caught the resulting regression (switching a stack left the old
+ * block displayed, with nothing left to update it) — this time the
+ * replacement landed in the SAME PR: `DisplayNodesWrapper`
+ * (`tilelayout-shared.tsx`) now keys its outer `<Key>` on `node.id` alone
+ * (inline, not via `activeKeyFor` — see that function's own doc comment for
+ * why `OverlayNodeWrapper` deliberately keeps using it, unchanged), so the
+ * leaf's whole subtree — chrome included — no longer remounts on a switch.
+ * `pane-leaf-chrome.tsx` owns a narrower, INNER remount instead, scoped to
+ * just the active block's own `<Block>` instance, keyed on
+ * `NodeModel.activeBlockId` (types.ts) — that's what now gives a fresh
+ * `ViewModel` to the newly-active member, and what `closeBlockInStack`'s
+ * comment below used to lean on `disposeNodeModel` for.
  *
- * `NodeModel.activeBlockId` (types.ts) exists as additive, currently-inert
- * groundwork for that future change — no production consumer reads it yet.
+ * `cleanupNodeModels` (`layoutNodeModels.ts`) — real leaf deletion, not
+ * active-member churn — is unaffected and still disposes normally.
  */
 
 import { findNode } from "./layoutNode";
 import type { LayoutModel } from "./layoutModel";
-import { disposeNodeModel } from "./layoutNodeModels";
 import { closeNode } from "./layoutMagnify";
 
 /** The node's stack, or `[blockId]` when it has none yet (back-compat: a
@@ -71,7 +70,6 @@ export function pushBlockOntoStack(model: LayoutModel, nodeId: string, blockId: 
     const stack = effectiveStack(node.data);
     const nextStack = stack.includes(blockId) ? stack : [...stack, blockId];
     setActive(node.data, blockId, nextStack);
-    disposeNodeModel(model, nodeId);
     model.updateTree(false);
     model.setter(model.localTreeStateAtom, { ...model.treeState });
     model.persistToBackend();
@@ -95,7 +93,6 @@ export function setActiveBlockInStack(model: LayoutModel, nodeId: string, blockI
         return; // already active
     }
     setActive(node.data, blockId, stack);
-    disposeNodeModel(model, nodeId);
     model.updateTree(false);
     model.setter(model.localTreeStateAtom, { ...model.treeState });
     model.persistToBackend();
@@ -135,20 +132,12 @@ export async function closeBlockInStack(model: LayoutModel, nodeId: string, bloc
         const nextActive = nextStack[Math.min(idx, nextStack.length - 1)];
         node.data.activeBlockId = nextActive;
         node.data.blockId = nextActive;
-        // Dispose ONLY here, inside this branch — this is the ONLY case
-        // where activeKeyFor's key actually changes, so it's the only case
-        // where the leaf genuinely remounts. Closing a BACKGROUND
-        // (non-active) member leaves activeBlockId untouched: the key
-        // doesn't change, the DisplayNode component stays mounted, and it's
-        // STILL holding a reference to this exact NodeModel via whatever
-        // `useNodeModel()` call it made at its last real mount. Disposing
-        // unconditionally would tear down that STILL-IN-USE component's
-        // isFocused/isMagnified/innerRect/etc out from under it — not a
-        // leak, an active regression: focus/magnify/geometry would freeze
-        // at whatever they were the instant a completely unrelated
-        // background tab closed. See this file's header comment for why
-        // this disposal itself can't be removed yet either.
-        disposeNodeModel(model, nodeId);
+        // No dispose here anymore — the leaf's NodeModel survives
+        // active-member churn regardless of whether the closed member was
+        // active or background; pane-leaf-chrome.tsx's own inner <Key>
+        // (keyed on activeBlockId) is what remounts the actual block
+        // content now, scoped to just that, not the whole leaf. See this
+        // file's header comment.
     }
     model.updateTree(false);
     model.setter(model.localTreeStateAtom, { ...model.treeState });

--- a/frontend/layout/lib/tilelayout-shared.tsx
+++ b/frontend/layout/lib/tilelayout-shared.tsx
@@ -168,7 +168,13 @@ export const DisplayNodesWrapper = (props: DisplayNodesWrapperProps) => {
     const leafs = () => props.layoutModel.leafs();
 
     return (
-        <Key each={leafs()} by={activeKeyFor}>
+        // Keyed on node.id alone — NOT activeKeyFor (which still includes
+        // activeBlockId for a stacked leaf; see that function's own doc
+        // comment). A leaf's whole subtree — DisplayNode, its NodeModel,
+        // chrome — must NOT remount when the active stack member switches;
+        // pane-leaf-chrome.tsx owns a narrower, inner remount scoped to just
+        // the active block instead. SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md.
+        <Key each={leafs()} by={(node) => node.id}>
             {(node) => <Dynamic component={props.DisplayNode} layoutModel={props.layoutModel} node={node()} />}
         </Key>
     );
@@ -351,6 +357,12 @@ export const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
 
     return (
         <div ref={overlayContainerRef} class="overlay-container" style={overlayStyle()}>
+            {/* Deliberately still activeKeyFor (includes activeBlockId for
+                a stacked leaf), unlike DisplayNodesWrapper above —
+                OverlayNode renders drag-overlay/placeholder geometry, not
+                block content, so it was never part of the chrome-flash
+                problem this PR fixes; left unchanged rather than as an
+                accidental side effect of touching the import. */}
             <Key each={leafs()} by={activeKeyFor}>
                 {(node) => <OverlayNode layoutModel={props.layoutModel} node={node()} />}
             </Key>

--- a/frontend/layout/lib/types.ts
+++ b/frontend/layout/lib/types.ts
@@ -363,6 +363,42 @@ export interface NodeModel {
      * itself is ever evicted.
      */
     activeBlockId?: Accessor<string>;
+    /**
+     * True forever, once this leaf's `blockStack` has ever had 2+ members —
+     * never resets to false even if the stack later shrinks back to 1.
+     * Monotonic (not "is currently a stack") on purpose: it drives whether a
+     * hoisted-chrome-capable `ViewModel` (e.g. `AgentViewModel`) suppresses
+     * `BlockFrame`'s own inline header via `noHeader`, and that header must
+     * come from the hoisted chrome from the moment it FIRST mounts (the
+     * 1→2-member transition) onward — flipping back to inline on a
+     * transient 2→1 dip would tear down and rebuild the header exactly the
+     * way this whole feature exists to prevent.
+     * `docs/specs/SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md`.
+     */
+    hasEverBeenMultiMember?: Accessor<boolean>;
+    /**
+     * The `ViewModel` instance the leaf's currently-mounted `Block` owns, or
+     * `null` in the brief window between an old stack member's `Block`
+     * unmounting and the new one's mounting. Pushed by `block.tsx` itself
+     * (`setActiveViewModel`, below) — deliberately NOT read from the global
+     * block-component registry (`frontend/app/store/block-component-registry.ts`),
+     * which is a plain `Map` (not reactive) and, more fundamentally, does
+     * not survive `Block`'s own dispose-on-unmount: the inner per-block
+     * remount this feature introduces (`pane-leaf-chrome.tsx`) unmounts
+     * `Block` on every switch, including a repeat one, so by the time a
+     * user switches back to a previously-seen member its old registry entry
+     * is already gone. This is the one live pointer hoisted chrome has to a
+     * callable `ViewModel` for `renderPaneChrome`/`setProgressBarMount`.
+     */
+    activeViewModel?: Accessor<ViewModel | null>;
+    /**
+     * Owner-checked the same way `unregisterBlockComponentModel` already is:
+     * `block.tsx` passes the exact registration object it owns, so a
+     * stale/delayed cleanup from an older mount can never clobber a newer
+     * mount's live registration (the identical race that pattern already
+     * guards against).
+     */
+    setActiveViewModel?: (vm: ViewModel | null, owner: object) => void;
     addEphemeralNodeToLayout: () => void;
     animationTimeS: Accessor<number>;
     isResizing: Accessor<boolean>;

--- a/frontend/layout/tests/layoutStack.test.ts
+++ b/frontend/layout/tests/layoutStack.test.ts
@@ -123,7 +123,7 @@ describe("layoutStack", () => {
             expect(data.blockId).toBe("b2"); // legacy field stays in sync
         });
 
-        it("evicts the node's cached NodeModel so the next lookup rebuilds it for the new active block", () => {
+        it("does NOT evict the node's cached NodeModel — the leaf stays mounted across a switch", () => {
             const model = createLayoutModel();
             const nodeId = insertRootBlock(model, "b1");
             model.getNodeModel(model.treeState.rootNode!); // populate the cache
@@ -131,35 +131,37 @@ describe("layoutStack", () => {
 
             pushBlockOntoStack(model, nodeId, "b2");
 
-            expect(model.nodeModels.has(nodeId)).toBe(false);
+            expect(model.nodeModels.has(nodeId)).toBe(true);
         });
 
-        // Leak fix: eviction used to be a bare `model.nodeModels.delete(nodeId)`
-        // — it removed the MAP ENTRY but never disposed the reactive root
-        // `getNodeModel` created the NodeModel's memos in (`runInModelRoot`
-        // ties them to the whole MODEL's lifetime, not to that one map entry).
-        // Every switch left the old memo set running, still subscribed,
-        // forever. This proves the fix by DIFFERENTIATING a truly-disposed
-        // memo from a merely-orphaned one: a disposed memo's return value
+        // SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md: eviction here
+        // used to be required because the OUTER leaf-level key
+        // (tilelayout-shared.tsx's DisplayNodesWrapper) used to include
+        // activeBlockId, forcing a full leaf remount on every switch. That
+        // key is now `node.id` alone — pane-leaf-chrome.tsx owns a
+        // narrower, INNER remount instead (scoped to just the active
+        // block's own <Block> instance) — so the leaf's NodeModel is no
+        // longer torn down on a switch; a still-mounted leaf component
+        // depends on it staying live. This proves that by DIFFERENTIATING a
+        // live memo from a frozen one: a disposed memo's return value
         // freezes at whatever it was computed as right before disposal and
-        // does not react to a LATER dependency change, whereas an orphaned
-        // (still-alive) one would keep updating. Falsifiable: reverting the
-        // `disposeNodeModel` change in layoutNodeModels.ts (back to a bare
-        // `.delete()`) makes this test fail, because the frozen assertion
-        // below would instead observe the live, updated value.
-        it("disposes the evicted NodeModel's reactive root, not just its map entry", () => {
+        // does not react to a LATER dependency change, whereas a live one
+        // keeps updating. Falsifiable: reintroducing a `disposeNodeModel`
+        // call in `pushBlockOntoStack` makes this test fail, because the
+        // assertion below would instead observe the frozen, stale value.
+        it("keeps the NodeModel's reactive root alive across the switch, not just its map entry", () => {
             const model = createLayoutModel();
             const nodeId = insertRootBlock(model, "b1");
             const node = model.treeState.rootNode!;
 
-            const evictedNodeModel = model.getNodeModel(node);
+            const nodeModel = model.getNodeModel(node);
             expect(model.nodeModelDisposers.has(nodeId)).toBe(true);
             // insertRootBlock inserts with `focused: true` — the lone leaf
             // starts out focused by default.
-            expect(evictedNodeModel.isFocused()).toBe(true);
+            expect(nodeModel.isFocused()).toBe(true);
 
-            pushBlockOntoStack(model, nodeId, "b2"); // triggers disposeNodeModel
-            expect(model.nodeModelDisposers.has(nodeId)).toBe(false); // disposer consumed, not leaked
+            pushBlockOntoStack(model, nodeId, "b2"); // must NOT dispose
+            expect(model.nodeModelDisposers.has(nodeId)).toBe(true); // disposer still tracked — not consumed
 
             // Un-focus — the identical treeState mutation layoutFocus.ts's
             // own validateFocusedNode uses internally
@@ -167,54 +169,38 @@ describe("layoutStack", () => {
             // model.setter(model.localTreeStateAtom, {...})), not the
             // public focusNode() action, since there's no second node here
             // to focus instead and that action's existence-check isn't the
-            // concern under test. A live isFocused memo would now read
-            // false; a disposed one stays frozen at its pre-disposal value.
+            // concern under test. A disposed isFocused memo would stay
+            // frozen at true; a live one reacts to false.
             model.treeState.focusedNodeId = undefined;
             model.setter(model.localTreeStateAtom, { ...model.treeState });
-            expect(evictedNodeModel.isFocused()).toBe(true); // frozen — proves disposal, not just eviction
-
-            // Contrast: a FRESH NodeModel for the same node, built after the
-            // focus change, correctly reflects live state — confirms the
-            // mutation itself worked and this isn't a false pass from a
-            // broken focus update.
-            const freshNodeModel = model.getNodeModel(node);
-            expect(freshNodeModel.isFocused()).toBe(false);
+            expect(nodeModel.isFocused()).toBe(false); // live — proves NOT disposed
         });
 
-        // reagent P1 on #3091: getNodeAdditionalPropertiesAtom used to be
-        // called UNCONDITIONALLY in getNodeModel, before the cache-miss
-        // check and outside the nested createRoot the P1 fix's own memos
-        // live in — so it built and leaked its own separate, uncached memo
-        // on every single getNodeModel/useNodeModel call (cache hits
-        // included, since it ran before the cache was even consulted), not
-        // just on the eviction path the other test above covers. Same
-        // frozen-vs-live differentiation, targeting THIS specific field.
-        it("disposes additionalProps' own memo too, not just the fields built inside the cache-miss block", () => {
+        // Same live-vs-frozen differentiation as the test above, targeting
+        // additionalProps specifically — this field is built by its own
+        // separate memo inside getNodeModel (see that function's own
+        // comment), so it needs its own proof that it isn't disposed either.
+        it("keeps additionalProps' own memo alive too, not just the fields built inside the cache-miss block", () => {
             const model = createLayoutModel();
             const nodeId = insertRootBlock(model, "b1");
             const node = model.treeState.rootNode!;
 
-            const evictedNodeModel = model.getNodeModel(node);
+            const nodeModel = model.getNodeModel(node);
             // The lone leaf already has real geometry (from
             // createLayoutModel's mocked 800x600 bounding rect) — capture
             // it rather than assume undefined.
-            const initialAddlProps = evictedNodeModel.additionalProps();
+            const initialAddlProps = nodeModel.additionalProps();
             expect(initialAddlProps).toBeDefined();
 
-            pushBlockOntoStack(model, nodeId, "b2"); // triggers disposeNodeModel
+            pushBlockOntoStack(model, nodeId, "b2"); // must NOT dispose
 
             // Set additionalProps for this node to a DIFFERENT value after
-            // disposal. A live memo would now read the new value; a
-            // disposed one stays frozen at its pre-disposal value.
+            // the switch. A disposed memo would stay frozen at the initial
+            // value; a live one reads the new value.
             model.setter(model.additionalProps, {
                 [nodeId]: { treeKey: "test" } as LayoutNodeAdditionalProps,
             });
-            expect(evictedNodeModel.additionalProps()).toEqual(initialAddlProps); // frozen — proves disposal
-
-            // Contrast: a fresh NodeModel for the same node correctly sees
-            // the live value.
-            const freshNodeModel = model.getNodeModel(node);
-            expect(freshNodeModel.additionalProps()).toEqual({ treeKey: "test" });
+            expect(nodeModel.additionalProps()).toEqual({ treeKey: "test" }); // live — proves NOT disposed
         });
 
         it("appending an already-present blockId re-activates it instead of duplicating the stack entry", () => {
@@ -268,7 +254,7 @@ describe("layoutStack", () => {
             expect(model.treeState.rootNode!.data).toEqual(before);
         });
 
-        it("evicts the cached NodeModel on a real switch, not on a no-op re-activation", () => {
+        it("does NOT evict the cached NodeModel, on a real switch or on a no-op re-activation", () => {
             const model = createLayoutModel();
             const nodeId = insertRootBlock(model, "b1");
             pushBlockOntoStack(model, nodeId, "b2"); // active = b2
@@ -278,7 +264,7 @@ describe("layoutStack", () => {
             expect(model.nodeModels.has(nodeId)).toBe(true);
 
             setActiveBlockInStack(model, nodeId, "b1"); // real switch
-            expect(model.nodeModels.has(nodeId)).toBe(false);
+            expect(model.nodeModels.has(nodeId)).toBe(true);
         });
     });
 
@@ -378,18 +364,25 @@ describe("layoutStack", () => {
             expect(stillMountedNodeModel.isFocused()).toBe(true); // live — proves NOT disposed
         });
 
-        it("DOES dispose the NodeModel when closing the active member — this case genuinely remounts", () => {
+        it("does NOT dispose the NodeModel when closing the active member either — the leaf still doesn't remount", () => {
             const model = createLayoutModel();
             const nodeId = insertRootBlock(model, "b1");
             pushBlockOntoStack(model, nodeId, "b2"); // stack: [b1,b2], active b2
             const node = model.treeState.rootNode!;
 
-            const evictedNodeModel = model.getNodeModel(node);
+            const nodeModel = model.getNodeModel(node);
             expect(model.nodeModelDisposers.has(nodeId)).toBe(true);
 
-            void closeBlockInStack(model, nodeId, "b2"); // b2 IS active — closing it changes activeBlockId
+            void closeBlockInStack(model, nodeId, "b2"); // b2 IS active — activeBlockId changes, but the leaf's own key doesn't
 
-            expect(model.nodeModelDisposers.has(nodeId)).toBe(false); // disposer consumed — confirms the fix didn't overcorrect into never disposing
+            expect(model.nodeModelDisposers.has(nodeId)).toBe(true); // disposer still tracked — not consumed
+
+            // Live-vs-frozen: focus the node after the close — a disposed
+            // memo would stay frozen at false (never explicitly focused
+            // above); a live one reacts.
+            model.treeState.focusedNodeId = nodeId;
+            model.setter(model.localTreeStateAtom, { ...model.treeState });
+            expect(nodeModel.isFocused()).toBe(true); // live — proves NOT disposed
         });
 
         it("closing the ACTIVE member picks its right neighbor", async () => {
@@ -499,15 +492,15 @@ describe("NodeModel.activeBlockId", () => {
     });
     afterEach(() => vi.useRealTimers());
 
-    // Additive, currently-inert groundwork (types.ts) for the future
-    // pane-leaf-chrome.tsx inner remount boundary — no production consumer
-    // reads it yet. Proves the memo re-derives from live tree state on every
-    // read rather than freezing at construction time, the same pattern
-    // already proven safe in agent-view.tsx's own activeBlockId memo.
-    // Mutates tree state directly (not via pushBlockOntoStack) so this test
-    // doesn't depend on whether that mutator disposes the NodeModel —
-    // that's a separate, currently-still-true invariant covered by the
-    // describe blocks above.
+    // Consumed by pane-leaf-chrome.tsx's inner <Key> and AgentPaneChrome
+    // (agent-view.tsx) to track the active stack member without the leaf
+    // itself remounting. Proves the memo re-derives from live tree state on
+    // every read rather than freezing at construction time, the same
+    // pattern already proven safe in agent-view.tsx's own (now-superseded)
+    // activeBlockId memo. Mutates tree state directly (not via
+    // pushBlockOntoStack) so this test doesn't depend on whether that
+    // mutator disposes the NodeModel — that's a separate invariant covered
+    // by the describe blocks above (it doesn't, as of this file).
     it("tracks the currently active stack member from live tree state", () => {
         const model = createLayoutModel();
         const nodeId = insertRootBlock(model, "b1");
@@ -523,13 +516,94 @@ describe("NodeModel.activeBlockId", () => {
         expect(nodeModel.activeBlockId!()).toBe("b2");
     });
 
-    it("a fresh NodeModel for the same node also picks up whatever the current active member is", () => {
+    it("the SAME NodeModel instance picks up the new active member after a switch (no eviction)", () => {
         const model = createLayoutModel();
         const nodeId = insertRootBlock(model, "b1");
-        pushBlockOntoStack(model, nodeId, "b2"); // evicts+disposes today — see describe blocks above
-
         const nodeModel = model.getNodeModel(model.treeState.rootNode!);
+
+        pushBlockOntoStack(model, nodeId, "b2");
+
+        expect(model.getNodeModel(model.treeState.rootNode!)).toBe(nodeModel); // same instance — not evicted
         expect(nodeModel.activeBlockId!()).toBe("b2");
+    });
+});
+
+describe("NodeModel.hasEverBeenMultiMember", () => {
+    beforeEach(() => {
+        layoutStateSignals.clear();
+        vi.useFakeTimers();
+    });
+    afterEach(() => vi.useRealTimers());
+
+    // Drives AgentViewModel.noHeader (agent-model.ts) — must be MONOTONIC,
+    // never resetting to false once true, or a hoisted header would tear
+    // down and rebuild the instant a stack shrank back to 1 member. See
+    // this field's own doc comment (types.ts).
+    it("is false for a non-stacked leaf and flips permanently true once the stack ever exceeds 1 member", () => {
+        const model = createLayoutModel();
+        const nodeId = insertRootBlock(model, "b1");
+        const nodeModel = model.getNodeModel(model.treeState.rootNode!);
+        expect(nodeModel.hasEverBeenMultiMember!()).toBe(false);
+
+        pushBlockOntoStack(model, nodeId, "b2"); // stack: [b1,b2]
+        expect(nodeModel.hasEverBeenMultiMember!()).toBe(true);
+
+        // Shrink back to 1 member — must NOT reset.
+        void closeBlockInStack(model, nodeId, "b2");
+        expect(nodeModel.hasEverBeenMultiMember!()).toBe(true);
+    });
+});
+
+describe("NodeModel.activeViewModel / setActiveViewModel", () => {
+    beforeEach(() => {
+        layoutStateSignals.clear();
+        vi.useFakeTimers();
+    });
+    afterEach(() => vi.useRealTimers());
+
+    // block.tsx pushes into this on mount/unmount (see that file's own
+    // comments) — this suite exercises just the NodeModel-side contract in
+    // isolation: a plain owner-checked signal pair, mirroring
+    // unregisterBlockComponentModel's owner-check pattern
+    // (block-component-registry.ts) so a stale/delayed cleanup from an
+    // older "owner" can never clobber a newer one's live registration.
+    it("starts null, is set by its owner, and reads back the set value", () => {
+        const model = createLayoutModel();
+        insertRootBlock(model, "b1");
+        const nodeModel = model.getNodeModel(model.treeState.rootNode!);
+        expect(nodeModel.activeViewModel!()).toBeNull();
+
+        const owner = {};
+        const vm = { viewType: "agent" } as unknown as ViewModel;
+        nodeModel.setActiveViewModel!(vm, owner);
+
+        expect(nodeModel.activeViewModel!()).toBe(vm);
+    });
+
+    it("a non-owning caller cannot clear a live registration", () => {
+        const model = createLayoutModel();
+        insertRootBlock(model, "b1");
+        const nodeModel = model.getNodeModel(model.treeState.rootNode!);
+
+        const owner = {};
+        const vm = { viewType: "agent" } as unknown as ViewModel;
+        nodeModel.setActiveViewModel!(vm, owner);
+
+        nodeModel.setActiveViewModel!(null, {}); // different owner — stale/delayed cleanup
+        expect(nodeModel.activeViewModel!()).toBe(vm); // untouched
+    });
+
+    it("the owning caller can clear its own registration", () => {
+        const model = createLayoutModel();
+        insertRootBlock(model, "b1");
+        const nodeModel = model.getNodeModel(model.treeState.rootNode!);
+
+        const owner = {};
+        const vm = { viewType: "agent" } as unknown as ViewModel;
+        nodeModel.setActiveViewModel!(vm, owner);
+
+        nodeModel.setActiveViewModel!(null, owner);
+        expect(nodeModel.activeViewModel!()).toBeNull();
     });
 });
 

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -4,6 +4,7 @@
 // SolidJS migration: all Jotai/React types replaced with SolidJS equivalents.
 
 import type { PaneVoiceHandle } from "@/app/hook/useVoiceInput";
+import type { NodeModel } from "@/layout/index";
 import type { SignalAtom } from "@/util/util";
 import type { Placement } from "@floating-ui/dom";
 import type * as rxjs from "rxjs";
@@ -549,6 +550,26 @@ declare global {
          *  by BlockFrame_Header (to render the mic button) and by the
          *  Ctrl+Shift+V global hotkey to retarget the voice session. */
         voiceHandle?: () => PaneVoiceHandle;
+        /** Renders this view's own pane chrome (header + any hoisted tab
+         *  strip) WRAPPED AROUND `content` — a stable outer shell that
+         *  survives an in-pane tab switch, instead of the default
+         *  `BlockFrame` header living inside `Block` (which remounts
+         *  per-switch). `content` is the switch-scoped, `<Key>`-wrapped
+         *  `Block` for whichever member is currently active; the
+         *  implementation decides where inside its own markup that content
+         *  slots in (e.g. below a floating tab strip, inside a specific
+         *  flex-column wrapper the chrome's own CSS positioning depends
+         *  on) — `pane-leaf-chrome.tsx` has no opinion on that internal
+         *  structure, only that `content` ends up mounted somewhere in the
+         *  returned tree. Takes the LEAF-level `NodeModel` (shared across
+         *  every stack member), not a per-block one. See
+         *  `docs/specs/SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md`. */
+        renderPaneChrome?: (nodeModel: NodeModel, content: JSX.Element) => JSX.Element;
+        /** Registers the DOM node hoisted chrome should portal a
+         *  per-block busy/progress indicator into, so the indicator's own
+         *  remount (tied to the active block) doesn't require the chrome
+         *  itself to remount. `null` on unmount/teardown. */
+        setProgressBarMount?: (el: HTMLDivElement | null) => void;
     }
 
     type UpdaterStatus = "up-to-date" | "checking" | "available" | "downloading" | "ready" | "error" | "installing";


### PR DESCRIPTION
## Summary

PR 3 of 3 for `docs/specs/SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md` (PR 1 = #3132, PR 2 = #3134, both merged). This lands the actual visible fix, deferred here because PR 1 alone (dropping `activeBlockId` from the leaf's remount key without a replacement mechanism) turned out to be a real regression — caught by ReAgent/Codex — that could only be fixed correctly by landing the replacement mechanism in the *same* change as the removal.

- New `frontend/app/tab/pane-leaf-chrome.tsx`: the router `tabcontent.tsx` now renders instead of `<Block>` directly. Always wraps a per-active-member, `<Key>`-scoped `<Block>` (via a block-scoped `NodeModel` wrapper, since the leaf's own `NodeModel.blockId` is frozen) — this inner remount is what updates displayed content on a switch now. When the active member's effective view type is `"agent"` and the leaf's stack has ever had 2+ members (`NodeModel.hasEverBeenMultiMember`, new, monotonic), wraps that in the active `ViewModel`'s own `renderPaneChrome` — a stable outer shell that survives every subsequent switch. Every other case is byte-for-byte today's passthrough.
- `layoutStack.ts`: the three block-stack mutators no longer dispose the leaf's `NodeModel` on an active-member change. `tilelayout-shared.tsx`: `DisplayNodesWrapper`'s outer `<Key>` now keys leaves on `node.id` alone (`OverlayNodeWrapper` deliberately unchanged — drag-overlay geometry, not content). Landing these together with the router above, per `layoutStack.ts`'s own header comment, is exactly what PR 1 got wrong.
- `NodeModel` gains `activeViewModel`/`setActiveViewModel` (`types.ts`, `layoutNodeModels.ts`), pushed by `block.tsx`'s existing `ViewModel` construct/cleanup effect (owner-checked the same way `unregisterBlockComponentModel` already is) — hoisted chrome's only live pointer to a callable `ViewModel`, since the global block-component registry is a plain `Map` (not reactive) and doesn't survive `Block`'s own dispose-on-unmount on every switch, including a repeat one.
- `agent-view.tsx` splits `AgentViewWrapper` into `AgentBlockContent` (becomes `AgentViewModel.viewComponent`, constructed fresh per stack member, unchanged internals) and `AgentPaneChrome` (the tab strip + progress-bar slot, mounted once per leaf via `renderPaneChrome`, bridges `progressBarMount`/`tabStripVisible` back to whichever `ViewModel` is currently active). `handleTabSwitch`/`handleTabClose`'s reveal gates are dropped on the branches only reachable once `hasEverBeenMultiMember()` is already true — chrome is hoisted and stable by construction by then.
- `blockutil.tsx`'s `ConnectionButton` fixed to read its `connection` prop reactively (a real latent bug Codex caught on PR #3134 — harmless there since nothing routed a changing blockId into a live header yet; this PR is what actually exercises it).

## Test plan

- [x] `npx vitest run` — full suite, 3900 passing / 3 skipped, no regressions.
- [x] `npx tsc -p tsconfig.json --noEmit` — clean.
- [x] New `frontend/app/tab/pane-leaf-chrome.test.tsx` — the spec's own acceptance criterion: mount, capture the hoisted chrome's DOM node reference, drive a switch, assert `===` on it afterward while the switch-scoped block content gets a genuinely fresh element.
- [x] `layoutStack.test.ts`'s frozen-vs-live assertions inverted (again — the first inversion on PR 1 was reverted when the regression was found) plus new coverage for `hasEverBeenMultiMember` and `activeViewModel`/`setActiveViewModel`.
- [ ] **Manual, in a live build — NOT done by me.** I don't have a way to visually verify a different pane's UI in this environment (AgentMux's own `UIScreenshot`/`UIClick`/`UIQuery` tools are scoped to my own pane only). The DOM/CSS containment chain changed meaningfully — `.agent-pane-stack` now sometimes sits OUTSIDE the leaf's own `BlockFrame` wrapper instead of always inside `.block-content` (see `agent-view.scss`'s updated comments for the full reasoning) — and genuinely needs a human or dev-server check before merge:
  - Switch Agent↔History several times — header/tab-strip must not flash on a repeat switch.
  - First History activation for a fresh agent — expected to still flash, per confirmed scope (not a bug).
  - "+" (new tab) / Quick Fork — existing gated settle must be unchanged.
  - Progress bar renders in the right place while an agent is busy, including after switching tabs.

<!-- agentmux:agent_id=camper -->