### PR TITLE
docs(spec): Phase 0 answered — bundle components have two unsynced stores

### DIFF
--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -342,6 +342,7 @@ partial list.
 | [`SPEC_EDITOR_MCP_OPEN_BLANK_PREVIEW_AND_PANE_REUSE_2026_08_03`](SPEC_EDITOR_MCP_OPEN_BLANK_PREVIEW_AND_PANE_REUSE_2026_08_03.md) | Plan: MCP-opened markdown blank-preview investigation + Editor-pane reuse |
 | [`SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09`](SPEC_FLOATING_PANE_REDOCK_DWELL_2026_09_09.md) | SPEC: Floating-pane redock — hover-intent dwell and a neutral parking zone |
 | [`SPEC_HEADLESS_TRANSIENT_RETRY_2026_08_31`](SPEC_HEADLESS_TRANSIENT_RETRY_2026_08_31.md) | Transient-failure retry for turns with no rendered pane |
+| [`SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09`](SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md) | Spec: Instruction and Memory Portability |
 | [`SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02`](SPEC_JEKT_CROSS_CHANNEL_TRUST_2026_09_02.md) | SPEC: Cross-channel jekt trust — closing the last unverifiable same-machine tier |
 | [`SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13`](SPEC_JEKT_LAN_WAN_TRUST_HARDENING_2026_08_13.md) | Spec: Securing LAN and WAN tier jekt delivery — closing cross-tenant and cross-network trust gaps |
 | [`SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03`](SPEC_MIGRATION_SYSTEM_HARDENING_2026_08_03.md) | Migration System Audit & Hardening Plan |
@@ -390,7 +391,6 @@ partial list.
 | [`SPEC_FLOATING_PANE_TEAROFF_CROSS_PLATFORM_2026-05-26`](SPEC_FLOATING_PANE_TEAROFF_CROSS_PLATFORM_2026-05-26.md) | Floating pane tear-off — cross-platform recipes |
 | [`SPEC_GLOBAL_IDENTITY_MEMORY_DRONE_2026_06_24`](SPEC_GLOBAL_IDENTITY_MEMORY_DRONE_2026_06_24.md) | SPEC — Global Identity, Memory, and Drone Definitions |
 | [`SPEC_INAPP_CLAUDE_OAUTH_LOGIN_2026_08_03`](SPEC_INAPP_CLAUDE_OAUTH_LOGIN_2026_08_03.md) | SPEC — In-app (no-shell) Claude OAuth login, revived, at all three auth surfaces |
-| [`SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09`](SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md) | Spec: Instruction and Memory Portability |
 | [`SPEC_ISOLATED_AUTH_DEFAULT_BY_CHANNEL_2026_08_06`](SPEC_ISOLATED_AUTH_DEFAULT_BY_CHANNEL_2026_08_06.md) | Spec: Make isolated auth the default for every non-`stable` channel |
 | [`SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31`](SPEC_ISOLATE_HOST_CLAUDE_MD_2026_08_31.md) | Spec: Stop the isolated Claude Code config dir from falling back to the host's `~/.claude/CLAUDE.md` |
 | [`SPEC_JEKT_LAN_TIER_SIGNING_2026_08_15`](SPEC_JEKT_LAN_TIER_SIGNING_2026_08_15.md) | SPEC: LAN-tier Ed25519 jekt signing |

--- a/docs/specs/SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md
+++ b/docs/specs/SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md
@@ -355,11 +355,29 @@ mechanism unspecified. Location *ownership* is the successor requirement.
 
 ### 5.4 One source of truth for components
 
-Resolve §3.4 before extending the format. Either the ref tables become
-authoritative and `export_bundle` reads them, or the inline columns stay
-authoritative and the ref tables are documented as a cache with a sync path.
-Adding `projectInstructions` to a format that already silently drops
-ref-table-bound skills would ship a second instance of the same bug.
+Resolve §3.4 before extending the format. Adding `projectInstructions` to a
+format that already silently drops ref-table-bound skills would ship a second
+instance of the same bug.
+
+**Either option has to close both directions of §3.4, not one.** The two losses
+have different shapes and a fix aimed at one leaves the other standing:
+
+- **Ref tables authoritative.** Pointing `export_bundle` at the ref tables fixes
+  bind-then-export. It does nothing for import-then-launch: all three import
+  paths still write only inline `mcp_servers`, and launch still reads refs, so
+  an imported server stays inert. This option is therefore *three* changes, not
+  one — export reads refs, **imports create the managed rows and bind them**,
+  and existing inline-only data is migrated into refs or it silently disappears
+  from every consumer at once. (Codex, PR #3149.)
+- **Inline columns authoritative.** The ref tables become a cache, which means a
+  sync path on every bind/unbind and a backfill for refs that have no inline
+  counterpart today. Launch would have to read through the same resolution, so
+  this is the larger change to the hot path.
+
+Recommendation: ref-authoritative, because launch is already the consumer that
+matters for correctness at runtime and the ref tables are where the UI writes.
+But it is not the cheap option it looks like from the export side alone, and
+the migration of existing inline-only data is the part to size first.
 
 ### 5.5 Format version debt this inherits
 
@@ -400,11 +418,12 @@ path and a two-way divergence (§3.4). What it leaves behind is no longer a
 question but a fix: reconcile the two stores, or the format grows on top of a
 known-lossy base. Still blocks Phase 3.
 
-**Phase 0b — reconcile components (§5.4).** Either the ref tables become
-authoritative and `export_bundle` reads them, or the inline columns stay
-authoritative and something syncs them on bind/unbind. Sizing this is its own
-exercise; `SPEC_BUNDLE_AS_CONTAINER_V2_2026_08_17.md` §91-95 deferred exactly
-this decision and named the trigger — "once the new ref tables have shipped and
+**Phase 0b — reconcile components (§5.4).** Whichever store wins, the fix has
+to close both directions: the ref-authoritative option is export-reads-refs
+**plus** imports creating and binding managed rows **plus** a migration of
+existing inline-only data, not just the first of those (Codex, PR #3149).
+`SPEC_BUNDLE_AS_CONTAINER_V2_2026_08_17.md` §91-95 deferred exactly this
+decision and named the trigger — "once the new ref tables have shipped and
 proven out" — which has now happened.
 
 **Phase 1 — export symmetry (§5.1).** One constant, one branch, one test. No

--- a/docs/specs/SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md
+++ b/docs/specs/SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md
@@ -1,6 +1,6 @@
 # Spec: Instruction and Memory Portability
 
-**Status:** proposed
+**Status:** active — Phases 1-2 landed (#3147); Phase 0 investigated 2026-09-09 and turned up a two-way divergence (§3.4), which makes Phase 0b its prerequisite. Phases 0b, 3 and 4 remain. Tracking: #3148.
 **Date:** 2026-09-09
 **Verified against:** `a86cdee50` (code, not spec prose)
 **Follows:** `SPEC_ARMORY_NAMING_CONSOLIDATION_2026_09_09.md` §8, which deferred
@@ -189,9 +189,52 @@ are read only by `Store::bundle_skill_list` (`storage/skills.rs:495`) and
 `Store::bundle_mcp_list` (`storage/mcp_servers.rs:257`), whose only callers are
 `app_api/skill.rs:542` and `app_api/mcp.rs:625`.
 
-**A skill or MCP server bound through the ref table and absent from the inline
-column does not appear in the ABF.** Whether a sync path exists elsewhere is
-unverified; §7 Phase 0 is to answer that before anything else is built on top.
+**Phase 0 answered this, 2026-09-09, and the answer is worse than the question
+assumed: there is no sync path, by design, and the divergence runs in both
+directions.**
+
+No code path writes both. Binding a skill or server to a bundle
+(`skill.catalog.bind_to_bundle`, `mcp.catalog.bind_to_bundle`) reaches
+`Store::managed_bind_bundle` (`storage/managed.rs:285`) and issues exactly one
+INSERT into the ref table (`storage/managed.rs:298-305`); the handler
+(`app_api/skill.rs:513`) never reads or writes the bundle row. Conversely
+`bundle.upsert` and the three ABF-import paths write the inline columns
+(`storage/bundles.rs:245-246`) and never call `bundle_skill_bind` /
+`bundle_mcp_bind`. The split is deliberate and stated in the v23 schema
+comment (`migrations.rs:198-199`): the inline columns are "still the .abf
+export/import" path while the ref tables are the live-resolution one.
+
+So the two consumers disagree, and each is authoritative for a different thing:
+
+| | ABF export reads | Agent launch reads |
+|---|---|---|
+| Skills | `bundle.skills` inline (`app_api/bundle.rs:388`) | `effective_skills` → ref table (`app_api/agent_open.rs:793`) |
+| MCP servers | `bundle.mcp_servers` inline (`bundle_export.rs:526`) | `effective_mcp_servers` → ref table (`app_api/agent_open.rs:812`) |
+
+Two concrete losses follow:
+
+1. **Bind, then export.** A skill or server added to a bundle in the Armory is
+   live at launch and visible in the UI, but the inline column is still `"[]"`,
+   so the `.abf` ships with empty `skills/` and `mcp/` directories **and no
+   warning**. ABF is advertised as a backup format; this is the same
+   silent-incompleteness class the export code already guards against for a
+   damaged store (`app_api/bundle.rs:390-395`).
+2. **Import, then launch.** `bundle.import` writes inline `mcp_servers` but
+   creates no `db_mcp_servers` rows and no ref rows (`app_api/bundle.rs`
+   contains zero `mcp_server_upsert*` calls), so imported servers are never
+   materialised at spawn — inert at runtime, exactly the state
+   `SPEC_BUNDLE_AS_CONTAINER_V2_2026_08_17.md:40-42` describes and the ref
+   tables were meant to replace.
+
+That spec kept the inline columns "as-is for this delivery" as an explicit
+non-goal (`:91-95`), to be revisited once the ref tables proved out. They have.
+Reconciling them is now a prerequisite of §5.4, not a nice-to-have: adding
+`components.projectInstructions` to a format that already drops ref-table-bound
+skills would ship a second instance of the same bug.
+
+Secondary: `bundle_delete` (`storage/bundles.rs:326`) issues only
+`DELETE FROM db_bundles` and there is deliberately no FK from the ref tables
+(`migrations.rs:727-741`), so deleting a bundle orphans its ref rows.
 
 ### 3.5 History files are in the archive but not in the manifest
 
@@ -352,8 +395,17 @@ answer and `$schema` alone does not.
 
 ## 7. Phases
 
-**Phase 0 — resolve §3.4.** Determine whether a sync path exists between the
-inline columns and the ref tables. Blocks Phase 3; blocks nothing else.
+**Phase 0 — DONE (2026-09-09), and it grew.** The investigation found no sync
+path and a two-way divergence (§3.4). What it leaves behind is no longer a
+question but a fix: reconcile the two stores, or the format grows on top of a
+known-lossy base. Still blocks Phase 3.
+
+**Phase 0b — reconcile components (§5.4).** Either the ref tables become
+authoritative and `export_bundle` reads them, or the inline columns stay
+authoritative and something syncs them on bind/unbind. Sizing this is its own
+exercise; `SPEC_BUNDLE_AS_CONTAINER_V2_2026_08_17.md` §91-95 deferred exactly
+this decision and named the trigger — "once the new ref tables have shipped and
+proven out" — which has now happened.
 
 **Phase 1 — export symmetry (§5.1).** One constant, one branch, one test. No
 format change. Independently shippable and revertible.


### PR DESCRIPTION
Records the answer to Phase 0 of `SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md` (#3144). Docs-only, no changeset. Tracking: #3148.

The spec's §3.4 said *"whether a sync path exists elsewhere is unverified; §7 Phase 0 is to answer that."* It has been answered, and the answer is worse than the question assumed.

**There is no sync path, by design, and the divergence runs in both directions.**

No code path writes both stores:
- Binding a skill or server to a bundle (`skill.catalog.bind_to_bundle`, `mcp.catalog.bind_to_bundle`) reaches `Store::managed_bind_bundle` (`storage/managed.rs:285`) and issues exactly one INSERT into the ref table (`:298-305`). The handler (`app_api/skill.rs:513`) never reads or writes the bundle row.
- `bundle.upsert` and the three ABF-import paths write the inline columns (`storage/bundles.rs:245-246`) and never call `bundle_skill_bind` / `bundle_mcp_bind`.
- The v23 schema comment states the split outright (`migrations.rs:198-199`): inline columns are "still the .abf export/import" path, ref tables are the live-resolution one.

So the two consumers disagree, each authoritative for a different thing:

| | ABF export reads | Agent launch reads |
|---|---|---|
| Skills | `bundle.skills` inline (`app_api/bundle.rs:388`) | `effective_skills` → ref table (`app_api/agent_open.rs:793`) |
| MCP servers | `bundle.mcp_servers` inline (`bundle_export.rs:526`) | `effective_mcp_servers` → ref table (`app_api/agent_open.rs:812`) |

**Two concrete losses:**

1. **Bind, then export.** A skill or server added to a bundle in the Armory is live at launch and visible in the UI, but the inline column is still `"[]"` — so the `.abf` ships with empty `skills/` and `mcp/` directories and no warning. ABF is advertised as a backup format.
2. **Import, then launch.** `bundle.import` writes inline `mcp_servers` but creates no `db_mcp_servers` rows and no ref rows, so imported servers are never materialised at spawn. This is exactly the "inert at runtime" state `SPEC_BUNDLE_AS_CONTAINER_V2_2026_08_17.md:40-42` describes and the ref tables were meant to replace.

Secondary: deleting a bundle orphans its ref rows — no FK, deliberately (`migrations.rs:727-741`).

That spec kept the inline columns "as-is for this delivery" as an explicit non-goal (`:91-95`), to be revisited "once the new ref tables have shipped and proven out". They have. This PR therefore adds **Phase 0b — reconcile the two stores** as a prerequisite of Phase 3: adding `components.projectInstructions` on top of a base that already drops ref-table-bound skills would ship the same bug twice.

Spec status moves `proposed` → `active` (Phases 1-2 landed in #3147). Index regenerated.

No code changes. Every claim carries a `file:line` and was verified against `b8b37f13d`.

**Verification**
```
scripts/check-spec-citations.sh  → ok (2 files checked)
task check:doc-status            → ok (2 docs checked)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
