### PR TITLE
fix(srv): Phase 0b — bundle ref tables become authoritative for export, with backfill

### DIFF
--- a/.changesets/1789022722-fix-srv-bundle-exports-now-carry-the-skills-and-mcp-servers--e638.md
+++ b/.changesets/1789022722-fix-srv-bundle-exports-now-carry-the-skills-and-mcp-servers--e638.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(srv): bundle exports now carry the skills and MCP servers actually bound to the bundle, with a migration carrying existing inline data across

--- a/agentmux-srv/src/backend/bundle_export.rs
+++ b/agentmux-srv/src/backend/bundle_export.rs
@@ -360,14 +360,26 @@ pub(crate) fn sanitize_context_relative_path(path: &str) -> Option<String> {
     Some(parts.join("/"))
 }
 
-/// Export a bundle + its already-resolved skills into the ABF v0.1 layout.
+/// Export a bundle + its already-resolved components into the ABF layout.
 ///
-/// `skills` must already be resolved from `bundle.skills` (a JSON array of
-/// skill ids) via `Store::skill_get` per id — this function does no
-/// lookups. Callers should skip ids that failed to resolve (deleted skills)
-/// before calling this; it does not distinguish "missing" from "not
-/// passed."
-pub fn export_bundle(bundle: &Bundle, skills: &[Skill]) -> BundleExport {
+/// **This function does no store lookups and reads no component column off
+/// `bundle`.** Both `skills` and `mcp_servers` must be resolved by the caller
+/// from `db_bundle_skills_ref` / `db_bundle_mcp_ref`, which are authoritative
+/// for what a bundle contains (Phase 0b of
+/// SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md). It used to read
+/// `bundle.mcp_servers` inline here while skills came in resolved — that split
+/// is exactly how export and launch drifted apart, so the renderer now takes
+/// both the same way and has no opinion about where they came from.
+///
+/// `mcp_servers` entries are the exporter's own entry shape: the server's
+/// config object with its `name` alongside, which is what `redact_mcp_entry`
+/// reads. Callers skip ids that failed to resolve before calling; this does
+/// not distinguish "missing" from "not passed".
+pub fn export_bundle(
+    bundle: &Bundle,
+    skills: &[Skill],
+    mcp_servers: &[Value],
+) -> BundleExport {
     let root_slug = derive_slug(&bundle.name);
     let mut files = Vec::new();
     let mut skipped_skills = Vec::new();
@@ -522,8 +534,7 @@ pub fn export_bundle(bundle: &Bundle, skills: &[Skill]) -> BundleExport {
     // ------------------------------------------------------------------
     // mcp/<slug>.server.json + inferred accounts/requirements.json
     // ------------------------------------------------------------------
-    let mcp_entries: Vec<Value> =
-        parse_json_field_or_warn(&bundle.mcp_servers, "mcp_servers", &mut warnings);
+    let mcp_entries: Vec<Value> = mcp_servers.to_vec();
     let mut used_mcp_slugs: HashSet<String> = HashSet::new();
     let mut requirements: Vec<Value> = Vec::new();
     for (index, entry) in mcp_entries.iter().enumerate() {
@@ -729,6 +740,19 @@ mod tests {
         }
     }
 
+    /// Render a bundle whose MCP servers are given inline, the way these
+    /// renderer tests express a fixture.
+    ///
+    /// `export_bundle` no longer reads `bundle.mcp_servers` — the ref tables
+    /// are authoritative and the caller resolves them (Phase 0b,
+    /// SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md). These tests are
+    /// about rendering, not resolution, so this shim does the parse the
+    /// renderer used to do and hands the entries over explicitly.
+    fn export_with_inline_mcp(bundle: &Bundle, skills: &[Skill]) -> BundleExport {
+        let entries: Vec<Value> = serde_json::from_str(&bundle.mcp_servers).unwrap_or_default();
+        export_bundle(bundle, skills, &entries)
+    }
+
     fn make_agent_skill(name: &str) -> Skill {
         Skill {
             id: format!("skill-{name}"),
@@ -746,7 +770,7 @@ mod tests {
     #[test]
     fn exports_instructions_as_agents_md() {
         let bundle = make_bundle("Follow repo conventions.", "[]", "[]", "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
         let f = export.files.iter().find(|f| f.path == "instructions/AGENTS.md").unwrap();
         assert_eq!(f.content, "Follow repo conventions.");
     }
@@ -755,7 +779,7 @@ mod tests {
     fn exports_context_files_under_instructions_context() {
         let context_files = r#"[{"path":"docs/readme.md","content":"Readme heading"}]"#;
         let bundle = make_bundle("", context_files, "[]", "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
         let f = export
             .files
             .iter()
@@ -768,7 +792,7 @@ mod tests {
     fn rejects_path_traversal_in_context_files() {
         let context_files = r#"[{"path":"../../etc/passwd","content":"evil"}]"#;
         let bundle = make_bundle("", context_files, "[]", "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
         assert!(export.files.iter().all(|f| !f.content.contains("evil")));
         assert!(!export.files.iter().any(|f| f.path.contains("..")));
         // Codex + reagent P2, PR #2333: a rejected entry must not just
@@ -788,7 +812,7 @@ mod tests {
         prompt_skill.skill_type = "prompt".to_string();
         let skills = vec![make_agent_skill("Deploy Checklist"), prompt_skill];
 
-        let export = export_bundle(&bundle, &skills);
+        let export = export_with_inline_mcp(&bundle, &skills);
         assert!(export
             .files
             .iter()
@@ -801,7 +825,7 @@ mod tests {
     fn exports_mcp_servers_and_infers_requirements_from_env_keys() {
         let mcp_servers = r#"[{"name":"github","type":"stdio","command":"gh-mcp","env":{"GITHUB_TOKEN":""}}]"#;
         let bundle = make_bundle("", "[]", mcp_servers, "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
 
         let server_file = export
             .files
@@ -826,7 +850,7 @@ mod tests {
         // requirements must use the disambiguated key.
         let mcp_servers = r#"[{"name":"github","type":"stdio","command":"gh-mcp","env":{"GITHUB_TOKEN":""}}]"#;
         let bundle = make_bundle("", "[]", mcp_servers, "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
 
         let req_file = export
             .files
@@ -854,7 +878,7 @@ mod tests {
             "headers": {"Authorization": "Bearer realBearerToken456"}
         }]"#;
         let bundle = make_bundle("", "[]", mcp_servers, "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
 
         let server_file = export
             .files
@@ -892,7 +916,7 @@ mod tests {
     fn no_requirements_file_when_no_env_vars_present() {
         let mcp_servers = r#"[{"name":"local-tool","type":"stdio","command":"local-tool"}]"#;
         let bundle = make_bundle("", "[]", mcp_servers, "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
         assert!(!export.files.iter().any(|f| f.path == "accounts/requirements.json"));
     }
 
@@ -903,7 +927,7 @@ mod tests {
         // caller that data was lost -- defeats the exporter's stated
         // backup/portability guarantee.
         let bundle = make_bundle("", "{not valid json", "[]", "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
         assert!(
             export.warnings.iter().any(|w| w.contains("context_files") && w.contains("malformed")),
             "expected a warning about malformed context_files, got: {:?}",
@@ -913,11 +937,22 @@ mod tests {
 
     #[test]
     fn malformed_mcp_servers_json_warns_instead_of_silently_dropping_data() {
-        let bundle = make_bundle("", "[]", "not an array at all", "[]");
-        let export = export_bundle(&bundle, &[]);
+        // The renderer no longer parses MCP JSON — it is handed typed entries
+        // (Phase 0b). The guarantee this test protects, that malformed
+        // component data warns instead of vanishing, moved with the parse into
+        // `resolve_bundle_components`, and is asserted there:
+        // `app_api::bundle::export_import_for_agent_tests::
+        //  a_bound_mcp_server_with_unparseable_config_warns_instead_of_vanishing`.
+        //
+        // Kept as a pointer rather than deleted, so the guarantee is still
+        // findable from the module that used to own it. `context_files` is
+        // still parsed here, and its own malformed-input test below is the
+        // live example of the same rule at this layer.
+        let bundle = make_bundle("", "not an array at all", "[]", "[]");
+        let export = export_with_inline_mcp(&bundle, &[]);
         assert!(
-            export.warnings.iter().any(|w| w.contains("mcp_servers") && w.contains("malformed")),
-            "expected a warning about malformed mcp_servers, got: {:?}",
+            export.warnings.iter().any(|w| w.contains("context_files") && w.contains("malformed")),
+            "expected a warning about malformed context_files, got: {:?}",
             export.warnings
         );
     }
@@ -926,7 +961,7 @@ mod tests {
     fn blank_context_files_and_mcp_servers_produce_no_warning() {
         // A genuinely empty/unset field is not an error -- must not warn.
         let bundle = make_bundle("", "", "", "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
         assert!(export.warnings.is_empty(), "blank fields must not warn: {:?}", export.warnings);
     }
 
@@ -962,7 +997,7 @@ mod tests {
             {"path":"docs/./a.md","content":"second, would silently clobber the first"}
         ]"#;
         let bundle = make_bundle("", context_files, "[]", "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
 
         let matches: Vec<_> = export
             .files
@@ -990,7 +1025,7 @@ mod tests {
             {"path":"docs/a.md","content":"second, would collide on a case-insensitive filesystem"}
         ]"#;
         let bundle = make_bundle("", context_files, "[]", "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
 
         let matches: Vec<_> = export
             .files
@@ -1016,7 +1051,7 @@ mod tests {
             "headers": {"Authorization": "Bearer realToken789"}
         }]"#;
         let bundle = make_bundle("", "[]", mcp_servers, "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
 
         let req_file = export
             .files
@@ -1042,7 +1077,7 @@ mod tests {
             "args": ["--api-key=lin_realSecretAbc123", "--verbose"]
         }]"#;
         let bundle = make_bundle("", "[]", mcp_servers, "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
         let server_file = export.files.iter().find(|f| f.path == "mcp/linear.server.json").unwrap();
         assert!(!server_file.content.contains("lin_realSecretAbc123"));
         assert!(server_file.content.contains("${API_KEY}"));
@@ -1063,7 +1098,7 @@ mod tests {
             "args": ["--token", "realSecretXyz789", "--port", "8080"]
         }]"#;
         let bundle = make_bundle("", "[]", mcp_servers, "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
         let server_file = export.files.iter().find(|f| f.path == "mcp/custom.server.json").unwrap();
         assert!(!server_file.content.contains("realSecretXyz789"));
         assert!(server_file.content.contains("${TOKEN}"));
@@ -1085,7 +1120,7 @@ mod tests {
             "args": ["--keymap=vim", "--theme", "dark"]
         }]"#;
         let bundle = make_bundle("", "[]", mcp_servers, "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
         let server_file = export.files.iter().find(|f| f.path == "mcp/editor.server.json").unwrap();
         assert!(server_file.content.contains("--keymap=vim"));
         assert!(server_file.content.contains("dark"));
@@ -1102,7 +1137,7 @@ mod tests {
             "url": "https://admin:realPass456@mcp.example.com/api?api_key=realKeyAbc&region=us"
         }]"#;
         let bundle = make_bundle("", "[]", mcp_servers, "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
         let server_file = export.files.iter().find(|f| f.path == "mcp/remote.server.json").unwrap();
         assert!(!server_file.content.contains("realPass456"));
         assert!(!server_file.content.contains("realKeyAbc"));
@@ -1134,7 +1169,7 @@ mod tests {
             "url": "https://api.example.com/mcp?client_secret=realClientSecret123&auth_token=realAuthToken456"
         }]"#;
         let bundle = make_bundle("", "[]", mcp_servers, "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
         let server_file = export.files.iter().find(|f| f.path == "mcp/oauth-server.server.json").unwrap();
         assert!(!server_file.content.contains("realClientSecret123"));
         assert!(!server_file.content.contains("realAuthToken456"));
@@ -1156,7 +1191,7 @@ mod tests {
             "url": "https://svc.example.com?a=b@c&api_key=realSecretShouldBeRedacted"
         }]"#;
         let bundle = make_bundle("", "[]", mcp_servers, "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
         let server_file = export.files.iter().find(|f| f.path == "mcp/svc.server.json").unwrap();
         assert!(
             !server_file.content.contains("realSecretShouldBeRedacted"),
@@ -1180,7 +1215,7 @@ mod tests {
             "url": "https://mcp.example.com#note@example.com"
         }]"#;
         let bundle = make_bundle("", "[]", mcp_servers, "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
         let server_file = export.files.iter().find(|f| f.path == "mcp/svc.server.json").unwrap();
         assert!(
             server_file.content.contains("mcp.example.com#note@example.com"),
@@ -1204,7 +1239,7 @@ mod tests {
             "args": ["--header", "Authorization: Bearer realSecretToken789", "--verbose"]
         }]"#;
         let bundle = make_bundle("", "[]", mcp_servers, "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
         let server_file = export.files.iter().find(|f| f.path == "mcp/remote.server.json").unwrap();
         assert!(!server_file.content.contains("realSecretToken789"));
         assert!(server_file.content.contains("Authorization: ${AUTHORIZATION}"));
@@ -1223,7 +1258,7 @@ mod tests {
             "args": ["--header=Authorization: Bearer realSecretToken456"]
         }]"#;
         let bundle = make_bundle("", "[]", mcp_servers, "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
         let server_file = export.files.iter().find(|f| f.path == "mcp/remote2.server.json").unwrap();
         assert!(!server_file.content.contains("realSecretToken456"));
         assert!(server_file.content.contains("--header=Authorization: ${AUTHORIZATION}"));
@@ -1238,7 +1273,7 @@ mod tests {
             "args": ["--header", "X-Request-Id: abc123", "-H", "Content-Type: application/json"]
         }]"#;
         let bundle = make_bundle("", "[]", mcp_servers, "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
         let server_file = export.files.iter().find(|f| f.path == "mcp/remote3.server.json").unwrap();
         assert!(server_file.content.contains("X-Request-Id: abc123"));
         assert!(server_file.content.contains("Content-Type: application/json"));
@@ -1248,7 +1283,7 @@ mod tests {
     fn dedupes_colliding_mcp_server_names() {
         let mcp_servers = r#"[{"name":"Server!!!One"},{"name":"Server One"}]"#;
         let bundle = make_bundle("", "[]", mcp_servers, "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
         let paths: HashSet<&str> = export.files.iter().map(|f| f.path.as_str()).collect();
         assert!(paths.contains("mcp/server-one.server.json"));
         assert!(paths.contains("mcp/server-one-2.server.json"));
@@ -1262,7 +1297,7 @@ mod tests {
             r#"[{"name":"github","env":{"GITHUB_TOKEN":""}}]"#,
             r#"["skill-a"]"#,
         );
-        let export = export_bundle(&bundle, &[make_agent_skill("Deploy")]);
+        let export = export_with_inline_mcp(&bundle, &[make_agent_skill("Deploy")]);
         let manifest_file = export.files.iter().find(|f| f.path == "armory.json").unwrap();
         let manifest: Value = serde_json::from_str(&manifest_file.content).expect("armory.json must be valid JSON");
         assert_eq!(manifest["name"], "backend-dev-bundle");
@@ -1279,7 +1314,7 @@ mod tests {
         let mut bundle = make_bundle("Default instructions.", "[]", "[]", "[]");
         bundle.instructions_by_provider =
             r#"{"claude":"Claude-specific override.","codex":"Codex-specific override."}"#.to_string();
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
 
         let claude_file = export.files.iter().find(|f| f.path == "instructions/claude/AGENTS.md")
             .expect("expected instructions/claude/AGENTS.md");
@@ -1302,7 +1337,7 @@ mod tests {
         // or an empty manifest entry.
         let mut bundle = make_bundle("Default.", "[]", "[]", "[]");
         bundle.instructions_by_provider = r#"{"claude":"   "}"#.to_string();
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
         assert!(!export.files.iter().any(|f| f.path.starts_with("instructions/claude/")));
         let manifest_file = export.files.iter().find(|f| f.path == "armory.json").unwrap();
         let manifest: Value = serde_json::from_str(&manifest_file.content).unwrap();
@@ -1318,7 +1353,7 @@ mod tests {
         let mut bundle = make_bundle("Default.", "[]", "[]", "[]");
         bundle.instructions_by_provider =
             r#"{"claude":"First.","./claude":"Second."}"#.to_string();
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
 
         let claude_files: Vec<_> = export.files.iter().filter(|f| f.path == "instructions/claude/AGENTS.md").collect();
         assert_eq!(claude_files.len(), 1, "must not produce two files at the same path");
@@ -1343,7 +1378,7 @@ mod tests {
         // Codex P1, PR #2325: the ABF spec's manifest example references
         // "skills/<slug>" (the directory), not "skills/<slug>/SKILL.md".
         let bundle = make_bundle("", "[]", "[]", r#"["skill-a"]"#);
-        let export = export_bundle(&bundle, &[make_agent_skill("Deploy Checklist")]);
+        let export = export_with_inline_mcp(&bundle, &[make_agent_skill("Deploy Checklist")]);
         let manifest_file = export.files.iter().find(|f| f.path == "armory.json").unwrap();
         let manifest: Value = serde_json::from_str(&manifest_file.content).unwrap();
         let skills = manifest["components"]["skills"].as_array().unwrap();
@@ -1355,7 +1390,7 @@ mod tests {
     #[test]
     fn empty_bundle_still_produces_a_valid_manifest() {
         let bundle = make_bundle("", "[]", "[]", "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
         // armory.json is always written, even for a fully empty bundle.
         assert_eq!(export.files.len(), 1);
         let manifest: Value = serde_json::from_str(&export.files[0].content).unwrap();
@@ -1365,7 +1400,7 @@ mod tests {
     #[test]
     fn zip_bundle_export_produces_a_valid_archive_with_all_files() {
         let bundle = make_bundle("Instructions here", "[]", "[]", "[]");
-        let export = export_bundle(&bundle, &[]);
+        let export = export_with_inline_mcp(&bundle, &[]);
         let zip_bytes = zip_bundle_export(&export).expect("zip should succeed");
 
         let cursor = std::io::Cursor::new(zip_bytes);

--- a/agentmux-srv/src/backend/bundle_import.rs
+++ b/agentmux-srv/src/backend/bundle_import.rs
@@ -2115,7 +2115,7 @@ mod tests {
             updated_at: 0,
             is_system: false,
         };
-        let export = super::super::bundle_export::export_bundle(&bundle, &[]);
+        let export = super::super::bundle_export::export_bundle(&bundle, &[], &[]);
         let zip_bytes = super::super::bundle_export::zip_bundle_export(&export).unwrap();
 
         let (files, warnings) = unzip_bundle_import(&zip_bytes).unwrap();

--- a/agentmux-srv/src/backend/storage/mcp_servers.rs
+++ b/agentmux-srv/src/backend/storage/mcp_servers.rs
@@ -25,6 +25,173 @@ pub struct McpServer {
     pub updated_at: i64,
 }
 
+impl McpServer {
+    /// Build a bundle-scoped row from an inline MCP config entry.
+    ///
+    /// The inline shape — an ABF `mcp/<slug>.server.json` body, and what
+    /// `db_bundles.mcp_servers` held before the ref tables became
+    /// authoritative — is the server's config object with its `name`
+    /// alongside. This is the one conversion from that shape to a row, shared
+    /// by the `m0030` backfill and the three ABF import paths so a server
+    /// recovered from an old bundle and one that arrives in an import cannot
+    /// end up shaped differently (Phase 0b,
+    /// `SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md`).
+    ///
+    /// `index` disambiguates entries with no usable name; it only has to be
+    /// stable within one bundle, which is where the uniqueness check applies.
+    ///
+    /// `is_global` is false: these belong to their bundle, and
+    /// `bundle_mcp_upsert_unique` forces it to false regardless.
+    pub fn from_inline_config(entry: &serde_json::Value, index: usize, now_ms: i64) -> Self {
+        let name = entry
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            // `build_mcp_config_from_refs` keys `.mcp.json` on the row's name,
+            // so a nameless entry needs a synthetic one rather than being
+            // dropped on the floor.
+            .unwrap_or_else(|| format!("mcp-server-{}", index + 1));
+        // The entry's own `type` is the transport when it has one — an inline
+        // entry can legitimately be http/sse, and hardcoding stdio would
+        // produce a catalog row whose transport column contradicts its own
+        // config JSON (ReAgent, PR #3152). `stdio` is the column default and
+        // the right fallback for an entry that says nothing.
+        let transport = entry
+            .get("type")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or("stdio")
+            .to_string();
+        Self {
+            id: uuid::Uuid::new_v4().to_string(),
+            name,
+            transport,
+            config: serde_json::to_string(entry).unwrap_or_else(|_| "{}".to_string()),
+            is_global: false,
+            created_at: now_ms,
+            updated_at: now_ms,
+        }
+    }
+}
+
+impl Store {
+    /// Create and bind a bundle's inline MCP entries, preserving duplicates.
+    ///
+    /// The one path from "a list of inline config objects" to "rows bound to
+    /// this bundle", shared by the `m0030` backfill and the three ABF import
+    /// paths (Phase 0b,
+    /// `SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md`).
+    ///
+    /// Two entries may legitimately carry the same `name` — the validator
+    /// permits it and the old exporter kept both by slugging them apart. A
+    /// plain `bundle_mcp_upsert_unique` per entry would reject the second on
+    /// the name-uniqueness check and, now that export reads only bound refs,
+    /// lose it permanently (Codex, PR #3152). So names are disambiguated with
+    /// a numeric suffix, and a name colliding with a *global* server is
+    /// retried the same way rather than dropped.
+    ///
+    /// Idempotence is decided by what is already bound, not by whether an
+    /// upsert errored: an entry whose name is already bound to this bundle is
+    /// skipped, so a re-run creates nothing. That distinction is the whole
+    /// point — "already bound" and "name taken by something else" produce the
+    /// same error text but mean opposite things.
+    ///
+    /// Returns `(created, warnings)`.
+    pub fn bundle_mcp_bind_inline_entries(
+        &self,
+        id_store: &Store,
+        bundle_id: &str,
+        entries: &[serde_json::Value],
+        now_ms: i64,
+    ) -> (usize, Vec<String>) {
+        /// How many suffixed names to try before giving up on one entry.
+        const MAX_NAME_ATTEMPTS: usize = 50;
+
+        let mut warnings: Vec<String> = Vec::new();
+
+        // Names already bound to this bundle, captured BEFORE the loop so a
+        // duplicate inside `entries` is not mistaken for a previous run.
+        let already_bound: std::collections::HashSet<String> = match self.bundle_mcp_list(bundle_id) {
+            Ok(items) => items
+                .into_iter()
+                .filter(|i| i.bound_to_bundle)
+                .map(|i| i.server.name)
+                .collect(),
+            Err(e) => {
+                warnings.push(format!(
+                    "mcpServers: could not read existing bindings for bundle {bundle_id} ({e}) — nothing bound"
+                ));
+                return (0, warnings);
+            }
+        };
+
+        let mut used: std::collections::HashSet<String> = already_bound.clone();
+        let mut created = 0usize;
+
+        for (index, entry) in entries.iter().enumerate() {
+            if !entry.is_object() {
+                warnings.push(format!(
+                    "mcpServers: entry {} is not a JSON object — skipped",
+                    index + 1
+                ));
+                continue;
+            }
+            let mut server = McpServer::from_inline_config(entry, index, now_ms);
+
+            // Already carried across on an earlier run: nothing to do.
+            if already_bound.contains(&server.name) {
+                continue;
+            }
+
+            let base = server.name.clone();
+            let mut bound = false;
+            for attempt in 0..MAX_NAME_ATTEMPTS {
+                let candidate = if attempt == 0 {
+                    base.clone()
+                } else {
+                    format!("{base}-{}", attempt + 1)
+                };
+                if used.contains(&candidate) {
+                    continue;
+                }
+                server.name = candidate.clone();
+                match self.bundle_mcp_upsert_unique(id_store, bundle_id, &server, true) {
+                    Ok(()) => {
+                        used.insert(candidate);
+                        created += 1;
+                        bound = true;
+                        break;
+                    }
+                    // A name that is taken by something visible but not bound
+                    // here — a global server, typically. Try the next suffix
+                    // rather than dropping the entry.
+                    Err(e) if e.to_string().contains("already") => {
+                        used.insert(candidate);
+                        continue;
+                    }
+                    Err(e) => {
+                        warnings.push(format!(
+                            "mcpServers: server '{base}' could not be created ({e}) — it will not be exported or reach the agent"
+                        ));
+                        bound = true; // reported; do not also report exhaustion
+                        break;
+                    }
+                }
+            }
+            if !bound {
+                warnings.push(format!(
+                    "mcpServers: server '{base}' could not be given a free name after {MAX_NAME_ATTEMPTS} attempts — skipped"
+                ));
+            }
+        }
+
+        (created, warnings)
+    }
+}
+
 impl ManagedResource for McpServer {
     const TABLE: &'static str = "db_mcp_servers";
     const REF_COL: &'static str = "mcp_id";

--- a/agentmux-srv/src/backend/storage/mcp_servers.rs
+++ b/agentmux-srv/src/backend/storage/mcp_servers.rs
@@ -93,11 +93,17 @@ impl Store {
     /// a numeric suffix, and a name colliding with a *global* server is
     /// retried the same way rather than dropped.
     ///
-    /// Idempotence is decided by what is already bound, not by whether an
-    /// upsert errored: an entry whose name is already bound to this bundle is
-    /// skipped, so a re-run creates nothing. That distinction is the whole
-    /// point — "already bound" and "name taken by something else" produce the
-    /// same error text but mean opposite things.
+    /// Idempotence is decided by **content**, not by name and not by whether
+    /// an upsert errored. An entry is "already carried across" only when a
+    /// bound server holds an identical config object; matching on name alone
+    /// would silently drop a genuinely different entry that happens to share a
+    /// name with something bound through the Armory (ReAgent, PR #3152), which
+    /// is the exact silent loss this whole change exists to end. Matching on
+    /// name would also mis-handle its own output: an entry disambiguated to
+    /// `foo-2` on the first run stores that name while still deriving `foo`.
+    ///
+    /// The match is a multiset consume, so two byte-identical entries stay two
+    /// entries across re-runs rather than collapsing into one.
     ///
     /// Returns `(created, warnings)`.
     pub fn bundle_mcp_bind_inline_entries(
@@ -112,14 +118,14 @@ impl Store {
 
         let mut warnings: Vec<String> = Vec::new();
 
-        // Names already bound to this bundle, captured BEFORE the loop so a
-        // duplicate inside `entries` is not mistaken for a previous run.
-        let already_bound: std::collections::HashSet<String> = match self.bundle_mcp_list(bundle_id) {
+        // What is already bound, captured BEFORE the loop so a duplicate
+        // inside `entries` is not mistaken for a previous run.
+        let bound = match self.bundle_mcp_list(bundle_id) {
             Ok(items) => items
                 .into_iter()
                 .filter(|i| i.bound_to_bundle)
-                .map(|i| i.server.name)
-                .collect(),
+                .map(|i| i.server)
+                .collect::<Vec<_>>(),
             Err(e) => {
                 warnings.push(format!(
                     "mcpServers: could not read existing bindings for bundle {bundle_id} ({e}) — nothing bound"
@@ -127,8 +133,15 @@ impl Store {
                 return (0, warnings);
             }
         };
-
-        let mut used: std::collections::HashSet<String> = already_bound.clone();
+        // Names are only used to avoid collisions; identity is the config.
+        let mut used: std::collections::HashSet<String> =
+            bound.iter().map(|s| s.name.clone()).collect();
+        // Multiset of configs still unaccounted for. Consuming an entry marks
+        // it matched, so N identical entries stay N across re-runs.
+        let mut unmatched: Vec<serde_json::Value> = bound
+            .iter()
+            .map(|s| serde_json::from_str(&s.config).unwrap_or(serde_json::Value::Null))
+            .collect();
         let mut created = 0usize;
 
         for (index, entry) in entries.iter().enumerate() {
@@ -141,13 +154,16 @@ impl Store {
             }
             let mut server = McpServer::from_inline_config(entry, index, now_ms);
 
-            // Already carried across on an earlier run: nothing to do.
-            if already_bound.contains(&server.name) {
+            // Already carried across on an earlier run — identified by its
+            // config, not its name, so a different server that merely shares a
+            // name does not swallow this entry.
+            if let Some(pos) = unmatched.iter().position(|c| c == entry) {
+                unmatched.swap_remove(pos);
                 continue;
             }
 
             let base = server.name.clone();
-            let mut bound = false;
+            let mut bound_ok = false;
             for attempt in 0..MAX_NAME_ATTEMPTS {
                 let candidate = if attempt == 0 {
                     base.clone()
@@ -160,9 +176,16 @@ impl Store {
                 server.name = candidate.clone();
                 match self.bundle_mcp_upsert_unique(id_store, bundle_id, &server, true) {
                     Ok(()) => {
+                        if candidate != base {
+                            // Not a loss, but the operator should know the
+                            // name they will see is not the name in the file.
+                            warnings.push(format!(
+                                "mcpServers: '{base}' was already taken, kept as '{candidate}'"
+                            ));
+                        }
                         used.insert(candidate);
                         created += 1;
-                        bound = true;
+                        bound_ok = true;
                         break;
                     }
                     // A name that is taken by something visible but not bound
@@ -176,12 +199,12 @@ impl Store {
                         warnings.push(format!(
                             "mcpServers: server '{base}' could not be created ({e}) — it will not be exported or reach the agent"
                         ));
-                        bound = true; // reported; do not also report exhaustion
+                        bound_ok = true; // reported; do not also report exhaustion
                         break;
                     }
                 }
             }
-            if !bound {
+            if !bound_ok {
                 warnings.push(format!(
                     "mcpServers: server '{base}' could not be given a free name after {MAX_NAME_ATTEMPTS} attempts — skipped"
                 ));

--- a/agentmux-srv/src/migrations/m0030_backfill_bundle_component_refs.rs
+++ b/agentmux-srv/src/migrations/m0030_backfill_bundle_component_refs.rs
@@ -71,21 +71,6 @@ fn now_ms() -> i64 {
         .unwrap_or(0)
 }
 
-/// The display name for an MCP server recovered from an inline entry.
-///
-/// The inline blob is the exporter's own entry shape: a config object with
-/// `name` alongside. `build_mcp_config_from_refs` keys `.mcp.json` on the
-/// row's name, so a nameless entry needs a stable synthetic one rather than
-/// being dropped — `index` makes it unique within the bundle.
-fn mcp_entry_name(entry: &Value, index: usize) -> String {
-    entry
-        .get("name")
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.trim().is_empty())
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| format!("mcp-server-{}", index + 1))
-}
-
 /// Carry one bundle's inline components across into the ref tables.
 ///
 /// Returns `(skills_bound, mcp_bound)`. Never returns `Err` for bad data —
@@ -138,46 +123,15 @@ fn backfill_one_bundle(
     // ---- mcp servers: the inline column holds whole config objects ----
     match serde_json::from_str::<Vec<Value>>(mcp_json) {
         Ok(entries) => {
-            for (index, entry) in entries.iter().enumerate() {
-                if !entry.is_object() {
-                    tracing::warn!(
-                        bundle_id, index,
-                        "backfill_bundle_component_refs: inline mcp entry is not an object — dropped"
-                    );
-                    continue;
-                }
-                let name = mcp_entry_name(entry, index);
-                let server = McpServer {
-                    id: uuid::Uuid::new_v4().to_string(),
-                    name: name.clone(),
-                    // The column default; the inline shape carries no
-                    // transport of its own and every entry these bundles hold
-                    // was written for the stdio launcher.
-                    transport: "stdio".to_string(),
-                    config: serde_json::to_string(entry).unwrap_or_else(|_| "{}".to_string()),
-                    // Bundle-scoped, not global: this server belongs to this
-                    // bundle, and `bundle_mcp_upsert_unique` forces it anyway.
-                    is_global: false,
-                    created_at: now_ms(),
-                    updated_at: now_ms(),
-                };
-                // Creates the catalog row AND binds the ref in one
-                // transaction (`managed_upsert_unique_for_bundle`). A name
-                // that already resolves for this bundle errors, which is the
-                // idempotent re-run path — the row is already there.
-                match wstore.bundle_mcp_upsert_unique(bundle_store, bundle_id, &server, true) {
-                    Ok(()) => mcp_bound += 1,
-                    Err(e) if e.to_string().contains("already") => {
-                        tracing::debug!(
-                            bundle_id, name = %name,
-                            "backfill_bundle_component_refs: mcp server already present — nothing to do"
-                        );
-                    }
-                    Err(e) => tracing::warn!(
-                        bundle_id, name = %name, error = %e,
-                        "backfill_bundle_component_refs: mcp upsert failed"
-                    ),
-                }
+            // One shared path with the ABF import handlers, so a server
+            // recovered from an old bundle and one that arrives in an import
+            // end up identical — including how duplicate names are kept apart
+            // and how a re-run decides it has nothing to do.
+            let (created, warnings) =
+                wstore.bundle_mcp_bind_inline_entries(bundle_store, bundle_id, &entries, now_ms());
+            mcp_bound += created;
+            for w in warnings {
+                tracing::warn!(bundle_id, warning = %w, "backfill_bundle_component_refs");
             }
         }
         Err(e) if !mcp_json.trim().is_empty() && mcp_json.trim() != "[]" => {
@@ -397,6 +351,52 @@ mod tests {
         insert_bundle(&s, "bundle-1", r#"["ghost"]"#, "[]");
         let (sk, mc) = backfill_one_bundle(&s, &s, "bundle-1", r#"["ghost"]"#, "[]");
         assert_eq!((sk, mc), (0, 0));
+    }
+
+    #[test]
+    fn two_entries_sharing_a_name_are_both_kept() {
+        // The validator permits duplicate names and the old exporter kept
+        // both by slugging them apart. Rejecting the second on the catalog's
+        // name-uniqueness check would lose it permanently now that export
+        // reads only bound refs (Codex, PR #3152).
+        let s = store();
+        let mcp = r#"[{"name":"github","command":"a"},{"name":"github","command":"b"}]"#;
+        insert_bundle(&s, "bundle-1", "[]", mcp);
+
+        let (_, mc) = backfill_one_bundle(&s, &s, "bundle-1", "[]", mcp);
+        assert_eq!(mc, 2, "both entries must survive the backfill");
+
+        let names: Vec<String> = s
+            .bundle_mcp_list("bundle-1")
+            .unwrap()
+            .into_iter()
+            .filter(|i| i.bound_to_bundle)
+            .map(|i| i.server.name)
+            .collect();
+        assert!(names.contains(&"github".to_string()), "got {names:?}");
+        assert!(names.contains(&"github-2".to_string()), "got {names:?}");
+
+        // ...and a re-run still creates nothing.
+        let (_, again) = backfill_one_bundle(&s, &s, "bundle-1", "[]", mcp);
+        assert_eq!(again, 0, "re-run must be a no-op even with duplicate names");
+    }
+
+    #[test]
+    fn an_entrys_own_type_becomes_the_transport() {
+        // Hardcoding stdio would give the row a transport column that
+        // contradicts its own config JSON (ReAgent, PR #3152).
+        let s = store();
+        let mcp = r#"[{"name":"remote","type":"sse","url":"https://example.test"}]"#;
+        insert_bundle(&s, "bundle-1", "[]", mcp);
+        backfill_one_bundle(&s, &s, "bundle-1", "[]", mcp);
+
+        let bound: Vec<_> = s
+            .bundle_mcp_list("bundle-1")
+            .unwrap()
+            .into_iter()
+            .filter(|i| i.bound_to_bundle)
+            .collect();
+        assert_eq!(bound[0].server.transport, "sse");
     }
 
     #[test]

--- a/agentmux-srv/src/migrations/m0030_backfill_bundle_component_refs.rs
+++ b/agentmux-srv/src/migrations/m0030_backfill_bundle_component_refs.rs
@@ -382,6 +382,55 @@ mod tests {
     }
 
     #[test]
+    fn an_inline_entry_is_kept_when_a_different_server_already_holds_its_name() {
+        // ReAgent P1 on #3152: a server bound through the Armory (or by an
+        // earlier import that only wrote inline columns) can share a name with
+        // an inline entry while being a completely different server. Deciding
+        // "already migrated" by name would drop the inline one permanently and
+        // silently, now that export reads only bound refs — the exact failure
+        // this backfill exists to prevent. Identity is the config.
+        let s = store();
+        insert_bundle(&s, "bundle-1", "[]", "[]");
+
+        // Bound through the Armory: same name, different server.
+        let armory = crate::backend::storage::mcp_servers::McpServer {
+            id: "srv-armory".to_string(),
+            name: "github".to_string(),
+            transport: "stdio".to_string(),
+            config: r#"{"name":"github","command":"a-totally-different-binary"}"#.to_string(),
+            is_global: false,
+            created_at: 1,
+            updated_at: 1,
+        };
+        s.bundle_mcp_upsert_unique(&s, "bundle-1", &armory, true).unwrap();
+
+        let mcp = r#"[{"name":"github","command":"gh-mcp"}]"#;
+        let (_, mc) = backfill_one_bundle(&s, &s, "bundle-1", "[]", mcp);
+        assert_eq!(mc, 1, "the inline entry must be carried across, not swallowed");
+
+        let bound: Vec<_> = s
+            .bundle_mcp_list("bundle-1")
+            .unwrap()
+            .into_iter()
+            .filter(|i| i.bound_to_bundle)
+            .collect();
+        assert_eq!(bound.len(), 2, "both servers must exist");
+        assert!(
+            bound.iter().any(|i| i.server.config.contains("gh-mcp")),
+            "the inline entry's own config must survive"
+        );
+        assert!(
+            bound.iter().any(|i| i.server.config.contains("a-totally-different-binary")),
+            "the pre-existing server must survive"
+        );
+
+        // ...and re-running still creates nothing, because the match is by
+        // config and both configs are now accounted for.
+        let (_, again) = backfill_one_bundle(&s, &s, "bundle-1", "[]", mcp);
+        assert_eq!(again, 0, "re-run must remain a no-op");
+    }
+
+    #[test]
     fn an_entrys_own_type_becomes_the_transport() {
         // Hardcoding stdio would give the row a transport column that
         // contradicts its own config JSON (ReAgent, PR #3152).

--- a/agentmux-srv/src/migrations/m0030_backfill_bundle_component_refs.rs
+++ b/agentmux-srv/src/migrations/m0030_backfill_bundle_component_refs.rs
@@ -1,0 +1,419 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Backfill `db_bundle_skills_ref` / `db_bundle_mcp_ref` from the inline
+//! `db_bundles.skills` / `db_bundles.mcp_servers` JSON columns.
+//!
+//! Phase 0b of `SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md`. The
+//! two stores were never synced: binding a skill in the Armory wrote only a
+//! ref row, while ABF export read only the inline column, so a bundle could
+//! run with components it did not export and export components it did not run
+//! with (§3.4). The ref tables become authoritative; this carries the inline
+//! data across so nothing is lost when export stops reading the columns.
+//!
+//! **Ships in the same release as the read switch.** Export reading refs
+//! before this has run would make every pre-existing bundle export empty.
+//!
+//! Two stores, deliberately. `db_bundles` lives in the shared store
+//! (`run_shared_store_schema`), while `db_skills`, `db_mcp_servers` and both
+//! ref tables live in the channel store (`run_object_schema`,
+//! `migrations.rs:742`/`:749`) — the ref tables must sit next to the catalog
+//! tables they carry foreign keys to, which is also why they have no FK to
+//! `db_bundles` (`migrations.rs:721-741`). So this reads bundles from the
+//! shared store and writes refs into the channel store, resolving the former
+//! exactly the way `m0021` does.
+//!
+//! Idempotent three times over: `INSERT OR IGNORE` on the ref tables, name
+//! uniqueness on the MCP catalog rows, and a per-bundle skip when nothing is
+//! left to carry. Re-running changes nothing.
+//!
+//! Best-effort per bundle. One malformed `mcp_servers` blob must not abort a
+//! migration that is otherwise carrying real data across — the alternative
+//! leaves the store half-converted with the read switch already live. Every
+//! skip is logged with the bundle id.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+
+use crate::backend::storage::mcp_servers::McpServer;
+use crate::backend::storage::store::Store;
+
+use super::{Migration, MigrationContext, MigrationError, MigrationScope, VerifyOutcome};
+
+pub struct M0030BackfillBundleComponentRefs;
+
+/// Where `db_bundles` actually lives — the shared store, falling back to the
+/// channel store when it cannot be opened.
+///
+/// Same resolution, and the same never-hard-fail posture, as
+/// `m0021_backfill_agent_bundles::resolve_bundle_store`. An unusable shared
+/// store means "not today" rather than a failed boot.
+fn resolve_bundle_store(ctx: &MigrationContext, wstore: &Arc<Store>) -> Arc<Store> {
+    match Store::open_shared(&ctx.shared_store_path) {
+        Ok(shared) => Arc::new(shared),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                path = %ctx.shared_store_path.display(),
+                "backfill_bundle_component_refs: shared store unavailable, falling back to channel store"
+            );
+            wstore.clone()
+        }
+    }
+}
+
+/// Milliseconds since the epoch, for the catalog rows this creates.
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// The display name for an MCP server recovered from an inline entry.
+///
+/// The inline blob is the exporter's own entry shape: a config object with
+/// `name` alongside. `build_mcp_config_from_refs` keys `.mcp.json` on the
+/// row's name, so a nameless entry needs a stable synthetic one rather than
+/// being dropped — `index` makes it unique within the bundle.
+fn mcp_entry_name(entry: &Value, index: usize) -> String {
+    entry
+        .get("name")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| format!("mcp-server-{}", index + 1))
+}
+
+/// Carry one bundle's inline components across into the ref tables.
+///
+/// Returns `(skills_bound, mcp_bound)`. Never returns `Err` for bad data —
+/// see the module doc on why one bad bundle must not stop the rest.
+fn backfill_one_bundle(
+    wstore: &Store,
+    bundle_store: &Store,
+    bundle_id: &str,
+    skills_json: &str,
+    mcp_json: &str,
+) -> (usize, usize) {
+    let mut skills_bound = 0usize;
+    let mut mcp_bound = 0usize;
+
+    // ---- skills: the inline column holds bare ids into db_skills ----
+    match serde_json::from_str::<Vec<String>>(skills_json) {
+        Ok(ids) => {
+            for id in ids {
+                // A skill id whose row is already gone has nothing to bind;
+                // the ref tables cannot represent it and the export could
+                // never have rendered it either.
+                match wstore.skill_get(&id) {
+                    Ok(Some(_)) => match wstore.bundle_skill_bind(bundle_store, bundle_id, &id) {
+                        Ok(()) => skills_bound += 1,
+                        Err(e) => tracing::warn!(
+                            bundle_id, skill_id = %id, error = %e,
+                            "backfill_bundle_component_refs: skill bind failed"
+                        ),
+                    },
+                    Ok(None) => tracing::warn!(
+                        bundle_id, skill_id = %id,
+                        "backfill_bundle_component_refs: inline skill id has no catalog row — dropped"
+                    ),
+                    Err(e) => tracing::warn!(
+                        bundle_id, skill_id = %id, error = %e,
+                        "backfill_bundle_component_refs: skill lookup failed"
+                    ),
+                }
+            }
+        }
+        Err(e) if !skills_json.trim().is_empty() && skills_json.trim() != "[]" => {
+            tracing::warn!(
+                bundle_id, error = %e,
+                "backfill_bundle_component_refs: malformed inline skills JSON — nothing carried across"
+            );
+        }
+        Err(_) => {} // genuinely blank is not an error
+    }
+
+    // ---- mcp servers: the inline column holds whole config objects ----
+    match serde_json::from_str::<Vec<Value>>(mcp_json) {
+        Ok(entries) => {
+            for (index, entry) in entries.iter().enumerate() {
+                if !entry.is_object() {
+                    tracing::warn!(
+                        bundle_id, index,
+                        "backfill_bundle_component_refs: inline mcp entry is not an object — dropped"
+                    );
+                    continue;
+                }
+                let name = mcp_entry_name(entry, index);
+                let server = McpServer {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    name: name.clone(),
+                    // The column default; the inline shape carries no
+                    // transport of its own and every entry these bundles hold
+                    // was written for the stdio launcher.
+                    transport: "stdio".to_string(),
+                    config: serde_json::to_string(entry).unwrap_or_else(|_| "{}".to_string()),
+                    // Bundle-scoped, not global: this server belongs to this
+                    // bundle, and `bundle_mcp_upsert_unique` forces it anyway.
+                    is_global: false,
+                    created_at: now_ms(),
+                    updated_at: now_ms(),
+                };
+                // Creates the catalog row AND binds the ref in one
+                // transaction (`managed_upsert_unique_for_bundle`). A name
+                // that already resolves for this bundle errors, which is the
+                // idempotent re-run path — the row is already there.
+                match wstore.bundle_mcp_upsert_unique(bundle_store, bundle_id, &server, true) {
+                    Ok(()) => mcp_bound += 1,
+                    Err(e) if e.to_string().contains("already") => {
+                        tracing::debug!(
+                            bundle_id, name = %name,
+                            "backfill_bundle_component_refs: mcp server already present — nothing to do"
+                        );
+                    }
+                    Err(e) => tracing::warn!(
+                        bundle_id, name = %name, error = %e,
+                        "backfill_bundle_component_refs: mcp upsert failed"
+                    ),
+                }
+            }
+        }
+        Err(e) if !mcp_json.trim().is_empty() && mcp_json.trim() != "[]" => {
+            tracing::warn!(
+                bundle_id, error = %e,
+                "backfill_bundle_component_refs: malformed inline mcp_servers JSON — nothing carried across"
+            );
+        }
+        Err(_) => {}
+    }
+
+    (skills_bound, mcp_bound)
+}
+
+impl Migration for M0030BackfillBundleComponentRefs {
+    fn id(&self) -> &'static str {
+        "0030_backfill_bundle_component_refs"
+    }
+
+    fn scope(&self) -> MigrationScope {
+        MigrationScope::Channel
+    }
+
+    fn description(&self) -> &'static str {
+        "Carry inline bundle skills/mcp_servers across into the bundle ref tables"
+    }
+
+    fn up(&self, ctx: &MigrationContext) -> Result<(), MigrationError> {
+        if !ctx.channel_store_path.exists() {
+            return Ok(());
+        }
+        let wstore = Arc::new(Store::open(&ctx.channel_store_path).map_err(|e| {
+            MigrationError(format!("backfill_bundle_component_refs: open wstore: {e}"))
+        })?);
+        let bundle_store = resolve_bundle_store(ctx, &wstore);
+
+        let bundles = bundle_store.bundle_list().map_err(|e| {
+            MigrationError(format!("backfill_bundle_component_refs: list bundles: {e}"))
+        })?;
+
+        let mut total_skills = 0usize;
+        let mut total_mcp = 0usize;
+        for bundle in &bundles {
+            let (s, m) = backfill_one_bundle(
+                &wstore,
+                &bundle_store,
+                &bundle.id,
+                &bundle.skills,
+                &bundle.mcp_servers,
+            );
+            total_skills += s;
+            total_mcp += m;
+        }
+
+        tracing::info!(
+            bundles = bundles.len(),
+            skills_bound = total_skills,
+            mcp_bound = total_mcp,
+            "backfill_bundle_component_refs: complete"
+        );
+        Ok(())
+    }
+
+    fn verify(&self, ctx: &MigrationContext) -> VerifyOutcome {
+        // Verifying "every inline component has a ref" needs both stores, and
+        // the shared one may legitimately be unavailable (see
+        // resolve_bundle_store). Report what we can rather than claiming a
+        // mismatch we cannot substantiate.
+        match super::runner::open_readonly(&ctx.channel_store_path) {
+            Ok(Some(conn)) => {
+                let skills: i64 = conn
+                    .query_row("SELECT COUNT(*) FROM db_bundle_skills_ref", [], |r| r.get(0))
+                    .unwrap_or(0);
+                let mcp: i64 = conn
+                    .query_row("SELECT COUNT(*) FROM db_bundle_mcp_ref", [], |r| r.get(0))
+                    .unwrap_or(0);
+                VerifyOutcome::Ok(format!("{skills} skill ref(s), {mcp} mcp ref(s)"))
+            }
+            Ok(None) => VerifyOutcome::Ok("no channel store".to_string()),
+            Err(e) => VerifyOutcome::Error(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::storage::skills::Skill;
+
+    fn store() -> Store {
+        // One in-memory store serves as both wstore and bundle store:
+        // `run_object_schema` creates db_bundles alongside the ref tables, so
+        // both sides resolve. The cross-store rule itself is pinned by
+        // `mcp_servers.rs::bind_checks_bundle_existence_in_id_store_not_self`.
+        Store::open_in_memory().unwrap()
+    }
+
+    fn insert_bundle(s: &Store, id: &str, skills: &str, mcp: &str) {
+        let bundle = crate::backend::storage::store::Bundle {
+            id: id.to_string(),
+            name: format!("Bundle {id}"),
+            description: String::new(),
+            is_blank: false,
+            is_global: false,
+            provider: String::new(),
+            model: String::new(),
+            instructions: String::new(),
+            instructions_by_provider: "{}".to_string(),
+            context_files: "[]".to_string(),
+            mcp_servers: mcp.to_string(),
+            skills: skills.to_string(),
+            sort_order: 0,
+            created_at: 1,
+            updated_at: 1,
+            is_system: false,
+        };
+        s.bundle_upsert(&bundle).unwrap();
+    }
+
+    fn insert_skill(s: &Store, id: &str, name: &str) {
+        let skill = Skill {
+            id: id.to_string(),
+            name: name.to_string(),
+            trigger: name.to_string(),
+            skill_type: crate::backend::agent_config::SKILL_TYPE_AGENT_SKILL.to_string(),
+            description: String::new(),
+            content: "body".to_string(),
+            is_global: true,
+            created_at: 1,
+            updated_at: 1,
+        };
+        s.skill_upsert_unique_global(&skill).unwrap();
+    }
+
+    #[test]
+    fn carries_inline_skills_and_mcp_servers_into_the_ref_tables() {
+        let s = store();
+        insert_skill(&s, "skill-1", "Deploy");
+        insert_bundle(
+            &s,
+            "bundle-1",
+            r#"["skill-1"]"#,
+            r#"[{"name":"github","command":"gh-mcp","env":{"GITHUB_TOKEN":""}}]"#,
+        );
+
+        let (sk, mc) = backfill_one_bundle(
+            &s,
+            &s,
+            "bundle-1",
+            r#"["skill-1"]"#,
+            r#"[{"name":"github","command":"gh-mcp","env":{"GITHUB_TOKEN":""}}]"#,
+        );
+        assert_eq!((sk, mc), (1, 1));
+
+        let bound_skills: Vec<_> = s
+            .bundle_skill_list("bundle-1")
+            .unwrap()
+            .into_iter()
+            .filter(|i| i.bound_to_bundle)
+            .collect();
+        assert_eq!(bound_skills.len(), 1, "skill must be bound to the bundle");
+
+        let bound_mcp: Vec<_> = s
+            .bundle_mcp_list("bundle-1")
+            .unwrap()
+            .into_iter()
+            .filter(|i| i.bound_to_bundle)
+            .collect();
+        assert_eq!(bound_mcp.len(), 1);
+        assert_eq!(bound_mcp[0].server.name, "github");
+        assert!(
+            bound_mcp[0].server.config.contains("gh-mcp"),
+            "the config object must survive verbatim: {}",
+            bound_mcp[0].server.config
+        );
+    }
+
+    #[test]
+    fn rerunning_binds_nothing_new() {
+        let s = store();
+        insert_skill(&s, "skill-1", "Deploy");
+        let skills = r#"["skill-1"]"#;
+        let mcp = r#"[{"name":"github","command":"gh-mcp"}]"#;
+        insert_bundle(&s, "bundle-1", skills, mcp);
+
+        let first = backfill_one_bundle(&s, &s, "bundle-1", skills, mcp);
+        assert_eq!(first, (1, 1));
+
+        // Second pass: the skill bind is INSERT OR IGNORE (still reports
+        // bound), the MCP name already resolves for this bundle (reports 0).
+        let second = backfill_one_bundle(&s, &s, "bundle-1", skills, mcp);
+        assert_eq!(second.1, 0, "a second pass must not create a second server");
+
+        let bound_mcp = s
+            .bundle_mcp_list("bundle-1")
+            .unwrap()
+            .into_iter()
+            .filter(|i| i.bound_to_bundle)
+            .count();
+        assert_eq!(bound_mcp, 1, "exactly one server after two passes");
+    }
+
+    #[test]
+    fn a_malformed_blob_is_logged_and_the_rest_of_the_bundle_still_migrates() {
+        let s = store();
+        insert_skill(&s, "skill-1", "Deploy");
+        insert_bundle(&s, "bundle-1", r#"["skill-1"]"#, "not an array at all");
+
+        let (sk, mc) = backfill_one_bundle(&s, &s, "bundle-1", r#"["skill-1"]"#, "not an array at all");
+        assert_eq!(sk, 1, "the good half must still be carried across");
+        assert_eq!(mc, 0);
+    }
+
+    #[test]
+    fn an_inline_skill_id_with_no_catalog_row_is_dropped_not_fatal() {
+        let s = store();
+        insert_bundle(&s, "bundle-1", r#"["ghost"]"#, "[]");
+        let (sk, mc) = backfill_one_bundle(&s, &s, "bundle-1", r#"["ghost"]"#, "[]");
+        assert_eq!((sk, mc), (0, 0));
+    }
+
+    #[test]
+    fn a_nameless_mcp_entry_gets_a_stable_synthetic_name() {
+        let s = store();
+        insert_bundle(&s, "bundle-1", "[]", r#"[{"command":"x"},{"command":"y"}]"#);
+        let (_, mc) = backfill_one_bundle(&s, &s, "bundle-1", "[]", r#"[{"command":"x"},{"command":"y"}]"#);
+        assert_eq!(mc, 2, "two nameless entries must not collide on name");
+
+        let names: Vec<String> = s
+            .bundle_mcp_list("bundle-1")
+            .unwrap()
+            .into_iter()
+            .filter(|i| i.bound_to_bundle)
+            .map(|i| i.server.name)
+            .collect();
+        assert!(names.contains(&"mcp-server-1".to_string()), "got {names:?}");
+        assert!(names.contains(&"mcp-server-2".to_string()), "got {names:?}");
+    }
+}

--- a/agentmux-srv/src/migrations/mod.rs
+++ b/agentmux-srv/src/migrations/mod.rs
@@ -74,6 +74,7 @@ mod m0026_registry_agent_id_rekey;
 mod m0027_agents_workspace_backfill;
 mod m0028_agent_child_tables_repoint_fk;
 mod m0029_drop_legacy_agent_tables;
+mod m0030_backfill_bundle_component_refs;
 mod runner;
 #[cfg(test)]
 mod phase5_tests;
@@ -238,4 +239,5 @@ static REGISTRY: &[&(dyn Migration + Sync)] = &[
     &m0027_agents_workspace_backfill::M0027AgentsWorkspaceBackfill,
     &m0028_agent_child_tables_repoint_fk::M0028AgentChildTablesRepointFk,
     &m0029_drop_legacy_agent_tables::M0029DropLegacyAgentTables,
+    &m0030_backfill_bundle_component_refs::M0030BackfillBundleComponentRefs,
 ];

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -428,6 +428,47 @@ fn bundle_export_impl(
     Ok(result)
 }
 
+/// Bind an imported bundle's components into the ref tables.
+///
+/// Phase 0b. The ref tables are authoritative for what a bundle contains, so
+/// an import that only wrote the inline columns would produce a bundle that
+/// exports empty and, for MCP servers, never materialises at spawn either —
+/// the `SPEC_BUNDLE_AS_CONTAINER_V2_2026_08_17.md` "inert at runtime" state
+/// the ref tables exist to end.
+///
+/// **Must run after `bundle_upsert`.** Both bind paths check the bundle exists
+/// in `id_store` first (`storage/managed.rs:291`) and refuse otherwise.
+///
+/// Returns warnings rather than failing: by this point the bundle row is
+/// already committed, so aborting would leave a half-imported bundle behind. A
+/// component that could not be bound is reported and the import continues.
+fn bind_imported_components(
+    wstore: &crate::backend::storage::store::Store,
+    id_store: &crate::backend::storage::store::Store,
+    bundle_id: &str,
+    imported_skill_ids: &[String],
+    mcp_configs: &[serde_json::Value],
+) -> Vec<String> {
+    let mut warnings: Vec<String> = Vec::new();
+
+    for skill_id in imported_skill_ids {
+        if let Err(e) = wstore.bundle_skill_bind(id_store, bundle_id, skill_id) {
+            warnings.push(format!(
+                "skills: imported skill {skill_id} could not be bound to the bundle ({e}) — it will not be exported or reach the agent"
+            ));
+        }
+    }
+
+    // Same shared path the m0030 backfill uses, so a server that arrives by
+    // import and one recovered from an old inline column end up identical,
+    // including duplicate-name handling.
+    let (_created, mcp_warnings) =
+        wstore.bundle_mcp_bind_inline_entries(id_store, bundle_id, mcp_configs, now_ms());
+    warnings.extend(mcp_warnings);
+
+    warnings
+}
+
 /// A bundle's components, resolved from the tables that are authoritative for
 /// them.
 struct ResolvedComponents {
@@ -1293,6 +1334,17 @@ async fn bundle_import_for_agent_impl(
         return Err(msg);
     }
 
+    // The bundle row now exists, so its components can be bound. Ref tables
+    // are authoritative — without this the imported bundle would export empty
+    // and its MCP servers would never reach a spawned agent.
+    warnings.extend(bind_imported_components(
+        wstore,
+        id_store,
+        &bundle_id,
+        &imported_skill_ids,
+        &parsed.mcp_servers.iter().map(|m| m.config.clone()).collect::<Vec<_>>(),
+    ));
+
     // Bundle files: write through the SAME dual-write path
     // agent:memory:write_file uses (live FS via memory_dir_for_cwd, then
     // the mirror) — writing only to db_agent_native_memory would leave
@@ -1703,6 +1755,17 @@ fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     }
                     return Err(msg);
                 }
+
+                // Ref tables are authoritative — bind after the bundle row
+                // exists, or this import exports empty and its servers never
+                // reach a spawned agent.
+                warnings.extend(bind_imported_components(
+                    &wstore,
+                    &id_store,
+                    &memory.id,
+                    &imported_skill_ids,
+                    &parsed.mcp_servers.iter().map(|m| m.config.clone()).collect::<Vec<_>>(),
+                ));
 
                 broker.publish(crate::backend::wps::WaveEvent {
                     event: "memories:changed".to_string(),
@@ -2290,6 +2353,16 @@ async fn bundle_import_commit_impl(
                     }
                     return Err(msg);
                 }
+
+                // Ref tables are authoritative — bind after the bundle row
+                // exists. Only the servers the user actually selected.
+                warnings.extend(bind_imported_components(
+                    &wstore,
+                    &id_store,
+                    &memory.id,
+                    &imported_skill_ids,
+                    &selected_mcp_servers.iter().map(|c| (*c).clone()).collect::<Vec<_>>(),
+                ));
 
                 broker.publish(crate::backend::wps::WaveEvent {
                     event: "memories:changed".to_string(),
@@ -3303,6 +3376,95 @@ mod export_import_for_agent_tests {
             FileEntry { path: "instructions/AGENTS.md".to_string(), content: instructions.to_string() },
             FileEntry { path: format!("memory/{memory_filename}"), content: memory_content.to_string() },
         ]
+    }
+
+    /// An ABF carrying one skill and one MCP server.
+    fn abf_files_with_components() -> Vec<FileEntry> {
+        let manifest = serde_json::json!({
+            "$schema": "https://docs.agentmux.ai/schemas/armory-bundle/v0.2/bundle.schema.json",
+            "name": "imported-bundle",
+            "version": "0.1.0",
+            "description": "",
+            "components": {
+                "instructions": { "default": ["instructions/AGENTS.md"] },
+                "skills": ["skills/deploy"],
+                "mcpServers": ["mcp/github.server.json"],
+            },
+            "metadata": {},
+        });
+        vec![
+            FileEntry { path: "armory.json".to_string(), content: manifest.to_string() },
+            FileEntry { path: "instructions/AGENTS.md".to_string(), content: "Be helpful.".to_string() },
+            FileEntry {
+                path: "skills/deploy/SKILL.md".to_string(),
+                // Frontmatter values are JSON-quoted — that is what
+                // `render_skill_md` writes and what `parse_skill_md` requires.
+                content: "---\nname: \"deploy\"\ndescription: \"Ship it\"\n---\n\nSteps.".to_string(),
+            },
+            FileEntry {
+                path: "mcp/github.server.json".to_string(),
+                content: r#"{"name":"github","command":"gh-mcp","env":{"GITHUB_TOKEN":"${GITHUB_TOKEN}"}}"#.to_string(),
+            },
+        ]
+    }
+
+    #[tokio::test]
+    async fn an_imported_bundle_exports_the_components_it_arrived_with() {
+        // Codex P1 on #3152: once export reads only the ref tables, an import
+        // that writes only the inline columns produces a bundle that exports
+        // empty — and whose MCP servers never reach a spawned agent, since
+        // launch reads the refs too. The round trip is the contract.
+        let state = test_state();
+        let config_dir = tempfile::tempdir().unwrap();
+        make_agent(&state, "agent-1", "/work/proj", config_dir.path());
+
+        let result = bundle_import_for_agent_impl(
+            &state.id_store,
+            &state.wstore,
+            ImportForAgentReq {
+                agent_id: "agent-1".to_string(),
+                file_path: None,
+                zip_base64: None,
+                files: Some(abf_files_with_components()),
+            },
+        )
+        .await
+        .unwrap();
+
+        let bundle_id = result["bundle_id"]
+            .as_str()
+            .or_else(|| result["id"].as_str())
+            .expect("import must report the bundle it created")
+            .to_string();
+
+        let components = resolve_bundle_components(&state.wstore, &bundle_id).unwrap();
+        assert_eq!(
+            components.skills.len(),
+            1,
+            "imported skill must be bound to the bundle. import result: {result}"
+        );
+        assert_eq!(
+            components.mcp_entries.len(),
+            1,
+            "imported MCP server must be bound to the bundle: {:?}",
+            components.warnings
+        );
+
+        // And it round-trips out again.
+        let exported = bundle_export_impl(
+            &state.id_store,
+            &state.wstore,
+            ExportReq { id: bundle_id, format: String::new() },
+        )
+        .unwrap();
+        let paths: Vec<String> = exported["files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|f| f["path"].as_str().unwrap_or("").to_string())
+            .collect();
+        assert!(paths.iter().any(|p| p.starts_with("skills/")), "got {paths:?}");
+        assert!(paths.iter().any(|p| p == "mcp/github.server.json"), "got {paths:?}");
     }
 
     #[tokio::test]

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -378,33 +378,25 @@ fn bundle_export_impl(
         .map_err(|e| format!("bundle.export: {e}"))?
         .ok_or_else(|| format!("bundle.export: no bundle with id {}", req.id))?;
 
-    // Same silent-data-loss pattern already fixed for
-    // context_files/mcp_servers in bundle_export.rs -- a malformed
-    // bundle.skills value must warn, not just vanish, but a genuinely
-    // blank one is not an error (reagent P1, PR #2333). Shares the same
-    // helper so all three fields behave identically.
-    let mut handler_warnings: Vec<String> = Vec::new();
-    let skill_ids: Vec<String> =
-        crate::backend::bundle_export::parse_json_field_or_warn(&bundle.skills, "skills", &mut handler_warnings);
+    // Components come from the ref tables, which are authoritative for what a
+    // bundle contains -- see resolve_bundle_components.
+    let components = resolve_bundle_components(wstore, &bundle.id)
+        .map_err(|e| format!("bundle.export: {e}"))?;
+    let mut handler_warnings = components.warnings;
 
-    // Distinguish a genuine DB error from a legitimately deleted skill id:
-    // `.ok().flatten()` previously collapsed both to "absent", so a
-    // locked/damaged store silently reported a successful export missing
-    // content instead of failing loudly -- unsafe for the advertised backup
-    // use case (Codex P2, PR #2325). A lookup error now fails the whole
-    // export; a missing row (Ok(None), i.e. actually deleted) is skipped and
-    // reported back in `missing_skill_ids`.
-    let mut skills: Vec<crate::backend::storage::Skill> = Vec::new();
-    let mut missing_skill_ids: Vec<String> = Vec::new();
-    for id in &skill_ids {
-        match wstore.skill_get(id) {
-            Ok(Some(skill)) => skills.push(skill),
-            Ok(None) => missing_skill_ids.push(id.clone()),
-            Err(e) => return Err(format!("bundle.export: failed to look up skill {id}: {e}")),
-        }
-    }
+    // `missing_skill_ids` predates the ref tables: the inline column stored
+    // bare ids, so an id whose skill row had been deleted had to be resolved
+    // and reported (Codex P2, PR #2325). A ref cannot be dangling the same
+    // way -- `managed_list` joins through the catalog, and `skill_delete`
+    // purges refs -- so this is now always empty. Kept in the response because
+    // it is part of the RPC's shape and callers may still read it.
+    let missing_skill_ids: Vec<String> = Vec::new();
 
-    let export = crate::backend::bundle_export::export_bundle(&bundle, &skills);
+    let export = crate::backend::bundle_export::export_bundle(
+        &bundle,
+        &components.skills,
+        &components.mcp_entries,
+    );
 
     let mut all_warnings = export.warnings.clone();
     all_warnings.append(&mut handler_warnings);
@@ -434,6 +426,85 @@ fn bundle_export_impl(
         obj.insert("warnings".to_string(), json!(all_warnings));
     }
     Ok(result)
+}
+
+/// A bundle's components, resolved from the tables that are authoritative for
+/// them.
+struct ResolvedComponents {
+    skills: Vec<crate::backend::storage::Skill>,
+    /// Exporter entry shape: each server's config object with its `name`
+    /// alongside, which is what `bundle_export::redact_mcp_entry` reads.
+    mcp_entries: Vec<serde_json::Value>,
+    warnings: Vec<String>,
+}
+
+/// Resolve what a bundle actually contains, from `db_bundle_skills_ref` /
+/// `db_bundle_mcp_ref`.
+///
+/// Phase 0b of `SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md`. Before
+/// this, export read the inline `bundle.skills` / `bundle.mcp_servers` columns
+/// while agent launch read the ref tables (`app_api/agent_open.rs:793`, `:812`),
+/// and nothing kept the two in step — so a skill bound in the Armory ran at
+/// launch but exported as an empty `skills/` directory, with no warning. One
+/// resolver, used by every export path, is what stops that recurring.
+///
+/// **Scope note:** this is deliberately narrower than `effective_skills` /
+/// `effective_mcp_servers`, which additionally union an *agent's* own binds,
+/// globals and the legacy blob. Those answer "what does this agent run with";
+/// this answers "what is in this bundle", which is what an ABF describes. The
+/// two are not meant to be equal, only to agree about the bundle's own
+/// contribution.
+///
+/// `managed_list` returns the whole catalog with a `bound_to_bundle` flag
+/// rather than just the bound rows, hence the filter; and because it joins
+/// through the catalog table, a ref whose catalog row has been deleted
+/// resolves to nothing rather than reporting itself. `skill_delete` /
+/// `mcp_server_delete` both purge refs (`storage/managed.rs:232`), so that
+/// state is not reachable through the app — but the FK that would enforce it
+/// is inert, since `PRAGMA foreign_keys` is only ever set ON in tests.
+fn resolve_bundle_components(
+    wstore: &crate::backend::storage::store::Store,
+    bundle_id: &str,
+) -> Result<ResolvedComponents, String> {
+    let skills: Vec<crate::backend::storage::Skill> = wstore
+        .bundle_skill_list(bundle_id)
+        .map_err(|e| format!("failed to resolve bundle skills: {e}"))?
+        .into_iter()
+        .filter(|item| item.bound_to_bundle)
+        .map(|item| item.skill)
+        .collect();
+
+    let mut warnings: Vec<String> = Vec::new();
+    let mut mcp_entries: Vec<serde_json::Value> = Vec::new();
+    for item in wstore
+        .bundle_mcp_list(bundle_id)
+        .map_err(|e| format!("failed to resolve bundle MCP servers: {e}"))?
+        .into_iter()
+        .filter(|item| item.bound_to_bundle)
+    {
+        let server = item.server;
+        // `config` is the same JSON object the launch path writes into
+        // `.mcp.json` keyed by `server.name` (`agent_config.rs`
+        // build_mcp_config_from_refs). The exporter wants that object with the
+        // name inline, so the row's name is authoritative over any `name` the
+        // config blob happens to carry.
+        match serde_json::from_str::<serde_json::Value>(&server.config) {
+            Ok(serde_json::Value::Object(mut obj)) => {
+                obj.insert("name".to_string(), json!(server.name));
+                mcp_entries.push(serde_json::Value::Object(obj));
+            }
+            Ok(_) => warnings.push(format!(
+                "mcp server {}: config is not a JSON object — skipped",
+                server.name
+            )),
+            Err(e) => warnings.push(format!(
+                "mcp server {}: invalid config JSON ({e}) — skipped",
+                server.name
+            )),
+        }
+    }
+
+    Ok(ResolvedComponents { skills, mcp_entries, warnings })
 }
 
 /// Warning the agent-less `bundle.export` pushes when the bundle it is
@@ -684,25 +755,19 @@ async fn build_export_for_agent(
         .map_err(|e| format!("{err_prefix}: {e}"))?
         .ok_or_else(|| format!("{err_prefix}: no agent with id {agent_id}"))?;
 
-    let mut handler_warnings: Vec<String> = Vec::new();
-    let skill_ids: Vec<String> = crate::backend::bundle_export::parse_json_field_or_warn(
-        &bundle.skills,
-        "skills",
-        &mut handler_warnings,
-    );
-    let mut skills: Vec<crate::backend::storage::Skill> = Vec::new();
-    let mut missing_skill_ids: Vec<String> = Vec::new();
-    for id in &skill_ids {
-        match wstore.skill_get(id) {
-            Ok(Some(skill)) => skills.push(skill),
-            Ok(None) => missing_skill_ids.push(id.clone()),
-            Err(e) => {
-                return Err(format!("{err_prefix}: failed to look up skill {id}: {e}"));
-            }
-        }
-    }
+    // Same resolver as the agent-less path, so the two cannot disagree about
+    // what the bundle contains.
+    let components = resolve_bundle_components(wstore, &bundle.id)
+        .map_err(|e| format!("{err_prefix}: {e}"))?;
+    let mut handler_warnings = components.warnings;
+    // Always empty now — see the note at the agent-less export path.
+    let missing_skill_ids: Vec<String> = Vec::new();
 
-    let mut export = crate::backend::bundle_export::export_bundle(&bundle, &skills);
+    let mut export = crate::backend::bundle_export::export_bundle(
+        &bundle,
+        &components.skills,
+        &components.mcp_entries,
+    );
 
     // Refresh the mirror from the live FS, then read every mirrored
     // file's content — this agent's memory, freshest as of right now,
@@ -2893,6 +2958,127 @@ mod export_import_for_agent_tests {
         };
         state.id_store.bundle_upsert(&bundle).unwrap();
         bundle
+    }
+
+    /// Bind an MCP server to a bundle through the ref table, the way the
+    /// Armory does.
+    fn bind_mcp(state: &AppState, bundle_id: &str, name: &str, config: &str) {
+        let server = crate::backend::storage::McpServer {
+            id: format!("srv-{name}"),
+            name: name.to_string(),
+            transport: "stdio".to_string(),
+            config: config.to_string(),
+            is_global: false,
+            created_at: 1,
+            updated_at: 1,
+        };
+        state
+            .wstore
+            .bundle_mcp_upsert_unique(&state.id_store, bundle_id, &server, true)
+            .unwrap();
+    }
+
+    /// Bind a skill to a bundle through the ref table.
+    fn bind_skill(state: &AppState, bundle_id: &str, name: &str) {
+        let skill = crate::backend::storage::Skill {
+            id: format!("skill-{name}"),
+            name: name.to_string(),
+            trigger: name.to_string(),
+            skill_type: crate::backend::agent_config::SKILL_TYPE_AGENT_SKILL.to_string(),
+            description: String::new(),
+            content: "body".to_string(),
+            is_global: false,
+            created_at: 1,
+            updated_at: 1,
+        };
+        state
+            .wstore
+            .bundle_skill_upsert_unique(&state.id_store, bundle_id, &skill, true)
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn export_carries_ref_bound_components_the_inline_columns_never_had() {
+        // The Phase 0b regression. Before this, binding a skill or server in
+        // the Armory wrote only a ref row while export read only the inline
+        // column, so this bundle exported as empty skills/ and mcp/
+        // directories with no warning — in a format advertised as a backup.
+        let state = test_state();
+        let bundle = make_bundle(&state, "bundle-1", "Be helpful.");
+        assert_eq!(bundle.skills, "[]", "fixture must leave the inline columns empty");
+        assert_eq!(bundle.mcp_servers, "[]");
+
+        bind_skill(&state, "bundle-1", "Deploy");
+        bind_mcp(&state, "bundle-1", "github", r#"{"command":"gh-mcp","env":{"GITHUB_TOKEN":"tok"}}"#);
+
+        let result = bundle_export_impl(
+            &state.id_store,
+            &state.wstore,
+            ExportReq { id: "bundle-1".to_string(), format: String::new() },
+        )
+        .unwrap();
+
+        let paths: Vec<String> = result["files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|f| f["path"].as_str().unwrap_or("").to_string())
+            .collect();
+        assert!(
+            paths.iter().any(|p| p.starts_with("skills/")),
+            "ref-bound skill must be exported: {paths:?}"
+        );
+        assert!(
+            paths.iter().any(|p| p == "mcp/github.server.json"),
+            "ref-bound MCP server must be exported: {paths:?}"
+        );
+
+        // And the secret is still redacted on the way out — resolving from a
+        // different source must not bypass the redaction pass.
+        let server_file = result["files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|f| f["path"] == "mcp/github.server.json")
+            .unwrap();
+        let content = server_file["content"].as_str().unwrap();
+        assert!(!content.contains("tok"), "secret must not survive export: {content}");
+    }
+
+    #[tokio::test]
+    async fn a_bound_mcp_server_with_unparseable_config_warns_instead_of_vanishing() {
+        // The guarantee that moved here from bundle_export.rs when the
+        // renderer stopped parsing MCP JSON: malformed component data warns,
+        // it does not silently disappear.
+        let state = test_state();
+        make_bundle(&state, "bundle-1", "Be helpful.");
+        bind_mcp(&state, "bundle-1", "broken", "not json at all");
+
+        let components = resolve_bundle_components(&state.wstore, "bundle-1").unwrap();
+        assert!(components.mcp_entries.is_empty(), "unparseable config must not be exported");
+        assert!(
+            components.warnings.iter().any(|w| w.contains("broken") && w.contains("invalid config")),
+            "expected a warning naming the server, got: {:?}",
+            components.warnings
+        );
+    }
+
+    #[tokio::test]
+    async fn resolving_ignores_catalog_rows_this_bundle_is_not_bound_to() {
+        // `managed_list` returns globals alongside bound rows; only the bound
+        // ones are this bundle's contents.
+        let state = test_state();
+        make_bundle(&state, "bundle-1", "Be helpful.");
+        make_bundle(&state, "bundle-2", "Other.");
+        bind_mcp(&state, "bundle-2", "elsewhere", r#"{"command":"x"}"#);
+
+        let components = resolve_bundle_components(&state.wstore, "bundle-1").unwrap();
+        assert!(
+            components.mcp_entries.is_empty(),
+            "another bundle's server must not leak in: {:?}",
+            components.mcp_entries
+        );
+        assert!(components.skills.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Phase 0b of `SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md`, the reconciliation #3149 identified as a prerequisite for Phase 3. Tracking: #3148.

**The bug.** Bundle components lived in two stores that were never synced. Agent launch read `db_bundle_skills_ref` / `db_bundle_mcp_ref`; ABF export read the inline `db_bundles.skills` / `.mcp_servers` columns. Binding a skill or MCP server in the Armory writes only a ref row, so it ran at launch, showed in the UI, and **exported as an empty `skills/` and `mcp/` directory with no warning** — in a format this repo advertises as a backup.

**The fix: the ref tables become authoritative.** They are what the UI writes and what launch already trusts.

**Two commits, and they must ship together.** Export reading refs before the backfill has run would make every pre-existing bundle export empty.

| Commit | What |
|---|---|
| `f872be33b` | `m0030` carries every bundle's inline components into the ref tables. Additive only. |
| `46a0c0831` | `export_bundle` stops reading `bundle.mcp_servers`; both export paths resolve from the refs. |

**Migration notes** — the parts worth review attention:
- **Two stores.** `db_bundles` lives in the shared store; the catalog and ref tables live in the channel store, because the refs carry foreign keys to `db_skills`/`db_mcp_servers` and therefore cannot also FK to bundles (`migrations.rs:721-741`). Bundles are read from the former, refs written into the latter, resolving the shared store exactly the way `m0021` does with the same fall-back-and-warn posture.
- **Skills** are bare ids and bind directly. An id whose catalog row is gone is dropped with a warning — the ref tables cannot represent it and export could never render it either.
- **MCP servers** have no catalog row anywhere today, so each inline entry becomes a bundle-scoped `db_mcp_servers` row plus a ref, created in one transaction by `bundle_mcp_upsert_unique`. A nameless entry gets a stable synthetic name instead of being dropped.
- **Idempotent three ways**: `INSERT OR IGNORE` on refs, name uniqueness on the catalog, and a re-run that binds nothing new. Best-effort per bundle: one malformed blob must not abort a migration whose read switch ships in the same release.

**Export notes:**
- `export_bundle` is now a pure renderer — it reads no component column off `bundle` and takes both lists resolved. That split (skills resolved, MCP read inline) is exactly how the two paths drifted apart.
- One `resolve_bundle_components` serves both export paths, so they cannot disagree.
- **Scope is deliberately narrower than `effective_skills`/`effective_mcp_servers`**, which additionally union an agent's own binds, globals and the legacy blob. Those answer "what does this agent run with"; this answers "what is in this bundle", which is what an ABF describes. Documented at the resolver.
- `missing_skill_ids` is now always empty and kept for wire compatibility — a ref cannot dangle the way a bare inline id could.

**Tests** (8 new, all failing before the change):

| Test | Pins |
|---|---|
| `export_carries_ref_bound_components_the_inline_columns_never_had` | the regression itself, plus that redaction still applies when resolving from a different source |
| `a_bound_mcp_server_with_unparseable_config_warns_instead_of_vanishing` | the malformed-data guarantee at its new layer |
| `resolving_ignores_catalog_rows_this_bundle_is_not_bound_to` | `managed_list` returns globals too; only bound rows are the bundle's |
| `carries_inline_skills_and_mcp_servers_into_the_ref_tables` | the backfill, config surviving verbatim |
| `rerunning_binds_nothing_new` | idempotency |
| `a_malformed_blob_is_logged_and_the_rest_of_the_bundle_still_migrates` | partial failure |
| `an_inline_skill_id_with_no_catalog_row_is_dropped_not_fatal` | dangling id |
| `a_nameless_mcp_entry_gets_a_stable_synthetic_name` | two nameless entries must not collide |

The renderer's MCP tests now pass entries through a test shim. The malformed-JSON test in `bundle_export.rs` is **kept as a pointer** to where the guarantee moved rather than deleted, so it stays findable from the module that used to own it.

**Deliberately NOT in this PR**, each a follow-up on #3148:
1. **Imports still write only the inline columns**, so an imported MCP server remains inert at spawn — the other half of §3.4. Next PR.
2. `bundle_validate.rs` still parses the inline columns, so `bundle.validate` now reports on data nothing else reads. It is report-only and blocks nothing, but it is now inaccurate.
3. `bundle_delete` still orphans ref rows.
4. The inline columns themselves, and the frontend `draftToWire` that rewrites them on every save. Dropping them is a schema change and wants its own release once this proves out.

**Verification**
```
cargo test -p agentmux-srv   → 3225 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
