### PR TITLE
Clare@starpower: fix(cef): move the CEF verification gates out of markdown into tested scripts

### DIFF
--- a/.changesets/1789016663-fix-cef-move-the-cef-carry-set-gates-into-tested-scripts-2uu7.md
+++ b/.changesets/1789016663-fix-cef-move-the-cef-carry-set-gates-into-tested-scripts-2uu7.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): move the CEF carry-set gates into tested scripts

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -135,6 +135,17 @@ jobs:
       - name: Scrollbar cursor gate
         run: bash scripts/check-scrollbar-cursor.sh
 
+      # scripts/cef-verify.sh is the carry-set gate for the CEF fork
+      # (docs/cef-build/CEF_FORK_MAINTENANCE.md §5). It runs against a CEF
+      # checkout, which CI does not have -- so what runs here is its TEST SUITE,
+      # against synthetic fixtures. That is the point: four bugs in the previous
+      # markdown version of these checks made them incapable of failing (or, in
+      # one case, made them overwrite the build output they were verifying), and
+      # none were visible by reading. This is the run that would have caught all
+      # four.
+      - name: cef-verify self-test
+        run: bash scripts/cef-verify.test.sh
+
       - name: Input-handler layout-read gate
         run: bash tools/lint/check-input-handler-layout-reads.sh
 

--- a/docs/cef-build/CEF_FORK_MAINTENANCE.md
+++ b/docs/cef-build/CEF_FORK_MAINTENANCE.md
@@ -268,96 +268,31 @@ Run this against any `agentmuxai/<ms>` before building or releasing from it. It 
 cheap and it is the only thing that catches Layer B gaps.
 
 ```bash
-# Paste into a shell, then run:
-#   cef_verify                      # integration branch 7778 on remote 'agentmuxai'
-#   cef_verify 7977 fork            # milestone 7977, remote named 'fork'
-#   cef_verify a1b2c3d4...          # an exact SHA -- see section 8, P3
-#
-# A function, not a bare script: a top-level `exit 1` would close the shell of
-# anyone who pasted this, which is a poor reward for following the doc.
-cef_verify() {
-  local REF="${1:-7778}"
-  local REMOTE="${2:-${REMOTE:-agentmuxai}}"
-  local BR
-
-  if [[ "$REF" =~ ^[0-9]+$ ]]; then
-    # A bare milestone number means the integration branch on REMOTE.
-    # REMOTE is whatever YOU named the agentmuxai/cef remote. The companion
-    # runbooks add it as 'agentmuxai'; some checkouts call it 'fork'. Hard-coding
-    # it either errors out or silently resolves a same-named ref from an
-    # unrelated remote -- the class of failure this gate exists to catch.
-    git remote get-url "$REMOTE" >/dev/null 2>&1 || {
-      echo "No remote '$REMOTE'. Pass it: cef_verify $REF <remote>  (git remote -v)" >&2
-      return 1
-    }
-    # MANDATORY. These branches get force-updated mid-port; a stale ref gives a
-    # confident, wrong answer. Section 1.2 -- skipping this put a false claim in
-    # an earlier revision of this very doc.
-    git fetch "$REMOTE" --prune || return 1
-    BR="$REMOTE/$REF"
-  else
-    # Anything else is used verbatim: a tag, a full SHA, a local branch. This is
-    # what section 8's P3 needs -- verifying a RELEASE ARTIFACT means checking
-    # the commit it was built from, not whatever the branch has become since. A
-    # fix landed after the build would otherwise make the gate pass for an
-    # artifact that does not contain it.
-    BR="$REF"
-  fi
-
-  git rev-parse --verify -q "${BR}^{commit}" >/dev/null || {
-    echo "Cannot resolve '$BR'. The integration branch is named for the milestone alone." >&2
-    return 1
-  }
-
-  local ok=0 miss=0
-  _probe() {  # _probe <path> <identifier-absent-upstream>
-    if git show "${BR}:$1" 2>/dev/null | grep -qF "$2"; then
-      ok=$((ok+1));   printf 'OK   %s\n' "$1"
-    else
-      miss=$((miss+1)); printf 'MISS %s\n' "$1"
-    fi
-  }
-
-  # ---- Layer A: patch file present AND registered in patch.cfg ----
-  local name
-  for name in rwhv_background_opaque_check views_caption_rightclick_passthrough \
-              agentmux_process_requirement; do
-    if git cat-file -e "${BR}:patch/patches/${name}.patch" 2>/dev/null \
-       && git show "${BR}:patch/patch.cfg" | grep -q "'name': '${name}'"; then
-      ok=$((ok+1));   printf 'OK   patch/%s\n' "$name"
-    else
-      miss=$((miss+1)); printf 'MISS patch/%s\n' "$name"
-    fi
-  done
-
-  # ---- Layer B: all 18 fork-modified CEF sources (section 3) ----
-  # Identifiers, not filenames: every one of these files exists upstream, so a
-  # file-existence check proves nothing. Each identifier is asserted absent
-  # upstream and present in the fork, so it actually discriminates.
-  _probe include/views/cef_window.h                        BeginWindowDrag
-  _probe libcef/browser/views/window_impl.h                BeginWindowDrag
-  _probe libcef/browser/views/window_impl.cc               BeginWindowDrag
-  _probe libcef/renderer/blink_glue.h                      SetBaseBackgroundColorOverrideTransparent
-  _probe libcef/renderer/blink_glue.cc                     SetBaseBackgroundColorOverrideTransparent
-  _probe libcef/renderer/browser_config.h                  background_transparent
-  _probe libcef/renderer/render_manager.cc                 background_transparent
-  _probe libcef/common/mojom/cef.mojom                     background_transparent
-  _probe libcef/browser/browser_info_manager.cc            background_transparent
-  _probe libcef/browser/browser_platform_delegate.cc       background_transparent
-  _probe libcef/browser/browser_platform_delegate_create.cc is_views_hosted
-  _probe libcef/browser/browser_host_base.cc               'IsWindowless() || is_views_hosted()'
-  _probe libcef/browser/context.cc                         is_transparent
-  _probe libcef/browser/context.h                          transparent_state
-  _probe libcef/browser/views/browser_view_impl.cc         ApplyToCurrentRWHView
-  _probe libcef/browser/views/browser_view_impl.h          LayerTreeHost
-  _probe libcef/browser/views/window_view.cc               CalculateRenderPasses
-  _probe include/internal/cef_types.h                      'or a frameless window'
-
-  unset -f _probe
-  echo "--- $BR: $ok OK, $miss MISS (expect 21 OK, 0 MISS) ---"
-  [ "$miss" -eq 0 ]
-}
+scripts/cef-verify.sh                    # milestone 7778, probes for the clone
+scripts/cef-verify.sh --ref 7977         # a milestone => <remote>/<ref>
+scripts/cef-verify.sh --ref a1b2c3d      # exact ref/tag/SHA, used verbatim (§8 P3)
+scripts/cef-verify.sh --repo ~/src/cef   # explicit clone: validated, never guessed past
+scripts/cef-verify.sh --remote fork      # whatever you named agentmuxai/cef
 ```
+
+Exit 0 = all 21 present. It never modifies the repository it inspects.
+
+**This lives in `scripts/cef-verify.sh`, not in this document, and that is a
+deliberate correction.** These checks were originally markdown code blocks here,
+and four separate bugs shipped in them — each one making the check incapable of
+failing, or worse:
+
+| Bug | Effect |
+|---|---|
+| `sed` without `/g` | left `-o` on the real object — the verification **overwrote the build output** |
+| pristine build compiled from `/tmp` | differed on the embedded DWARF source path alone, so the comparison could never fire |
+| `git -C ""` | does not fail; answers for the current directory, silently returning Chromium's HEAD |
+| `set -o pipefail` + `grep -q` | grep exits on first match, `git show` takes SIGPIPE, pipeline reports failure **despite** the match |
+
+None were visible by reading. All four die to `scripts/cef-verify.test.sh`,
+which CI runs on every PR against synthetic fixtures. Shell embedded in
+markdown is untested by construction; that is the whole lesson, and it cost four
+rounds of review to learn.
 
 Expect **21 `OK`** against a complete `agentmuxai/<ms>`.
 
@@ -522,51 +457,29 @@ Compile the file twice — from the working tree, and from pristine upstream —
 compare both against the object that was actually linked:
 
 ```bash
-cd out/Release_GN_arm64
-
-# BOTH no-symbol patches, as a pair. Checking only one lets the recipe report
-# success while the other is absent -- and the macOS-critical one is the second.
-check_patch() {  # check_patch <source-path> <object-path>
-  local SRC="$1" OBJ="$2" ok=1
-  local CMD; CMD=$(ninja -C . -t commands "$OBJ" | tail -1)
-
-  # ${VAR//a/b} and sed's /g are BOTH mandatory. The object path appears TWICE
-  # in the command -- `-MF <obj>.d` and `-o <obj>` -- so a non-global replace
-  # redirects only the depfile and leaves `-o` pointing at the REAL object. It
-  # does not fail: it OVERWRITES your build output. That happened while writing
-  # this section, which is why the guard below exists.
-  local A="${CMD//$OBJ//tmp/A.o}"
-  case "$A" in *"-o $OBJ"*) echo "ABORT $SRC: rewritten command still targets $OBJ"; return 1 ;; esac
-
-  # (A) working-tree source at its ORIGINAL path, vs the shipped object.
-  # The path must not change here: under symbol_level=1 the compiler embeds the
-  # source path in DWARF, so compiling identical content from /tmp yields a
-  # DIFFERENT object. Verified: same content, different path -> objects differ.
-  eval "$A"
-
-  # (B) and (C) patched vs pristine content, both from the SAME synthetic path,
-  # so the only difference between them is content. Comparing the shipped object
-  # against a /tmp-compiled *pristine* build would be meaningless -- it always
-  # differs, on the path alone, whether or not the patch is present. An earlier
-  # revision of this recipe did exactly that, so its "shipped != unpatched" leg
-  # could never fire.
-  cp "../../$SRC" /tmp/probe.cc
-  eval "$(echo "${CMD//$OBJ//tmp/B.o}" | sed "s#\.\./\.\./$SRC#/tmp/probe.cc#g")"
-  git -C ../.. show "HEAD:$SRC" > /tmp/probe.cc
-  eval "$(echo "${CMD//$OBJ//tmp/C.o}" | sed "s#\.\./\.\./$SRC#/tmp/probe.cc#g")"
-
-  cmp -s /tmp/A.o "$OBJ" || { echo "FAIL $SRC: shipped object does not match the working tree"; ok=0; }
-  cmp -s /tmp/B.o /tmp/C.o && { echo "FAIL $SRC: patch is a no-op — nothing distinguishes it from upstream"; ok=0; }
-  [ "$ok" = 1 ] && echo "OK   $SRC"
-  rm -f /tmp/A.o /tmp/B.o /tmp/C.o /tmp/probe.cc
-  [ "$ok" = 1 ]
-}
-
-check_patch base/apple/mach_port_rendezvous_mac.cc \
-            obj/base/base/mach_port_rendezvous_mac.o                    # agentmux_process_requirement
-check_patch content/browser/renderer_host/render_widget_host_view_base.cc \
-            obj/content/browser/browser/render_widget_host_view_base.o  # rwhv_background_opaque_check
+scripts/cef-verify-patches.sh --build-dir out/Release_GN_arm64
 ```
+
+Expect one `OK` per no-symbol patch (two today). It never writes to the build
+directory — `scripts/cef-verify.test.sh` asserts that with a fake compiler,
+because an earlier inline version of this check *did* write to it (below).
+
+Three compiles, isolating one variable at a time:
+
+| | |
+|---|---|
+| **A** | working-tree source at its **original** path — must equal the shipped object |
+| **B** | working-tree content from a synthetic path |
+| **C** | pristine upstream content from the **same** synthetic path |
+
+`A == shipped` proves the artifact was built from what is checked out. `B != C`
+proves the patch materially changes codegen — which A alone cannot show, since a
+patch compiling to upstream's bytes would also pass.
+
+**B and C must share a path.** Under `symbol_level=1` the compiler embeds the
+source path in DWARF, so comparing the shipped object against a `/tmp`-compiled
+pristine build always differs — on the path alone, patched or not. An earlier
+version did exactly that, and its "shipped != unpatched" leg could never fire.
 
 Expect **two** `OK` lines. `views_caption_rightclick_passthrough` is not listed
 because it adds a symbol and §7.2 already covers it.

--- a/scripts/cef-verify-patches.sh
+++ b/scripts/cef-verify-patches.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# cef-verify-patches.sh — prove the no-symbol CEF patches are in a built artifact.
+#
+# docs/cef-build/CEF_FORK_MAINTENANCE.md §7.2b
+#
+# THE PROBLEM: two of the three Chromium-side patches add no symbol.
+# agentmux_process_requirement rewrites the body of an existing function and
+# rwhv_background_opaque_check changes one call inside one, so `nm` cannot see
+# either and §7.2's symbol probes cannot answer whether they reached the build.
+#
+# THE METHOD: three compiles, isolating one variable at a time.
+#   A  working-tree source at its ORIGINAL path  -> must equal the shipped object
+#   B  working-tree content from a synthetic path
+#   C  pristine upstream content from the SAME synthetic path
+#   A == shipped  proves the artifact was built from what is checked out.
+#   B != C        proves the patch materially changes codegen, which A alone
+#                 cannot show (a patch compiling to upstream's bytes would pass).
+#
+# Why B and C share a path: under symbol_level=1 the compiler embeds the source
+# path in DWARF, so comparing the shipped object against a /tmp-compiled pristine
+# build always differs -- on the path alone, patched or not. An earlier version
+# did exactly that and its "shipped != unpatched" leg could never fire.
+#
+# Usage:
+#   scripts/cef-verify-patches.sh --build-dir out/Release_GN_arm64
+#   scripts/cef-verify-patches.sh --build-dir <dir> --pair <src>:<obj>   (repeatable)
+#
+# Exit 0 = every pair verified. Never writes to the build directory.
+
+set -euo pipefail
+
+BUILD_DIR="" ; PAIRS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --build-dir) BUILD_DIR="${2:-}"; shift 2 ;;
+    --pair)      PAIRS+=("${2:-}"); shift 2 ;;
+    -h|--help)   sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "cef-verify-patches: unknown argument '$1'" >&2; exit 1 ;;
+  esac
+done
+[ -n "$BUILD_DIR" ] || { echo "cef-verify-patches: --build-dir is required" >&2; exit 1; }
+[ -d "$BUILD_DIR" ] || { echo "cef-verify-patches: no such build dir: $BUILD_DIR" >&2; exit 1; }
+
+if [ "${#PAIRS[@]}" -eq 0 ]; then
+  PAIRS=(
+    "base/apple/mach_port_rendezvous_mac.cc:obj/base/base/mach_port_rendezvous_mac.o"
+    "content/browser/renderer_host/render_widget_host_view_base.cc:obj/content/browser/browser/render_widget_host_view_base.o"
+  )
+fi
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+ok=0; fail=0
+
+cd "$BUILD_DIR"
+for pair in "${PAIRS[@]}"; do
+  SRC="${pair%%:*}" ; OBJ="${pair##*:}"
+  [ -f "$OBJ" ] || { echo "FAIL $SRC: no such object $OBJ"; fail=$((fail+1)); continue; }
+
+  CMD="$(ninja -C . -t commands "$OBJ" | tail -1)"
+
+  # ${VAR//a/b} and sed's /g are BOTH mandatory: the object path appears TWICE
+  # in a Chromium compile line (`-MF <obj>.d` and `-o <obj>`). A non-global
+  # replace redirects only the depfile and leaves `-o` on the REAL object -- it
+  # does not error, it OVERWRITES the build output. The guard below refuses to
+  # run any command that could still do that.
+  A_CMD="${CMD//$OBJ/$TMP/A.o}"
+  B_CMD="$(printf '%s' "$CMD" | sed "s#$OBJ#$TMP/B.o#g; s#\.\./\.\./$SRC#$TMP/probe.cc#g")"
+  C_CMD="$(printf '%s' "$CMD" | sed "s#$OBJ#$TMP/C.o#g; s#\.\./\.\./$SRC#$TMP/probe.cc#g")"
+  for c in "$A_CMD" "$B_CMD" "$C_CMD"; do
+    case "$c" in *"-o $OBJ"*)
+      echo "ABORT $SRC: a rewritten command still targets $OBJ - refusing to run"; exit 1 ;;
+    esac
+  done
+
+  eval "$A_CMD"
+  cp "../../$SRC" "$TMP/probe.cc" ; eval "$B_CMD"
+  git -C ../.. show "HEAD:$SRC" > "$TMP/probe.cc" ; eval "$C_CMD"
+
+  bad=0
+  cmp -s "$TMP/A.o" "$OBJ"     || { echo "FAIL $SRC: shipped object does not match the working tree"; bad=1; }
+  cmp -s "$TMP/B.o" "$TMP/C.o" && { echo "FAIL $SRC: patch is a no-op - nothing distinguishes it from upstream"; bad=1; }
+  if [ "$bad" = 0 ]; then echo "OK   $SRC"; ok=$((ok+1)); else fail=$((fail+1)); fi
+  rm -f "$TMP/A.o" "$TMP/B.o" "$TMP/C.o" "$TMP/probe.cc"
+done
+
+echo "--- $ok verified, $fail failed ---"
+[ "$fail" -eq 0 ]

--- a/scripts/cef-verify.sh
+++ b/scripts/cef-verify.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# cef-verify.sh — verify a CEF fork ref carries the whole AgentMux carry-set.
+#
+# docs/cef-build/CEF_FORK_MAINTENANCE.md (§3 the inventory, §5 this gate)
+#
+# THE RULE: AgentMux carries four changes on top of CEF, spanning 18 CEF source
+# files and 3 Chromium-side patches. Every one must survive every milestone
+# upgrade. Layer A (patches under cef/patch/) fails loudly when it goes missing;
+# Layer B (edits to libcef/** and include/**) fails SILENTLY — the tree still
+# compiles, because our additions are additive. This gate is the only thing that
+# checks Layer B.
+#
+# Why this is a script and not a snippet in the doc. Three separate versions of
+# these checks, written as markdown code blocks, shipped bugs that made them
+# incapable of failing:
+#   * a `sed` without /g redirected only the depfile and left `-o` pointing at
+#     the real object — the "verification" OVERWROTE the build output;
+#   * a pristine build compiled from /tmp differed from the shipped object on
+#     the embedded DWARF source path alone, so the comparison could never fire;
+#   * `git -C ""` does not fail — it answers for the current directory, which
+#     silently returned Chromium's HEAD instead of the fork's.
+# None were visible by reading. All three die to a single test run, which is
+# what scripts/cef-verify.test.sh now does on every PR.
+#
+# Usage:
+#   scripts/cef-verify.sh                      # milestone 7778, probe for the clone
+#   scripts/cef-verify.sh --ref 7977           # a milestone => <remote>/<ref>
+#   scripts/cef-verify.sh --ref a1b2c3d        # an exact ref/tag/SHA, used verbatim
+#   scripts/cef-verify.sh --repo ~/src/cef     # explicit clone (validated, never guessed past)
+#   scripts/cef-verify.sh --remote fork        # whatever you named agentmuxai/cef
+#
+# Exit 0 = all 21 present. Exit 1 = something is missing, or the clone/ref could
+# not be resolved. It never modifies the repository it inspects.
+
+set -euo pipefail
+
+REPO="" ; REF="7778" ; REMOTE="${REMOTE:-agentmuxai}" ; QUIET=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo)   REPO="${2:-}"; shift 2 ;;
+    --ref)    REF="${2:-}"; shift 2 ;;
+    --remote) REMOTE="${2:-}"; shift 2 ;;
+    --quiet)  QUIET=1; shift ;;
+    -h|--help) sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "cef-verify: unknown argument '$1'" >&2; exit 1 ;;
+  esac
+done
+
+say() { [ "$QUIET" = 1 ] || printf '%s\n' "$*"; }
+
+# ── Locate the fork clone ───────────────────────────────────────────────────
+# A .git-less mirror (rsync --exclude=.git / robocopy /XD .git) is NOT a clone:
+# `git -C` on it walks UP and answers for the enclosing Chromium checkout. The
+# git-root test is what rejects that; the remote test rejects an unrelated repo.
+is_fork_clone() {
+  local d="$1"
+  [ -n "$d" ] && [ -d "$d" ] || return 1
+  [ "$(git -C "$d" rev-parse --show-toplevel 2>/dev/null)" = "$(cd "$d" 2>/dev/null && pwd -P)" ] || return 1
+  git -C "$d" remote -v 2>/dev/null | grep -q 'agentmuxai/cef'
+}
+
+if [ -n "$REPO" ]; then
+  # An explicit --repo is a HARD requirement. Falling back to a probed path when
+  # the override is wrong would report a different checkout's HEAD and look fine.
+  is_fork_clone "$REPO" || { echo "cef-verify: --repo '$REPO' is not an agentmuxai/cef git root" >&2; exit 1; }
+else
+  for c in "$HOME/cef-build/chromium/chromium/src/cef" \
+           "$HOME/cef-build/chromium/cef" \
+           "$HOME/cef-build/chromium_git/cef"; do
+    if is_fork_clone "$c"; then REPO="$c"; break; fi
+  done
+  [ -n "$REPO" ] || { echo "cef-verify: no agentmuxai/cef clone found (a .git-less mirror does not count); pass --repo" >&2; exit 1; }
+fi
+
+# ── Resolve the ref ─────────────────────────────────────────────────────────
+if printf '%s' "$REF" | grep -qE '^[0-9]+$'; then
+  git -C "$REPO" remote get-url "$REMOTE" >/dev/null 2>&1 \
+    || { echo "cef-verify: no remote '$REMOTE' in $REPO; pass --remote" >&2; exit 1; }
+  git -C "$REPO" fetch "$REMOTE" --prune >/dev/null 2>&1 || true
+  BR="$REMOTE/$REF"
+else
+  BR="$REF"   # tag / SHA / local branch, used verbatim — see §8 P3
+fi
+git -C "$REPO" rev-parse --verify -q "${BR}^{commit}" >/dev/null \
+  || { echo "cef-verify: cannot resolve '$BR' in $REPO" >&2; exit 1; }
+
+# ── The carry-set ───────────────────────────────────────────────────────────
+# <path>|<identifier absent upstream, present in the fork>
+# Probe identifiers, not filenames: every one of these files exists upstream.
+CARRY_SET='
+include/views/cef_window.h|BeginWindowDrag
+libcef/browser/views/window_impl.h|BeginWindowDrag
+libcef/browser/views/window_impl.cc|BeginWindowDrag
+libcef/renderer/blink_glue.h|SetBaseBackgroundColorOverrideTransparent
+libcef/renderer/blink_glue.cc|SetBaseBackgroundColorOverrideTransparent
+libcef/renderer/browser_config.h|background_transparent
+libcef/renderer/render_manager.cc|background_transparent
+libcef/common/mojom/cef.mojom|background_transparent
+libcef/browser/browser_info_manager.cc|background_transparent
+libcef/browser/browser_platform_delegate.cc|background_transparent
+libcef/browser/browser_platform_delegate_create.cc|is_views_hosted
+libcef/browser/browser_host_base.cc|IsWindowless() || is_views_hosted()
+libcef/browser/context.cc|is_transparent
+libcef/browser/context.h|transparent_state
+libcef/browser/views/browser_view_impl.cc|ApplyToCurrentRWHView
+libcef/browser/views/browser_view_impl.h|LayerTreeHost
+libcef/browser/views/window_view.cc|CalculateRenderPasses
+include/internal/cef_types.h|or a frameless window
+'
+PATCHES='rwhv_background_opaque_check views_caption_rightclick_passthrough agentmux_process_requirement'
+
+ok=0 ; miss=0
+for name in $PATCHES; do
+  cfg=$(git -C "$REPO" show "${BR}:patch/patch.cfg" 2>/dev/null || true)
+  if git -C "$REPO" cat-file -e "${BR}:patch/patches/${name}.patch" 2>/dev/null \
+     && [[ "$cfg" == *"'name': '${name}'"* ]]; then
+    ok=$((ok+1)); say "OK   patch/$name"
+  else
+    miss=$((miss+1)); say "MISS patch/$name"
+  fi
+done
+
+while IFS='|' read -r path ident; do
+  [ -n "$path" ] || continue
+  # Substring test in bash, NOT `git show | grep -q`. With `set -o pipefail`
+  # grep -q exits on the first match, git show takes SIGPIPE, and the pipeline
+  # reports FAILURE despite the match -- a race that depends on how early in the
+  # file the match sits. It reported a false MISS on cef_types.h (match at line
+  # 446) while passing on every smaller file. Caught by the test suite; the
+  # markdown version of this check had the same latent bug and got away with it.
+  content=$(git -C "$REPO" show "${BR}:${path}" 2>/dev/null || true)
+  if [[ "$content" == *"$ident"* ]]; then
+    ok=$((ok+1)); say "OK   $path"
+  else
+    miss=$((miss+1)); say "MISS $path"
+  fi
+done <<EOF
+$(printf '%s' "$CARRY_SET")
+EOF
+
+total=$((ok+miss))
+say "--- $BR: $ok OK, $miss MISS (expect $total OK, 0 MISS) ---"
+[ "$miss" -eq 0 ]

--- a/scripts/cef-verify.sh
+++ b/scripts/cef-verify.sh
@@ -76,7 +76,13 @@ fi
 if printf '%s' "$REF" | grep -qE '^[0-9]+$'; then
   git -C "$REPO" remote get-url "$REMOTE" >/dev/null 2>&1 \
     || { echo "cef-verify: no remote '$REMOTE' in $REPO; pass --remote" >&2; exit 1; }
-  git -C "$REPO" fetch "$REMOTE" --prune >/dev/null 2>&1 || true
+  # MANDATORY, and a failure here is FATAL. These branches get force-updated
+  # mid-port, so a stale remote-tracking ref answers confidently about state
+  # that has since moved -- which is precisely how a wrong claim about the 152
+  # port got into CEF_FORK_MAINTENANCE.md §1.2. If the network or auth is down,
+  # the correct outcome is "I cannot tell you", not "21 OK" against yesterday.
+  git -C "$REPO" fetch "$REMOTE" --prune >/dev/null 2>&1 \
+    || { echo "cef-verify: fetch from '$REMOTE' failed; refusing to verify against a possibly stale ref" >&2; exit 1; }
   BR="$REMOTE/$REF"
 else
   BR="$REF"   # tag / SHA / local branch, used verbatim — see §8 P3

--- a/scripts/cef-verify.test.sh
+++ b/scripts/cef-verify.test.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# cef-verify.test.sh — tests for scripts/cef-verify.sh.
+#
+# This file is the whole point of scripts/cef-verify.sh existing. The same
+# checks previously lived as markdown code blocks in
+# docs/cef-build/CEF_FORK_MAINTENANCE.md, and shipped four bugs that made them
+# incapable of failing or actively destructive:
+#
+#   1. `sed` without /g left `-o` pointing at the real object — the verification
+#      OVERWROTE the build output it was verifying.
+#   2. A pristine build compiled from /tmp differed from the shipped object on
+#      the embedded DWARF source path alone, so the comparison never fired.
+#   3. `git -C ""` does not fail; it answers for the current directory, quietly
+#      returning Chromium's HEAD instead of the fork's.
+#   4. `set -o pipefail` + `grep -q`: grep exits on first match, `git show` takes
+#      SIGPIPE, and the pipeline reports failure DESPITE the match — a race that
+#      only bit files where the match sits late (cef_types.h, line 446).
+#
+# None were visible by reading. Every one dies to a test run. Case 4 has a
+# dedicated regression test below because it was intermittent, which is the
+# worst kind to leave uncovered.
+#
+# Usage: bash scripts/cef-verify.test.sh    (exit 0 = all pass)
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/cef-verify.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+pass=0; fail=0
+
+ok()   { pass=$((pass+1)); printf '  PASS  %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf '  FAIL  %s\n     -> %s\n' "$1" "${2:-}"; }
+
+# Build a synthetic fork clone that satisfies the whole carry-set. The file
+# list is read from the script itself so the fixture cannot drift from it; the
+# assertions below are about MECHANICS (parsing, refs, guards, exit codes),
+# which is where every real bug has been.
+make_fixture() {
+  local dir="$1" ; mkdir -p "$dir" ; ( cd "$dir"
+    git init -q . && git remote add agentmuxai https://github.com/agentmuxai/cef.git
+    mkdir -p patch/patches
+    : > patch/patch.cfg
+    for n in rwhv_background_opaque_check views_caption_rightclick_passthrough agentmux_process_requirement; do
+      echo "stub patch $n" > "patch/patches/$n.patch"
+      printf "  {\n    'name': '%s',\n  },\n" "$n" >> patch/patch.cfg
+    done
+    # One file per carry-set row, containing its identifier.
+    sed -n "/^CARRY_SET='/,/^'$/p" "$SCRIPT" | grep '|' | while IFS='|' read -r path ident; do
+      [ -n "$path" ] || continue
+      mkdir -p "$(dirname "$path")"
+      # The identifier goes EARLY, with a lot of content AFTER it. That is the
+      # shape that triggers bug 4: `grep -q` exits on the FIRST match, so it
+      # stops reading while `git show` is still writing, git takes SIGPIPE, and
+      # under pipefail the pipeline reports failure despite the match. Real
+      # cef_types.h matches at line 446 of a much larger file, which is why it
+      # was the only false MISS.
+      #
+      # Two earlier versions of this fixture did not reproduce it: 600 lines of
+      # padding (fits the ~64 KiB pipe buffer), then 4000 lines with the
+      # identifier LAST -- where grep reads to EOF and never exits early, so
+      # there is no SIGPIPE at all. Both passed against a deliberately broken
+      # script. The bug is about WHERE the match sits, not how big the file is.
+      { echo "$ident"
+        for _ in $(seq 1 4000); do
+          echo "// trailing filler so git show is still writing when grep -q exits"
+        done; } > "$path"
+    done
+    git add -A && git -c user.email=t@t -c user.name=t commit -q -m "carry-set complete"
+  ) }
+
+FIX="$TMP/fork"; make_fixture "$FIX"
+HEAD_SHA="$(git -C "$FIX" rev-parse HEAD)"
+
+# 1. Complete carry-set -> all present, exit 0.
+out=$("$SCRIPT" --repo "$FIX" --ref "$HEAD_SHA" 2>&1); rc=$?
+if [ $rc -eq 0 ] && printf '%s' "$out" | grep -q '21 OK, 0 MISS'; then
+  ok "complete carry-set: 21 OK, exit 0"
+else bad "complete carry-set" "rc=$rc last=$(printf '%s' "$out" | tail -1)"; fi
+
+# 2. REGRESSION (bug 4): identifiers sit ~600 lines into each file. A
+#    `git show | grep -q` implementation under pipefail reports false MISSes
+#    here. Passing case 1 with these fixtures IS the regression test; assert
+#    explicitly that no MISS was printed.
+if ! printf '%s' "$out" | grep -q '^MISS'; then
+  ok "no false MISS when the identifier sits late in a large file (pipefail/SIGPIPE)"
+else bad "pipefail regression" "$(printf '%s' "$out" | grep '^MISS' | head -2 | tr '\n' ' ')"; fi
+
+# 3. A missing Layer B file is caught.
+BROKEN="$TMP/broken"; cp -R "$FIX" "$BROKEN"
+rm -f "$BROKEN/libcef/renderer/blink_glue.cc"
+git -C "$BROKEN" -c user.email=t@t -c user.name=t commit -qam "drop a carry-set file"
+out=$("$SCRIPT" --repo "$BROKEN" --ref "$(git -C "$BROKEN" rev-parse HEAD)" 2>&1); rc=$?
+if [ $rc -ne 0 ] && printf '%s' "$out" | grep -q 'MISS libcef/renderer/blink_glue.cc'; then
+  ok "missing Layer B file -> MISS + non-zero exit"
+else bad "missing Layer B file" "rc=$rc"; fi
+
+# 4. A patch present on disk but NOT registered in patch.cfg is caught.
+UNREG="$TMP/unreg"; cp -R "$FIX" "$UNREG"
+grep -v "agentmux_process_requirement" "$UNREG/patch/patch.cfg" > "$UNREG/patch/patch.cfg.new"
+mv "$UNREG/patch/patch.cfg.new" "$UNREG/patch/patch.cfg"
+git -C "$UNREG" -c user.email=t@t -c user.name=t commit -qam "unregister a patch"
+out=$("$SCRIPT" --repo "$UNREG" --ref "$(git -C "$UNREG" rev-parse HEAD)" 2>&1); rc=$?
+if [ $rc -ne 0 ] && printf '%s' "$out" | grep -q 'MISS patch/agentmux_process_requirement'; then
+  ok "patch file present but unregistered -> MISS"
+else bad "unregistered patch" "rc=$rc"; fi
+
+# 5. (bug 3) A .git-less mirror inside another repo must be REJECTED, not
+#    silently answered for by the enclosing checkout.
+OUTER="$TMP/outer"; mkdir -p "$OUTER/src/cef"
+( cd "$OUTER" && git init -q . && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m outer )
+out=$("$SCRIPT" --repo "$OUTER/src/cef" --ref 7778 2>&1); rc=$?
+if [ $rc -ne 0 ] && printf '%s' "$out" | grep -q 'not an agentmuxai/cef git root'; then
+  ok "git-less mirror rejected (no walk-up into the enclosing repo)"
+else bad "mirror walk-up" "rc=$rc out=$out"; fi
+
+# 6. An explicit --repo that is wrong must FAIL, never fall back to a probe path.
+out=$("$SCRIPT" --repo "$TMP/does-not-exist" --ref 7778 2>&1); rc=$?
+if [ $rc -ne 0 ] && printf '%s' "$out" | grep -q 'not an agentmuxai/cef git root'; then
+  ok "invalid explicit --repo is fatal, not a fallback"
+else bad "explicit repo override" "rc=$rc"; fi
+
+# 7. A milestone with no such remote fails clearly rather than guessing.
+out=$("$SCRIPT" --repo "$FIX" --ref 7778 --remote nosuchremote 2>&1); rc=$?
+if [ $rc -ne 0 ] && printf '%s' "$out" | grep -q "no remote 'nosuchremote'"; then
+  ok "unknown remote fails with a clear message"
+else bad "unknown remote" "rc=$rc"; fi
+
+# 8. An unresolvable ref fails rather than reporting a clean bill of health.
+out=$("$SCRIPT" --repo "$FIX" --ref deadbeefdeadbeef 2>&1); rc=$?
+if [ $rc -ne 0 ] && printf '%s' "$out" | grep -q 'cannot resolve'; then
+  ok "unresolvable ref fails"
+else bad "unresolvable ref" "rc=$rc"; fi
+
+# 9. The gate must never modify the repository it inspects.
+before=$(git -C "$FIX" status --porcelain; git -C "$FIX" rev-parse HEAD)
+"$SCRIPT" --repo "$FIX" --ref "$HEAD_SHA" >/dev/null 2>&1
+after=$(git -C "$FIX" status --porcelain; git -C "$FIX" rev-parse HEAD)
+if [ "$before" = "$after" ]; then ok "inspected repo is left untouched"
+else bad "repo mutated by the gate"; fi
+
+# ── scripts/cef-verify-patches.sh ───────────────────────────────────────────
+# Fake ninja + fake compiler, so the COMMAND-REWRITING logic is covered. That is
+# where the destructive bug lived: a non-global replace left `-o` on the real
+# object and the "verification" overwrote the build output. The fake compiler
+# embeds the SOURCE PATH in its output, modelling the DWARF path embedding that
+# made the original comparison unfalsifiable.
+PSCRIPT="$HERE/cef-verify-patches.sh"
+PT="$TMP/pbuild"; mkdir -p "$PT/out/build/obj" "$PT/bin"
+( cd "$PT" && git init -q . )
+cat > "$PT/bin/fakecc" <<'CC'
+#!/usr/bin/env bash
+# Writes "<source-path>|<source-contents>" to the -o target: sensitive to BOTH
+# the path (like DWARF) and the content (like real codegen).
+out=""; src=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -MF) shift 2 ;;
+    *.cc) src="$1"; shift ;;
+    *) shift ;;
+  esac
+done
+{ printf '%s|' "$src"; cat "$src"; } > "$out"
+CC
+cat > "$PT/bin/ninja" <<CC
+#!/usr/bin/env bash
+# Emits a Chromium-shaped compile line: the object path appears TWICE.
+echo "fakecc -MMD -MF obj/x.o.d -c ../../src.cc -o obj/x.o"
+CC
+chmod +x "$PT/bin/fakecc" "$PT/bin/ninja"
+export PATH="$PT/bin:$PATH"
+
+# Committed (pristine) source, then a working-tree modification = "the patch".
+echo "pristine body" > "$PT/src.cc"
+git -C "$PT" add -A && git -C "$PT" -c user.email=t@t -c user.name=t commit -qm pristine
+echo "patched body" > "$PT/src.cc"
+( cd "$PT/out/build" && fakecc -MF obj/x.o.d -c ../../src.cc -o obj/x.o )   # the "shipped" object
+OBJ_BEFORE=$(shasum < "$PT/out/build/obj/x.o")
+
+out=$("$PSCRIPT" --build-dir "$PT/out/build" --pair "src.cc:obj/x.o" 2>&1); rc=$?
+if [ $rc -eq 0 ] && printf '%s' "$out" | grep -q '^OK   src.cc'; then
+  ok "patches: shipped==tree and patch changes codegen -> OK"
+else bad "patches happy path" "rc=$rc out=$(printf '%s' "$out" | tail -2 | tr '\n' ' ')"; fi
+
+if [ "$OBJ_BEFORE" = "$(shasum < "$PT/out/build/obj/x.o")" ]; then
+  ok "patches: the real object is byte-untouched (no -o leaking onto it)"
+else bad "patches: REAL OBJECT WAS OVERWRITTEN"; fi
+
+# A "patch" that changes nothing must be reported as a no-op, not as verified.
+git -C "$PT" -c user.email=t@t -c user.name=t commit -qam "adopt the patched body upstream"
+( cd "$PT/out/build" && fakecc -MF obj/x.o.d -c ../../src.cc -o obj/x.o )
+out=$("$PSCRIPT" --build-dir "$PT/out/build" --pair "src.cc:obj/x.o" 2>&1); rc=$?
+if [ $rc -ne 0 ] && printf '%s' "$out" | grep -q 'patch is a no-op'; then
+  ok "patches: a no-op patch is reported, not silently verified"
+else bad "patches no-op detection" "rc=$rc"; fi
+
+printf '\ncef-verify.test: %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/scripts/cef-verify.test.sh
+++ b/scripts/cef-verify.test.sh
@@ -140,6 +140,24 @@ after=$(git -C "$FIX" status --porcelain; git -C "$FIX" rev-parse HEAD)
 if [ "$before" = "$after" ]; then ok "inspected repo is left untouched"
 else bad "repo mutated by the gate"; fi
 
+# 10. A FAILED FETCH must be fatal, even when a stale remote-tracking ref still
+#     resolves locally. Verifying against yesterday's ref is the exact
+#     false-positive that put a wrong claim about the 152 port into the doc
+#     (CEF_FORK_MAINTENANCE.md §1.2) -- a confident answer about state that has
+#     since moved. Every other test here passes --ref <SHA>, which skips the
+#     fetch entirely, so without this case that path is unexercised.
+STALE="$TMP/stale"; cp -R "$FIX" "$STALE"
+# The URL must still LOOK like the fork (is_fork_clone greps for agentmuxai/cef)
+# while being unreachable -- otherwise the repo check rejects it first and this
+# test passes without ever reaching the fetch, which is how it was written the
+# first time.
+git -C "$STALE" remote set-url agentmuxai "$TMP/unreachable/agentmuxai/cef.git"
+git -C "$STALE" update-ref refs/remotes/agentmuxai/7778 "$(git -C "$STALE" rev-parse HEAD)"
+out=$("$SCRIPT" --repo "$STALE" --ref 7778 2>&1); rc=$?
+if [ $rc -ne 0 ] && ! printf '%s' "$out" | grep -q '21 OK, 0 MISS'; then
+  ok "failed fetch is fatal, even with a resolvable stale ref"
+else bad "stale-ref after failed fetch" "rc=$rc last=$(printf '%s' "$out" | tail -1)"; fi
+
 # ── scripts/cef-verify-patches.sh ───────────────────────────────────────────
 # Fake ninja + fake compiler, so the COMMAND-REWRITING logic is covered. That is
 # where the destructive bug lived: a non-global replace left `-o` on the real


### PR DESCRIPTION
## Why

The carry-set gate and the no-symbol patch check lived as code blocks in `docs/cef-build/CEF_FORK_MAINTENANCE.md`. **Four separate bugs shipped in them**, each making the check incapable of failing — or worse:

| # | Bug | Effect |
|---|---|---|
| 1 | `sed` without `/g` | left `-o` on the real object — the verification **overwrote the build output**. Two objects in the macOS tree had to be rebuilt and the framework relinked. |
| 2 | pristine build compiled from `/tmp` | differed on the embedded DWARF source path alone, so `shipped != unpatched` could never fire and an unpatched object would still report `OK` |
| 3 | `git -C ""` | does not fail — answers for the current directory, silently returning **Chromium's** HEAD instead of the fork's |
| 4 | `set -o pipefail` + `grep -q` | grep exits on first match, `git show` takes SIGPIPE, pipeline reports failure **despite** the match |

None were visible by reading. **Bug 4 was found by writing the test.**

## What's here

```
scripts/cef-verify.sh          carry-set gate, 21 probes, --ref / --repo / --remote
scripts/cef-verify-patches.sh  three-way differential compile for the two patches nm cannot see
scripts/cef-verify.test.sh     12 tests, run by ci-pr.yml on every PR
```

CI can't run the gates themselves (no CEF checkout), so what runs is the **test suite against synthetic fixtures** — which is precisely the run that would have caught all four bugs.

## The tests are checked to actually fail

| Mutation | Result |
|---|---|
| reintroduce bug 4 | `12 passed` → **`10 passed, 2 failed`** |
| reintroduce bug 1 | ABORT guard fires, refuses to run rather than corrupting |

Getting the fixture right took three attempts, and **both wrong ones are recorded in the test file**:

- 600 lines of padding — fits inside the ~64 KiB pipe buffer, no SIGPIPE
- 4000 lines with the identifier **last** — grep reads to EOF, never exits early, so again no SIGPIPE

The bug is about **where the match sits**, not file size. A regression test that cannot fail is the same defect as the code it guards, so I verified in both directions rather than trusting a green run.

## Verified against reality, not just fixtures

```
scripts/cef-verify-patches.sh --build-dir out/Release_GN_arm64
  OK   base/apple/mach_port_rendezvous_mac.cc
  OK   content/browser/renderer_host/render_widget_host_view_base.cc

scripts/cef-verify.sh --ref 7778   ->  21 OK, 0 MISS
scripts/cef-verify.sh --ref 7977   ->  21 OK, 0 MISS
```

**`7977` now passes too** — someone merged both 152 feature branches via `integration-7977` while this was being written, which closes the gap agentmuxai/cef#9 was opened for. I'll close that PR as superseded.

## Doc changes

`CEF_FORK_MAINTENANCE.md` keeps the reasoning, the inventory and the failure history; anything executable now points at the scripts. Zero inline shell functions remain.

<!-- agentmux:agent_id=clare -->