### PR TITLE
fix(ci): rename the WinGet identifier to AgentMux.AI

### DIFF
--- a/.changesets/1789029506-fix-ci-bootstrap-the-winget-identifier-as-agentmux-ai-distin-9jo9.md
+++ b/.changesets/1789029506-fix-ci-bootstrap-the-winget-identifier-as-agentmux-ai-distin-9jo9.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(ci): bootstrap the WinGet identifier as AgentMux.AI, distinct from the published MSIX identity

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,6 +379,12 @@ jobs:
   # ── Phase 4: Distribution channels — DISABLED 2026-08-12 ──────────────────
   # MS Store is uploaded manually; WinGet automation never worked (see header
   # comment above). Both job bodies kept for reference, fully commented out.
+  # WinGet identifier corrected to AgentMux.AI 2026-09-10 (distinct from the
+  # already-published MSIX/Store identity AgentMux.AgentMux — see
+  # docs/specs/SPEC_WINGET_PACKAGE_BOOTSTRAP_2026_09_10.md) so this job is
+  # ready to uncomment once that spec's bootstrap PR merges into
+  # microsoft/winget-pkgs. Still commented out here: `wingetcreate update`
+  # requires the manifest to already exist, which it doesn't yet.
   # winget:
   #   name: Submit WinGet update
   #   needs: [verify, publish]
@@ -412,7 +418,7 @@ jobs:
   #           exit 1
   #         fi
   #         echo "WinGet installer URL: $INSTALLER_URL"
-  #         ./wingetcreate.exe update AgentMux.AgentMux \
+  #         ./wingetcreate.exe update AgentMux.AI \
   #           --version "${VERSION}" \
   #           --urls "$INSTALLER_URL" \
   #           --submit \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,7 +19,11 @@ vars:
     DATE: '{{if eq OS "windows"}}pwsh -Command Get-Date -UFormat{{else}}date{{end}}'
     ARTIFACTS_BUCKET: agentmux-github-artifacts/staging
     RELEASES_BUCKET: dl.agentmux.ai/releases
-    WINGET_PACKAGE: AgentMux.AgentMux
+    # WinGet PackageIdentifier — distinct from the already-published MSIX/Store
+    # identity (AgentMux.AgentMux, Store ID 9P9QCXNNCRK3). Never submitted to
+    # winget-pkgs yet, so free to pick; see
+    # docs/specs/SPEC_WINGET_PACKAGE_BOOTSTRAP_2026_09_10.md.
+    WINGET_PACKAGE: AgentMux.AI
 
 tasks:
     changeset:

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -349,6 +349,7 @@ partial list.
 | [`SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29`](SPEC_MUXBUS_MULTI_TIER_DISCOVERY_AND_REMOTE_INVOCATION_2026_07_29.md) | Spec: multi-tier discovery + remote API invocation over muxbus |
 | [`SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04`](SPEC_TRAY_OPTIONAL_BACKGROUND_SERVICE_2026_09_04.md) | Spec: optional system-tray + persistent background service, cross-platform |
 | [`SPEC_WINDOW_NAME_API_HARDENING_2026_08_08`](SPEC_WINDOW_NAME_API_HARDENING_2026_08_08.md) | SPEC: Window-name App API hardening (phantom-id success + status codes) |
+| [`SPEC_WINGET_PACKAGE_BOOTSTRAP_2026_09_10`](SPEC_WINGET_PACKAGE_BOOTSTRAP_2026_09_10.md) | WinGet package bootstrap: `AgentMux.AI` |
 
 ### proposed
 

--- a/docs/specs/SPEC_WINGET_PACKAGE_BOOTSTRAP_2026_09_10.md
+++ b/docs/specs/SPEC_WINGET_PACKAGE_BOOTSTRAP_2026_09_10.md
@@ -1,0 +1,91 @@
+# WinGet package bootstrap: `AgentMux.AI`
+
+**Author:** Agent3
+**Created:** 2026-09-10
+**Status:** Active — implementing
+**Related:** `Taskfile.yml` (`artifacts:winget:publish:*`), `.github/workflows/release.yml` (commented-out `winget` job), `docs/specs/SPEC_UNIFIED_RELEASE_CICD_2026_06_29.md`, `docs/specs/SPEC_RELEASE_CICD_CORRECTION_2026_06_30.md`, `docs/specs/SPEC_MSIX_PACKAGING_2026_05_30.md` (the **separate, already-published** MSIX/Store identity — see §2)
+
+---
+
+## 1. Problem
+
+AgentMux has never actually been submitted to WinGet (`microsoft/winget-pkgs`).
+Release automation for it exists but has been **disabled since 2026-08-12**
+(commit `411056d`, PR #2549): the CI job called `wingetcreate update
+AgentMux.AgentMux`, which only works against an **existing** manifest. No
+manifest was ever bootstrapped via a first-time `wingetcreate new`
+submission, so the job failed identically on every release back through at
+least v0.54.14 (`repos/microsoft/winget-pkgs/.../AgentMux was not found`).
+It was `continue-on-error: true` (never blocked a release) but provided zero
+value, so it was turned off rather than left failing silently forever.
+
+## 2. Naming — `AgentMux.AI`, and why it's safe to pick freely
+
+WinGet's `PackageIdentifier` is its own namespace, independent of the MSIX
+package identity already published to the Microsoft Store. **These are two
+different things that happen to look similar:**
+
+| Identity | Value | Status | Safe to rename? |
+|---|---|---|---|
+| MSIX `Identity/@Name` (Store) | `AgentMux.AgentMux` | **Already published** — Store ID `9P9QCXNNCRK3`, PFN `AgentMux.AgentMux_vqr1k32tkfk4y` (`packaging/msix/AppxManifest.xml.template`, `scripts/package-msix.ps1`) | **No** — changing it would break the update chain for existing Store installs. Out of scope here; untouched by this spec. |
+| WinGet `PackageIdentifier` | previously planned as `AgentMux.AgentMux` (`Taskfile.yml`'s `WINGET_PACKAGE` var, the disabled CI job) | **Never submitted** — no manifest exists in `microsoft/winget-pkgs` | **Yes** — nothing is published under it yet, so there is no compatibility cost to choosing a different identifier now, before the one-time bootstrap. |
+
+Decision (repo owner, 2026-09-10): the WinGet identifier is **`AgentMux.AI`**
+— `Publisher = AgentMux`, `PackageName` segment `AI`. This does not touch the
+MSIX/Store identity at all; it only renames the not-yet-existing WinGet
+manifest's identifier before it's created for the first time.
+
+## 3. What changes in this repo
+
+- `Taskfile.yml`: `WINGET_PACKAGE: AgentMux.AgentMux` → `AgentMux.AI`.
+- `.github/workflows/release.yml`: fix the identifier in the commented-out
+  `winget` job's `wingetcreate update` call for when it's re-enabled. **Not
+  re-enabled in this PR** — `wingetcreate update` still requires the manifest
+  to exist first; flipping it on now would just resume the same failure mode
+  under the new name. Re-enable as a follow-up once §4's bootstrap PR is
+  merged into `microsoft/winget-pkgs`.
+- This spec, as the record of the decision and the two-identity distinction
+  in §2 (so nobody "fixes" the MSIX identity to match the WinGet one later).
+
+## 4. Bootstrap procedure (one-time, manual — the actual "deploy" step)
+
+Not automatable the first time: `wingetcreate new` walks/generates a fresh
+manifest and opens a PR against `microsoft/winget-pkgs`, a repo this project
+doesn't own.
+
+1. Install `wingetcreate` (`winget install Microsoft.WingetCreate` or fetch
+   the release binary directly).
+2. Run against the latest real GitHub Release asset — installer is Inno Setup
+   (`scripts/package-installer.ps1`), a native WinGet `InstallerType: inno`,
+   which WinGet handles with standard silent-install switches automatically:
+   ```
+   wingetcreate new AgentMux.AI \
+     --version <ver> \
+     --urls "https://github.com/agentmuxai/agentmux/releases/download/v<ver>/AgentMux-<ver>-x64-setup.exe" \
+     --submit \
+     --token $WINGET_TOKEN
+   ```
+   Publisher: `AgentMux`. PackageName: `AgentMux`. License: `Apache-2.0`
+   (`package.json`'s `license` field — matches the real repo license).
+3. This opens a PR on `microsoft/winget-pkgs`. Automated validation there
+   checks the URL is reachable, the installer runs silently, and the
+   version/hash match. A human moderator merges on success — typically within
+   a day or two, out of this repo's control.
+4. Once merged upstream, re-enable the `winget` job in `release.yml` (switch
+   `wingetcreate new` → `update` in the bootstrap's mental model — the CI job
+   already uses `update`, it just needs uncommenting) so every future release
+   auto-submits a version-bump PR.
+
+## 5. Verification
+
+- `Taskfile.yml`/`release.yml` reference the new identifier consistently
+  (`grep -rn "AgentMux.AgentMux"` should only still match the MSIX-specific
+  files listed in §2's table — `packaging/msix/`, `scripts/package-msix.ps1`,
+  and historical/archive docs describing the Store identity).
+- `WINGET_TOKEN` repo secret already exists (confirmed via
+  `gh api repos/agentmuxai/agentmux/actions/secrets`) — not re-verified for
+  validity/scope here; the bootstrap submission itself is the real test.
+- Bootstrap success: the `microsoft/winget-pkgs` PR opens and its automated
+  validation checks pass. Full success (merged, `winget show AgentMux.AI`
+  resolves for any Windows user) depends on Microsoft's moderation queue and
+  is outside this repo's control/timeline.

--- a/docs/specs/SPEC_WINGET_PACKAGE_BOOTSTRAP_2026_09_10.md
+++ b/docs/specs/SPEC_WINGET_PACKAGE_BOOTSTRAP_2026_09_10.md
@@ -57,16 +57,29 @@ doesn't own.
    the release binary directly).
 2. Run against the latest real GitHub Release asset — installer is Inno Setup
    (`scripts/package-installer.ps1`), a native WinGet `InstallerType: inno`,
-   which WinGet handles with standard silent-install switches automatically:
+   which WinGet handles with standard silent-install switches automatically.
+   **Corrected 2026-09-10 (Codex, PR #3159 review):** `new`'s only positional
+   argument is the installer URL(s) — there is no `--version`/`--urls`/
+   `--submit` flag on `new` (those exist on `update`, the *ongoing*-release
+   command, not the one-time bootstrap). Passing `AgentMux.AI` positionally,
+   as an earlier draft of this doc did, would be parsed as a malformed
+   installer URL and fail before ever reaching manifest creation. Verified
+   directly against `wingetcreate.exe new --help` (v1.12.13.0):
    ```
-   wingetcreate new AgentMux.AI \
-     --version <ver> \
-     --urls "https://github.com/agentmuxai/agentmux/releases/download/v<ver>/AgentMux-<ver>-x64-setup.exe" \
-     --submit \
+   wingetcreate.exe new \
+     "https://github.com/agentmuxai/agentmux/releases/download/v<ver>/AgentMux-<ver>-x64-setup.exe" \
      --token $WINGET_TOKEN
    ```
-   Publisher: `AgentMux`. PackageName: `AgentMux`. License: `Apache-2.0`
-   (`package.json`'s `license` field — matches the real repo license).
+   `new` downloads the installer, extracts what metadata it can, then
+   **interactively prompts** for the fields it can't infer — Package
+   Identifier, Publisher, Package Name, License, etc. Answer those prompts:
+   PackageIdentifier `AgentMux.AI`, Publisher `AgentMux`, PackageName
+   `AgentMux`, License `Apache-2.0` (`package.json`'s `license` field —
+   matches the real repo license). Passing `--token` is what makes it submit
+   directly on completion (vs. `--out <dir>` to only write the manifest
+   locally for a dry-run/inspection first, which is worth doing at least once
+   before the real submission, given the interactive surface here was already
+   wrong once).
 3. This opens a PR on `microsoft/winget-pkgs`. Automated validation there
    checks the URL is reachable, the installer runs silently, and the
    version/hash match. A human moderator merges on success — typically within


### PR DESCRIPTION
## Summary

- WinGet release automation has been **disabled since 2026-08-12** (#2549): `wingetcreate update` requires an existing manifest in `microsoft/winget-pkgs`, which was never bootstrapped — it failed identically on every release back through at least v0.54.14.
- Before doing that one-time bootstrap (tracked as the actual "deploy" step, done separately against `microsoft/winget-pkgs`, not this repo), rename the planned identifier per repo owner's decision: `AgentMux.AgentMux` → **`AgentMux.AI`**.
- Safe to rename freely: nothing has ever been published under the WinGet identifier. This is **not** the same identity as the already-live MSIX/Microsoft Store package (`AgentMux.AgentMux`, Store ID `9P9QCXNNCRK3`, PFN `AgentMux.AgentMux_vqr1k32tkfk4y`) — that one stays untouched, since changing it would break the update chain for existing Store installs. See the new spec for the full distinction.

## Changes

- `Taskfile.yml`: `WINGET_PACKAGE: AgentMux.AgentMux` → `AgentMux.AI`, with a comment pointing at the spec so the two identities don't get conflated later.
- `.github/workflows/release.yml`: corrected the identifier inside the **commented-out** `winget` job (still disabled — `wingetcreate update` needs the manifest to exist first; re-enabling is a follow-up once the bootstrap PR merges upstream).
- `docs/specs/SPEC_WINGET_PACKAGE_BOOTSTRAP_2026_09_10.md`: records the decision, the two-identity distinction, and the bootstrap procedure (installer is Inno Setup → native WinGet `InstallerType: inno`; license `Apache-2.0` from `package.json`; `WINGET_TOKEN` repo secret already exists).
- `docs/specs/INDEX.md`: regenerated (`bash scripts/gen-docs-index.sh`) to include the new spec.

## Test plan

- [x] `task --list` parses `Taskfile.yml` cleanly after the edit.
- [x] `grep -rn "AgentMux\.AgentMux"` confirms only the MSIX-specific files/comments still reference the old identity — nothing else needed updating.
- [x] `gh api repos/agentmuxai/agentmux/actions/secrets` confirms `WINGET_TOKEN` already exists (not re-verified for validity/scope — the actual bootstrap submission is the real test of that).
- [ ] Not yet done: the actual `wingetcreate new AgentMux.AI ...` bootstrap PR against `microsoft/winget-pkgs` — that's the follow-up "deploy" step once this merges, tracked in the spec's §4.

<!-- agentmux:agent_id=agent3 -->