### PR TITLE
Manoz@Area54: fix(agent-pane): background shell output no longer pins a turn in Working

### DIFF
--- a/.changesets/1789029739-fix-agent-pane-background-shell-output-no-longer-pins-a-fini-2je4.md
+++ b/.changesets/1789029739-fix-agent-pane-background-shell-output-no-longer-pins-a-fini-2je4.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): background shell output no longer pins a finished turn in Working

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -351,7 +351,7 @@ export function dispatch(
                 console.info(
                     "[wave-turn]",
                     `pane=${blockId.slice(0, 7)}`,
-                    `watchdog: no recovery — idleSinceMs=${ev.idleSinceMs} thresholdMs=${ev.thresholdMs}`,
+                    `watchdog: no recovery — idleSinceMs=${ev.idleSinceMs} warnAtMs=${ev.thresholdMs} recoverAtMs=${ev.recoverThresholdMs}`,
                     exempt ? `EXEMPT toolsActive=${p.toolsActive} currentTool=${slot.state.currentTool ?? "?"}` : "",
                 );
             }

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -228,6 +228,24 @@ export function update(
             if (state.lastEventMs == null) {
                 return { state, events: [] };
             }
+            // FIX 1 — shell OUTPUT alone is not evidence this turn is alive.
+            // The flush queue batches six independent queues and dispatches one
+            // StreamFlushObserved if ANY of them had content. A live background
+            // shell writing to its dock row therefore refreshed lastEventMs on
+            // every flush, holding idleSinceMs permanently below the recovery
+            // threshold — the pane sat in Streaming for as long as the process
+            // lived (5h observed, and the same shape as the 12h incident in
+            // retro-persistent-agent-working-status-stuck-2026-07-16.md).
+            //
+            // Nothing about that output implies the MODEL is working, so it
+            // neither bumps the idle clock nor promotes the phase. The event is
+            // still emitted: other consumers legitimately track flushes.
+            if (command.turnRelevant === false) {
+                return {
+                    state,
+                    events: [{ type: "stream-flush-observed", addedCount: command.addedCount }],
+                };
+            }
             const newBuf = state.streaming.bufferSize + command.addedCount;
             // Dual-write: while Streaming, mirror bufferSize + lastEventMs.
             // PROMOTE to Streaming from Submitting (the normal hand-off) AND
@@ -268,7 +286,16 @@ export function update(
                     : state.turnPhase.kind === "Submitting"
                         || state.turnPhase.kind === "Idle"
                         || state.turnPhase.kind === "Disconnected"
-                        || (state.turnPhase.kind === "Done" && state.turnPhase.outcome === "completed")
+                        || (state.turnPhase.kind === "Done"
+                            && state.turnPhase.outcome === "completed"
+                            // FIX 2 — resurrect a COMPLETED turn only for a
+                            // flush that actually added document nodes. The
+                            // multi-round continuation this branch exists for
+                            // (#2420) always opens with a new node; a flush
+                            // carrying only chunk appends or shell traffic is
+                            // not a new round, and treating it as one is how a
+                            // finished turn silently went back to "Working…".
+                            && command.addedCount > 0)
                         ? {
                               kind: "Streaming",
                               bufferSize: newBuf,
@@ -389,6 +416,17 @@ export function update(
                         type: "stream-stuck",
                         idleSinceMs,
                         thresholdMs: STUCK_THRESHOLD_MS,
+                        // FIX 3 — the bar this warning is measured against
+                        // (45s) is NOT the bar for recovery (180s, or more
+                        // under a rate-limit backoff). Reporting only the
+                        // former reads as "past the threshold and still not
+                        // recovering", which is exactly how this stall was
+                        // misdiagnosed while it was happening.
+                        recoverThresholdMs:
+                            state.turnPhase.kind === "Streaming"
+                            && state.turnPhase.waitingReason === "rate_limited"
+                                ? (state.turnPhase.retryAfterMs ?? 0) + LIVENESS_RECOVERY_MS
+                                : LIVENESS_RECOVERY_MS,
                     },
                 ],
             };

--- a/frontend/app/store/agent-pane-state/turn-liveness-shell-output.test.ts
+++ b/frontend/app/store/agent-pane-state/turn-liveness-shell-output.test.ts
@@ -1,0 +1,127 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regression tests for the five-hour stuck-"Working…" stall reproduced from a
+ * real session (2026-09-09, block f861ac9c: turn ended 23:12:30Z, pane stayed
+ * in Streaming until 04:13Z).
+ *
+ * The mechanism, in three parts — each has a test below:
+ *   1. output from a live BACKGROUND shell refreshed the turn idle clock on
+ *      every flush, holding it permanently under the recovery bar;
+ *   2. a zero-node flush resurrected an already-completed turn;
+ *   3. the stuck diagnostic reported the 45s warning bar, not the 180s
+ *      recovery bar, so the logs read as "past the threshold, still stuck".
+ *
+ * Part 1 is the load-bearing one: on its own it kept the pane pinned for as
+ * long as the background process lived.
+ */
+
+import { describe, expect, it } from "vitest";
+import { update } from "./reducer";
+import { initialState, LIVENESS_RECOVERY_MS, STUCK_THRESHOLD_MS } from "./types";
+
+const ready = (at: number) =>
+    update(initialState("test-agent"), { type: "StreamSubscribe", at }).state;
+
+/** A live Streaming turn with no tool running — the state the stall sat in. */
+const streamingIdle = (at = 1000) => {
+    const s = update(ready(at), { type: "TurnStart", at }).state;
+    return update(s, { type: "StreamFlushObserved", addedCount: 1, at }).state;
+};
+
+describe("background shell output is not turn liveness", () => {
+    it("does not refresh the idle clock", () => {
+        const s = streamingIdle(1000);
+        const before = s.lastEventMs;
+        const after = update(s, {
+            type: "StreamFlushObserved",
+            addedCount: 0,
+            at: 50_000,
+            turnRelevant: false,
+        }).state;
+        expect(after.lastEventMs).toBe(before);
+    });
+
+    it("lets the watchdog recover a turn that only background output kept alive", () => {
+        // The actual stall: a flush every ~50s for hours. Each one reset the
+        // clock, so idleSinceMs never reached LIVENESS_RECOVERY_MS and the
+        // watchdog declined forever. With the flush marked non-turn-relevant
+        // the clock keeps running and recovery fires on schedule.
+        let s = streamingIdle(1000);
+        for (let t = 50_000; t < LIVENESS_RECOVERY_MS + 1000; t += 50_000) {
+            s = update(s, {
+                type: "StreamFlushObserved",
+                addedCount: 0,
+                at: t,
+                turnRelevant: false,
+            }).state;
+        }
+        const tick = update(s, {
+            type: "StreamWatchdogTick",
+            nowMs: 1000 + LIVENESS_RECOVERY_MS + 1,
+        });
+        expect(tick.state.turnPhase.kind).toBe("Idle");
+        expect(tick.events.some((e) => e.type === "working-recovered")).toBe(true);
+    });
+
+    it("still emits the flush event so other consumers are unaffected", () => {
+        const r = update(streamingIdle(1000), {
+            type: "StreamFlushObserved",
+            addedCount: 0,
+            at: 50_000,
+            turnRelevant: false,
+        });
+        expect(r.events).toEqual([{ type: "stream-flush-observed", addedCount: 0 }]);
+    });
+
+    it("treats an unmarked flush as turn-relevant, preserving old behaviour", () => {
+        // Only the flush queue knows the difference; every other dispatcher
+        // (and every pre-existing test) omits the flag and must be unchanged.
+        const s = streamingIdle(1000);
+        const after = update(s, { type: "StreamFlushObserved", addedCount: 1, at: 50_000 }).state;
+        expect(after.lastEventMs).toBe(50_000);
+    });
+});
+
+describe("a zero-node flush does not resurrect a completed turn", () => {
+    const completed = (at: number) => {
+        const s = streamingIdle(at);
+        return update(s, { type: "TurnEnd", at: at + 10, outcome: "completed" }).state;
+    };
+
+    it("stays Done for a flush that added no document nodes", () => {
+        const s = completed(1000);
+        expect(s.turnPhase.kind).toBe("Done");
+        const after = update(s, { type: "StreamFlushObserved", addedCount: 0, at: 2000 }).state;
+        expect(after.turnPhase.kind).toBe("Done");
+    });
+
+    it("still promotes for a real next round, which opens with a node", () => {
+        // The multi-round tool-continuation case this branch exists for
+        // (#2420) must keep working — it always adds an assistant node.
+        const s = completed(1000);
+        const after = update(s, { type: "StreamFlushObserved", addedCount: 1, at: 2000 }).state;
+        expect(after.turnPhase.kind).toBe("Streaming");
+    });
+});
+
+describe("the stuck diagnostic reports the bar it is measured against", () => {
+    it("carries both the warning bar and the recovery bar", () => {
+        const s = streamingIdle(1000);
+        const r = update(s, {
+            type: "StreamWatchdogTick",
+            nowMs: 1000 + STUCK_THRESHOLD_MS + 1,
+        });
+        const stuck = r.events.find((e) => e.type === "stream-stuck");
+        expect(stuck).toBeDefined();
+        // Reporting only thresholdMs made the logs read as "idle exceeded the
+        // threshold and it still did not recover" — the misreading that cost a
+        // day of diagnosis. The two bars are 45s and 180s and differ by 4x.
+        expect(stuck).toMatchObject({
+            thresholdMs: STUCK_THRESHOLD_MS,
+            recoverThresholdMs: LIVENESS_RECOVERY_MS,
+        });
+        expect(r.state.turnPhase.kind).toBe("Streaming");
+    });
+});

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -502,7 +502,25 @@ export type AgentPaneCommand =
      * RAF flush observed by useAgentStream — bumps bufferSize +
      * lastEventTime. No state change beyond those counters.
      */
-    | { type: "StreamFlushObserved"; addedCount: number; at: number }
+    | {
+          type: "StreamFlushObserved";
+          addedCount: number;
+          at: number;
+          /**
+           * Did this flush carry anything that is evidence the TURN is alive —
+           * document nodes, node updates, tool chunks, or a new shell node?
+           *
+           * `false` means the flush was shell OUTPUT only. That is a live
+           * BACKGROUND process writing to its dock row; it says nothing about
+           * whether the model is doing anything, so it must not refresh the
+           * turn idle clock or resurrect a finished turn. Omitted is treated as
+           * `true` — only the flush queue knows the difference, and only it
+           * sets this.
+           *
+           * See docs/reports/REPORT_AGENT_PANE_PROGRESS_INDICATORS_CONSOLIDATION_2026_09_09.md.
+           */
+          turnRelevant?: boolean;
+      }
     /**
      * Periodic tick from useAgentStream's watchdog interval. Emits a
      * `stream-stuck` diagnostic past `STUCK_THRESHOLD_MS`, and — past the
@@ -828,7 +846,16 @@ export type AgentPaneEvent =
            */
           type: "stream-stuck";
           idleSinceMs: number;
+          /** The WARNING bar (STUCK_THRESHOLD_MS). Crossing it is cosmetic. */
           thresholdMs: number;
+          /**
+           * The bar that would actually force this turn back to Idle. Always
+           * larger than `thresholdMs`, and larger still under a rate-limit
+           * backoff. Reported because a diagnostic that shows only the warning
+           * bar reads as "past the threshold and still stuck", which is how a
+           * real 5h stall was misread while it was in progress.
+           */
+          recoverThresholdMs: number;
       }
     | {
           /**

--- a/frontend/app/view/agent/stream-flush-queue.ts
+++ b/frontend/app/view/agent/stream-flush-queue.ts
@@ -223,6 +223,23 @@ export function createStreamFlushQueue(model: AgentPaneModel): StreamFlushQueue 
                 type: "StreamFlushObserved",
                 addedCount: batchNew.length,
                 at: Date.now(),
+                // Shell CHUNKS and EXITS are excluded deliberately: they are a
+                // background process writing to (or closing) its own dock row,
+                // which says nothing about whether the model is working. Every
+                // other queue does imply turn activity — a new node, an update,
+                // a tool chunk, or the agent opening a shell in the first place.
+                //
+                // Without this split, output from a long-lived background shell
+                // refreshed the turn idle clock on every flush and pinned the
+                // pane in Streaming for as long as that process lived. The
+                // module comment above already noted that an all-empty flush
+                // never dispatches; the gap was that a shell-output-only flush
+                // is empty AS FAR AS THE TURN IS CONCERNED and still did.
+                turnRelevant:
+                    batchNew.length > 0
+                    || batchUpdates.length > 0
+                    || batchChunks.length > 0
+                    || batchShellCreates.length > 0,
             });
         });
     }


### PR DESCRIPTION
## The stall, from a real session

Block `f861ac9c`, 2026-09-09. Backend `turn_active` flips:

```
23:11:38  active=true
23:12:30  active=false     ← turn genuinely ends
   ... 5h 00m of silence ...
04:13:03  active=true      ← next user message
```

The backend was right for five hours. The pane showed "Working…" throughout and gated input behind <kbd>Esc</kbd>.

Frontend `[wave-turn]` for the same window:

```
23:12:30  Idle → Done       cmd=TurnEnd
23:13:01  Done → Streaming  cmd=StreamFlushObserved toolsActive=0 currentTool=-
   ... no further transitions ...
watchdog: no recovery — idleSinceMs=48624 thresholdMs=45000     (every 2 min, for 5h)
```

Third recurrence of this shape — see `retro-persistent-agent-working-status-stuck-2026-07-16` (12h) and `REPORT_AGENTA_STUCK_WORKING_INVESTIGATION_2026_08_14`.

## Three defects

### 1. Background shell output counted as turn liveness — the load-bearing one

`flushPendingNodes` batches **six** independent queues and dispatches one `StreamFlushObserved` if *any* had content. The reducer bumps `lastEventMs` on every one.

So a live **background** shell writing to its dock row refreshed the *turn's* idle clock on every flush. That's why `idleSinceMs` reads 48624, 50003, 49374 at successive ticks instead of climbing — it was reset every ~50s by `task dev` output, never reached `LIVENESS_RECOVERY_MS` (180s), and the pane stayed pinned for exactly as long as that process lived.

Shell **chunks** and **exits** no longer mark a flush turn-relevant. Nodes, updates, tool chunks and shell **creates** still do — the agent opening a shell is turn activity; that shell's later output is not.

The module's own doc comment already asserted *"no empty StreamFlushObserved is ever dispatched"*. True only for the all-six-empty case. A shell-output-only flush is empty **as far as the turn is concerned** and still dispatched. That gap is the bug.

**This fix alone would have prevented the stall.**

### 2. A zero-node flush resurrected a completed turn

`Done{completed}` → `Streaming` is deliberate for multi-round continuations (#2420) — but those always open with a new document node. Promotion now requires `addedCount > 0`. In the trace above it fired 31s after `TurnEnd` with `addedCount=0`, `toolsActive=0`, no current tool.

### 3. The diagnostic reported the wrong bar

`stream-stuck` carried only `STUCK_THRESHOLD_MS` (45s — a cosmetic warning) where any reader assumes the recovery bar (180s). So the log reads *"idle exceeded the threshold and it still didn't recover"*.

**That misled me for most of a day** — I told the repo owner the watchdog had "agreed the pane was idle and refused to recover", when in fact it had never come within 130s of its bar. It now carries both, and logs `warnAtMs` / `recoverAtMs`.

## Compatibility

`turnRelevant` is optional and **absent means true**, so every other dispatcher and all pre-existing tests keep their exact behaviour. Only the flush queue — the one caller that can tell the difference — sets it.

## Tests

7 new, incl. `lets the watchdog recover a turn that only background output kept alive`, which replays the ~50s flush cadence across the full recovery window and asserts recovery now fires. Also pins that a real next round (which adds a node) still promotes, so #2420 isn't regressed.

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` over `store/agent-pane-state/`, `store/agent-document/`, `view/agent/` — **2135 passed, 0 failed** (136 files)

## Context

P2 of `docs/reports/REPORT_AGENT_PANE_PROGRESS_INDICATORS_CONSOLIDATION_2026_09_09.md`. P1 (one predicate for both indicators) merged in #3143. P3 (ambient Haiku narration of a backgrounded task) is separate and still to come.

Note the report's other P2 lead — `ScrubOrphanedInProgress` having zero dispatch sites — is **not** what bit here (`toolsActive=0` throughout). Still real debt, but a different bug; left alone deliberately.

<!-- agentmux:agent_id=manoz -->
