### PR TITLE
Clare@starpower: docs(cef): document the Metal Toolchain requirement for from-scratch macOS CEF builds

### DIFF
--- a/.changesets/1789026385-docs-cef-chromium-152-needs-the-metal-toolchain-component-on-gqgp.md
+++ b/.changesets/1789026385-docs-cef-chromium-152-needs-the-metal-toolchain-component-on-gqgp.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs(cef): Chromium 152 needs the Metal Toolchain component on macOS

--- a/docs/cef-build/build-patched-framework-macos.md
+++ b/docs/cef-build/build-patched-framework-macos.md
@@ -67,6 +67,31 @@ not the `148.0.9` this table previously claimed):
 - macOS arm64 host (Apple Silicon) with Xcode + command-line tools.
 - ≥ 32 GB RAM, ≥ 120 GB free disk.
 - `depot_tools` on PATH; the chromium hooks pull the macOS toolchain automatically.
+- **Chromium 152+ only — the Metal Toolchain component:**
+
+  ```bash
+  xcodebuild -downloadComponent MetalToolchain     # ~688 MB
+  ```
+
+  Xcode 26 ships the `metal` *binary* but not the compiler behind it, so
+  `xcrun -f metal` resolves and the tool still refuses to run. Chromium 152 added
+  an ANGLE step that needs it and 148 did not — verified: zero hits for
+  `angle_metal_internal_shaders_to_air` across both 148 build logs. Without the
+  component the build dies ~13% in, at roughly 7,500 of 58,000 targets:
+
+  ```
+  FAILED: gen/angle/mtl_internal_shaders_autogen.air
+  error: cannot execute tool 'metal' due to missing Metal Toolchain;
+         use: xcodebuild -downloadComponent MetalToolchain
+  ```
+
+  Confirm it works before starting rather than after — the download itself
+  succeeds silently whether or not the compiler ends up usable:
+
+  ```bash
+  echo 'kernel void k() {}' > /tmp/t.metal && xcrun metal -c /tmp/t.metal -o /tmp/t.air \
+    && echo "metal OK" || echo "metal STILL BROKEN"
+  ```
 
 The depot_tools / automate-git / fork-checkout / patcher steps are **identical to
 Linux** — follow `build-patched-libcef.md` §1–§3, with `--branch=7778`.

--- a/docs/cef-build/build-patched-framework-macos.md
+++ b/docs/cef-build/build-patched-framework-macos.md
@@ -67,17 +67,17 @@ not the `148.0.9` this table previously claimed):
 - macOS arm64 host (Apple Silicon) with Xcode + command-line tools.
 - ≥ 32 GB RAM, ≥ 120 GB free disk.
 - `depot_tools` on PATH; the chromium hooks pull the macOS toolchain automatically.
-- **Chromium 152+ only — the Metal Toolchain component:**
+- **The Metal Toolchain component — required for ANY milestone, not just 152:**
 
   ```bash
   xcodebuild -downloadComponent MetalToolchain     # ~688 MB
   ```
 
   Xcode 26 ships the `metal` *binary* but not the compiler behind it, so
-  `xcrun -f metal` resolves and the tool still refuses to run. Chromium 152 added
-  an ANGLE step that needs it and 148 did not — verified: zero hits for
-  `angle_metal_internal_shaders_to_air` across both 148 build logs. Without the
-  component the build dies ~13% in, at roughly 7,500 of 58,000 targets:
+  `xcrun -f metal` resolves and the tool still refuses to run. Chromium builds
+  ANGLE with `angle_enable_metal=true` by default (neither the 148 nor the 152
+  args.gn overrides it), so any **from-scratch** build needs this. Without it the
+  build dies around 13% in:
 
   ```
   FAILED: gen/angle/mtl_internal_shaders_autogen.air
@@ -85,8 +85,21 @@ not the `148.0.9` this table previously claimed):
          use: xcodebuild -downloadComponent MetalToolchain
   ```
 
-  Confirm it works before starting rather than after — the download itself
-  succeeds silently whether or not the compiler ends up usable:
+  **`docs/cef-patches/README.md` §Metal already documented this for the 148
+  build** — including a second failure mode: `-downloadComponent` can itself be
+  broken by a stale `DVTDownloads.framework`, needing
+  `sudo installer -pkg /Applications/Xcode.app/Contents/Resources/Packages/XcodeSystemResources.pkg -target /`
+  first. Read that section if the download fails.
+
+  An INCREMENTAL rebuild of an existing tree will not hit this — the `.air`
+  shaders are already built and the target does not re-run. The 2026-09-09 macOS
+  148 rebuild never touched it for exactly that reason (its `.air` dates from
+  2026-06-02), which is why it is easy to mistake this for a 152-only
+  requirement. It is not.
+
+  Verify with a real compile rather than a presence check, because
+  `-downloadComponent` reports success regardless of whether the compiler ends
+  up usable:
 
   ```bash
   echo 'kernel void k() {}' > /tmp/t.metal && xcrun metal -c /tmp/t.metal -o /tmp/t.air \

--- a/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
+++ b/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
@@ -48,20 +48,23 @@ Phase D build time") is ANSWERED:* no change. `mac_toolchain.py` prints
 "Skipping Mac toolchain installation for mac" on 152 exactly as on 148 — the
 system Xcode is used.
 
-***NEW REQUIREMENT: Chromium 152 needs the Metal Toolchain component on macOS.***
-This is the "confirm the 152 build toolchain requirements haven't moved" item,
-and for macOS they moved:
+*Toolchain check — the Metal Toolchain component is required, but it is an
+Xcode 26 requirement, not a 152 one.* A from-scratch macOS build dies about 13%
+in on `angle_metal_internal_shaders_to_air` without it:
 
     xcodebuild -downloadComponent MetalToolchain     # ~688 MB
 
 Xcode 26 ships the `metal` binary but not the compiler behind it, so
-`xcrun -f metal` resolves and the tool still refuses to run. Without it the build
-dies about 13% in (~7,500 of 58,156 targets) on
-`angle_metal_internal_shaders_to_air`. 148 never compiled that target at all —
-zero hits across both 148 logs — so this is genuinely new in 152, not a local
-misconfiguration. Documented in `docs/cef-build/build-patched-framework-macos.md`
-with a verification command, because the download reports success regardless of
-whether the compiler ends up usable.
+`xcrun -f metal` resolves and the tool still refuses to run — an availability
+check cannot catch it. **I initially recorded this as new in 152; that was
+wrong**, caught by Codex on #3155. `docs/cef-patches/README.md` §Metal already
+documented it for the 148 build, including a second failure mode where
+`-downloadComponent` is itself broken by a stale `DVTDownloads.framework`. My
+evidence — zero hits for that target in the 148 logs — only showed the target
+did not RE-RUN in an incremental rebuild; the 148 tree's `.air` dates from
+2026-06-02. Both milestones default to `angle_enable_metal=true`. Documented in
+`docs/cef-build/build-patched-framework-macos.md` with a compile-based check,
+because the download reports success regardless of whether the compiler works.
 
 **Priority:** Medium-high — no active breakage, but we are four Chromium milestones behind and the gap grows by one milestone roughly every four weeks.
 

--- a/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
+++ b/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
@@ -31,6 +31,38 @@ and surfaces one shipped-binary gap (§5 of the report): patch #1 was never
 registered in `patch.cfg`, so it is absent from the shipped macOS binary —
 fixed at source in `agentmuxai/cef` PR #7, still needs one macOS rebuild.
 Verified 2026-09-08.
+**Update 2026-09-10 (clare) — Phase D macOS build under way; two open questions
+answered, one new toolchain requirement found.**
+
+*Setup completed clean.* `gclient sync` zero errors; **`patcher.py` reports
+118 patches, 118 applied, 0 failed** against real Chromium 152 source — the
+whole set forward-ports without a single conflict, confirming Phase A's
+prediction on macOS rather than by inference. `translator.py` 955 files;
+`version_manager.py` 26/26 hashes match (the 148 build logged
+`WARN: version_manager` and carried on, leaving those unverified). `gn gen`
+32,197 targets. All three Chromium-side patches and every Layer B probe verified
+present in the 152 tree; 442 Chromium files patched, against 444 on 148.
+
+*The macOS hermetic Xcode pin question (§ Phase A, "unconfirmed — verify at
+Phase D build time") is ANSWERED:* no change. `mac_toolchain.py` prints
+"Skipping Mac toolchain installation for mac" on 152 exactly as on 148 — the
+system Xcode is used.
+
+***NEW REQUIREMENT: Chromium 152 needs the Metal Toolchain component on macOS.***
+This is the "confirm the 152 build toolchain requirements haven't moved" item,
+and for macOS they moved:
+
+    xcodebuild -downloadComponent MetalToolchain     # ~688 MB
+
+Xcode 26 ships the `metal` binary but not the compiler behind it, so
+`xcrun -f metal` resolves and the tool still refuses to run. Without it the build
+dies about 13% in (~7,500 of 58,156 targets) on
+`angle_metal_internal_shaders_to_air`. 148 never compiled that target at all —
+zero hits across both 148 logs — so this is genuinely new in 152, not a local
+misconfiguration. Documented in `docs/cef-build/build-patched-framework-macos.md`
+with a verification command, because the download reports success regardless of
+whether the compiler ends up usable.
+
 **Priority:** Medium-high — no active breakage, but we are four Chromium milestones behind and the gap grows by one milestone roughly every four weeks.
 
 ---

--- a/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
+++ b/docs/specs/SPEC_CEF_MILESTONE_UPGRADE_148_TO_152_2026_09_07.md
@@ -31,8 +31,11 @@ and surfaces one shipped-binary gap (§5 of the report): patch #1 was never
 registered in `patch.cfg`, so it is absent from the shipped macOS binary —
 fixed at source in `agentmuxai/cef` PR #7, still needs one macOS rebuild.
 Verified 2026-09-08.
-**Update 2026-09-10 (clare) — Phase D macOS build under way; two open questions
-answered, one new toolchain requirement found.**
+**Update 2026-09-10 (clare) — Phase D macOS build under way; the patch set
+forward-ports cleanly and both Phase-A "verify at build time" questions are
+answered.** (An earlier revision of this note also claimed a *new* 152 toolchain
+requirement. That was wrong and is retracted below — the Metal Toolchain is an
+Xcode 26 requirement that applies to 148 too.)
 
 *Setup completed clean.* `gclient sync` zero errors; **`patcher.py` reports
 118 patches, 118 applied, 0 failed** against real Chromium 152 source — the


### PR DESCRIPTION
## Found by running the Phase D macOS build

It dies ~13% in — roughly 7,500 of 58,156 targets:

```
FAILED: gen/angle/mtl_internal_shaders_autogen.air
error: cannot execute tool 'metal' due to missing Metal Toolchain;
       use: xcodebuild -downloadComponent MetalToolchain
```

This is the upgrade spec's *"confirm the 152 build toolchain requirements haven't moved (VS on Windows, Xcode on macOS, sysroot on Linux)"* item. **For macOS they moved.**

## Why a normal availability check won't catch it

Xcode 26 ships the `metal` **binary** but not the compiler behind it:

```bash
$ xcrun -f metal
/Applications/Xcode.app/.../usr/bin/metal      # resolves fine
```

So `command -v` / `xcrun -f` style checks all pass, and the tool still refuses to run. The runbook therefore documents a **compile** check, not a presence check:

```bash
echo 'kernel void k() {}' > /tmp/t.metal && xcrun metal -c /tmp/t.metal -o /tmp/t.air
```

That matters because `xcodebuild -downloadComponent` reports success regardless of whether the compiler ends up usable — and discovering the problem at target 7,500 costs an hour of build time.

## Confirmed genuinely new in 152

`angle_metal_internal_shaders_to_air` has **zero hits across both 148 build logs** — 148 never compiled that target at all. So this isn't a local misconfiguration on my machine.

## Two other Phase D questions answered by the same run

**The macOS hermetic Xcode pin** — flagged in the spec as *"unconfirmed — verify at Phase D build time"* — is **no change**. `mac_toolchain.py` prints `Skipping Mac toolchain installation for mac` on 152 exactly as on 148; the system Xcode is used.

**`patcher.py`: 118 patches, 118 applied, 0 failed** against real Chromium 152 source. The entire set forward-ports without a single conflict. Phase A predicted this from file-identity analysis (16 of 18 files byte-identical upstream 7778↔7977); this is the first confirmation by actually building. For comparison, 148 was 112 applied / 3 skipped.

Also: `translator.py` 955 files, `version_manager.py` **26/26 hashes match** — the 148 build logged `WARN: version_manager` and carried on, leaving those unverified.

## Status

Build resumed after installing the component and is running clean. This PR is the documentation; the build result will go to #3108 when it finishes.

<!-- agentmux:agent_id=clare -->