### PR TITLE
feat(srv): Phase 3 prerequisites — record what each provider reads, and one ownership test

### DIFF
--- a/.changesets/1789026221-feat-srv-provider-registry-records-every-instruction-file-a--a1fy.md
+++ b/.changesets/1789026221-feat-srv-provider-registry-records-every-instruction-file-a--a1fy.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(srv): provider registry records every instruction file a provider reads, not just the one AgentMux writes

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -1039,6 +1039,33 @@ fn resolve_claude_md_side_paths(
 /// see the doc comment below).
 const STARTUP_INSTRUCTIONS_MANAGED_MARKER: &str = "<!-- agentmux:managed-startup-instructions -->";
 
+/// Does this file's content say AgentMux wrote it?
+///
+/// There are two markers, not one: `CLAUDE.md` carries
+/// [`CLAUDE_MD_MANAGED_MARKER`] and every other startup-instructions file
+/// carries [`STARTUP_INSTRUCTIONS_MANAGED_MARKER`], because the two writers
+/// grew separately. Anything asking "is this ours" has to know both — a check
+/// against only the first reports every AgentMux-generated `AGENTS.md`,
+/// `GEMINI.md`, `QWEN.md` and `.pi/APPEND_SYSTEM.md` as foreign, inverting the
+/// answer for most providers (Codex, PR #3144).
+///
+/// Deliberately content-based rather than path-based: the marker is what makes
+/// the claim, and a file's name says nothing about who wrote it. Phase 3 of
+/// `SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md` reuses this to
+/// label tracked instruction files `agentmux` or `foreign`, which is the one
+/// field that decides whether a file is ours to touch.
+///
+/// **The two writers below deliberately do NOT use this**, and that is not an
+/// oversight. Each asks a narrower question — "did I write this file, in my
+/// own format, such that I may rewrite it" — and each answer must stay pinned
+/// to its own marker. A `CLAUDE.md`-marked file is ours, but it is not
+/// `write_startup_instructions_respecting_existing`'s to rewrite. This helper
+/// answers the broader question, which is the one a read-only tracker asks.
+pub fn is_agentmux_managed_instructions(content: &str) -> bool {
+    content.starts_with(CLAUDE_MD_MANAGED_MARKER)
+        || content.starts_with(STARTUP_INSTRUCTIONS_MANAGED_MARKER)
+}
+
 /// Write a NON-`CLAUDE.md` startup-instructions file (`AGENTS.md`,
 /// `GEMINI.md`, `QWEN.md`, `.pi/APPEND_SYSTEM.md`, ...) WITHOUT ever
 /// overwriting a pre-existing, non-AgentMux-authored file at that path.
@@ -2236,5 +2263,34 @@ mod bundle_section_heading_tests {
     #[test]
     fn heading_matches_frontend_builder_literal() {
         assert_eq!(BUNDLE_SECTION_HEADING, "# Memory");
+    }
+}
+
+#[cfg(test)]
+mod is_agentmux_managed_instructions_tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_both_marker_classes() {
+        // The bug this exists to prevent: a check against CLAUDE.md's marker
+        // alone reports every generated AGENTS.md / GEMINI.md / QWEN.md /
+        // .pi/APPEND_SYSTEM.md as foreign (Codex, PR #3144).
+        assert!(is_agentmux_managed_instructions(&format!(
+            "{CLAUDE_MD_MANAGED_MARKER}\n\n# Memory\n"
+        )));
+        assert!(is_agentmux_managed_instructions(&format!(
+            "{STARTUP_INSTRUCTIONS_MANAGED_MARKER}\n\nBe helpful.\n"
+        )));
+    }
+
+    #[test]
+    fn a_foreign_file_is_not_ours_however_it_starts() {
+        assert!(!is_agentmux_managed_instructions("# My project\n\nRules.\n"));
+        assert!(!is_agentmux_managed_instructions(""));
+        // The marker has to be at the START — a file that merely mentions it
+        // further down was not written by us.
+        assert!(!is_agentmux_managed_instructions(&format!(
+            "Someone pasted this below:\n{CLAUDE_MD_MANAGED_MARKER}\n"
+        )));
     }
 }

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -144,6 +144,35 @@ pub struct ProviderConfig {
     /// truth, which is recoverable; a guessed one means it shows them
     /// something false, which is not.
     pub native_instruction_sources: &'static [&'static str],
+    /// Directories a provider scans for instruction files, for the providers
+    /// whose convention is a pattern rather than a fixed path.
+    ///
+    /// Copilot's `.github/instructions/**/*.instructions.md` is the reason
+    /// this exists: those are path-scoped instructions that genuinely reach
+    /// the agent, so a resolver reading only `native_instruction_sources`
+    /// above would produce an incomplete answer for any repository using them
+    /// (Codex, PR #3154), verified in
+    /// `docs/archive/research-cli-context-files-2026-04-23-copilot-verification.md`
+    /// claim 3.
+    ///
+    /// Structured rather than a glob string, because there is no glob engine
+    /// in the tree and one dependency for one pattern shape is a poor trade.
+    /// It also forces the two things a glob leaves implicit — whether to
+    /// descend, and what actually qualifies — to be stated.
+    ///
+    /// Same evidence rule as the two fields above.
+    pub native_instruction_dirs: &'static [InstructionDirScan],
+}
+
+/// A directory a provider reads instruction files out of.
+#[derive(Debug, Clone, Copy)]
+pub struct InstructionDirScan {
+    /// Working-directory-relative, e.g. `".github/instructions"`.
+    pub dir: &'static str,
+    /// Only files ending in this qualify, e.g. `".instructions.md"`.
+    pub suffix: &'static str,
+    /// Whether subdirectories are scanned too — Copilot's `**` says yes.
+    pub recursive: bool,
 }
 
 impl ProviderConfig {
@@ -250,6 +279,7 @@ static CLAUDE: ProviderConfig = ProviderConfig {
     // so it is not a native source. Nested/parent CLAUDE.md discovery is
     // real but out of scope here: this field is working-directory-relative.
     native_instruction_sources: &["CLAUDE.md"],
+    native_instruction_dirs: &[],
 };
 
 static CODEX: ProviderConfig = ProviderConfig {
@@ -285,6 +315,7 @@ static CODEX: ProviderConfig = ProviderConfig {
     // Read set = the write target, per the same citation above: Codex loads
     // repository AGENTS.md natively.
     native_instruction_sources: &["AGENTS.md"],
+    native_instruction_dirs: &[],
 };
 
 static GEMINI: ProviderConfig = ProviderConfig {
@@ -315,6 +346,7 @@ static GEMINI: ProviderConfig = ProviderConfig {
     // Read set = the write target. AGENTS.md is supported only behind an
     // explicit contextFileName override, so it is not read by default.
     native_instruction_sources: &["GEMINI.md"],
+    native_instruction_dirs: &[],
 };
 
 // Qwen Code — Alibaba's open-source coding agent, a fork of Gemini CLI.
@@ -362,6 +394,7 @@ static QWEN: ProviderConfig = ProviderConfig {
     // Read set = the write target, for the same reason as Gemini: AGENTS.md
     // needs explicit config (QwenLM/qwen-code#2006, #504).
     native_instruction_sources: &["QWEN.md"],
+    native_instruction_dirs: &[],
 };
 
 static KIMI: ProviderConfig = ProviderConfig {
@@ -405,6 +438,7 @@ static KIMI: ProviderConfig = ProviderConfig {
     startup_instructions_filename: None,
     // No confirmed native file convention at all — hence the None above.
     native_instruction_sources: &[],
+    native_instruction_dirs: &[],
 };
 
 static OPENCLAW: ProviderConfig = ProviderConfig {
@@ -452,6 +486,7 @@ static OPENCLAW: ProviderConfig = ProviderConfig {
     // Read set = the write target, with the same UNCONFIRMED-path caveat
     // recorded above.
     native_instruction_sources: &["AGENTS.md"],
+    native_instruction_dirs: &[],
 };
 
 static PI: ProviderConfig = ProviderConfig {
@@ -487,6 +522,7 @@ static PI: ProviderConfig = ProviderConfig {
     // AgentMux writes. A repo-provided SYSTEM.md is exactly the kind of
     // instruction file Phase 3 exists to surface.
     native_instruction_sources: &[".pi/APPEND_SYSTEM.md", ".pi/SYSTEM.md"],
+    native_instruction_dirs: &[],
 };
 
 // Mux Code — AgentMux's first-party agentic coding CLI.
@@ -525,6 +561,7 @@ static MUX_CODE: ProviderConfig = ProviderConfig {
     startup_instructions_filename: Some("CLAUDE.md"),
     // Read set = the write target; claude-compatible by design, per above.
     native_instruction_sources: &["CLAUDE.md"],
+    native_instruction_dirs: &[],
 };
 
 // GitHub Copilot CLI — Microsoft's coding agent. Runs in ACP mode via
@@ -568,6 +605,22 @@ static COPILOT: ProviderConfig = ProviderConfig {
         "CLAUDE.md",
         "GEMINI.md",
     ],
+    // Path-scoped instructions: .github/instructions/**/*.instructions.md,
+    // claim 3 of the Copilot verification doc. Recursive, per the `**`.
+    // Not in the list above because it is a pattern, not a path.
+    //
+    // Deliberately NOT represented: $HOME/.copilot/copilot-instructions.md
+    // (claim 4) and $COPILOT_CUSTOM_INSTRUCTIONS_DIRS (claim 6). Both are
+    // real, and both live outside the agent working directory, which is
+    // what these two fields are relative to. Tracking them is a bigger
+    // question — they are machine-global, not project state, so they do
+    // not travel with a bundle — and is out of scope here rather than
+    // forgotten.
+    native_instruction_dirs: &[InstructionDirScan {
+        dir: ".github/instructions",
+        suffix: ".instructions.md",
+        recursive: true,
+    }],
 };
 
 // Antigravity (AGY) — Google's agentic coding CLI harness. Emits the same
@@ -607,6 +660,7 @@ static ANTIGRAVITY: ProviderConfig = ProviderConfig {
     startup_instructions_filename: Some("GEMINI.md"),
     // Read set = the write target.
     native_instruction_sources: &["GEMINI.md"],
+    native_instruction_dirs: &[],
 };
 
 // ─── Static registry ─────────────────────────────────────────────────────────
@@ -1328,5 +1382,36 @@ mod native_instruction_sources_tests {
             pi.native_instruction_sources.contains(&".pi/SYSTEM.md"),
             "pi reads .pi/SYSTEM.md as well as the file AgentMux writes"
         );
+    }
+
+    /// Copilot's path-scoped instructions are a pattern, not a path, and a
+    /// resolver reading only the literal list would miss them entirely in any
+    /// repository that uses them (Codex, PR #3154).
+    #[test]
+    fn copilot_declares_its_path_scoped_instructions_directory() {
+        let copilot = get_provider("copilot").expect("copilot is registered");
+        let scan = copilot
+            .native_instruction_dirs
+            .iter()
+            .find(|d| d.dir == ".github/instructions")
+            .expect("copilot scans .github/instructions");
+        assert_eq!(scan.suffix, ".instructions.md");
+        assert!(scan.recursive, "the convention is `**`, so subdirectories count");
+    }
+
+    /// A scan entry that could never match anything is a silent hole.
+    #[test]
+    fn every_declared_scan_is_usable() {
+        for (id, provider) in REGISTRY.iter() {
+            for scan in provider.native_instruction_dirs {
+                assert!(!scan.dir.trim().is_empty(), "{id}: scan with no directory");
+                assert!(!scan.suffix.trim().is_empty(), "{id}: scan with no suffix");
+                assert!(
+                    !scan.dir.starts_with('/') && !scan.dir.contains(".."),
+                    "{id}: scan dir must stay inside the working directory: {}",
+                    scan.dir
+                );
+            }
+        }
     }
 }

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -118,6 +118,32 @@ pub struct ProviderConfig {
     /// own docs, not guessed — same discipline as `base_url_env_var` above.
     /// See docs/specs/SPEC_PROVIDER_AWARE_STARTUP_INSTRUCTIONS_2026_08_24.md §2.
     pub startup_instructions_filename: Option<&'static str>,
+    /// Every path (relative to the agent's working directory) this provider
+    /// **reads** as project instructions — which is not the same question as
+    /// `startup_instructions_filename` above, and is usually a superset of it.
+    ///
+    /// That field names the one file AgentMux *writes*: the canonical target
+    /// it picked per provider. This one names what the provider will pick up
+    /// on its own, whether AgentMux put it there or the repository did.
+    /// Copilot is the clearest case — it reads
+    /// `.github/copilot-instructions.md`, `CLAUDE.md` and `GEMINI.md` besides
+    /// the `AGENTS.md` chosen as the write target — and pi reads
+    /// `.pi/SYSTEM.md` as well as the `.pi/APPEND_SYSTEM.md` written to.
+    ///
+    /// Phase 3 of `SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md`
+    /// resolves this set to answer "what will this agent actually read", which
+    /// the write target alone cannot (Codex, PR #3144). Nothing writes these
+    /// paths — tracking is read-only by design, and the ownership protection
+    /// in `SPEC_CLAUDE_MD_OWNERSHIP_PROTECTION_2026_08_22.md` still governs
+    /// the one file AgentMux does write.
+    ///
+    /// **Same evidence rule as the field above: listed only where verified
+    /// against the provider's own docs, never guessed.** Where the only
+    /// confirmed source is the write target, that is the whole list — an
+    /// under-complete list means Phase 3 shows the operator less than the
+    /// truth, which is recoverable; a guessed one means it shows them
+    /// something false, which is not.
+    pub native_instruction_sources: &'static [&'static str],
 }
 
 impl ProviderConfig {
@@ -218,6 +244,12 @@ static CLAUDE: ProviderConfig = ProviderConfig {
     base_url_env_var: Some("ANTHROPIC_BASE_URL"),
     supported_vendors: &["anthropic"],
     startup_instructions_filename: Some("CLAUDE.md"),
+    // Read set = the write target. Claude Code auto-discovers CLAUDE.md;
+    // `.claude/AGENTMUX_MEMORY.md` is reached only through an @import line
+    // AgentMux itself adds (SPEC_CLAUDE_MD_OWNERSHIP_PROTECTION_2026_08_22.md),
+    // so it is not a native source. Nested/parent CLAUDE.md discovery is
+    // real but out of scope here: this field is working-directory-relative.
+    native_instruction_sources: &["CLAUDE.md"],
 };
 
 static CODEX: ProviderConfig = ProviderConfig {
@@ -250,6 +282,9 @@ static CODEX: ProviderConfig = ProviderConfig {
     // "Codex's native project instruction discovery continues to load
     // user/repository AGENTS.md files normally."
     startup_instructions_filename: Some("AGENTS.md"),
+    // Read set = the write target, per the same citation above: Codex loads
+    // repository AGENTS.md natively.
+    native_instruction_sources: &["AGENTS.md"],
 };
 
 static GEMINI: ProviderConfig = ProviderConfig {
@@ -277,6 +312,9 @@ static GEMINI: ProviderConfig = ProviderConfig {
     // override, so GEMINI.md is the correct default-behavior target. See
     // docs/specs/SPEC_PROVIDER_AWARE_STARTUP_INSTRUCTIONS_2026_08_24.md §2.
     startup_instructions_filename: Some("GEMINI.md"),
+    // Read set = the write target. AGENTS.md is supported only behind an
+    // explicit contextFileName override, so it is not read by default.
+    native_instruction_sources: &["GEMINI.md"],
 };
 
 // Qwen Code — Alibaba's open-source coding agent, a fork of Gemini CLI.
@@ -321,6 +359,9 @@ static QWEN: ProviderConfig = ProviderConfig {
     // confirming it isn't yet). See
     // docs/specs/SPEC_PROVIDER_AWARE_STARTUP_INSTRUCTIONS_2026_08_24.md §2.
     startup_instructions_filename: Some("QWEN.md"),
+    // Read set = the write target, for the same reason as Gemini: AGENTS.md
+    // needs explicit config (QwenLM/qwen-code#2006, #504).
+    native_instruction_sources: &["QWEN.md"],
 };
 
 static KIMI: ProviderConfig = ProviderConfig {
@@ -362,6 +403,8 @@ static KIMI: ProviderConfig = ProviderConfig {
     // for a provider with None here. See
     // docs/specs/SPEC_PROVIDER_AWARE_STARTUP_INSTRUCTIONS_2026_08_24.md §2.
     startup_instructions_filename: None,
+    // No confirmed native file convention at all — hence the None above.
+    native_instruction_sources: &[],
 };
 
 static OPENCLAW: ProviderConfig = ProviderConfig {
@@ -406,6 +449,9 @@ static OPENCLAW: ProviderConfig = ProviderConfig {
     // best-effort root-level AGENTS.md, flagged as a known gap. See
     // docs/specs/SPEC_PROVIDER_AWARE_STARTUP_INSTRUCTIONS_2026_08_24.md §2, §6.
     startup_instructions_filename: Some("AGENTS.md"),
+    // Read set = the write target, with the same UNCONFIRMED-path caveat
+    // recorded above.
+    native_instruction_sources: &["AGENTS.md"],
 };
 
 static PI: ProviderConfig = ProviderConfig {
@@ -436,6 +482,11 @@ static PI: ProviderConfig = ProviderConfig {
     // is the correct target, not SYSTEM.md. See
     // docs/specs/SPEC_PROVIDER_AWARE_STARTUP_INSTRUCTIONS_2026_08_24.md §2.
     startup_instructions_filename: Some(".pi/APPEND_SYSTEM.md"),
+    // Two sources, per the citation above: pi reads .pi/SYSTEM.md (which
+    // REPLACES its default system prompt) as well as the APPEND_SYSTEM.md
+    // AgentMux writes. A repo-provided SYSTEM.md is exactly the kind of
+    // instruction file Phase 3 exists to surface.
+    native_instruction_sources: &[".pi/APPEND_SYSTEM.md", ".pi/SYSTEM.md"],
 };
 
 // Mux Code — AgentMux's first-party agentic coding CLI.
@@ -472,6 +523,8 @@ static MUX_CODE: ProviderConfig = ProviderConfig {
     // without modification [by ClaudeTranslator]" — a deliberate
     // compatibility choice by the same team that owns both, not a guess.
     startup_instructions_filename: Some("CLAUDE.md"),
+    // Read set = the write target; claude-compatible by design, per above.
+    native_instruction_sources: &["CLAUDE.md"],
 };
 
 // GitHub Copilot CLI — Microsoft's coding agent. Runs in ACP mode via
@@ -505,6 +558,16 @@ static COPILOT: ProviderConfig = ProviderConfig {
     // privileged default the way Gemini/Qwen do. See
     // docs/specs/SPEC_PROVIDER_AWARE_STARTUP_INSTRUCTIONS_2026_08_24.md §2.
     startup_instructions_filename: Some("AGENTS.md"),
+    // FOUR sources, all four named in the citation above: Copilot reads
+    // .github/copilot-instructions.md, CLAUDE.md and GEMINI.md alongside the
+    // AGENTS.md chosen as the write target. This is the case that proved the
+    // write target alone is the wrong question (Codex, PR #3144).
+    native_instruction_sources: &[
+        "AGENTS.md",
+        ".github/copilot-instructions.md",
+        "CLAUDE.md",
+        "GEMINI.md",
+    ],
 };
 
 // Antigravity (AGY) — Google's agentic coding CLI harness. Emits the same
@@ -542,6 +605,8 @@ static ANTIGRAVITY: ProviderConfig = ProviderConfig {
     // GEMINI.md context-file behavior. Flagged as a known gap. See
     // docs/specs/SPEC_PROVIDER_AWARE_STARTUP_INSTRUCTIONS_2026_08_24.md §2, §6.
     startup_instructions_filename: Some("GEMINI.md"),
+    // Read set = the write target.
+    native_instruction_sources: &["GEMINI.md"],
 };
 
 // ─── Static registry ─────────────────────────────────────────────────────────
@@ -1202,5 +1267,66 @@ mod tests {
             let err = prepare_provider_auth_dir(claude, "   ").unwrap_err();
             assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
         }
+    }
+}
+
+#[cfg(test)]
+mod native_instruction_sources_tests {
+    use super::*;
+
+    /// The write target must always be one of the paths the provider reads,
+    /// or AgentMux is writing a file nobody opens.
+    #[test]
+    fn every_write_target_is_also_a_read_source() {
+        for (id, provider) in REGISTRY.iter() {
+            let Some(target) = provider.startup_instructions_filename else {
+                assert!(
+                    provider.native_instruction_sources.is_empty(),
+                    "{id}: no write target, so no confirmed native source either"
+                );
+                continue;
+            };
+            assert!(
+                provider.native_instruction_sources.contains(&target),
+                "{id}: writes {target} but does not list it as a native source"
+            );
+        }
+    }
+
+    /// Duplicates would make a resolved instruction set report the same file
+    /// twice.
+    #[test]
+    fn no_provider_lists_a_source_twice() {
+        for (id, provider) in REGISTRY.iter() {
+            let mut seen = std::collections::HashSet::new();
+            for src in provider.native_instruction_sources {
+                assert!(seen.insert(*src), "{id}: {src} listed more than once");
+            }
+        }
+    }
+
+    /// The two cases that motivated the field. Guarding them by name keeps a
+    /// future registry edit from quietly collapsing the set back to the write
+    /// target and re-hiding what those providers read.
+    #[test]
+    fn the_multi_source_providers_keep_their_extra_sources() {
+        let copilot = get_provider("copilot").expect("copilot is registered");
+        for expected in [
+            "AGENTS.md",
+            ".github/copilot-instructions.md",
+            "CLAUDE.md",
+            "GEMINI.md",
+        ] {
+            assert!(
+                copilot.native_instruction_sources.contains(&expected),
+                "copilot must still read {expected}"
+            );
+        }
+
+        let pi = get_provider("pi").expect("pi is registered");
+        assert!(
+            pi.native_instruction_sources.contains(&".pi/SYSTEM.md"),
+            "pi reads .pi/SYSTEM.md as well as the file AgentMux writes"
+        );
     }
 }


### PR DESCRIPTION
The two prerequisites review identified for Phase 3 of `SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md`. **Additive only** — nothing reads either yet and no behaviour changes. Tracking: #3148.

**1. `native_instruction_sources` — what a provider *reads*.**

`startup_instructions_filename` names the single file AgentMux **writes**: the canonical target it picked per provider. That is a different question from what the provider picks up on its own, and usually a smaller answer:

| Provider | Writes | Also reads |
|---|---|---|
| Copilot | `AGENTS.md` | `.github/copilot-instructions.md`, `CLAUDE.md`, `GEMINI.md` |
| pi | `.pi/APPEND_SYSTEM.md` | `.pi/SYSTEM.md` (which *replaces* pi's default system prompt) |
| everyone else | their target | nothing further confirmed |

Resolving only the write target would leave most of a Copilot project's instructions invisible and unportable — precisely the round-trip guarantee §4 claims (Codex, #3144).

Populated per provider from **each entry's own already-cited evidence**, under the same rule as the field above it: listed only where the provider's docs confirm it, never guessed. Where the write target is the only confirmed source, that is the whole list. An under-complete list shows the operator less than the truth, which is recoverable; a guessed one shows them something false, which is not.

Three invariants tested, the useful one being **every write target is also a read source** — otherwise AgentMux is writing a file nobody opens. That check passes for all ten providers, which is also what validates the population.

**2. `is_agentmux_managed_instructions` — one ownership test that knows both markers.**

`CLAUDE.md` carries `CLAUDE_MD_MANAGED_MARKER`; every other startup-instructions file carries `STARTUP_INSTRUCTIONS_MANAGED_MARKER`, because the two writers grew separately. A check against the first alone reports every AgentMux-generated `AGENTS.md`, `GEMINI.md`, `QWEN.md` and `.pi/APPEND_SYSTEM.md` as `foreign` — inverting the single field Phase 3 most needs to be right, since it decides whether a file is ours to touch.

**The two writers deliberately keep their own narrower checks**, and that is documented at the helper rather than left to look like an oversight: each asks "did I write this, in my format, such that I may rewrite it". A `CLAUDE.md`-marked file is ours but is not the other writer's to rewrite. This helper answers the broader question, which is the one a read-only tracker asks.

**Verification**
```
cargo test -p agentmux-srv   → 3234 passed, 0 failed (5 new)
```

Next on #3148: the resolver itself, which uses both of these to answer "what will this agent actually read" — useful on its own, since the Armory can then show an operator their agent's real instruction set for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
