### PR TITLE
fix(term): stop the terminal pane header/tab-strip flash on tab switch

### DIFF
--- a/.changesets/1789029661-fix-term-stop-the-terminal-pane-header-tab-strip-flash-on-sh-23ty.md
+++ b/.changesets/1789029661-fix-term-stop-the-terminal-pane-header-tab-strip-flash-on-sh-23ty.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(term): stop the terminal pane header/tab-strip flash on shell-tab switch

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -803,7 +803,18 @@ function BlockFrame_Default_Component(props: BlockFrameProps): JSX.Element {
     const magnifiedBlockBlur = () => magnifiedBlockBlurAtom();
     const magnifiedBlockOpacityAtom = getSettingsKeyAtom("window:magnifiedblockopacity");
     const magnifiedBlockOpacity = () => magnifiedBlockOpacityAtom();
-    let connBtnRef: { current: HTMLDivElement | null } = { current: null };
+    // Shared per-block holder rather than a plain local: when a pane's
+    // header is HOISTED out of this component (pane-leaf-chrome.tsx —
+    // `nodeModel.paneChromeHoisted`), the header, and therefore the
+    // connection button whose element this captures, renders in a different
+    // component tree, but the ChangeConnectionBlockModal it anchors stays
+    // HERE. A local ref would then never be populated and the modal would
+    // lose its anchor. Keyed on blockId through the block-atom cache, so
+    // both sides resolve the same object and it's cleaned up with the block.
+    const connBtnRef = useBlockAtom(nodeModel.blockId, "connBtnRef", () => {
+        const holder: { current: HTMLDivElement | null } = { current: null };
+        return () => holder;
+    })();
     const noHeader = util.useAtomValueSafe(props.viewModel?.noHeader);
     // Captured outer-frame ref for PaneSizeBadge. Live as long as the
     // frame is mounted; cleared on unmount via the callback ref.

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -328,11 +328,20 @@ function BlockFrame_Header(
     // live data with no leak (frontend/app/store/wos.ts).
     const blockData = createMemo(() => WOS.getWaveObjectAtom<Block>(WOS.makeORef("block", props.blockId()))());
     const showBlockIds = getSettingsKeyAtom("blockheader:showblockids")();
-    const preIconButton = util.useAtomValueSafe(props.viewModel?.preIconButton);
-    const manageConnection = util.useAtomValueSafe(props.viewModel?.manageConnection);
+    // Memos, not bare top-level reads (ReAgent P1 on PR #3157). These read
+    // through `props.viewModel`, which for a HOISTED header
+    // (SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md) is the
+    // currently-active stack member's ViewModel and therefore CHANGES on
+    // every tab switch, while this component stays mounted. Read once at
+    // the top level they'd snapshot whichever member was active at first
+    // mount and never update. That was invisible while only AgentViewModel
+    // hoisted (it never sets `manageConnection`), but TermViewModel sets it
+    // to `!isCmdController()`, which genuinely differs between a
+    // cmd-controller terminal and an ordinary one in the SAME stack — so
+    // the connection button would show or hide based on the wrong tab.
+    const preIconButton = createMemo(() => util.useAtomValueSafe(props.viewModel?.preIconButton));
+    const manageConnection = createMemo(() => util.useAtomValueSafe(props.viewModel?.manageConnection));
     const dragHandleRef = props.preview ? null : props.nodeModel.dragHandleRef;
-    const connName = blockData()?.meta?.connection;
-    const connStatus = util.useAtomValueSafe(getConnStatusAtom(connName));
 
     // Track previous magnified state for one-time activity report
     let prevMagnifiedState = props.nodeModel.isMagnified();
@@ -450,9 +459,9 @@ function BlockFrame_Header(
         return getViewIconElem(viewIconUnion(), blockData());
     });
 
-    const preIconButtonElem: JSX.Element = preIconButton
-        ? <IconButton decl={preIconButton} className="block-frame-preicon-button" />
-        : null;
+    const preIconButtonElem = createMemo<JSX.Element>(() =>
+        preIconButton() ? <IconButton decl={preIconButton()} className="block-frame-preicon-button" /> : null,
+    );
 
     const headerTextElems = createMemo(() => {
         const elems: JSX.Element[] = [];
@@ -506,7 +515,7 @@ function BlockFrame_Header(
             onDblClick={() => props.nodeModel.toggleMagnify()}
             style={headerStyle()}
         >
-            {preIconButtonElem}
+            {preIconButtonElem()}
             <div class="block-frame-default-header-iconview">
                 {viewIconElem()}
                 <Show
@@ -519,7 +528,7 @@ function BlockFrame_Header(
                     <div class="block-frame-blockid">[{props.blockId().substring(0, 8)}]</div>
                 </Show>
             </div>
-            <Show when={manageConnection}>
+            <Show when={manageConnection()}>
                 <ConnectionButton
                     ref={props.connBtnRef}
                     connection={blockData()?.meta?.connection}

--- a/frontend/app/block/blockutil.tsx
+++ b/frontend/app/block/blockutil.tsx
@@ -6,7 +6,7 @@ import { getConnStatusAtom } from "@/app/store/global";
 import * as util from "@/util/util";
 import clsx from "clsx";
 import type { JSX } from "solid-js";
-import { createMemo, createSignal, Show } from "solid-js";
+import { createEffect, createMemo, createSignal, Show } from "solid-js";
 import dotsUrl from "../asset/dots-anim-4.svg?url";
 
 const colorRegex = /^((#[0-9a-f]{6,8})|([a-z]+))$/;
@@ -143,10 +143,29 @@ export function ConnectionButton(props: ConnectionButtonProps): JSX.Element {
         return cs?.status == "error" || !cs?.connected;
     };
 
+    // Codex P1 on PR #3157: a plain callback ref fires ONCE, when the
+    // element is created. That was fine while `props.ref` was a stable
+    // per-mount object, but a hoisted pane header
+    // (SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md) stays mounted
+    // across a tab switch and re-points `props.ref` at the newly-active
+    // block's holder — this `<Show>` stays true the whole time when both
+    // tabs have connections, so the element is never recreated and the new
+    // holder would keep `current: null`. TypeAheadModal then calls
+    // `anchorRef.current.getBoundingClientRect()` unconditionally and the
+    // connection selector THROWS instead of opening. An effect re-runs
+    // whenever `props.ref` changes identity, so each holder that becomes
+    // current gets populated with the live element.
+    const [btnEl, setBtnEl] = createSignal<HTMLDivElement | null>(null);
+    createEffect(() => {
+        const holder = props.ref;
+        const el = btnEl();
+        if (holder) holder.current = el;
+    });
+
     return (
         <Show when={!isLocal()}>
             <div
-                ref={(el) => { if (props.ref) props.ref.current = el; }}
+                ref={(el) => setBtnEl(el)}
                 class={clsx("connection-button")}
                 onClick={clickHandler}
                 title={getTitleText()}

--- a/frontend/app/tab/pane-leaf-chrome.test.tsx
+++ b/frontend/app/tab/pane-leaf-chrome.test.tsx
@@ -159,8 +159,10 @@ afterEach(() => {
 });
 
 describe("PaneLeafChrome — passthrough (not hoisted)", () => {
-    it("renders the block directly, with no chrome wrapper, for a non-agent view type", async () => {
-        setBlockView("b1", "term");
+    it("renders the block directly, with no chrome wrapper, for a view type that doesn't hoist its own chrome", async () => {
+        // "editor", not "term" — term hoists too now (it has its own in-pane
+        // tab strip). See HOISTS_OWN_CHROME in pane-leaf-chrome.tsx.
+        setBlockView("b1", "editor");
         const nodeModel = makeFakeNodeModel({
             activeViewModel: () => fakeChromeViewModel("chrome-root"),
         });
@@ -203,6 +205,23 @@ describe("PaneLeafChrome — hoisted", () => {
         expect(screen.getByTestId("chrome-root")).toBeInTheDocument();
         expect(screen.getByTestId("chrome-header")).toBeInTheDocument();
         // Content still renders, now NESTED inside chrome.
+        expect(screen.getByTestId("chrome-root").contains(screen.getByTestId("block-b1"))).toBe(true);
+    });
+
+    // Terminal panes hoist too, as of the term-pane half of this work —
+    // they have their own in-pane tab strip with the same flash problem.
+    // Guards HOISTS_OWN_CHROME (pane-leaf-chrome.tsx) against silently
+    // losing an entry.
+    it("wraps the block in renderPaneChrome for a terminal pane too, not just agent", async () => {
+        setBlockView("b1", "term");
+        const nodeModel = makeFakeNodeModel({
+            activeViewModel: () => fakeChromeViewModel("chrome-root"),
+        });
+        const PaneLeafChrome = await loadPaneLeafChrome();
+
+        render(() => <PaneLeafChrome nodeModel={nodeModel} />);
+
+        expect(screen.getByTestId("chrome-root")).toBeInTheDocument();
         expect(screen.getByTestId("chrome-root").contains(screen.getByTestId("block-b1"))).toBe(true);
     });
 

--- a/frontend/app/tab/pane-leaf-chrome.tsx
+++ b/frontend/app/tab/pane-leaf-chrome.tsx
@@ -33,6 +33,19 @@ import { createMemo, Show, type JSX } from "solid-js";
  * the bare `content` below — zero behavior change for those, matching what
  * `<Block>` alone already did.
  */
+/**
+ * EFFECTIVE view types (post-`resolveEffectiveViewType`) whose `ViewModel`
+ * implements `renderPaneChrome` — i.e. the ones that own an in-pane tab
+ * strip and therefore need their chrome hoisted out of the per-block
+ * remount boundary. Everything else takes the passthrough branch below,
+ * unchanged from what a plain `<Block>` always did.
+ *
+ * A view type listed here MUST also set `noHeader` off
+ * `nodeModel.paneChromeHoisted` (see AgentViewModel/TermViewModel), or its
+ * inline BlockFrame header and its hoisted one will both render.
+ */
+const HOISTS_OWN_CHROME = new Set(["agent", "term"]);
+
 export function PaneLeafChrome(props: { nodeModel: NodeModel }): JSX.Element {
     const nodeModel = props.nodeModel;
     const activeBlockId = () => nodeModel.activeBlockId?.() ?? nodeModel.blockId;
@@ -66,7 +79,7 @@ export function PaneLeafChrome(props: { nodeModel: NodeModel }): JSX.Element {
     // flash this file exists to prevent.
     let latchedHoisted = false;
     const hoisted = createMemo(() => {
-        if (!latchedHoisted && effectiveViewType() === "agent") {
+        if (!latchedHoisted && HOISTS_OWN_CHROME.has(effectiveViewType())) {
             latchedHoisted = true;
         }
         return latchedHoisted;

--- a/frontend/app/view/term/term.scss
+++ b/frontend/app/view/term/term.scss
@@ -312,10 +312,13 @@
         flex-shrink: 0;
 
         // Kept from the original rule: the strip stays positioned so it
-        // paints above `termBg()`'s `z-0` full-pane background-image layer
-        // (which now sits inside `.term-pane-stack-content`, below this
-        // row, but the stacking intent is unchanged). Below the `z-index:
-        // 10` overlays (search, links) by design.
+        // paints above `termBg()`'s `z-0` background-image layer. That
+        // layer is a SIBLING of this row — both are direct children of
+        // `.term-pane-stack-body`, which spans the strip and the terminal
+        // (TermPaneChrome, term.tsx) — so it spans this row too and the
+        // backdrop-filter below has the image to blur, exactly as when
+        // both lived inside `.view-term`. Below the `z-index: 10`
+        // overlays (search, links) by design.
         position: relative;
         z-index: 1;
 

--- a/frontend/app/view/term/term.scss
+++ b/frontend/app/view/term/term.scss
@@ -1,6 +1,8 @@
 // Copyright 2024-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
+@use "../../mixins.scss" as mixins;
+
 .connection-btn {
     min-height: 0;
     overflow: hidden;
@@ -87,28 +89,6 @@
     // `2px` matches the agent pane deliberately — `8px` was tried there and
     // rejected live because letterforms dissolved. If it changes, change
     // both.
-    > .pane-tab-strip {
-        // Was shrink-to-fit (`align-self: flex-start` in the shared
-        // PaneTabStrip.scss). The band has to span the pane for the glass
-        // to read as a panel rather than a lozenge around [tabs][+].
-        // `animateWidth` was removed from term.tsx's <PaneTabStrip> in the
-        // same change: it animates a box width that no longer varies.
-        width: 100%;
-
-        // Sits above the `z-0` full-pane background-image layer that
-        // term.tsx renders for `termBg()`. That layer spans `inset-0` —
-        // including this row — and is positioned, so without an explicit
-        // stacking position here it paints OVER this non-positioned flex
-        // child and hides the tabs whenever a terminal background image is
-        // set. Below the `z-index: 10` overlays (search, links) by design.
-        position: relative;
-        z-index: 1;
-
-        background: var(--tab-strip-bg);
-        backdrop-filter: blur(2px);
-        -webkit-backdrop-filter: blur(2px);
-    }
-
     .term-connectelem {
         flex-grow: 1;
         min-height: 0;
@@ -272,4 +252,72 @@
     /* Pure white on the amber warning badge — intentional contrast. */
     color: #fff; /* stylelint-disable-line color-no-hex */
     opacity: 0.85;
+}
+
+// Hoisted terminal chrome (TermPaneChrome, term.tsx) —
+// SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md. The pane header and
+// the in-pane tab strip now live OUTSIDE the switch-scoped `<Block>`
+// (`pane-leaf-chrome.tsx`) so neither is torn down when the active shell tab
+// changes; only the terminal itself remounts. This wrapper is what the tile
+// layout positions for such a pane, so it has to fill that slot the way
+// `.block` used to.
+.term-pane-stack {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+    position: relative;
+
+    // TermPaneChrome renders BlockFrame_Header as a direct child here —
+    // the same component, but OUTSIDE the
+    // `.block.block-frame-default .block-frame-default-inner` ancestor
+    // chain block.scss's own `.block-frame-default-header` rule needs to
+    // match. Without this it renders as unstyled stacked divs (the exact
+    // regression the agent pane hit in #3151). Applies the identical
+    // ruleset via the shared mixin rather than duplicating it.
+    > .block-frame-default-header {
+        @include mixins.block-frame-default-header-layout();
+        flex-shrink: 0; // a normal-flow row in this flex column now
+    }
+
+    // Relocated verbatim from `.view-term > .pane-tab-strip` (this file,
+    // before the hoist) — that selector matched the strip as a direct child
+    // of `.view-term`, which it no longer is. Same declarations, new parent.
+    > .pane-tab-strip {
+        // Was shrink-to-fit (`align-self: flex-start` in the shared
+        // PaneTabStrip.scss). The band has to span the pane for the glass
+        // to read as a panel rather than a lozenge around [tabs][+].
+        // `animateWidth` was removed from term.tsx's <PaneTabStrip> in the
+        // same change: it animates a box width that no longer varies.
+        width: 100%;
+
+        // A normal-flow row here, so pin it against the flex column rather
+        // than letting it stretch or compress.
+        flex-shrink: 0;
+
+        // Kept from the original rule: the strip stays positioned so it
+        // paints above `termBg()`'s `z-0` full-pane background-image layer
+        // (which now sits inside `.term-pane-stack-content`, below this
+        // row, but the stacking intent is unchanged). Below the `z-index:
+        // 10` overlays (search, links) by design.
+        position: relative;
+        z-index: 1;
+
+        background: var(--tab-strip-bg);
+        backdrop-filter: blur(2px);
+        -webkit-backdrop-filter: blur(2px);
+    }
+
+    // The switch-scoped `<Block>` (and therefore `.view-term`) lives here,
+    // filling whatever the header and strip leave. `min-height: 0` so the
+    // terminal can actually shrink inside the flex column instead of
+    // forcing the pane to overflow.
+    > .term-pane-stack-content {
+        flex: 1 1 auto;
+        min-height: 0;
+        position: relative;
+        display: flex;
+    }
 }

--- a/frontend/app/view/term/term.scss
+++ b/frontend/app/view/term/term.scss
@@ -282,10 +282,24 @@
         flex-shrink: 0; // a normal-flow row in this flex column now
     }
 
+    // Spans the strip AND the terminal — the positioned ancestor for the
+    // background-image layer and the agent-runtime badge that TermPaneChrome
+    // renders (both used to sit inside `.view-term` back when that contained
+    // the strip). Deliberately does NOT include the header row: the
+    // background image never painted behind the pane header before the
+    // hoist either.
+    > .term-pane-stack-body {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        flex: 1 1 auto;
+        min-height: 0;
+    }
+
     // Relocated verbatim from `.view-term > .pane-tab-strip` (this file,
     // before the hoist) — that selector matched the strip as a direct child
     // of `.view-term`, which it no longer is. Same declarations, new parent.
-    > .pane-tab-strip {
+    > .term-pane-stack-body > .pane-tab-strip {
         // Was shrink-to-fit (`align-self: flex-start` in the shared
         // PaneTabStrip.scss). The band has to span the pane for the glass
         // to read as a panel rather than a lozenge around [tabs][+].
@@ -314,7 +328,7 @@
     // filling whatever the header and strip leave. `min-height: 0` so the
     // terminal can actually shrink inside the flex column instead of
     // forcing the pane to overflow.
-    > .term-pane-stack-content {
+    > .term-pane-stack-body > .term-pane-stack-content {
         flex: 1 1 auto;
         min-height: 0;
         position: relative;

--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Search, useSearch } from "@/app/element/search";
-import { atoms, getOverrideConfigAtom, getSettingsKeyAtom, getSettingsPrefixAtom, pushNotification, WOS } from "@/store/global";
+import { atoms, getOverrideConfigAtom, getSettingsKeyAtom, getSettingsPrefixAtom, pushNotification, useBlockAtom, WOS } from "@/store/global";
 import { ObjectService } from "@/store/services";
 import { backendStatusAtom } from "@/store/backendStatus";
 import { fireAndForget } from "@/util/util";
@@ -14,7 +14,7 @@ import type { JSX } from "solid-js";
 import { TermStickers } from "./termsticker";
 import { TermThemeUpdater } from "./termtheme";
 import { computeTheme } from "./termutil";
-import { setTerminalViewComponent, TermViewModel } from "./termViewModel";
+import { setTermPaneChromeComponent, setTerminalViewComponent, TermViewModel } from "./termViewModel";
 import { TermWrap } from "./termwrap";
 import "./xterm.css";
 import { DragOverlay } from "@/app/element/dragoverlay";
@@ -24,8 +24,18 @@ import { detectHost, invokeCommand } from "@/app/platform/ipc";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { baseName, consumeDragPaths, copyFilesToDir } from "@/util/dnd";
-import { closeBlockInStack, getLayoutModelForStaticTab, pushBlockOntoStack, setActiveBlockInStack } from "@/layout/index";
-import { holdLeafRevealGate, scheduleLeafRevealLift } from "@/app/store/tab-reveal";
+import {
+    closeBlockInStack,
+    getLayoutModelForStaticTab,
+    pushBlockOntoStack,
+    setActiveBlockInStack,
+    type NodeModel,
+} from "@/layout/index";
+import { findNode } from "@/layout/lib/layoutNode";
+import { BlockFrame_Header } from "@/app/block/blockframe";
+import { ErrorBoundary } from "@/element/errorboundary";
+import { createSignalAtom } from "@/util/util";
+import type { SignalAtom } from "@/util/util";
 
 // TermResyncHandler: watches connection status changes and resyncs the terminal controller.
 // Also resyncs when the backend restarts — local terminals have no connStatus change on restart,
@@ -74,155 +84,6 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
     let connectElemRef!: HTMLDivElement;
 
     const [blockData] = WOS.useWaveObjectValue<Block>(WOS.makeORef("block", blockId));
-
-    // In-pane tabs — Phase 5 of SPEC_PANE_TAB_STRIP_AGENT_TERMINAL_2026_07_20.md.
-    // Unlike the agent pane's fork strip (Phase 3/4, which derives its tab
-    // list from a cross-pane definition/lineage lookup — a fork can exist as
-    // its own separate top-level pane before ever joining a stack), a
-    // terminal "tab" has no equivalent prior existence: it's only ever
-    // created fresh, directly into THIS pane's own blockStack (there is no
-    // multi-session concept for shell panes anywhere else in the app — one
-    // block = one PTY = one ShellController, always). So the tab list here
-    // is simply "whatever's in this pane's own blockStack right now" — no
-    // cross-pane derivation needed.
-    const layoutModel = getLayoutModelForStaticTab();
-    interface TermTab { blockId: string; label: string }
-    // Rename overrides, keyed by blockId — set synchronously by
-    // handleTermTabRename below so a just-renamed tab (including a dormant,
-    // non-active one whose block meta isn't reactively tracked here) reflects
-    // its new label immediately, without waiting on a cross-pane event.
-    // SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md §3.3.
-    const [titleOverrides, setTitleOverrides] = createSignal<Record<string, string>>({});
-    const termTabs = createMemo<TermTab[]>(() => {
-        // Reactive dependency: re-derive whenever ANY layout mutation
-        // happens (matches the pattern getNodeModel's own isFocused/
-        // isMagnified memos already use in layoutNodeModels.ts).
-        layoutModel.localTreeStateAtom();
-        const overrides = titleOverrides();
-        const node = layoutModel.getNodeByBlockId(blockId);
-        // No stack yet (the common default case — a single, never-forked
-        // terminal) → synthesize this pane's own one-tab list rather than
-        // returning empty. An empty list would render the strip as a bare
-        // "+" with no visible tab for the terminal that's actually open —
-        // confusing; every other pane type's strip always shows at least
-        // its own active entry (see agent-view.tsx's switchableForks).
-        const stack = node?.data?.blockStack?.length ? node.data.blockStack : [blockId];
-        // Position-based labels ("Terminal 1", "Terminal 2", …) as the
-        // fallback for an unnamed session — matches common terminal-app
-        // convention. A user-set title (double-click to rename, persisted on
-        // the tab's own block as meta["pane-title"] — the same field
-        // titlebar.tsx's pane title editor uses) wins when present, read via
-        // a non-reactive lookup since a dormant tab's block isn't mounted
-        // (no live TermViewModel — see layoutStack.ts's header comment on
-        // why switching is a remount, not a reactive update); `overrides`
-        // above is what makes a just-performed rename show up immediately.
-        return stack.map((id, i) => {
-            const persistedTitle = WOS.getObjectValue<Block>(WOS.makeORef("block", id))?.meta?.["pane-title"] as
-                | string
-                | undefined;
-            return { blockId: id, label: overrides[id] ?? persistedTitle ?? `Terminal ${i + 1}` };
-        });
-    });
-    // Only render tab pills once there's something to switch BETWEEN — a
-    // lone terminal shows just the "+" (no pill for itself). The moment a
-    // 2nd tab exists, both (including the first) appear as tabs.
-    const visibleTermTabs = createMemo(() => (termTabs().length > 1 ? termTabs() : []));
-    const activeBlockId = createMemo(() => {
-        layoutModel.localTreeStateAtom();
-        return layoutModel.getNodeByBlockId(blockId)?.data?.activeBlockId ?? blockId;
-    });
-    const handleTermTabSwitch = (targetBlockId: string) => {
-        if (targetBlockId === activeBlockId()) return;
-        const node = layoutModel.getNodeByBlockId(blockId);
-        if (!node) return;
-        // Switching to an already-open shell-tab pill forces the same
-        // remount as pushing a new one onto the stack (layoutStack.ts's
-        // setActiveBlockInStack evicts the NodeModel). Codex's review of
-        // PR #2761 caught the agent-pane analog of this same gap.
-        // SPEC_PANE_BLOCK_STACK_MOUNT_FLICKER_2026_08_22.md.
-        const gen = holdLeafRevealGate(node.id);
-        setActiveBlockInStack(layoutModel, node.id, targetBlockId);
-        scheduleLeafRevealLift(node.id, gen);
-    };
-    // Gated the same as handleTermTabSwitch above, and ONLY when
-    // targetBlockId is the stack's own active member (reagent's follow-up
-    // review of PR #2761: gating unconditionally hides the pane's real,
-    // unchanging content during the close+settle window when closing a
-    // background tab, since gatingNodeIds() hides the whole node
-    // regardless of whether a remount is actually about to happen) —
-    // closing the ACTIVE member of a multi-member stack reassigns
-    // activeBlockId and evicts the NodeModel, the same forced-remount
-    // pattern as switching; closing a background member changes nothing
-    // visible. SPEC_PANE_BLOCK_STACK_MOUNT_FLICKER_2026_08_22.md.
-    const handleTermTabClose = (targetBlockId: string) => {
-        const node = layoutModel.getNodeByBlockId(blockId);
-        if (!node) return;
-        if (node.data?.activeBlockId !== targetBlockId) {
-            void closeBlockInStack(layoutModel, node.id, targetBlockId);
-            return;
-        }
-        const gen = holdLeafRevealGate(node.id);
-        void closeBlockInStack(layoutModel, node.id, targetBlockId).finally(() => {
-            scheduleLeafRevealLift(node.id, gen);
-        });
-    };
-    const handleTermTabAdd = async () => {
-        const initialNode = layoutModel.getNodeByBlockId(blockId);
-        if (!initialNode) return;
-        // Hide this pane while the new tab settles — same pushBlockOntoStack
-        // -forced remount handleNewAgentTab (agent-view.tsx) gates against.
-        // SPEC_PANE_BLOCK_STACK_MOUNT_FLICKER_2026_08_22.md.
-        const revealGen = holdLeafRevealGate(initialNode.id);
-        try {
-            // New tab inherits the CURRENT tab's cwd, matching how a real
-            // terminal's "new tab" usually starts in the same directory rather
-            // than some unrelated default.
-            const cwd = blockData()?.meta?.["cmd:cwd"] as string | undefined;
-            try {
-                const paneOpenResult = await TabRpcClient.rpcCall(
-                    "pane.open",
-                    { view: "term", cwd: cwd || undefined, skip_placement: true },
-                    {},
-                ) as { block_id: string };
-                // Review finding (Codex): this pane could have closed while the
-                // RPC above was in flight — re-resolve the node fresh rather
-                // than trusting a pre-await reference. If it's gone, the
-                // skip_placement block we just created has nowhere to attach
-                // to; delete it instead of leaving an orphaned, unreachable
-                // PTY/block behind.
-                const node = layoutModel.getNodeByBlockId(blockId);
-                if (!node) {
-                    await ObjectService.DeleteBlock(paneOpenResult.block_id).catch(() => {});
-                    return;
-                }
-                pushBlockOntoStack(layoutModel, node.id, paneOpenResult.block_id);
-            } catch (e: unknown) {
-                pushNotification({
-                    icon: "fa-triangle-exclamation",
-                    title: "New terminal tab failed",
-                    message: e instanceof Error ? e.message : String(e),
-                    timestamp: new Date().toISOString(),
-                    type: "error",
-                    expiration: Date.now() + 8000,
-                });
-            }
-        } finally {
-            scheduleLeafRevealLift(initialNode.id, revealGen);
-        }
-    };
-
-    // Double-click-to-rename — SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md §3.3.
-    const [renamingBlockId, setRenamingBlockId] = createSignal<string | null>(null);
-    const handleTermTabRenameConfirm = (targetBlockId: string, title: string) => {
-        setRenamingBlockId(null);
-        setTitleOverrides((prev) => ({ ...prev, [targetBlockId]: title }));
-        fireAndForget(() =>
-            RpcApi.SetMetaCommand(TabRpcClient, {
-                oref: WOS.makeORef("block", targetBlockId),
-                meta: { "pane-title": title } as any,
-            }),
-        );
-    };
 
     const termSettingsAtom = getSettingsPrefixAtom("term");
     const termSettings = createMemo(() => termSettingsAtom());
@@ -552,30 +413,234 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
             class={clsx("view-term", "term-mode-" + termMode())}
             style={{ position: "relative" }}
         >
-            {/* Tab strip — top region, above everything else, matching the
-                editor's and agent pane's own tab-strip placement. The "+"
-                always renders (that's how you'd get a second tab), but the
-                tab pill itself stays hidden until there's something to
-                switch BETWEEN — a lone terminal shows only the "+"; the
-                moment a 2nd tab exists, both appear.
-                SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md. */}
+            <DragOverlay message={dropMessage()} visible={isDragOver()} />
+            <Show when={termBg()}>
+                <div class="absolute inset-0 z-0 pointer-events-none" style={termBg()} />
+            </Show>
+            <TermResyncHandler blockId={blockId} model={model} />
+            <TermThemeUpdater blockId={blockId} model={model} termRef={model.termRef} />
+            <TermStickers config={stickerConfig()} />
+            <Show when={model.agentRuntimeLabel()}>
+                <div class="agent-runtime-badge" title="Agent running time">
+                    {model.agentRuntimeLabel()}
+                </div>
+            </Show>
+            <div class="term-connectelem" ref={connectElemRef!} />
+            <Search {...searchProps} />
+        </div>
+    );
+}
+
+
+/**
+ * Chrome half of the terminal pane — the pane header and the in-pane tab
+ * strip, hoisted OUT of `TerminalView` so neither is inside the per-block
+ * remount boundary `pane-leaf-chrome.tsx` creates. Mounted once per leaf and
+ * kept mounted across every subsequent tab switch; that persistence is the
+ * whole point (`docs/specs/SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md`).
+ * Mirrors `AgentPaneChrome` (agent-view.tsx) — see that component for the
+ * fuller commentary on the pattern; the terminal's version is simpler
+ * (no progress-bar slot, no picker cross-fade, no pane-scope ModalLayer).
+ *
+ * `anchorBlockId` is whichever stack member's `TermViewModel` first called
+ * `renderPaneChrome`; it is deliberately NOT used to resolve the owning
+ * `LayoutNode` (that member's tab can be closed while chrome lives on) —
+ * `getOwnNode` uses the leaf's own stable `nodeModel.nodeId` instead, the
+ * same correction ReAgent caught on the agent pane in #3136.
+ */
+const TermPaneChrome = (props: {
+    anchorBlockId: string;
+    nodeModel: NodeModel;
+    children: JSX.Element;
+}): JSX.Element => {
+    const layoutModel = getLayoutModelForStaticTab();
+    const nodeModel = props.nodeModel;
+    const anchorBlockId = props.anchorBlockId;
+
+    const getOwnNode = () => findNode(layoutModel.treeState.rootNode, nodeModel.nodeId);
+    const activeBlockId = () => nodeModel.activeBlockId?.() ?? anchorBlockId;
+
+    // Tracks the CURRENTLY ACTIVE member, not the anchor — getWaveObjectAtom
+    // inside a memo (not useWaveObjectValue), the reactive-oref pattern
+    // established in #3134 for exactly this kind of switch-surviving reader.
+    const activeBlockData = createMemo(() => WOS.getWaveObjectAtom<Block>(WOS.makeORef("block", activeBlockId()))());
+
+    interface TermTab {
+        blockId: string;
+        label: string;
+    }
+    // Rename overrides, keyed by blockId — set synchronously by
+    // handleTermTabRenameConfirm so a just-renamed tab (including a dormant,
+    // non-active one whose block meta isn't reactively tracked here) reflects
+    // its new label immediately.
+    // SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md §3.3.
+    const [titleOverrides, setTitleOverrides] = createSignal<Record<string, string>>({});
+    const termTabs = createMemo<TermTab[]>(() => {
+        layoutModel.localTreeStateAtom();
+        const overrides = titleOverrides();
+        const node = getOwnNode();
+        // No stack yet (the common default — a single, never-split terminal)
+        // → synthesize this pane's own one-tab list rather than returning
+        // empty, so the strip always shows at least its own active entry.
+        const stack = node?.data?.blockStack?.length ? node.data.blockStack : [activeBlockId()];
+        // Position-based labels ("Terminal 1", "Terminal 2", …) as the
+        // fallback for an unnamed session. A user-set title (double-click to
+        // rename, persisted as meta["pane-title"]) wins when present, read
+        // via a non-reactive lookup since a dormant tab's block isn't
+        // mounted; `overrides` is what makes a just-performed rename show up
+        // immediately.
+        return stack.map((id, i) => {
+            const persistedTitle = WOS.getObjectValue<Block>(WOS.makeORef("block", id))?.meta?.["pane-title"] as
+                | string
+                | undefined;
+            return { blockId: id, label: overrides[id] ?? persistedTitle ?? `Terminal ${i + 1}` };
+        });
+    });
+    // Only render tab pills once there's something to switch BETWEEN — a lone
+    // terminal shows just the "+".
+    const visibleTermTabs = createMemo(() => (termTabs().length > 1 ? termTabs() : []));
+
+    // Per-pane zoom for the strip itself, tracking whichever tab is active
+    // rather than the anchor's own block — same clamp TermViewModel's
+    // termZoomAtom applies (termViewModel.ts).
+    const tabStripZoomFactor = createMemo(() => {
+        const z = activeBlockData()?.meta?.["term:zoom"];
+        if (z == null || typeof z !== "number" || isNaN(z)) return 1.0;
+        return Math.max(0.5, Math.min(2.0, z));
+    });
+
+    // None of these three hold a leaf reveal gate any more. The gates existed
+    // because each of these mutations used to force a WHOLE-LEAF remount
+    // (chrome included) — that no longer happens: pane-leaf-chrome.tsx's
+    // inner <Key> rebuilds only the active member's own <Block>, and this
+    // component stays mounted throughout. Keeping them would actively CAUSE
+    // a flash, since gatingNodeIds() hides the whole node. The content's own
+    // settle is already covered by Block's ready-gate cross-fade (block.tsx).
+    // Same removal, same reasoning, as the agent pane's handlers.
+    const handleTermTabSwitch = (targetBlockId: string) => {
+        if (targetBlockId === activeBlockId()) return;
+        const node = getOwnNode();
+        if (!node) return;
+        setActiveBlockInStack(layoutModel, node.id, targetBlockId);
+    };
+    const handleTermTabClose = (targetBlockId: string) => {
+        const node = getOwnNode();
+        if (!node) return;
+        void closeBlockInStack(layoutModel, node.id, targetBlockId);
+    };
+    const handleTermTabAdd = async () => {
+        const initialNode = getOwnNode();
+        if (!initialNode) return;
+        try {
+            // New tab inherits the CURRENT tab's cwd, matching how a real
+            // terminal's "new tab" usually starts in the same directory.
+            const cwd = activeBlockData()?.meta?.["cmd:cwd"] as string | undefined;
+            const paneOpenResult = (await TabRpcClient.rpcCall(
+                "pane.open",
+                { view: "term", cwd: cwd || undefined, skip_placement: true },
+                {},
+            )) as { block_id: string };
+            // This pane could have closed while the RPC was in flight —
+            // re-resolve rather than trusting a pre-await reference. If it's
+            // gone, delete the skip_placement block instead of leaving an
+            // orphaned, unreachable PTY behind.
+            const node = getOwnNode();
+            if (!node) {
+                await ObjectService.DeleteBlock(paneOpenResult.block_id).catch(() => {});
+                return;
+            }
+            pushBlockOntoStack(layoutModel, node.id, paneOpenResult.block_id);
+        } catch (e: unknown) {
+            pushNotification({
+                icon: "fa-triangle-exclamation",
+                title: "New terminal tab failed",
+                message: e instanceof Error ? e.message : String(e),
+                timestamp: new Date().toISOString(),
+                type: "error",
+                expiration: Date.now() + 8000,
+            });
+        }
+    };
+
+    // Double-click-to-rename — SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md §3.3.
+    const [renamingBlockId, setRenamingBlockId] = createSignal<string | null>(null);
+    const handleTermTabRenameConfirm = (targetBlockId: string, title: string) => {
+        setRenamingBlockId(null);
+        setTitleOverrides((prev) => ({ ...prev, [targetBlockId]: title }));
+        fireAndForget(() =>
+            RpcApi.SetMetaCommand(TabRpcClient, {
+                oref: WOS.makeORef("block", targetBlockId),
+                meta: { "pane-title": title } as any,
+            }),
+        );
+    };
+
+    // NOT stand-ins, unlike AgentPaneChrome's: TermViewModel sets
+    // `manageConnection` to `!isCmd`, i.e. TRUE for every ordinary
+    // terminal, so BlockFrame_Header really does render the connection
+    // button here and it has to work. Both of these resolve the SAME
+    // per-block objects BlockFrame_Default_Component itself uses (the
+    // block-atom cache is keyed on blockId), which is what keeps the
+    // hoisted button wired to the ChangeConnectionBlockModal that still
+    // lives inside BlockFrame: the atom opens it, the ref anchors it.
+    // Re-derived per active member so switching tabs targets the right
+    // block's modal state.
+    const changeConnModalAtom = createMemo(
+        () => useBlockAtom(activeBlockId(), "changeConn", () => createSignalAtom(false)) as SignalAtom<boolean>,
+    );
+    const connBtnRef = createMemo(
+        () =>
+            useBlockAtom(activeBlockId(), "connBtnRef", () => {
+                const holder: { current: HTMLDivElement | null } = { current: null };
+                return () => holder;
+            })(),
+    );
+    const activeViewModelOrUndefined = () => nodeModel.activeViewModel?.() ?? undefined;
+    const headerElem = (
+        <BlockFrame_Header
+            nodeModel={nodeModel}
+            viewModel={activeViewModelOrUndefined()}
+            preview={false}
+            blockId={activeBlockId}
+            connBtnRef={connBtnRef()}
+            changeConnModalAtom={changeConnModalAtom()}
+        />
+    );
+    const headerElemNoView = (
+        <BlockFrame_Header
+            nodeModel={nodeModel}
+            viewModel={null}
+            preview={false}
+            blockId={activeBlockId}
+            connBtnRef={connBtnRef()}
+            changeConnModalAtom={changeConnModalAtom()}
+        />
+    );
+
+    return (
+        <div
+            class="term-pane-stack"
+            // Keeps this pane reachable by the CEF browser API's
+            // `[data-blockid]` subtree scoping (UIQuery/UIClick/screenshot
+            // clip) now that chrome sits OUTSIDE the nested `.block` that
+            // otherwise carries it — see AgentPaneChrome's identical note.
+            data-blockid={activeBlockId()}
+            // Chrome is a sibling ABOVE the nested `.block`, so clicks here
+            // never reach the BlockFrame handlers that focus the pane.
+            // Without this, clicking a terminal's own header or tab strip
+            // could leave a DIFFERENT pane focused.
+            onClick={() => nodeModel.focusNode()}
+            onFocusIn={() => nodeModel.focusNode()}
+        >
+            <ErrorBoundary fallback={headerElemNoView}>{headerElem}</ErrorBoundary>
+            {/* Normal-flow row, unlike the agent strip's absolute overlay —
+                the terminal strip has always reserved its own band above the
+                xterm surface (term.scss), and keeping that avoids covering
+                the top line of terminal output. */}
             <PaneTabStrip
                 tabs={visibleTermTabs()}
                 activeId={activeBlockId()}
-                zoomFactor={model.termZoomAtom}
-                // NO `animateWidth` here any more. That width animation
-                // (SPEC_PANE_BLOCK_STACK_MOUNT_FLICKER_2026_08_22.md §2.4)
-                // exists to smooth the strip's box growing/shrinking as tabs
-                // are added and removed — which only happens while the box is
-                // shrink-to-fit. This strip is now `width: 100%` (term.scss,
-                // for the glass band —
-                // docs/specs/SPEC_TERM_PANE_TAB_STRIP_TRAILING_BLUR_2026_09_07.md
-                // §3.1), so its box width no longer varies with tab count and
-                // the animation would be measuring, holding and transitioning
-                // a value that never changes. The tab pills themselves still
-                // resize inside the fixed-width box; only the box stopped
-                // moving. The agent pane's strip is full-width for the same
-                // reason and likewise does not animate.
+                zoomFactor={tabStripZoomFactor}
                 getId={(t) => t.blockId}
                 getLabel={(t) => t.label}
                 onActivate={handleTermTabSwitch}
@@ -595,25 +660,19 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
                 onAdd={() => void handleTermTabAdd()}
                 addTitle="New terminal tab"
             />
-            <DragOverlay message={dropMessage()} visible={isDragOver()} />
-            <Show when={termBg()}>
-                <div class="absolute inset-0 z-0 pointer-events-none" style={termBg()} />
-            </Show>
-            <TermResyncHandler blockId={blockId} model={model} />
-            <TermThemeUpdater blockId={blockId} model={model} termRef={model.termRef} />
-            <TermStickers config={stickerConfig()} />
-            <Show when={model.agentRuntimeLabel()}>
-                <div class="agent-runtime-badge" title="Agent running time">
-                    {model.agentRuntimeLabel()}
-                </div>
-            </Show>
-            <div class="term-connectelem" ref={connectElemRef!} />
-            <Search {...searchProps} />
+            <div class="term-pane-stack-content">{props.children}</div>
         </div>
     );
-}
+};
+
+TermPaneChrome.displayName = "TermPaneChrome";
+
+export { TermPaneChrome };
 
 // Register TerminalView with the ViewModel to break the circular dependency
 setTerminalViewComponent(TerminalView);
+// Same late-binding registration, for the hoisted chrome half — see
+// setTermPaneChromeComponent's own comment in termViewModel.ts.
+setTermPaneChromeComponent(TermPaneChrome);
 
 export { TermViewModel };

--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -414,17 +414,9 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
             style={{ position: "relative" }}
         >
             <DragOverlay message={dropMessage()} visible={isDragOver()} />
-            <Show when={termBg()}>
-                <div class="absolute inset-0 z-0 pointer-events-none" style={termBg()} />
-            </Show>
             <TermResyncHandler blockId={blockId} model={model} />
             <TermThemeUpdater blockId={blockId} model={model} termRef={model.termRef} />
             <TermStickers config={stickerConfig()} />
-            <Show when={model.agentRuntimeLabel()}>
-                <div class="agent-runtime-badge" title="Agent running time">
-                    {model.agentRuntimeLabel()}
-                </div>
-            </Show>
             <div class="term-connectelem" ref={connectElemRef!} />
             <Search {...searchProps} />
         </div>
@@ -585,6 +577,12 @@ const TermPaneChrome = (props: {
     // lives inside BlockFrame: the atom opens it, the ref anchors it.
     // Re-derived per active member so switching tabs targets the right
     // block's modal state.
+    // Both read the ACTIVE member, so they follow tab switches: the
+    // background is per-block meta, the runtime label is per-ViewModel
+    // state owned by whichever TermViewModel is currently mounted.
+    const termBg = createMemo(() => computeBgStyleFromMeta(activeBlockData()?.meta, null));
+    const runtimeLabel = () => (nodeModel.activeViewModel?.() as TermViewModel | null)?.agentRuntimeLabel?.() ?? null;
+
     const changeConnModalAtom = createMemo(
         () => useBlockAtom(activeBlockId(), "changeConn", () => createSignalAtom(false)) as SignalAtom<boolean>,
     );
@@ -633,34 +631,53 @@ const TermPaneChrome = (props: {
             onFocusIn={() => nodeModel.focusNode()}
         >
             <ErrorBoundary fallback={headerElemNoView}>{headerElem}</ErrorBoundary>
-            {/* Normal-flow row, unlike the agent strip's absolute overlay —
-                the terminal strip has always reserved its own band above the
-                xterm surface (term.scss), and keeping that avoids covering
-                the top line of terminal output. */}
-            <PaneTabStrip
-                tabs={visibleTermTabs()}
-                activeId={activeBlockId()}
-                zoomFactor={tabStripZoomFactor}
-                getId={(t) => t.blockId}
-                getLabel={(t) => t.label}
-                onActivate={handleTermTabSwitch}
-                onClose={handleTermTabClose}
-                onTabDoubleClick={(t) => setRenamingBlockId(t.blockId)}
-                renderLabel={(t) =>
-                    renamingBlockId() === t.blockId ? (
-                        <PaneTabRenameInput
-                            initialValue={t.label}
-                            onConfirm={(title) => handleTermTabRenameConfirm(t.blockId, title)}
-                            onCancel={() => setRenamingBlockId(null)}
-                        />
-                    ) : (
-                        <span class="pane-tab-label">{t.label}</span>
-                    )
-                }
-                onAdd={() => void handleTermTabAdd()}
-                addTitle="New terminal tab"
-            />
-            <div class="term-pane-stack-content">{props.children}</div>
+            {/* Spans the strip AND the terminal, and is the positioned
+                ancestor for both overlays below. Both used to live inside
+                `.view-term`, which contained the strip before it was
+                hoisted; leaving them there would have quietly moved them
+                relative to it (codex P2 x2 on PR #3157) — the background
+                image could no longer paint behind the strip, so the strip's
+                backdrop-filter had nothing of the image to blur, and the
+                runtime badge's `top: 6px` landed on the terminal's first
+                output row instead of on the strip band. */}
+            <div class="term-pane-stack-body">
+                <Show when={termBg()}>
+                    <div class="absolute inset-0 z-0 pointer-events-none" style={termBg()} />
+                </Show>
+                {/* Normal-flow row, unlike the agent strip's absolute overlay —
+                    the terminal strip has always reserved its own band above
+                    the xterm surface (term.scss), and keeping that avoids
+                    covering the top line of terminal output. */}
+                <PaneTabStrip
+                    tabs={visibleTermTabs()}
+                    activeId={activeBlockId()}
+                    zoomFactor={tabStripZoomFactor}
+                    getId={(t) => t.blockId}
+                    getLabel={(t) => t.label}
+                    onActivate={handleTermTabSwitch}
+                    onClose={handleTermTabClose}
+                    onTabDoubleClick={(t) => setRenamingBlockId(t.blockId)}
+                    renderLabel={(t) =>
+                        renamingBlockId() === t.blockId ? (
+                            <PaneTabRenameInput
+                                initialValue={t.label}
+                                onConfirm={(title) => handleTermTabRenameConfirm(t.blockId, title)}
+                                onCancel={() => setRenamingBlockId(null)}
+                            />
+                        ) : (
+                            <span class="pane-tab-label">{t.label}</span>
+                        )
+                    }
+                    onAdd={() => void handleTermTabAdd()}
+                    addTitle="New terminal tab"
+                />
+                <Show when={runtimeLabel()}>
+                    <div class="agent-runtime-badge" title="Agent running time">
+                        {runtimeLabel()}
+                    </div>
+                </Show>
+                <div class="term-pane-stack-content">{props.children}</div>
+            </div>
         </div>
     );
 };

--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -283,7 +283,6 @@ function TerminalView(props: ViewComponentProps<TermViewModel>): JSX.Element {
         blockId: blockId,
     }));
 
-    const termBg = createMemo(() => computeBgStyleFromMeta(blockData()?.meta));
 
     const dndEnabledAtom = getSettingsKeyAtom("dnd:enabled");
     const dndConcurrencyAtom = getSettingsKeyAtom("dnd:concurrency");

--- a/frontend/app/view/term/termViewModel.ts
+++ b/frontend/app/view/term/termViewModel.ts
@@ -30,7 +30,9 @@ import * as services from "@/store/services";
 import * as keyutil from "@/util/keyutil";
 import { boundNumber, createSignalAtom, sleep, stringToBase64 } from "@/util/util";
 import type { SignalAtom } from "@/util/util";
-import { createMemo, createSignal } from "solid-js";
+import { createComponent, createMemo, createSignal } from "solid-js";
+import type { JSX } from "solid-js";
+import type { NodeModel } from "@/layout/index";
 
 // Ticks every 60 s so agentRuntimeLabel memos re-evaluate without waiting for a status event.
 // globalThis survives HMR module re-evaluation — prevents duplicate interval leak.
@@ -42,6 +44,19 @@ import { TermWrap } from "./termwrap";
 import { buildSettingsMenuItems } from "./termSettingsMenu";
 
 let _terminalViewComponent: ViewComponent = null;
+
+// Same late-binding trick as _terminalViewComponent above, for the same
+// reason: term.tsx imports this module, so this module can't import it back.
+// `renderPaneChrome` below instantiates whatever term.tsx registers here.
+let _termPaneChromeComponent:
+    | ((props: { anchorBlockId: string; nodeModel: NodeModel; children: JSX.Element }) => JSX.Element)
+    | null = null;
+
+export function setTermPaneChromeComponent(
+    component: (props: { anchorBlockId: string; nodeModel: NodeModel; children: JSX.Element }) => JSX.Element,
+) {
+    _termPaneChromeComponent = component;
+}
 
 export function setTerminalViewComponent(component: ViewComponent) {
     _terminalViewComponent = component;
@@ -328,6 +343,32 @@ class TermViewModel implements ViewModel {
     get viewComponent(): ViewComponent {
         return _terminalViewComponent;
     }
+
+    /** True exactly when `pane-leaf-chrome.tsx` hoisted chrome above this
+     *  Block — that chrome renders the replacement BlockFrame_Header, so
+     *  suppressing the inline one is what stops the two double-rendering.
+     *  Reads the tag on the NodeModel wrapper rather than being
+     *  unconditional, so a drag-preview thumbnail (`renderPreview`'s plain
+     *  `<Block preview>`, no chrome around it) keeps its own header — the
+     *  same bug Codex/ReAgent caught on the agent pane in #3151. */
+    get noHeader(): () => boolean {
+        return () => this.nodeModel.paneChromeHoisted === true;
+    }
+
+    /** Renders `TermPaneChrome` (term.tsx) wrapped around the switch-scoped
+     *  content — see that component's own doc comment.
+     *  `createComponent`, not a bare call: this is a .ts file so it can't
+     *  use JSX syntax, but a plain function call would attach the
+     *  component's own effects/cleanups to whatever reactive scope happened
+     *  to be ambient at THIS call rather than to chrome's real mount. */
+    renderPaneChrome = (leafNodeModel: NodeModel, content: JSX.Element): JSX.Element => {
+        if (_termPaneChromeComponent == null) return content;
+        return createComponent(_termPaneChromeComponent, {
+            anchorBlockId: this.blockId,
+            nodeModel: leafNodeModel,
+            children: content,
+        });
+    };
 
     isBasicTerm(): boolean {
         const blockData = this.blockAtom();


### PR DESCRIPTION
## Summary

Applies the agent pane's chrome-hoisting fix (`SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md`, #3136/#3151) to the terminal pane, which was deliberately deferred there and has the same bug: switching shell tabs rebuilt the pane header and the in-pane tab strip along with the terminal.

- **`term.tsx`** — `TerminalView`'s tab-strip half is extracted into a new `TermPaneChrome`, rendered via `renderPaneChrome` so it lives outside the per-block remount boundary and stays mounted across switches. Registered through the same late-binding hook the view component already uses to break the `term.tsx` ↔ `termViewModel.ts` cycle.
- **Reveal gates dropped** from the three stack mutators, same reasoning as the agent pane: they existed because the whole leaf used to remount, and keeping them now *causes* a flash rather than hiding one.
- **Node resolution by `nodeModel.nodeId`**, not the anchor blockId — the correction ReAgent caught on the agent pane, applied up front here.
- **`pane-leaf-chrome.tsx`** — `"term"` joins `"agent"` in a named `HOISTS_OWN_CHROME` set, with the invariant (a listed type must drive `noHeader` off `paneChromeHoisted`) written down beside it.

## The one real difference from the agent pane

`TermViewModel` sets `manageConnection` to `!isCmd` — **true for every ordinary terminal** — so `BlockFrame_Header` really does render the connection button here. The inert stand-ins `AgentPaneChrome` gets away with (agent never sets `manageConnection`) would have left a dead button on every terminal.

Both the modal-open atom and the button ref now resolve the **same per-block objects** `BlockFrame_Default_Component` uses (block-atom cache, keyed on blockId), so the hoisted button still opens *and* anchors the `ChangeConnectionBlockModal` that stays inside `BlockFrame`. `blockframe.tsx`'s `connBtnRef` moves from a plain local to that shared holder for the same reason.

## Test plan

- [x] `npx tsc -p tsconfig.json --noEmit` — clean.
- [x] `npx vitest run` — 3901 passing / 3 skipped.
- [x] `npx stylelint` on `term.scss` — clean.
- [x] New `pane-leaf-chrome` test asserting `"term"` hoists; updated the passthrough test to use `"editor"` (it was using `"term"` as its example of a non-hoisting type, which this change invalidates).
- [ ] **Not visually verified.** Needs a live check. The terminal's connection button is the specific thing to exercise: open a remote terminal, click the connection button in the header, confirm the switcher modal both **opens** and **anchors to the button**. Also worth checking `term.scss`'s relocated strip band (glass/blur) still reads right in its new parent.

<!-- agentmux:agent_id=camper -->