### PR TITLE
Clare@starpower: fix(cef): bump the macOS CEF pin to 148.23.25 — ships the macOS 26 renderer fix

### DIFF
--- a/.changesets/1789018629-fix-cef-ship-the-macos-26-renderer-fix-bump-the-macos-cef-pi-b4pu.md
+++ b/.changesets/1789018629-fix-cef-ship-the-macos-26-renderer-fix-bump-the-macos-cef-pi-b4pu.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(cef): ship the macOS 26 renderer fix — bump the macOS CEF pin to 148.23.25

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,7 @@ jobs:
         run: |
           WIN_TAG="cef-windows-x86_64-148.0.7778.180"
           LINUX_TAG="cef-linux-x86_64-148.0.7778.180-codecs"
-          MACOS_TAG="cef-macos-arm64-148.23.23-codecs"
+          MACOS_TAG="cef-macos-arm64-148.23.25-codecs"
 
           # Chromium milestone = the leading dot-separated numeric segment
           # after the cef-<platform>-<arch>- prefix. Works across both

--- a/docs/cef-build/CEF_FORK_MAINTENANCE.md
+++ b/docs/cef-build/CEF_FORK_MAINTENANCE.md
@@ -517,17 +517,18 @@ All three pins live in one place — `release.yml`'s `cef-runtime-pins` job — 
 is correct and was a deliberate fix (PR #3086 and its follow-up). Keep it that
 way; do not reintroduce per-job literals.
 
-Current pins:
+**The live values are in `release.yml`, and are deliberately not repeated here.**
+This section previously pinned them inline and went stale the first time one was
+bumped — the same duplicated-value rot §5 and §7 keep running into. To read the
+current pins:
 
-```
-WIN_TAG="cef-windows-x86_64-148.0.7778.180"
-LINUX_TAG="cef-linux-x86_64-148.0.7778.180-codecs"
-MACOS_TAG="cef-macos-arm64-148.23.23-codecs"
+```bash
+sed -n '/cef-runtime-pins/,/MISMATCH/p' .github/workflows/release.yml | grep '_TAG='
 ```
 
 **Known sharp edge: the three tags use two different version schemes.** Windows
-and Linux carry the *Chromium* version (`148.0.7778.180`); macOS carries the
-*CEF* version (`148.23.23`). The job cross-checks only the leading milestone
+and Linux carry the *Chromium* version (e.g. `148.0.7778.180`); macOS carries
+the *CEF* version (e.g. `148.23.25`). The job cross-checks only the leading milestone
 (`148`), which is the one component the schemes agree on. That check is real but
 weak: **two tags can agree on `148` and still come from different fork commits
 with different carry-sets.** That is exactly the divergence §1 is about, and

--- a/docs/cef-build/build-patched-framework-macos.md
+++ b/docs/cef-build/build-patched-framework-macos.md
@@ -50,10 +50,10 @@ not the `148.0.9` this table previously claimed):
 |----------|-------|
 | Path | `~/cef-build/chromium/chromium/src/out/Release_GN_arm64/Chromium Embedded Framework.framework` |
 | Arch | Mach-O 64-bit arm64 |
-| Size (unstripped) | 547 MB |
-| Version (`Info.plist` `CFBundleShortVersionString`) | 148.23.23.0 |
-| `CEF_VERSION` (`cef_version.h`) | `148.23.23-rebuild-7778-codecs.3533+g6c570e2+chromium-148.0.7778.180` |
-| Released tag | `cef-macos-arm64-148.23.23-codecs` (adds `proprietary_codecs` etc. — see `docs/specs/SPEC_CEF_PROPRIETARY_CODECS_ALL_PLATFORMS_2026_07_26.md`) |
+| Size (unstripped) | 428 MB binary; 181 MB as the released `.tar.gz` |
+| Version (`Info.plist` `CFBundleShortVersionString`) | 148.23.25.0 |
+| Built from | `agentmuxai/cef` `1bee8b7da` (ancestor of `7778`) — the release's `--target`, so the tag records the build commit |
+| Released tag | `cef-macos-arm64-148.23.25-codecs` (2026-09-09; adds the macOS 26 renderer fix `agentmux_process_requirement` and the renderer-side transparency work over `148.23.23-codecs`) |
 | Patch symbol | `__ZN13CefWindowImpl15BeginWindowDragEv` (local symbol, `nm` type `t`) |
 
 > ⚠️ The patch symbol is **local**, not exported. Verify with full `nm` —
@@ -162,8 +162,11 @@ keys on the local symbol that `strip` removes — upload the **unstripped** fram
 
 ```bash
 CEF_OUT=~/cef-build/chromium/chromium/src/out/Release_GN_arm64
-# CEF version from Info.plist CFBundleShortVersionString (e.g. 148.23.23).
-CEF_VERSION="148.23.23"
+# CEF version from Info.plist CFBundleShortVersionString. READ IT FROM THE
+# BUILD -- do not copy this example, it is a placeholder that has gone stale
+# before. `/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" \
+#   "$CEF_OUT/Chromium Embedded Framework.framework/Versions/A/Resources/Info.plist"`
+CEF_VERSION="148.23.25"
 # Append a suffix (e.g. -codecs) whenever the build adds a distinguishing
 # feature over the last release at the same numeric CEF_VERSION — see
 # docs/specs/SPEC_CEF_PROPRIETARY_CODECS_ALL_PLATFORMS_2026_07_26.md and the

--- a/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
+++ b/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
@@ -55,7 +55,7 @@ Verified upstream state (`chromiumembedded/cef`, read from each branch's `CHROMI
 | **7977** | **152.0.7977.83** | newest stable branch — the target |
 | master | 152.0.7977.0 | |
 
-Our pins: `agentmux-cef/Cargo.toml` → `cef = { version = "148" }`; root `Cargo.toml` `[patch.crates-io]` → `cef-dll-sys` from `AgentU-asaf/cef-rs` @ `515b3ac53c`; runtime binaries from `agentmuxai/cef` releases (`cef-windows-x86_64-148.0.7778.180`, `cef-linux-x86_64-148.0.7778.180-codecs`, `cef-macos-arm64-148.23.23-codecs`).
+Our pins: `agentmux-cef/Cargo.toml` → `cef = { version = "148" }`; root `Cargo.toml` `[patch.crates-io]` → `cef-dll-sys` from `AgentU-asaf/cef-rs` @ `515b3ac53c`; runtime binaries from `agentmuxai/cef` releases (`cef-windows-x86_64-148.0.7778.180`, `cef-linux-x86_64-148.0.7778.180-codecs`, `cef-macos-arm64-148.23.25-codecs`, bumped from `148.23.23-codecs` on 2026-09-09 to ship the macOS 26 renderer fix).
 
 ---
 


### PR DESCRIPTION
```diff
-MACOS_TAG="cef-macos-arm64-148.23.23-codecs"
+MACOS_TAG="cef-macos-arm64-148.23.25-codecs"
```

Release side of #3108 **workstream A**. **Milestone stays 148** — this is *not* part of the 148→152 upgrade, and Windows/Linux need no rebuild, because the patch touches `base/apple/`, never compiled elsewhere.

## What 148.23.25 ships that 148.23.23 didn't

**`agentmux_process_requirement`** — the macOS 26 renderer fix (`-67030` / `errSecCSReqFailed`). Written in June and absent from **every shipped binary** until now: it was never registered in `patch.cfg`, and `patcher.py` reads that file to decide what to apply, so no build could ever have applied it.

**The renderer-side transparency work**, which `agentmuxai/7778` was itself missing until agentmuxai/cef#8. Building from `7778` before that merge would have fixed the crash-loop *and* regressed macOS window transparency at the same time, silently.

## Milestone gate

Re-ran the `cef-runtime-pins` check by hand:

```
windows m148   linux m148   macos m148   -> cross-check PASSES
```

## The release

[`cef-macos-arm64-148.23.25-codecs`](https://github.com/agentmuxai/cef/releases/tag/cef-macos-arm64-148.23.25-codecs), cut with `--target` at the **exact build commit** `1bee8b7da` (an ancestor of `7778`) rather than the branch tip, so the tag records what was actually built.

Confirmed *after* cutting that `targetCommitish` resolves to that SHA and not the default branch — that's the failure mode behind the 2026-07-28 tag-ordering incident documented in the macOS runbook.

## Verification — of the artifact, not the build tree

| Check | Result |
|---|---|
| carry-set at the build commit | `21 OK, 0 MISS` |
| `verify-cef-framework-darwin.sh` on the **extracted** tarball | exit 0 |
| `BeginWindowDrag` / `IsUniqueForCEF` / `IsAlloyContents` / `HasExternalParent` | 2 / 2 / 2 / 4 under full `nm` |
| the two patches that add **no symbol** | confirmed by differential compile |
| `Versions/Current` symlink chain | survives the tar round-trip |

## Not covered here

- **H.264 playback** — needs a packaged app, not a framework on disk. I'll fold it into a `task package:macos` run rather than claim it verified.
- **#3127** — Views transparency not gated on `is_frameless_`. Pre-existing and present in the previous release too; this build passes the carry-set gate at `21 OK` while carrying it, which is the concrete example of why a green gate isn't a release sign-off.

<!-- agentmux:agent_id=clare -->