### PR TITLE
ui(armory): rename the ABF tab to Bundles

### DIFF
--- a/.changesets/1789013957-ui-armory-rename-the-abf-tab-to-bundles-abf-stays-the-name-o-1d6a.md
+++ b/.changesets/1789013957-ui-armory-rename-the-abf-tab-to-bundles-abf-stays-the-name-o-1d6a.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+ui(armory): rename the ABF tab to Bundles; ABF stays the name of the import/export format

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -2121,7 +2121,7 @@ const AgentPresentationView = ({
             ]);
 
             // If this agent has a Bundle selected as its startup source
-            // (AgentStartupModal, Armory → ABF content), its
+            // (AgentStartupModal, Armory → Bundles content), its
             // `instructions` take precedence over the legacy freeform
             // "startup" blob — which has no live authoring UI anywhere, see
             // docs/specs/ARCHITECTURE_ARMORY_2026_07_20.md §5. Falls back to

--- a/frontend/app/view/agent/components/AgentNewBundleModal.tsx
+++ b/frontend/app/view/agent/components/AgentNewBundleModal.tsx
@@ -134,7 +134,7 @@ export const AgentNewBundleModalPanel = (
                                 onChange={() => setSeedMode("empty")}
                                 disabled={submitting()}
                             />
-                            <span>Start empty — add files later from the Armory (ABF)</span>
+                            <span>Start empty — add files later from the Armory (Bundles)</span>
                         </label>
                         <label class="agent-new-bundle-modal-radio">
                             <input

--- a/frontend/app/view/agent/components/AgentStartupModal.test.tsx
+++ b/frontend/app/view/agent/components/AgentStartupModal.test.tsx
@@ -98,14 +98,14 @@ describe("AgentStartupModal", () => {
 
         render(() => <AgentStartupModal agentId="agent-1" />);
         await screen.findByRole("combobox");
-        expect(screen.queryByText(/Armory → ABF/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Armory → Bundles/)).not.toBeInTheDocument();
 
         setAgentContent.mockResolvedValue({});
         const select = screen.getByRole("combobox");
         fireEvent.change(select, { target: { value: "bundle-1" } });
 
         await waitFor(() => {
-            expect(screen.getByText(/Armory → ABF/)).toBeInTheDocument();
+            expect(screen.getByText(/Armory → Bundles/)).toBeInTheDocument();
         });
     });
 

--- a/frontend/app/view/agent/components/AgentStartupModal.tsx
+++ b/frontend/app/view/agent/components/AgentStartupModal.tsx
@@ -106,7 +106,7 @@ export const AgentStartupModal = (props: AgentStartupModalProps): JSX.Element =>
                                 class="agent-primitive-modal-link-btn"
                                 onClick={() => void openOrFocusPaneByView("armory")}
                             >
-                                Armory → ABF
+                                Armory → Bundles
                             </button>
                             . Changing "{bundle().name}" there updates every agent using
                             it, including this one.

--- a/frontend/app/view/agent/components/AgentStashModal.tsx
+++ b/frontend/app/view/agent/components/AgentStashModal.tsx
@@ -74,7 +74,7 @@ export const AgentStashModal = (props: AgentStashModalProps): JSX.Element => {
         { id: "memory", label: "Personal Memory", icon: "brain" },
         { id: "mcp", label: "MCP Servers", icon: "plug" },
         { id: "skills", label: "Skills", icon: "wand-magic-sparkles" },
-        // layer-group: same icon armory-view.tsx's RAIL uses for "ABF" —
+        // layer-group: same icon armory-view.tsx's RAIL uses for "Bundles" —
         // this tab picks a bundle as startup instructions, so it's the same
         // concept scoped to one agent.
         { id: "startup", label: "Startup", icon: "layer-group" },

--- a/frontend/app/view/armory/armory-model.ts
+++ b/frontend/app/view/armory/armory-model.ts
@@ -38,7 +38,7 @@ export const ARMORY_SECTION_LABELS: Record<ArmorySection, string> = {
     memory: "Memory",
     skills: "Skills",
     mcp: "MCP Servers",
-    bundles: "ABF",
+    bundles: "Bundles",
 };
 
 function isArmorySection(v: unknown): v is ArmorySection {

--- a/frontend/app/view/armory/armory-model.ts
+++ b/frontend/app/view/armory/armory-model.ts
@@ -13,9 +13,9 @@ import { createMemo, type Accessor } from "solid-js";
 // brain (GlobalBrainManager, is_global Memory bundles) and the per-agent
 // native memory history (NativeMemoryManager) as sections inside one pane
 // — see docs/specs/SPEC_ARMORY_MEMORY_TAB_MERGE_2026_08_30.md. Distinct
-// from a bundle's own "bundles" section (label "ABF"; its backing
-// component, BundleManager, is itself a naming leftover — see
-// docs/specs/SPEC_MEMORY_VERSION_CONTROL_AND_ARMORY_AUDIT_2026_08_19.md §4.3).
+// from the "bundles" section (label "Bundles", backed by BundleManager —
+// renamed from MemoryManager in #3135; see
+// docs/specs/SPEC_ARMORY_NAMING_CONSOLIDATION_2026_09_09.md §9.1).
 //
 // "native_memory" is a legacy rail-section id: prior to the 08-30 merge it
 // was its own rail tab ("Personal Memory") — see

--- a/frontend/app/view/armory/armory-view.test.tsx
+++ b/frontend/app/view/armory/armory-view.test.tsx
@@ -18,7 +18,7 @@
  * docs/specs/SPEC_ARMORY_MEMORY_TAB_MERGE_2026_08_30.md then merged those
  * two rail tabs into a single "Memory" tab (brain icon), with Global and
  * Personal as a sub-nav inside that one pane instead of two rail entries.
- * Current rail order: Accounts, Memory, Skills, MCP Servers, ABF. These
+ * Current rail order: Accounts, Memory, Skills, MCP Servers, Bundles. These
  * tests guard the rail contents directly; `ArmorySection`'s type-level
  * rejection of `"identities"` is checked at compile time below (no runtime
  * assertion needed for that part).

--- a/frontend/app/view/armory/armory-view.test.tsx
+++ b/frontend/app/view/armory/armory-view.test.tsx
@@ -123,11 +123,11 @@ describe("ArmoryView rail", () => {
         expect(rail.querySelector(".bundle-manager-rail-item .fa-brain")).toBeInTheDocument();
     });
 
-    it("orders the rail as Accounts, Memory, Skills, MCP Servers, ABF", () => {
+    it("orders the rail as Accounts, Memory, Skills, MCP Servers, Bundles", () => {
         renderArmory();
         const rail = screen.getByLabelText("Armory section", { selector: "nav.bundle-manager-rail" });
         const labels = Array.from(rail.querySelectorAll("button span")).map((el) => el.textContent);
-        expect(labels).toEqual(["Accounts", "Memory", "Skills", "MCP Servers", "ABF"]);
+        expect(labels).toEqual(["Accounts", "Memory", "Skills", "MCP Servers", "Bundles"]);
     });
 });
 
@@ -246,21 +246,21 @@ describe("ArmoryView pane title", () => {
         expect(tabBar.compareDocumentPosition(section as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     });
 
-    it("highlights only the ABF entry in both the rail and the tab-bar", () => {
+    it("highlights only the Bundles entry in both the rail and the tab-bar", () => {
         renderArmory();
         const rail = screen.getByLabelText("Armory section", { selector: "nav.bundle-manager-rail" });
         const tabBar = screen.getByLabelText("Armory section", { selector: "nav.bundle-manager-tab-bar" });
         for (const nav of [rail, tabBar]) {
             const highlighted = Array.from(nav.querySelectorAll("button.is-abf-highlight"));
             expect(highlighted).toHaveLength(1);
-            expect(highlighted[0].textContent).toContain("ABF");
+            expect(highlighted[0].textContent).toContain("Bundles");
         }
     });
 
     it("viewName() reflects a pre-seeded armory:section meta value", () => {
         setBlockMeta({ "armory:section": "bundles" });
         const model = new ArmoryViewModel("test-block", null as any);
-        expect(model.viewName()).toBe("ABF");
+        expect(model.viewName()).toBe("Bundles");
     });
 
     it("falls back to 'Accounts' for an invalid armory:section meta value", () => {

--- a/frontend/app/view/armory/armory-view.tsx
+++ b/frontend/app/view/armory/armory-view.tsx
@@ -27,7 +27,7 @@ const RAIL: { id: ArmorySection; label: string; tooltip?: string; icon: string }
     { id: "memory",   label: ARMORY_SECTION_LABELS.memory,   tooltip: "Global (workspace-wide) and Personal (per-agent) memory", icon: "brain" },
     { id: "skills",   label: ARMORY_SECTION_LABELS.skills,   icon: "wand-magic-sparkles" },
     { id: "mcp",      label: ARMORY_SECTION_LABELS.mcp,      icon: "plug" },
-    { id: "bundles",  label: ARMORY_SECTION_LABELS.bundles,  tooltip: "Armory Bundle Format (ABF)", icon: "layer-group" },
+    { id: "bundles",  label: ARMORY_SECTION_LABELS.bundles,  tooltip: "Bundles — import and export as Armory Bundle Format (ABF)", icon: "layer-group" },
 ];
 
 const MEMORY_SUBNAV: { id: MemorySubsection; label: string }[] = [

--- a/frontend/app/view/bundle-summary.test.tsx
+++ b/frontend/app/view/bundle-summary.test.tsx
@@ -44,7 +44,7 @@ describe("BundleSummaryPanel", () => {
     it("renders the generic pointer-only form when agentId is absent", () => {
         render(() => <BundleSummaryPanel kind="Bundle" />);
         expect(screen.getByText(/Manage in Identity & Memory/)).toBeInTheDocument();
-        expect(screen.queryByText("This agent's own ABF")).not.toBeInTheDocument();
+        expect(screen.queryByText("This agent's own bundle")).not.toBeInTheDocument();
     });
 
     it("shows the bound bundle's name and provider when the agent has one", async () => {
@@ -73,7 +73,7 @@ describe("BundleSummaryPanel", () => {
         render(() => <BundleSummaryPanel kind="Bundle" agentId="agent-1" />);
 
         await waitFor(() => {
-            expect(screen.getByText(/has no ABF bundle of its own yet/)).toBeInTheDocument();
+            expect(screen.getByText(/has no bundle of its own yet/)).toBeInTheDocument();
         });
         expect(getMemory).not.toHaveBeenCalled();
     });
@@ -94,7 +94,7 @@ describe("BundleSummaryPanel", () => {
 
         render(() => <BundleSummaryPanel kind="Bundle" agentId="agent-1" />);
 
-        expect(screen.queryByText("This agent's own ABF")).not.toBeInTheDocument();
+        expect(screen.queryByText("This agent's own bundle")).not.toBeInTheDocument();
         expect(getMemory).not.toHaveBeenCalled();
     });
 });

--- a/frontend/app/view/bundle-summary.tsx
+++ b/frontend/app/view/bundle-summary.tsx
@@ -73,10 +73,10 @@ export const BundleSummaryPanel = (props: BundleSummaryPanelProps): JSX.Element 
         RpcApi.GetBundleCommand(TabRpcClient, { id }).catch(() => undefined),
     );
     // Identity items are still called "identity bundles"; the config
-    // collections are now branded "Armory Bundle Format (ABF)". `title` is
-    // the heading (room for the full name); `sentenceLabel` reads naturally
+    // collections are "Bundles" (ABF names only the file format). `title` is
+    // the heading; `sentenceLabel` reads naturally
     // in running prose below.
-    const title = props.kind === "Identity" ? "Identity bundles" : "Armory Bundle Format (ABF)";
+    const title = props.kind === "Identity" ? "Identity bundles" : "Bundles";
     const sentenceLabel = props.kind === "Identity" ? "Identity bundles" : "Bundles";
     const lowerPlural = props.kind === "Identity" ? "identities" : "bundles";
 

--- a/frontend/app/view/bundle-summary.tsx
+++ b/frontend/app/view/bundle-summary.tsx
@@ -88,7 +88,7 @@ export const BundleSummaryPanel = (props: BundleSummaryPanelProps): JSX.Element 
                 <Show when={props.agentId && boundBundle()}>
                     {(bundle) => (
                         <div class="bundle-summary-bound">
-                            <p class="bundle-summary-bound-label">This agent's own ABF</p>
+                            <p class="bundle-summary-bound-label">This agent's own bundle</p>
                             <p class="bundle-summary-bound-name">{bundle().name}</p>
                             <Show when={bundle().provider}>
                                 <p class="bundle-summary-bound-provider">
@@ -100,12 +100,12 @@ export const BundleSummaryPanel = (props: BundleSummaryPanelProps): JSX.Element 
                 </Show>
                 <Show when={props.agentId && boundBundleId() && !boundBundle.loading && !boundBundle()}>
                     <p class="bundle-summary-body bundle-summary-hint">
-                        This agent's ABF bundle couldn't be loaded (it may have been deleted).
+                        This agent's bundle couldn't be loaded (it may have been deleted).
                     </p>
                 </Show>
                 <Show when={props.agentId && agents().length > 0 && !boundBundleId()}>
                     <p class="bundle-summary-body bundle-summary-hint">
-                        This agent has no ABF bundle of its own yet.
+                        This agent has no bundle of its own yet.
                     </p>
                 </Show>
 

--- a/frontend/app/view/bundle/bundle-manager.tsx
+++ b/frontend/app/view/bundle/bundle-manager.tsx
@@ -507,7 +507,7 @@ const BundleManagerBody = (props: BundleManagerBodyProps): JSX.Element => {
     return (
         <PrimitiveListDetail
             showDetail={inDetail()}
-            backLabel="ABF"
+            backLabel="Bundles"
             onBack={handleBack}
             list={listView}
             detail={detailView}

--- a/frontend/app/view/bundle/bundle-model.ts
+++ b/frontend/app/view/bundle/bundle-model.ts
@@ -179,7 +179,7 @@ export class BundleViewModel implements ViewModel {
     // stay visually consistent; the brain icon is reserved for native memory.
     viewIcon: Accessor<string> = () => "layer-group";
     viewName: Accessor<string>;
-    viewText: Accessor<string | HeaderElem[]> = () => "ABF";
+    viewText: Accessor<string | HeaderElem[]> = () => "Bundles";
     noPadding: Accessor<boolean> = () => false;
 
     get viewComponent(): ViewComponent {
@@ -244,7 +244,7 @@ export class BundleViewModel implements ViewModel {
             : () => undefined;
         this.viewName = createMemo(() => {
             const block = this.blockAtom();
-            return (block?.meta?.["frame:title"] as string) ?? "ABF";
+            return (block?.meta?.["frame:title"] as string) ?? "Bundles";
         });
         this.agentId = createMemo(() => {
             const block = this.blockAtom();
@@ -277,7 +277,7 @@ export class BundleViewModel implements ViewModel {
             this.setMemories(list.filter((m) => !m.is_system));
             this.setError(null);
         } catch (e) {
-            this.setError(`Failed to load ABF bundles: ${(e as Error).message ?? e}`);
+            this.setError(`Failed to load bundles: ${(e as Error).message ?? e}`);
         }
     }
 

--- a/frontend/app/view/bundle/bundle-model.ts
+++ b/frontend/app/view/bundle/bundle-model.ts
@@ -1,9 +1,9 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// Armory Bundle Format (ABF) bundle manager — first-class management of
-// ABF bundles. User-facing name is "Armory Bundle Format (ABF)" (short
-// form "ABF"); the type/table stay `Memory` / `db_bundles`
+// Bundle manager — first-class management of bundles. User-facing name is
+// "Bundles" (ABF, the Armory Bundle Format, names only the import/export
+// file format); the type is `Bundle`, the table `db_bundles`
 // (SPEC_MEMORY_IDENTITY_ARCH §4.1). See
 // docs/specs/SPEC_ABF_V0_2_PROVIDER_AWARE_COMPONENTS_AND_NATIVE_MEMORY_2026_08_10.md
 // for the format itself.
@@ -174,7 +174,7 @@ export class BundleViewModel implements ViewModel {
     // umbrella event firing a refresh in both tabs is fine, not a bug.
     private unsubChanged: () => void;
 
-    // "layer-group" (not "brain") — matches the ABF tab icon in the Armory
+    // "layer-group" (not "brain") — matches the Bundles tab icon in the Armory
     // rail (armory-view.tsx) so the standalone bundle pane and the Armory nav
     // stay visually consistent; the brain icon is reserved for native memory.
     viewIcon: Accessor<string> = () => "layer-group";


### PR DESCRIPTION
Implements the §9.1 decision of `docs/specs/SPEC_ARMORY_NAMING_CONSOLIDATION_2026_09_09.md`: the Armory tab that lists bundles is called **Bundles**. **ABF** stays the name of the Armory Bundle Format and remains on import/export affordances, the structural validator copy, and the bundle form's field help (that copy is reworked together with the form in Phase 4).

User-visible changes:
- Armory rail label `ABF` → `Bundles` (`ARMORY_SECTION_LABELS.bundles`); persisted section key `bundles` unchanged.
- Bundle pane title / back label `ABF` → `Bundles`.
- Startup modal and new-bundle modal pointers `Armory → ABF` → `Armory → Bundles`.
- Bundle-summary noun labels: "This agent's own bundle", "has no bundle of its own yet".

Tests updated to the new labels (`armory-view.test.tsx` rail/highlight assertions, `AgentStartupModal.test.tsx`, `bundle-summary.test.tsx`). Verified: `tsc --noEmit` exit 0; targeted vitest 52 files / 662 tests green. Tracking: #2024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
