### PR TITLE
fix(srv): Phase 0b cleanup — purge refs on bundle delete, validate the bound components

### DIFF
--- a/.changesets/1789024994-fix-srv-deleting-a-bundle-purges-its-component-refs-bundle-v-5z1d.md
+++ b/.changesets/1789024994-fix-srv-deleting-a-bundle-purges-its-component-refs-bundle-v-5z1d.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(srv): deleting a bundle purges its component refs; bundle.validate checks the bound components rather than the retired inline columns

--- a/agentmux-srv/src/backend/bundle_validate.rs
+++ b/agentmux-srv/src/backend/bundle_validate.rs
@@ -47,13 +47,27 @@ pub struct ValidationReport {
     pub issues: Vec<ValidationIssue>,
 }
 
-/// Run every structural check against a bundle's JSON-encoded columns.
-pub fn validate_bundle(bundle: &Bundle) -> ValidationReport {
+/// Run every structural check against a bundle.
+///
+/// `mcp_entries` are the bundle's MCP servers **resolved from
+/// `db_bundle_mcp_ref`**, which is authoritative for what a bundle contains
+/// (Phase 0b, `SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md`). They
+/// are passed in rather than read off `bundle` for the same reason
+/// `export_bundle` takes them: this module does no Store lookups, and reading
+/// the inline `bundle.mcp_servers` column would validate data that nothing
+/// else consumes any more.
+///
+/// Pass an empty slice for an unsaved draft — a bundle with no row yet has no
+/// bindings to check.
+pub fn validate_bundle(bundle: &Bundle, mcp_entries: &[Value]) -> ValidationReport {
     let mut issues = Vec::new();
     validate_instructions_by_provider(bundle, &mut issues);
     validate_context_files(bundle, &mut issues);
-    validate_mcp_servers(bundle, &mut issues);
-    validate_skills(bundle, &mut issues);
+    validate_mcp_servers(mcp_entries, &mut issues);
+    // `skills` had exactly two checks, malformed JSON and a duplicate id, and
+    // the ref table makes both unrepresentable: `db_bundle_skills_ref` has a
+    // PRIMARY KEY (bundle_id, skill_id), and every id it yields came from a
+    // join against the catalog. There is nothing structural left to check.
 
     let is_valid = !issues.iter().any(|i| i.severity == IssueSeverity::Error);
     ValidationReport { is_valid, issues }
@@ -151,14 +165,8 @@ fn validate_context_files(bundle: &Bundle, issues: &mut Vec<ValidationIssue>) {
 /// into distinct slugs (`unique_skill_slug`), so a duplicate `name` can't
 /// actually collide on disk — flagged as a warning rather than an error
 /// since it's very likely a copy-paste mistake, not a structural break.
-fn validate_mcp_servers(bundle: &Bundle, issues: &mut Vec<ValidationIssue>) {
+fn validate_mcp_servers(entries: &[Value], issues: &mut Vec<ValidationIssue>) {
     const FIELD: &str = "mcp_servers";
-    let mut warnings = Vec::new();
-    let entries: Vec<Value> = parse_json_field_or_warn(&bundle.mcp_servers, FIELD, &mut warnings);
-    for w in warnings {
-        push_error(issues, FIELD, w);
-    }
-
     let mut seen_names: HashSet<String> = HashSet::new();
     for (index, entry) in entries.iter().enumerate() {
         if !entry.is_object() {
@@ -181,28 +189,22 @@ fn validate_mcp_servers(bundle: &Bundle, issues: &mut Vec<ValidationIssue>) {
     }
 }
 
-/// `skills` is just a JSON array of skill ids — the only structural checks
-/// possible without a Store lookup (which this module deliberately never
-/// does) are malformed JSON and an id listed more than once.
-fn validate_skills(bundle: &Bundle, issues: &mut Vec<ValidationIssue>) {
-    const FIELD: &str = "skills";
-    let mut warnings = Vec::new();
-    let ids: Vec<String> = parse_json_field_or_warn(&bundle.skills, FIELD, &mut warnings);
-    for w in warnings {
-        push_error(issues, FIELD, w);
-    }
-
-    let mut seen: HashSet<&str> = HashSet::new();
-    for id in &ids {
-        if !seen.insert(id.as_str()) {
-            push_warning(issues, FIELD, format!("skill id \"{id}\" is listed more than once"));
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Validate a bundle whose MCP servers are written inline, the way these
+    /// fixtures express them.
+    ///
+    /// `validate_bundle` no longer reads that column — the ref tables are
+    /// authoritative and the caller resolves them (Phase 0b,
+    /// `SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md`). These tests
+    /// are about the checks themselves, not about resolution, so this shim
+    /// does the parse the validator used to do and passes the entries in.
+    fn validate_with_inline_mcp(bundle: &Bundle) -> ValidationReport {
+        let entries: Vec<Value> = serde_json::from_str(&bundle.mcp_servers).unwrap_or_default();
+        validate_bundle(bundle, &entries)
+    }
 
     fn make_bundle(
         instructions_by_provider: &str,
@@ -233,7 +235,7 @@ mod tests {
     #[test]
     fn empty_bundle_is_valid_with_no_issues() {
         let bundle = make_bundle("{}", "[]", "[]", "[]");
-        let report = validate_bundle(&bundle);
+        let report = validate_with_inline_mcp(&bundle);
         assert!(report.is_valid);
         assert!(report.issues.is_empty());
     }
@@ -241,14 +243,14 @@ mod tests {
     #[test]
     fn known_provider_keys_pass() {
         let bundle = make_bundle(r#"{"claude":"x","codex":"y"}"#, "[]", "[]", "[]");
-        let report = validate_bundle(&bundle);
+        let report = validate_with_inline_mcp(&bundle);
         assert!(report.is_valid, "{:?}", report.issues);
     }
 
     #[test]
     fn unknown_provider_key_is_an_error() {
         let bundle = make_bundle(r#"{"chatgpt-desktop":"x"}"#, "[]", "[]", "[]");
-        let report = validate_bundle(&bundle);
+        let report = validate_with_inline_mcp(&bundle);
         assert!(!report.is_valid);
         assert!(report.issues.iter().any(|i| i.severity == IssueSeverity::Error
             && i.field == "instructions_by_provider"
@@ -258,7 +260,7 @@ mod tests {
     #[test]
     fn malformed_instructions_by_provider_json_is_an_error() {
         let bundle = make_bundle("not json", "[]", "[]", "[]");
-        let report = validate_bundle(&bundle);
+        let report = validate_with_inline_mcp(&bundle);
         assert!(!report.is_valid);
         assert!(report.issues.iter().any(|i| i.field == "instructions_by_provider"
             && i.message.contains("malformed JSON")));
@@ -270,14 +272,14 @@ mod tests {
         // like the canonical id does, since export/import both treat them
         // as the same provider (providers::get_provider handles aliases).
         let bundle = make_bundle(r#"{"claude-code":"x"}"#, "[]", "[]", "[]");
-        let report = validate_bundle(&bundle);
+        let report = validate_with_inline_mcp(&bundle);
         assert!(report.is_valid, "{:?}", report.issues);
     }
 
     #[test]
     fn multiple_unknown_provider_keys_are_each_reported() {
         let bundle = make_bundle(r#"{"foo":"a","bar":"b"}"#, "[]", "[]", "[]");
-        let report = validate_bundle(&bundle);
+        let report = validate_with_inline_mcp(&bundle);
         assert!(!report.is_valid);
         let provider_errors: Vec<_> = report
             .issues
@@ -290,7 +292,7 @@ mod tests {
     #[test]
     fn unsafe_context_file_path_is_an_error() {
         let bundle = make_bundle("{}", r#"[{"path":"../../etc/passwd","content":"x"}]"#, "[]", "[]");
-        let report = validate_bundle(&bundle);
+        let report = validate_with_inline_mcp(&bundle);
         assert!(!report.is_valid);
         assert!(report.issues.iter().any(|i| i.field == "context_files"
             && i.message.contains("not a safe relative path")));
@@ -304,7 +306,7 @@ mod tests {
             "[]",
             "[]",
         );
-        let report = validate_bundle(&bundle);
+        let report = validate_with_inline_mcp(&bundle);
         assert!(!report.is_valid);
         assert!(report.issues.iter().any(|i| i.field == "context_files" && i.message.contains("collides")));
     }
@@ -312,7 +314,7 @@ mod tests {
     #[test]
     fn malformed_context_files_json_is_an_error() {
         let bundle = make_bundle("{}", "not json", "[]", "[]");
-        let report = validate_bundle(&bundle);
+        let report = validate_with_inline_mcp(&bundle);
         assert!(!report.is_valid);
         assert!(report.issues.iter().any(|i| i.field == "context_files" && i.message.contains("malformed")));
     }
@@ -325,7 +327,7 @@ mod tests {
             r#"[{"name":"fs","command":"a"},{"name":"FS","command":"b"}]"#,
             "[]",
         );
-        let report = validate_bundle(&bundle);
+        let report = validate_with_inline_mcp(&bundle);
         assert!(report.is_valid, "warnings must not flip is_valid: {:?}", report.issues);
         assert!(report.issues.iter().any(|i| i.severity == IssueSeverity::Warning
             && i.field == "mcp_servers"));
@@ -334,24 +336,31 @@ mod tests {
     #[test]
     fn non_object_mcp_entry_is_an_error() {
         let bundle = make_bundle("{}", "[]", r#"["not-an-object"]"#, "[]");
-        let report = validate_bundle(&bundle);
+        let report = validate_with_inline_mcp(&bundle);
         assert!(!report.is_valid);
         assert!(report.issues.iter().any(|i| i.field == "mcp_servers" && i.message.contains("not a JSON object")));
     }
 
     #[test]
-    fn duplicate_skill_id_is_a_warning_not_an_error() {
+    fn skills_are_no_longer_validated_because_both_checks_became_impossible() {
+        // This replaces `duplicate_skill_id_is_a_warning_not_an_error` and
+        // `malformed_skills_json_is_an_error`. Those checked the inline
+        // `skills` column, which nothing reads now that `db_bundle_skills_ref`
+        // is authoritative (Phase 0b). Neither failure it guarded can be
+        // represented any more: the ref table has a PRIMARY KEY
+        // (bundle_id, skill_id) so an id cannot appear twice, and ids come out
+        // of a join against the catalog rather than out of parsed JSON, so
+        // there is nothing to be malformed.
+        //
+        // Kept as a record of where those guarantees went, rather than a
+        // silent deletion of two tests.
         let bundle = make_bundle("{}", "[]", "[]", r#"["skill-1","skill-1"]"#);
-        let report = validate_bundle(&bundle);
+        let report = validate_with_inline_mcp(&bundle);
         assert!(report.is_valid, "{:?}", report.issues);
-        assert!(report.issues.iter().any(|i| i.severity == IssueSeverity::Warning && i.field == "skills"));
-    }
-
-    #[test]
-    fn malformed_skills_json_is_an_error() {
-        let bundle = make_bundle("{}", "[]", "[]", "not json");
-        let report = validate_bundle(&bundle);
-        assert!(!report.is_valid);
-        assert!(report.issues.iter().any(|i| i.field == "skills" && i.message.contains("malformed")));
+        assert!(
+            !report.issues.iter().any(|i| i.field == "skills"),
+            "the inline skills column must no longer produce issues: {:?}",
+            report.issues
+        );
     }
 }

--- a/agentmux-srv/src/backend/storage/managed.rs
+++ b/agentmux-srv/src/backend/storage/managed.rs
@@ -243,6 +243,33 @@ impl Store {
         Ok(rows > 0)
     }
 
+    /// Purge every bundle-level ref for `bundle_id`, for one resource kind.
+    ///
+    /// The mirror of `managed_delete`'s ref purge, from the other side: that
+    /// one runs when a catalog row goes away, this one when a bundle does.
+    /// Neither can rely on the declared foreign keys, which only cascade when
+    /// `PRAGMA foreign_keys` is ON — and it is only ever set in tests. The
+    /// bundle side additionally *cannot* have an enforcing FK at all, since
+    /// `db_bundles` lives in a different physical database from the ref tables
+    /// (`migrations.rs:721-741`).
+    ///
+    /// Returns the number of refs removed.
+    pub(super) fn managed_unbind_all_for_bundle<R: ManagedResource>(
+        &self,
+        bundle_id: &str,
+    ) -> Result<usize, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute(
+            &format!(
+                "DELETE FROM {} WHERE {} = ?1",
+                R::BUNDLE_REF_TABLE,
+                Owner::Bundle.key_col()
+            ),
+            params![bundle_id],
+        )?;
+        Ok(rows)
+    }
+
     /// Insert the agent-level ref (idempotent). Errors if `agent_id` is not
     /// a LOCAL agent: the ref table's FK would otherwise swallow
     /// the `INSERT OR IGNORE` silently for a cross-channel agent, which is

--- a/agentmux-srv/src/backend/storage/mcp_servers.rs
+++ b/agentmux-srv/src/backend/storage/mcp_servers.rs
@@ -78,6 +78,23 @@ impl McpServer {
 }
 
 impl Store {
+    /// Drop every skill and MCP ref belonging to `bundle_id`.
+    ///
+    /// Call after deleting the bundle itself. `bundle_delete` lives on the
+    /// store that owns `db_bundles`, which does not have the ref tables at all
+    /// — they sit beside the catalog tables they key into — so the cleanup
+    /// cannot happen inside it and has to be driven from the handler, where
+    /// both stores are in scope. Without it a deleted bundle leaves its refs
+    /// behind, and a future bundle reusing that id would inherit them.
+    ///
+    /// Returns `(skill_refs_removed, mcp_refs_removed)`.
+    pub fn bundle_unbind_all_components(&self, bundle_id: &str) -> Result<(usize, usize), StoreError> {
+        let skills = self
+            .managed_unbind_all_for_bundle::<super::skills::Skill>(bundle_id)?;
+        let mcp = self.managed_unbind_all_for_bundle::<McpServer>(bundle_id)?;
+        Ok((skills, mcp))
+    }
+
     /// Create and bind a bundle's inline MCP entries, preserving duplicates.
     ///
     /// The one path from "a list of inline config objects" to "rows bound to

--- a/agentmux-srv/src/server/agent_handlers/bundle.rs
+++ b/agentmux-srv/src/server/agent_handlers/bundle.rs
@@ -99,18 +99,29 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
         }),
     );
 
-    let wstore = state.id_store.clone();
+    let id_store = state.id_store.clone();
+    let component_store = state.wstore.clone();
     let broker = state.broker.clone();
     engine.register_typed(
         COMMAND_DELETE_MEMORY,
         move |cmd: CommandDeleteBundleData, _ctx| {
-            let wstore = wstore.clone();
+            let id_store = id_store.clone();
+            let component_store = component_store.clone();
             let broker = broker.clone();
             async move {
-                let deleted = wstore
+                let deleted = id_store
                     .bundle_delete(&cmd.id)
                     .map_err(|e| format!("deletememory: {e}"))?;
                 if deleted {
+                    // This is the delete the Armory actually calls
+                    // (`rpc-api/bundle.ts`), so the ref purge has to live here
+                    // too — fixing only `bundle.delete` left the product path
+                    // orphaning refs (Codex, PR #3153). Shared helper, not a
+                    // second copy of the logic.
+                    crate::server::app_api::bundle::purge_bundle_component_refs(
+                        &component_store,
+                        &cmd.id,
+                    );
                     broker.publish(crate::backend::wps::WaveEvent {
                         event: "memories:changed".to_string(),
                         scopes: vec![],

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -107,9 +107,12 @@ fn register_bundle_get(engine: &Arc<WshRpcEngine>, state: &AppState) {
     engine.register_handler(COMMAND_BUNDLE_GET, make(state.clone()));
 }
 
-fn register_bundle_validate(engine: &Arc<WshRpcEngine>, _state: &AppState) {
-    let handler: crate::backend::rpc::engine::CommandHandler =
-        Box::new(move |data, _ctx| Box::pin(async move { Ok(Some(bundle_validate_impl(data)?)) }));
+fn register_bundle_validate(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let handler: crate::backend::rpc::engine::CommandHandler = Box::new(move |data, _ctx| {
+        let wstore = wstore.clone();
+        Box::pin(async move { Ok(Some(bundle_validate_impl(&wstore, data)?)) })
+    });
     engine.register_handler(COMMAND_BUNDLE_VALIDATE, handler);
 }
 
@@ -275,9 +278,11 @@ fn register_bundle_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
 fn register_bundle_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let make = |state: &AppState| -> crate::backend::rpc::engine::CommandHandler {
         let id_store = state.id_store.clone();
+        let wstore = state.wstore.clone();
         let broker = state.broker.clone();
         Box::new(move |data, _ctx| {
             let id_store = id_store.clone();
+            let wstore = wstore.clone();
             let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
@@ -292,6 +297,23 @@ fn register_bundle_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 match id_store.bundle_delete(&req.id) {
                     Ok(deleted) => {
                         if deleted {
+                            // The refs live in the other store and no FK
+                            // reaches across, so nothing else would remove
+                            // them — and a later bundle reusing this id would
+                            // inherit components nobody chose. Best-effort:
+                            // the bundle is already gone, so a failure here
+                            // must not turn a successful delete into an error.
+                            match wstore.bundle_unbind_all_components(&req.id) {
+                                Ok((skills, mcp)) if skills + mcp > 0 => tracing::info!(
+                                    bundle_id = %req.id, skills, mcp,
+                                    "bundle.delete: purged component refs"
+                                ),
+                                Ok(_) => {}
+                                Err(e) => tracing::warn!(
+                                    bundle_id = %req.id, error = %e,
+                                    "bundle.delete: component refs left behind"
+                                ),
+                            }
                             broker.publish(crate::backend::wps::WaveEvent {
                                 event: "memories:changed".to_string(),
                                 scopes: vec![], sender: String::new(), persist: 0, data: None,
@@ -471,12 +493,12 @@ fn bind_imported_components(
 
 /// A bundle's components, resolved from the tables that are authoritative for
 /// them.
-struct ResolvedComponents {
-    skills: Vec<crate::backend::storage::Skill>,
+pub(super) struct ResolvedComponents {
+    pub(super) skills: Vec<crate::backend::storage::Skill>,
     /// Exporter entry shape: each server's config object with its `name`
     /// alongside, which is what `bundle_export::redact_mcp_entry` reads.
-    mcp_entries: Vec<serde_json::Value>,
-    warnings: Vec<String>,
+    pub(super) mcp_entries: Vec<serde_json::Value>,
+    pub(super) warnings: Vec<String>,
 }
 
 /// Resolve what a bundle actually contains, from `db_bundle_skills_ref` /
@@ -503,7 +525,7 @@ struct ResolvedComponents {
 /// `mcp_server_delete` both purge refs (`storage/managed.rs:232`), so that
 /// state is not reachable through the app — but the FK that would enforce it
 /// is inert, since `PRAGMA foreign_keys` is only ever set ON in tests.
-fn resolve_bundle_components(
+pub(super) fn resolve_bundle_components(
     wstore: &crate::backend::storage::store::Store,
     bundle_id: &str,
 ) -> Result<ResolvedComponents, String> {
@@ -3116,6 +3138,33 @@ mod export_import_for_agent_tests {
             .unwrap();
         let content = server_file["content"].as_str().unwrap();
         assert!(!content.contains("tok"), "secret must not survive export: {content}");
+    }
+
+    #[tokio::test]
+    async fn deleting_a_bundle_takes_its_component_refs_with_it() {
+        // No FK reaches from the ref tables to db_bundles — they live in
+        // different physical databases — so nothing else removes these, and a
+        // later bundle reusing the id would inherit components nobody chose.
+        let state = test_state();
+        make_bundle(&state, "bundle-1", "Be helpful.");
+        bind_skill(&state, "bundle-1", "Deploy");
+        bind_mcp(&state, "bundle-1", "github", r#"{"command":"gh-mcp"}"#);
+
+        let before = resolve_bundle_components(&state.wstore, "bundle-1").unwrap();
+        assert_eq!(before.skills.len(), 1);
+        assert_eq!(before.mcp_entries.len(), 1);
+
+        assert!(state.id_store.bundle_delete("bundle-1").unwrap());
+        let (skills, mcp) = state.wstore.bundle_unbind_all_components("bundle-1").unwrap();
+        assert_eq!((skills, mcp), (1, 1), "both refs must be purged");
+
+        // Re-create a bundle with the same id: it must start empty.
+        make_bundle(&state, "bundle-1", "Reused id.");
+        let after = resolve_bundle_components(&state.wstore, "bundle-1").unwrap();
+        assert!(
+            after.skills.is_empty() && after.mcp_entries.is_empty(),
+            "a reused bundle id must not inherit the old bundle's components"
+        );
     }
 
     #[tokio::test]

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -297,23 +297,7 @@ fn register_bundle_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 match id_store.bundle_delete(&req.id) {
                     Ok(deleted) => {
                         if deleted {
-                            // The refs live in the other store and no FK
-                            // reaches across, so nothing else would remove
-                            // them — and a later bundle reusing this id would
-                            // inherit components nobody chose. Best-effort:
-                            // the bundle is already gone, so a failure here
-                            // must not turn a successful delete into an error.
-                            match wstore.bundle_unbind_all_components(&req.id) {
-                                Ok((skills, mcp)) if skills + mcp > 0 => tracing::info!(
-                                    bundle_id = %req.id, skills, mcp,
-                                    "bundle.delete: purged component refs"
-                                ),
-                                Ok(_) => {}
-                                Err(e) => tracing::warn!(
-                                    bundle_id = %req.id, error = %e,
-                                    "bundle.delete: component refs left behind"
-                                ),
-                            }
+                            purge_bundle_component_refs(&wstore, &req.id);
                             broker.publish(crate::backend::wps::WaveEvent {
                                 event: "memories:changed".to_string(),
                                 scopes: vec![], sender: String::new(), persist: 0, data: None,
@@ -448,6 +432,37 @@ fn bundle_export_impl(
         obj.insert("warnings".to_string(), json!(all_warnings));
     }
     Ok(result)
+}
+
+/// Drop a deleted bundle's component refs.
+///
+/// Called from **both** delete paths — `bundle.delete` here and `deletememory`
+/// in `agent_handlers/bundle.rs`, which is the one the Armory actually calls.
+/// Fixing only the first left the product path orphaning refs (Codex, PR
+/// #3153), so this exists to make "both" mean one implementation.
+///
+/// `bundle_delete` runs on the store that owns `db_bundles`, which has no ref
+/// tables — they sit beside the catalog tables they key into, in the other
+/// database, which is also why no foreign key reaches across
+/// (`migrations.rs:721-741`). So the purge cannot live inside it and has to be
+/// driven from a handler, where both stores are in scope.
+///
+/// Best-effort by design: the bundle row is already gone by the time this
+/// runs, so a failure here must not turn a successful delete into an error.
+pub(crate) fn purge_bundle_component_refs(
+    wstore: &crate::backend::storage::store::Store,
+    bundle_id: &str,
+) {
+    match wstore.bundle_unbind_all_components(bundle_id) {
+        Ok((skills, mcp)) if skills + mcp > 0 => {
+            tracing::info!(bundle_id, skills, mcp, "bundle delete: purged component refs")
+        }
+        Ok(_) => {}
+        Err(e) => tracing::warn!(
+            bundle_id, error = %e,
+            "bundle delete: component refs left behind"
+        ),
+    }
 }
 
 /// Bind an imported bundle's components into the ref tables.
@@ -3155,8 +3170,15 @@ mod export_import_for_agent_tests {
         assert_eq!(before.mcp_entries.len(), 1);
 
         assert!(state.id_store.bundle_delete("bundle-1").unwrap());
+        // Through the shared helper both delete RPCs call — `bundle.delete`
+        // here and `deletememory`, the one the Armory actually uses. Fixing
+        // only one left the product path orphaning refs (Codex, PR #3153).
+        purge_bundle_component_refs(&state.wstore, "bundle-1");
         let (skills, mcp) = state.wstore.bundle_unbind_all_components("bundle-1").unwrap();
-        assert_eq!((skills, mcp), (1, 1), "both refs must be purged");
+        assert_eq!(
+            (skills, mcp), (0, 0),
+            "the purge must have already removed both refs"
+        );
 
         // Re-create a bundle with the same id: it must start empty.
         make_bundle(&state, "bundle-1", "Reused id.");
@@ -3164,6 +3186,35 @@ mod export_import_for_agent_tests {
         assert!(
             after.skills.is_empty() && after.mcp_entries.is_empty(),
             "a reused bundle id must not inherit the old bundle's components"
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_reports_a_malformed_bound_component_instead_of_passing() {
+        // Codex on #3153: the resolver drops a bound server whose config will
+        // not parse and says so in a warning. Discarding that left validate
+        // reporting is_valid for exactly the component it exists to catch —
+        // the entry is absent from the resolved list, so nothing downstream
+        // could have seen it.
+        let state = test_state();
+        make_bundle(&state, "bundle-1", "Be helpful.");
+        bind_mcp(&state, "bundle-1", "broken", "not json at all");
+
+        let report = crate::server::app_api::bundle_validate_impl(
+            &state.wstore,
+            json!({ "id": "bundle-1", "name": "Bundle bundle-1" }),
+        )
+        .unwrap();
+
+        assert_eq!(
+            report["is_valid"], json!(false),
+            "a bound component that cannot load must not validate clean: {report}"
+        );
+        let issues = report["issues"].as_array().unwrap();
+        assert!(
+            issues.iter().any(|i| i["field"] == "mcp_servers"
+                && i["message"].as_str().unwrap_or("").contains("broken")),
+            "the issue must name the server: {issues:?}"
         );
     }
 

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -791,11 +791,30 @@ pub(crate) async fn bundle_get_impl(
 /// (reuses its `normalize_bundle_upsert_input`), not just an id, so the
 /// Armory editor's "Validate" button can check an unsaved draft (including a
 /// brand-new bundle with no id yet) rather than only whatever was last
-/// persisted. Read-only: never touches the Store.
-pub(crate) fn bundle_validate_impl(data: serde_json::Value) -> Result<serde_json::Value, String> {
+/// persisted.
+///
+/// Reads the bundle's bound MCP servers when the draft names a persisted
+/// bundle. Before Phase 0b this was fully store-free and validated the inline
+/// `mcp_servers` column; the ref tables are authoritative now, so validating
+/// that column would report on data nothing else consumes
+/// (`SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md` §3.4). An unsaved
+/// draft has no bindings, so it is still checked without touching the store.
+pub(crate) fn bundle_validate_impl(
+    wstore: &crate::backend::storage::store::Store,
+    data: serde_json::Value,
+) -> Result<serde_json::Value, String> {
     let memory: Bundle = serde_json::from_value(bundle::normalize_bundle_upsert_input(data))
         .map_err(|e| format!("bundle.validate: {e}"))?;
-    let report = crate::backend::bundle_validate::validate_bundle(&memory);
+    let mcp_entries = if memory.id.is_empty() {
+        Vec::new()
+    } else {
+        // A draft for a bundle that does not exist yet resolves to nothing,
+        // which is the same as an unsaved draft — not an error.
+        bundle::resolve_bundle_components(wstore, &memory.id)
+            .map(|c| c.mcp_entries)
+            .unwrap_or_default()
+    };
+    let report = crate::backend::bundle_validate::validate_bundle(&memory, &mcp_entries);
     serde_json::to_value(&report).map_err(|e| e.to_string())
 }
 

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -48,7 +48,7 @@ mod pane;
 mod blockfile;
 pub(crate) mod session;
 mod identity;
-mod bundle;
+pub(crate) mod bundle;
 mod memory;
 mod skill;
 mod mcp;
@@ -805,16 +805,38 @@ pub(crate) fn bundle_validate_impl(
 ) -> Result<serde_json::Value, String> {
     let memory: Bundle = serde_json::from_value(bundle::normalize_bundle_upsert_input(data))
         .map_err(|e| format!("bundle.validate: {e}"))?;
-    let mcp_entries = if memory.id.is_empty() {
-        Vec::new()
+    let (mcp_entries, resolve_warnings) = if memory.id.is_empty() {
+        (Vec::new(), Vec::new())
     } else {
-        // A draft for a bundle that does not exist yet resolves to nothing,
-        // which is the same as an unsaved draft — not an error.
-        bundle::resolve_bundle_components(wstore, &memory.id)
-            .map(|c| c.mcp_entries)
-            .unwrap_or_default()
+        // A store failure must NOT read as "this bundle has no components":
+        // that would return a clean, apparently-successful report for a check
+        // that never ran (Codex, PR #3153). The UI is built to show a failed
+        // validate; give it one.
+        let resolved = bundle::resolve_bundle_components(wstore, &memory.id)
+            .map_err(|e| format!("bundle.validate: {e}"))?;
+        (resolved.mcp_entries, resolved.warnings)
     };
-    let report = crate::backend::bundle_validate::validate_bundle(&memory, &mcp_entries);
+    let mut report = crate::backend::bundle_validate::validate_bundle(&memory, &mcp_entries);
+
+    // The resolver drops a bound server whose config will not parse, and says
+    // so in a warning. Discarding that left the validator reporting `is_valid`
+    // for exactly the malformed component it exists to catch (Codex, PR
+    // #3153) — the entry is absent from `mcp_entries`, so nothing downstream
+    // could see it. Surface each as an error: unlike a duplicate name, an
+    // unusable config is not a stylistic warning, it is a component that will
+    // not load.
+    for w in resolve_warnings {
+        report.issues.push(crate::backend::bundle_validate::ValidationIssue {
+            severity: crate::backend::bundle_validate::IssueSeverity::Error,
+            field: "mcp_servers".to_string(),
+            message: w,
+        });
+    }
+    report.is_valid = !report
+        .issues
+        .iter()
+        .any(|i| i.severity == crate::backend::bundle_validate::IssueSeverity::Error);
+
     serde_json::to_value(&report).map_err(|e| e.to_string())
 }
 


### PR DESCRIPTION
The two items #3152's body listed as deferred. Follow-up to #3152 (Phase 0b). Tracking: #3148.

**1. Deleting a bundle left its component refs behind.**

`bundle_delete` lives on the store that owns `db_bundles`, which does not have the ref tables at all — they sit beside the catalog tables they key into, in the other database. That is also why no foreign key reaches across (`migrations.rs:721-741`). So nothing removed a deleted bundle's refs, and a later bundle reusing that id would inherit components nobody chose.

The handler now purges them, since it is the only place both stores are in scope. Best-effort: the bundle is already gone by then, so a failure here must not turn a successful delete into an error. `managed_unbind_all_for_bundle` mirrors `managed_delete`'s existing purge from the other side — neither can rely on the declared FKs, which only cascade when `PRAGMA foreign_keys` is ON, and it is only ever set in tests.

**2. `bundle.validate` was reporting on retired data.**

It parsed the inline `mcp_servers`/`skills` columns, so after #3152 it validated data nothing else consumes. It now takes the resolved MCP entries the same way `export_bundle` does — the module keeps its no-Store-access rule, and the handler resolves them when the draft names a persisted bundle. An unsaved draft still validates without touching the store, which is what that RPC exists for.

**The skills checks are gone rather than moved**, because both became impossible to fail. `db_bundle_skills_ref` has a `PRIMARY KEY (bundle_id, skill_id)` so an id cannot repeat, and ids come out of a join against the catalog rather than out of parsed JSON, so nothing can be malformed. The two tests are replaced by one that records this, rather than deleted quietly — same treatment as the malformed-MCP test in #3152.

**Tests**

| Test | Pins |
|---|---|
| `deleting_a_bundle_takes_its_component_refs_with_it` | refs purged, and a bundle reusing the id starts empty |
| `skills_are_no_longer_validated_because_both_checks_became_impossible` | the inline column produces no issues, and why |

Validator tests now go through a `validate_with_inline_mcp` shim, the same pattern #3152 used for the renderer: these tests are about the checks, not about resolution.

**Verification**
```
cargo test -p agentmux-srv   → 3229 passed, 0 failed
```

Remaining on #3148 after this: removing the inline columns themselves and the frontend `draftToWire` that still rewrites them. That is a schema change and wants its own release now that the read paths are off them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
