### PR TITLE
fix(srv): integration tests no longer trigger a real macOS Keychain prompt

### DIFF
--- a/.changesets/1789018616-fix-srv-integration-tests-no-longer-trigger-a-real-macos-key-bm6w.md
+++ b/.changesets/1789018616-fix-srv-integration-tests-no-longer-trigger-a-real-macos-key-bm6w.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(srv): integration tests no longer trigger a real macOS Keychain prompt

--- a/agentmux-srv/src/bootstrap.rs
+++ b/agentmux-srv/src/bootstrap.rs
@@ -1076,9 +1076,30 @@ pub fn spawn_background_subsystems(
     ));
 
     // Cloud push subscriber — single WS connection per sidecar that the cloud
-    // uses to push reactive injections instead of polling.
-    // No-op until the user connects via muxbus.login.
-    crate::muxbus::cloud_subscriber::CloudSubscriber::init_global(id_store.clone());
+    // uses to push reactive injections instead of polling. The WS connection
+    // itself is a no-op until the user connects via muxbus.login, but
+    // `init_global` registers the muxbus credential with the broker
+    // scheduler unconditionally, which calls `Store::muxbus_is_fresh()` —
+    // a real, synchronous OS-keychain read — almost immediately. That read
+    // is the automatic (non-user-triggered) keychain touch
+    // docs/retro/retro-macos-muxbus-keychain-prompt-storm-2026-08-19.md
+    // investigates; skipping `init_global` entirely is not a no-op the way
+    // the comment above might suggest.
+    //
+    // `AGENTMUX_DISABLE_CLOUD_SUBSCRIBER` exists so `agentmux-srv/tests/
+    // integration_test.rs` can spawn the real binary without that read
+    // firing. Those tests spawn an ad-hoc/dev-signed `target/debug`
+    // binary, which is never on the Keychain ACL's trusted-signature list
+    // (only specific notarized, Developer-ID-signed installs are) — so
+    // every spawned test process gets its own interactive consent prompt
+    // for the SAME real credential, on whatever macOS account happens to
+    // be running the test. Confirmed live: a `cargo test -p agentmux-srv`
+    // run produced 4 near-simultaneous prompts, one per spawned subprocess,
+    // on a shared dev machine. Off by default — the shipped app and `task
+    // dev` must keep muxbus reconnect-on-launch working exactly as before.
+    if !cloud_subscriber_disabled_from_env() {
+        crate::muxbus::cloud_subscriber::CloudSubscriber::init_global(id_store.clone());
+    }
 
     // Discord messaging bridge — connects to Discord Gateway if configured.
     // Set messaging:discord:enabled + messaging:discord:token in settings.json to activate.
@@ -2045,4 +2066,56 @@ pub fn install_agent_turn_delivery(state: &AppState) {
                 }
             }
         }));
+}
+
+/// Should `CloudSubscriber::init_global` be skipped this run?
+///
+/// Presence-based, matching the `AGENTMUX_DEV`/`AGENTMUX_TRAY` idiom
+/// elsewhere in this codebase. See the call site's doc comment for why
+/// skipping this matters: `init_global` triggers a real, synchronous
+/// OS-keychain read almost immediately, which macOS gates behind an
+/// interactive consent prompt for any process whose code signature isn't
+/// on the target credential's trusted-signer ACL — exactly the case for an
+/// ad-hoc/dev-signed `target/debug` binary spawned by an integration test.
+fn cloud_subscriber_disabled_from_env() -> bool {
+    std::env::var("AGENTMUX_DISABLE_CLOUD_SUBSCRIBER").is_ok()
+}
+
+#[cfg(test)]
+mod cloud_subscriber_gate_tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Serialize: both tests mutate the same process-global env var, and
+    // `cargo test` runs tests in parallel by default within one binary.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn lock() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[test]
+    fn defaults_to_enabled_so_shipped_and_dev_behavior_is_unchanged() {
+        let _guard = lock();
+        std::env::remove_var("AGENTMUX_DISABLE_CLOUD_SUBSCRIBER");
+        assert!(
+            !cloud_subscriber_disabled_from_env(),
+            "must default to false — the shipped app and `task dev` need the \
+             real muxbus reconnect-on-launch behavior with no opt-out set"
+        );
+    }
+
+    #[test]
+    fn is_disabled_when_the_var_is_present_regardless_of_value() {
+        let _guard = lock();
+        // Presence-based, not value-based — matches AGENTMUX_DEV/AGENTMUX_TRAY.
+        // An empty value must still disable it; a caller setting the var to
+        // "" to mean "off" would otherwise silently get the opposite of
+        // what every other flag in this idiom does.
+        std::env::set_var("AGENTMUX_DISABLE_CLOUD_SUBSCRIBER", "");
+        assert!(cloud_subscriber_disabled_from_env());
+        std::env::set_var("AGENTMUX_DISABLE_CLOUD_SUBSCRIBER", "1");
+        assert!(cloud_subscriber_disabled_from_env());
+        std::env::remove_var("AGENTMUX_DISABLE_CLOUD_SUBSCRIBER");
+    }
 }

--- a/agentmux-srv/tests/integration_test.rs
+++ b/agentmux-srv/tests/integration_test.rs
@@ -124,6 +124,11 @@ fn spawn_backend() -> (SrvGuard, String, String, String) {
 
     let child = Command::new(binary)
         .env("AGENTMUX_AUTH_KEY", auth_key)
+        // See bootstrap.rs's cloud_subscriber_disabled_from_env doc comment:
+        // without this, every spawn here fires a real OS-keychain read from
+        // an ad-hoc/dev-signed binary, which macOS gates behind an
+        // interactive consent prompt on whatever account runs this suite.
+        .env("AGENTMUX_DISABLE_CLOUD_SUBSCRIBER", "1")
         .stdin(Stdio::piped())
         .stderr(Stdio::piped())
         .stdout(Stdio::null())
@@ -225,6 +230,7 @@ fn spawn_backend_with_data_dir(data_dir: &std::path::Path) -> (SrvGuard, String,
     let child = Command::new(binary)
         .env("AGENTMUX_AUTH_KEY", auth_key)
         .env("AGENTMUX_DATA_DIR", data_dir)
+        .env("AGENTMUX_DISABLE_CLOUD_SUBSCRIBER", "1")
         .stdin(Stdio::piped())
         .stderr(Stdio::piped())
         .stdout(Stdio::null())


### PR DESCRIPTION
Fixes the exact symptom hit this session: running `cargo test -p agentmux-srv` on a real Mac produced 4 near-simultaneous interactive Keychain prompts, with no indication of which process or why, requiring the person at the keyboard to deny each one blind.

## Root cause

`agentmux-srv/tests/integration_test.rs` spawns the real compiled `agentmux-srv` binary (`spawn_backend`/`spawn_backend_with_data_dir`) to test it end-to-end. That binary's normal startup unconditionally calls `CloudSubscriber::init_global`, which registers the muxbus credential with the broker scheduler and triggers `Store::muxbus_is_fresh()` — a real, synchronous OS-keychain read — almost immediately.

This repo already has a retro on the general phenomenon (`docs/retro/retro-macos-muxbus-keychain-prompt-storm-2026-08-19.md`), but it addressed the *shipped app's* prompt count (collapsing 12 keychain entries down, adding read timeouts). It didn't cover an *automated test run* reaching the real keychain at all.

The keychain entry's ACL only trusts specific notarized, Developer-ID-signed installs. An ad-hoc/dev-signed `target/debug` binary is never on that list, so macOS surfaces a fresh interactive consent prompt for **every spawned test process** — on whatever account happens to be running the suite, which on a shared dev machine may not even be the person who triggered the test run.

## Fix

`AGENTMUX_DISABLE_CLOUD_SUBSCRIBER` — presence-based, matching the `AGENTMUX_DEV`/`AGENTMUX_TRAY` idiom already used in this codebase — gates the `init_global` call in `bootstrap.rs`. **Off by default**: the shipped app and `task dev` keep the real muxbus reconnect-on-launch behavior exactly as before. Both spawn sites in `integration_test.rs` now set it.

## Verification

Two levels:

1. **Unit tests** on the gate function: defaults to enabled with no var set, disabled regardless of value once the var is present (empty string included — matching the presence-based idiom, not a value check).
2. **The actual regression, empirically** — not just testing the gate logic in isolation:
   - Captured wall-clock start time.
   - Ran `cargo test --test integration_test -p agentmux-srv` — **5 passed**, all the subprocess-spawning tests (`auth_rejects_missing_key`, `auth_accepts_valid_header`, `health_returns_200`, `restore_last_session_survives_a_real_process_restart`, `sigterm_exits_process`) still exercise real IPC/lifecycle behavior against the spawned binary.
   - Searched the macOS unified log (`log show --predicate 'eventMessage contains "keychain"'`) for any prompt event from `target/debug/agentmux-srv` since that timestamp.
   - **Zero.** The same class of run previously produced 4.

`cargo test -p agentmux-srv -- --test-threads=1`: **3197 passed** (2 more than before — the new gate tests), 0 failed.

<!-- agentmux:agent_id=agento -->