### PR TITLE
feat(srv): Phase 3 — track project instructions across launches

### DIFF
--- a/.changesets/1789031080-feat-srv-track-what-each-agent-reads-as-project-instructions-rfl0.md
+++ b/.changesets/1789031080-feat-srv-track-what-each-agent-reads-as-project-instructions-rfl0.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(srv): track what each agent reads as project instructions, so a repository file changing between launches is detectable

--- a/agentmux-srv/src/backend/storage/agents.rs
+++ b/agentmux-srv/src/backend/storage/agents.rs
@@ -511,6 +511,11 @@ impl Store {
     }
 
     /// Delete all seeded agents (is_seeded=1). Used by reseed to clear built-in agents.
+    ///
+    /// No project-instruction cleanup here, unlike `agent_def_delete`: this
+    /// removes template rows, and a template is never launched — observations
+    /// are recorded by `agent.open`, so a template has none to forget (Codex,
+    /// PR #3162).
     pub fn agent_def_delete_seeded(&self) -> Result<usize, StoreError> {
         // Consolidation Phase 3b (PR 2): only the template rows go. Every
         // `is_template = 0` row — a user clone OR an agent launched from a
@@ -1256,6 +1261,20 @@ impl Store {
             conn.execute("DELETE FROM db_agents WHERE id=?1", params![id])?
         };
         if rows > 0 {
+            // Project-instruction observations are keyed by agent id with no
+            // foreign key (they record files this agent READS, which is not a
+            // relationship SQLite can enforce), so nothing else would remove
+            // them and a future agent reusing this id would inherit somebody
+            // else's baseline — every file reporting `unchanged` against
+            // observations that were never made about it. Cleaned up here,
+            // beside the row it belongs to, rather than left to each caller
+            // (ReAgent, PR #3162).
+            if let Err(e) = self.project_instructions_forget(id) {
+                tracing::warn!(
+                    agent_def_id = %id, error = %e,
+                    "agent_def_delete: project-instruction observations left behind"
+                );
+            }
             if let Some(reg) = self.registry() {
                 if let Err(e) = reg.hard_delete(id) {
                     tracing::warn!(

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -341,7 +341,23 @@ pub const SHARED_STORE_SCHEMA_VERSION: i64 = 9;
 ///        `m0029` runs later in the same upgrade pass and correctly drops
 ///        what the rename just produced — no special-casing needed, and no
 ///        data is stranded under the old name.
-pub const OBJECT_SCHEMA_VERSION: i64 = 32;
+///   v33 — `db_agent_project_instructions`: what each agent was last observed
+///        to read as project instructions from its working directory, keyed
+///        `(agent_id, path)`. Phase 3 of
+///        `SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md`.
+///
+///        Records a content hash and an observation time, never the content:
+///        this is a tracking table, not a mirror. The distinction from
+///        `db_agent_native_memory` above is deliberate — that one stores
+///        content because it is a durable copy of files AgentMux may have to
+///        serve when the originals are unreachable, whereas these files
+///        belong to the repository, are always readable from it, and are
+///        never written by AgentMux. Storing their content would create a
+///        second copy of somebody else's file with no one to keep it honest.
+///
+///        Purely additive: nothing reads it at launch, and an agent with no
+///        row simply has no prior observation to compare against.
+pub const OBJECT_SCHEMA_VERSION: i64 = 33;
 /// `user_version` value stamped into `filestore.db`.
 pub const FILESTORE_SCHEMA_VERSION: i64 = 1;
 /// `user_version` value stamped into `sagas.db`.
@@ -798,6 +814,23 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             last_seen_path     TEXT NOT NULL DEFAULT '',
             last_seen_mtime_ms INTEGER NOT NULL DEFAULT 0,
             PRIMARY KEY (agent_id, filename)
+        );
+
+        -- v33: what each agent was last observed to READ as project
+        -- instructions. Hash and timestamp only, never content — these files
+        -- belong to the repository and are always readable from it, unlike
+        -- db_agent_native_memory above, which mirrors content precisely
+        -- because the originals can become unreachable. See
+        -- SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md Phase 3.
+        CREATE TABLE IF NOT EXISTS db_agent_project_instructions (
+            agent_id      TEXT NOT NULL,
+            path          TEXT NOT NULL,
+            content_hash  TEXT NOT NULL DEFAULT '',
+            size_bytes    INTEGER NOT NULL DEFAULT 0,
+            owner         TEXT NOT NULL DEFAULT 'foreign',
+            existed       INTEGER NOT NULL DEFAULT 0,
+            observed_at   INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (agent_id, path)
         );
 
         -- v24: append-only version history for native memory content — see

--- a/agentmux-srv/src/backend/storage/mod.rs
+++ b/agentmux-srv/src/backend/storage/mod.rs
@@ -24,6 +24,7 @@ pub mod filestore;
 pub mod history;
 pub mod identities;
 pub mod managed;
+pub mod project_instructions;
 pub mod mcp_servers;
 pub mod bundles;
 pub mod migrations;

--- a/agentmux-srv/src/backend/storage/project_instructions.rs
+++ b/agentmux-srv/src/backend/storage/project_instructions.rs
@@ -118,9 +118,16 @@ impl Store {
 
     /// Forget everything recorded for `agent_id`.
     ///
-    /// For agent deletion. Nothing else should call it: dropping observations
-    /// resets every file to `FirstSeen`, which silently discards the drift
-    /// this table exists to surface.
+    /// Called by `agent_def_delete`, beside the row these observations belong
+    /// to. There is no foreign key to enforce it — they record files an agent
+    /// *reads*, which is not a relationship SQLite can express — so without
+    /// that call the rows outlive the agent and a future agent reusing the id
+    /// inherits somebody else's baseline, every file reporting `unchanged`
+    /// against observations never made about it (ReAgent, PR #3162).
+    ///
+    /// Nothing else should call it: dropping observations resets every file to
+    /// `FirstSeen`, which silently discards the drift this table exists to
+    /// surface.
     pub fn project_instructions_forget(&self, agent_id: &str) -> Result<usize, StoreError> {
         let conn = self.conn.lock().unwrap();
         Ok(conn.execute(
@@ -207,6 +214,40 @@ mod tests {
         assert_eq!(s.project_instructions_forget("a1").unwrap(), 1);
         assert!(s.project_instructions_list("a1").unwrap().is_empty());
         assert_eq!(s.project_instructions_list("a2").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn deleting_an_agent_forgets_its_observations() {
+        // Without this the rows outlive the agent, and an agent reusing the id
+        // inherits a baseline that was never about it — every file reporting
+        // `unchanged` against somebody else's observations (ReAgent, #3162).
+        let s = Store::open_in_memory().unwrap();
+        let mut def: crate::backend::storage::AgentDefinition =
+            serde_json::from_value(serde_json::json!({
+                "id": "doomed",
+                "slug": "doomed",
+                "name": "Doomed",
+                "icon": "robot",
+                "provider": "claude",
+                "description": "",
+                "working_directory": "",
+                "created_at": 1,
+            }))
+            .unwrap();
+        s.agent_def_insert(&mut def).unwrap();
+        s.project_instructions_record("doomed", &[obs("CLAUDE.md", "h1", true)]).unwrap();
+        s.project_instructions_record("survivor", &[obs("CLAUDE.md", "h1", true)]).unwrap();
+
+        assert!(s.agent_def_delete("doomed").unwrap());
+        assert!(
+            s.project_instructions_list("doomed").unwrap().is_empty(),
+            "a deleted agent must not leave observations behind"
+        );
+        assert_eq!(
+            s.project_instructions_list("survivor").unwrap().len(),
+            1,
+            "and must not take anyone else's with it"
+        );
     }
 
     #[test]

--- a/agentmux-srv/src/backend/storage/project_instructions.rs
+++ b/agentmux-srv/src/backend/storage/project_instructions.rs
@@ -1,0 +1,240 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tracking for what an agent reads as project instructions.
+//!
+//! Phase 3 of `SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md`. The
+//! resolver in `backend::project_instructions` answers "what will this agent
+//! read, right now". This records those answers so the next one can be
+//! compared against the last, which is what makes a repository's own
+//! `CLAUDE.md` changing under a running agent visible at all.
+//!
+//! **Hash and metadata only, never content.** `db_agent_native_memory` mirrors
+//! content because it is a durable copy of files that can become unreachable;
+//! these files belong to the repository, are always readable from it, and are
+//! never written by AgentMux. A second copy of somebody else's file, with
+//! nothing keeping it honest, would be a liability rather than a feature.
+
+use rusqlite::params;
+use serde::Serialize;
+
+use super::error::StoreError;
+use super::store::Store;
+
+/// One recorded observation of one instruction file.
+#[derive(Debug, Clone, Serialize)]
+pub struct ProjectInstructionObservation {
+    pub path: String,
+    pub content_hash: String,
+    pub size_bytes: i64,
+    /// `"agentmux"` or `"foreign"`, as the resolver classified it.
+    pub owner: String,
+    pub existed: bool,
+    pub observed_at: i64,
+}
+
+/// How a file compares to the last time it was observed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InstructionChange {
+    /// No prior observation — the first time this agent was looked at.
+    FirstSeen,
+    Unchanged,
+    /// Content differs from the last observation.
+    Modified,
+    /// Present now, absent before.
+    Added,
+    /// Absent now, present before.
+    Removed,
+}
+
+impl Store {
+    /// Record what was observed, replacing the previous observation.
+    ///
+    /// Last-write-wins per `(agent_id, path)`: this is a "what did it look
+    /// like most recently" record, not a history. Version history for these
+    /// files would mean storing their content, which is exactly what this
+    /// table declines to do — the repository's own version control already
+    /// owns that job for the repository's own files.
+    pub fn project_instructions_record(
+        &self,
+        agent_id: &str,
+        observations: &[ProjectInstructionObservation],
+    ) -> Result<(), StoreError> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        for obs in observations {
+            tx.execute(
+                "INSERT INTO db_agent_project_instructions
+                    (agent_id, path, content_hash, size_bytes, owner, existed, observed_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                 ON CONFLICT(agent_id, path) DO UPDATE SET
+                    content_hash = excluded.content_hash,
+                    size_bytes   = excluded.size_bytes,
+                    owner        = excluded.owner,
+                    existed      = excluded.existed,
+                    observed_at  = excluded.observed_at",
+                params![
+                    agent_id,
+                    obs.path,
+                    obs.content_hash,
+                    obs.size_bytes,
+                    obs.owner,
+                    if obs.existed { 1 } else { 0 },
+                    obs.observed_at,
+                ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Every recorded observation for `agent_id`, path-ordered.
+    pub fn project_instructions_list(
+        &self,
+        agent_id: &str,
+    ) -> Result<Vec<ProjectInstructionObservation>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT path, content_hash, size_bytes, owner, existed, observed_at
+             FROM db_agent_project_instructions
+             WHERE agent_id = ?1
+             ORDER BY path",
+        )?;
+        let rows = stmt
+            .query_map(params![agent_id], |row| {
+                Ok(ProjectInstructionObservation {
+                    path: row.get(0)?,
+                    content_hash: row.get(1)?,
+                    size_bytes: row.get(2)?,
+                    owner: row.get(3)?,
+                    existed: row.get::<_, i64>(4)? != 0,
+                    observed_at: row.get(5)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Forget everything recorded for `agent_id`.
+    ///
+    /// For agent deletion. Nothing else should call it: dropping observations
+    /// resets every file to `FirstSeen`, which silently discards the drift
+    /// this table exists to surface.
+    pub fn project_instructions_forget(&self, agent_id: &str) -> Result<usize, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        Ok(conn.execute(
+            "DELETE FROM db_agent_project_instructions WHERE agent_id = ?1",
+            params![agent_id],
+        )?)
+    }
+}
+
+/// Compare a fresh observation against the recorded one.
+///
+/// Free function rather than a `Store` method: it is pure, and keeping it that
+/// way means the comparison can be unit-tested without a database and reused
+/// wherever both halves are already in hand.
+pub fn classify_change(
+    previous: Option<&ProjectInstructionObservation>,
+    current_exists: bool,
+    current_hash: &str,
+) -> InstructionChange {
+    let Some(prev) = previous else {
+        return InstructionChange::FirstSeen;
+    };
+    match (prev.existed, current_exists) {
+        (false, false) => InstructionChange::Unchanged,
+        (false, true) => InstructionChange::Added,
+        (true, false) => InstructionChange::Removed,
+        (true, true) => {
+            // An empty hash means the file could not be read this time — a
+            // permissions change, or bytes that stopped being UTF-8. Calling
+            // that "modified" would be a guess; calling it unchanged would
+            // hide it. The resolver already reports the error alongside, so
+            // the honest answer here is that nothing is known to have changed.
+            if current_hash.is_empty() || prev.content_hash.is_empty() {
+                InstructionChange::Unchanged
+            } else if prev.content_hash == current_hash {
+                InstructionChange::Unchanged
+            } else {
+                InstructionChange::Modified
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn obs(path: &str, hash: &str, existed: bool) -> ProjectInstructionObservation {
+        ProjectInstructionObservation {
+            path: path.to_string(),
+            content_hash: hash.to_string(),
+            size_bytes: 1,
+            owner: "foreign".to_string(),
+            existed,
+            observed_at: 1,
+        }
+    }
+
+    #[test]
+    fn recording_twice_replaces_rather_than_duplicates() {
+        let s = Store::open_in_memory().unwrap();
+        s.project_instructions_record("a1", &[obs("CLAUDE.md", "h1", true)]).unwrap();
+        s.project_instructions_record("a1", &[obs("CLAUDE.md", "h2", true)]).unwrap();
+
+        let rows = s.project_instructions_list("a1").unwrap();
+        assert_eq!(rows.len(), 1, "one row per (agent, path)");
+        assert_eq!(rows[0].content_hash, "h2", "latest observation wins");
+    }
+
+    #[test]
+    fn observations_are_scoped_to_their_agent() {
+        let s = Store::open_in_memory().unwrap();
+        s.project_instructions_record("a1", &[obs("CLAUDE.md", "h1", true)]).unwrap();
+        s.project_instructions_record("a2", &[obs("CLAUDE.md", "other", true)]).unwrap();
+        assert_eq!(s.project_instructions_list("a1").unwrap()[0].content_hash, "h1");
+        assert_eq!(s.project_instructions_list("a2").unwrap()[0].content_hash, "other");
+    }
+
+    #[test]
+    fn forgetting_one_agent_leaves_the_others_alone() {
+        let s = Store::open_in_memory().unwrap();
+        s.project_instructions_record("a1", &[obs("CLAUDE.md", "h1", true)]).unwrap();
+        s.project_instructions_record("a2", &[obs("CLAUDE.md", "h1", true)]).unwrap();
+        assert_eq!(s.project_instructions_forget("a1").unwrap(), 1);
+        assert!(s.project_instructions_list("a1").unwrap().is_empty());
+        assert_eq!(s.project_instructions_list("a2").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn classify_covers_every_transition() {
+        let present = obs("CLAUDE.md", "h1", true);
+        let absent = obs("CLAUDE.md", "", false);
+
+        assert_eq!(classify_change(None, true, "h1"), InstructionChange::FirstSeen);
+        assert_eq!(classify_change(Some(&present), true, "h1"), InstructionChange::Unchanged);
+        assert_eq!(classify_change(Some(&present), true, "h2"), InstructionChange::Modified);
+        assert_eq!(classify_change(Some(&present), false, ""), InstructionChange::Removed);
+        assert_eq!(classify_change(Some(&absent), true, "h1"), InstructionChange::Added);
+        assert_eq!(classify_change(Some(&absent), false, ""), InstructionChange::Unchanged);
+    }
+
+    #[test]
+    fn an_unreadable_file_is_not_reported_as_modified() {
+        // The resolver leaves the hash empty when it cannot read the bytes.
+        // Guessing "modified" from that would cry wolf on a permissions
+        // change; the resolver reports the error separately.
+        let present = obs("CLAUDE.md", "h1", true);
+        assert_eq!(classify_change(Some(&present), true, ""), InstructionChange::Unchanged);
+
+        let unreadable_before = obs("CLAUDE.md", "", true);
+        assert_eq!(
+            classify_change(Some(&unreadable_before), true, "h1"),
+            InstructionChange::Unchanged,
+            "no baseline to compare against either"
+        );
+    }
+}

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -957,6 +957,20 @@ pub(super) fn write_agent_config_files(
 
     crate::backend::agent_config::write_managed_skill_file_manifest(base_path, &new_managed_skill_paths);
 
+    // Record what this agent will read as project instructions, now that
+    // AgentMux's own files are in their final state for this launch — observed
+    // before the write, this would record the previous launch's content.
+    //
+    // Phase 3 of SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md.
+    // Observing at open is the spec's §8 decision 2: it costs nothing, catches
+    // the case that matters (the repository changed since last launch), and
+    // avoids a watcher. Drift *during* a session is deliberately not covered
+    // yet — revisit only if it shows up in practice.
+    //
+    // Best-effort: an agent must never fail to launch because a tracking row
+    // could not be written.
+    observe_project_instructions(wstore, agent, &expanded_dir);
+
     tracing::info!(
         agent_id = %agent.id,
         work_dir = %expanded_dir,
@@ -965,6 +979,52 @@ pub(super) fn write_agent_config_files(
     );
 
     Ok(())
+}
+
+/// Resolve and record this agent's project instructions.
+///
+/// Split out so the launch path reads as one line and this can be tested on
+/// its own. Never returns an error: see the call site.
+pub(super) fn observe_project_instructions(
+    wstore: &crate::backend::storage::store::Store,
+    agent: &crate::backend::storage::AgentDefinition,
+    working_dir: &str,
+) {
+    use crate::backend::storage::project_instructions::ProjectInstructionObservation;
+
+    let files = crate::backend::project_instructions::resolve_project_instructions(
+        &agent.provider,
+        working_dir,
+    );
+    if files.is_empty() {
+        return;
+    }
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+    let observations: Vec<ProjectInstructionObservation> = files
+        .iter()
+        .map(|f| ProjectInstructionObservation {
+            path: f.path.clone(),
+            content_hash: f.content_hash.clone(),
+            size_bytes: f.size_bytes as i64,
+            owner: match f.owner {
+                crate::backend::project_instructions::InstructionOwner::Agentmux => "agentmux",
+                crate::backend::project_instructions::InstructionOwner::Foreign => "foreign",
+            }
+            .to_string(),
+            existed: f.exists,
+            observed_at: now,
+        })
+        .collect();
+
+    if let Err(e) = wstore.project_instructions_record(&agent.id, &observations) {
+        tracing::warn!(
+            agent_id = %agent.id, error = %e,
+            "agent.open: could not record project-instruction observations"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -402,10 +402,43 @@ fn register_agent_project_instructions(engine: &Arc<WshRpcEngine>, state: &AppSt
                     &agent.provider,
                     &work_dir,
                 );
+
+                // Compare against what was recorded at the last launch, so a
+                // repository file that changed underneath is visible rather
+                // than merely present. Observations are written at
+                // `agent.open` (`observe_project_instructions`) — this RPC
+                // stays a pure read, which is why a file edited since the last
+                // launch reports `modified` every time it is called until the
+                // agent is next opened.
+                let previous = state
+                    .wstore
+                    .project_instructions_list(&agent.id)
+                    .unwrap_or_default();
+                let enriched: Vec<serde_json::Value> = files
+                    .iter()
+                    .map(|f| {
+                        let prev = previous.iter().find(|p| p.path == f.path);
+                        let change = crate::backend::storage::project_instructions::classify_change(
+                            prev,
+                            f.exists,
+                            &f.content_hash,
+                        );
+                        let mut v = serde_json::to_value(f).unwrap_or_default();
+                        if let Some(obj) = v.as_object_mut() {
+                            obj.insert("change".to_string(), json!(change));
+                            obj.insert(
+                                "last_observed_at".to_string(),
+                                json!(prev.map(|p| p.observed_at)),
+                            );
+                        }
+                        v
+                    })
+                    .collect();
+
                 Ok(Some(json!({
                     "provider": agent.provider,
                     "working_directory": work_dir,
-                    "files": files,
+                    "files": enriched,
                 })))
             })
         })
@@ -3337,6 +3370,73 @@ mod export_import_for_agent_tests {
             issues.iter().any(|i| i["field"] == "mcp_servers"
                 && i["message"].as_str().unwrap_or("").contains("broken")),
             "the issue must name the server: {issues:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_foreign_instruction_file_changing_between_launches_is_visible() {
+        // The point of tracking: a repository's own CLAUDE.md can be the
+        // majority of what an agent is told, and until now nothing recorded
+        // enough about one to notice it had changed.
+        use crate::backend::storage::project_instructions::InstructionChange;
+
+        let state = test_state();
+        let work = tempfile::tempdir().unwrap();
+        let config_dir = tempfile::tempdir().unwrap();
+        make_agent(&state, "agent-1", work.path().to_str().unwrap(), config_dir.path());
+        let agent = state.wstore.agent_def_get("agent-1").unwrap().unwrap();
+
+        std::fs::write(work.path().join("CLAUDE.md"), "original rules").unwrap();
+
+        // First launch: nothing recorded yet.
+        let first = crate::backend::project_instructions::resolve_project_instructions(
+            &agent.provider,
+            work.path().to_str().unwrap(),
+        );
+        let claude = first.iter().find(|f| f.path == "CLAUDE.md").unwrap();
+        assert_eq!(
+            crate::backend::storage::project_instructions::classify_change(
+                None, claude.exists, &claude.content_hash
+            ),
+            InstructionChange::FirstSeen
+        );
+        crate::server::app_api::agent_open::observe_project_instructions(
+            &state.wstore,
+            &agent,
+            work.path().to_str().unwrap(),
+        );
+
+        // The repository changes underneath.
+        std::fs::write(work.path().join("CLAUDE.md"), "somebody edited this").unwrap();
+
+        let second = crate::backend::project_instructions::resolve_project_instructions(
+            &agent.provider,
+            work.path().to_str().unwrap(),
+        );
+        let claude = second.iter().find(|f| f.path == "CLAUDE.md").unwrap();
+        let recorded = state.wstore.project_instructions_list("agent-1").unwrap();
+        let prev = recorded.iter().find(|p| p.path == "CLAUDE.md");
+        assert_eq!(
+            crate::backend::storage::project_instructions::classify_change(
+                prev, claude.exists, &claude.content_hash
+            ),
+            InstructionChange::Modified,
+            "an edit between launches must be detectable"
+        );
+
+        // Observing again settles it.
+        crate::server::app_api::agent_open::observe_project_instructions(
+            &state.wstore,
+            &agent,
+            work.path().to_str().unwrap(),
+        );
+        let recorded = state.wstore.project_instructions_list("agent-1").unwrap();
+        let prev = recorded.iter().find(|p| p.path == "CLAUDE.md");
+        assert_eq!(
+            crate::backend::storage::project_instructions::classify_change(
+                prev, claude.exists, &claude.content_hash
+            ),
+            InstructionChange::Unchanged
         );
     }
 

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -414,7 +414,7 @@ fn register_agent_project_instructions(engine: &Arc<WshRpcEngine>, state: &AppSt
                     .wstore
                     .project_instructions_list(&agent.id)
                     .unwrap_or_default();
-                let enriched: Vec<serde_json::Value> = files
+                let mut enriched: Vec<serde_json::Value> = files
                     .iter()
                     .map(|f| {
                         let prev = previous.iter().find(|p| p.path == f.path);
@@ -434,6 +434,33 @@ fn register_agent_project_instructions(engine: &Arc<WshRpcEngine>, state: &AppSt
                         v
                     })
                     .collect();
+
+                // A path the resolver no longer returns at all — a scanned
+                // `.github/instructions/*.instructions.md` deleted since the
+                // last launch — would otherwise just vanish from the response,
+                // never reported as `removed`, and recreating it later would
+                // read as `unchanged` against the stale row (Codex, PR #3162).
+                // The declared paths always come back (absent ones included),
+                // so this only ever fires for dynamically scanned files.
+                for prev in previous.iter().filter(|p| !files.iter().any(|f| f.path == p.path)) {
+                    let change = crate::backend::storage::project_instructions::classify_change(
+                        Some(prev),
+                        false,
+                        "",
+                    );
+                    enriched.push(json!({
+                        "path": prev.path,
+                        "exists": false,
+                        "size_bytes": 0,
+                        "content_hash": "",
+                        "owner": prev.owner,
+                        "content": "",
+                        "truncated": false,
+                        "error": serde_json::Value::Null,
+                        "change": change,
+                        "last_observed_at": prev.observed_at,
+                    }));
+                }
 
                 Ok(Some(json!({
                     "provider": agent.provider,
@@ -3370,6 +3397,58 @@ mod export_import_for_agent_tests {
             issues.iter().any(|i| i["field"] == "mcp_servers"
                 && i["message"].as_str().unwrap_or("").contains("broken")),
             "the issue must name the server: {issues:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_scanned_file_deleted_after_launch_is_reported_removed() {
+        // Codex on #3162: the resolver stops returning a scanned path once the
+        // file is gone, so iterating current files only made it vanish from
+        // the response instead of reporting `removed` — and the stale row
+        // meant recreating it would later read as `unchanged`.
+        use crate::backend::storage::project_instructions::{
+            classify_change, InstructionChange, ProjectInstructionObservation,
+        };
+
+        let state = test_state();
+        let work = tempfile::tempdir().unwrap();
+        let config_dir = tempfile::tempdir().unwrap();
+        make_agent(&state, "agent-1", work.path().to_str().unwrap(), config_dir.path());
+
+        // Recorded at a previous launch, and since deleted from disk.
+        state
+            .wstore
+            .project_instructions_record(
+                "agent-1",
+                &[ProjectInstructionObservation {
+                    path: ".github/instructions/gone.instructions.md".to_string(),
+                    content_hash: "h1".to_string(),
+                    size_bytes: 3,
+                    owner: "foreign".to_string(),
+                    existed: true,
+                    observed_at: 1,
+                }],
+            )
+            .unwrap();
+
+        let current = crate::backend::project_instructions::resolve_project_instructions(
+            "copilot",
+            work.path().to_str().unwrap(),
+        );
+        assert!(
+            !current.iter().any(|f| f.path.ends_with("gone.instructions.md")),
+            "precondition: the resolver no longer returns a deleted scanned file"
+        );
+
+        let previous = state.wstore.project_instructions_list("agent-1").unwrap();
+        let orphan = previous
+            .iter()
+            .find(|p| p.path.ends_with("gone.instructions.md"))
+            .unwrap();
+        assert_eq!(
+            classify_change(Some(orphan), false, ""),
+            InstructionChange::Removed,
+            "a prior observation with no current file is a removal"
         );
     }
 


### PR DESCRIPTION
Phase 3 of `SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md`, the tracking half. Builds on #3156, which answered *what an agent reads right now*. This records those answers so the next one can be compared against the last — which is what makes a repository's own `CLAUDE.md` changing under an agent **visible** rather than merely present. Tracking: #3148.

**Schema v33** adds `db_agent_project_instructions`, keyed `(agent_id, path)`, holding a content hash, size, owner and observation time.

**Hash and metadata only, never content.** `db_agent_native_memory` mirrors content because it is a durable copy of files that can become unreachable. These files belong to the repository, are always readable from it, and are never written by AgentMux — a second copy of somebody else's file, with nothing keeping it honest, would be a liability rather than a feature. The distinction is stated in the schema doc so the next person does not "fix" the asymmetry.

**Observation happens at `agent.open`**, after AgentMux's own files reach their final state for that launch. Observing earlier would record the *previous* launch's content. Best-effort throughout: an agent must never fail to launch because a tracking row could not be written.

That is the spec's §8 decision 2 — it costs nothing, catches the case that matters (the repository changed since last launch), and avoids a watcher. **Drift during a session remains uncovered**, deliberately; the RPC therefore reports `modified` on every call until the agent is next opened, which is stated at the call site rather than left to surprise someone.

**`classify_change` is pure** — a function over `(previous, exists, hash)` — so every transition is unit-testable without a database.

| Transition | Result |
|---|---|
| No prior observation | `first_seen` |
| Same hash | `unchanged` |
| Different hash | `modified` |
| Absent → present | `added` |
| Present → absent | `removed` |
| Hash unavailable either side | `unchanged` |

That last row is the one worth arguing about. The resolver leaves the hash empty when it cannot read the bytes, so guessing `modified` would cry wolf on a permissions change, while calling it unchanged hides nothing — the resolver already reports the error alongside.

`agent.project_instructions` now returns each file's `change` and `last_observed_at` beside its current state, and **stays a pure read**: writes happen at launch.

**Tests** — 6 new. Store-level: replace-not-duplicate, per-agent scoping, forget-one-leaves-others. Pure: every transition, and the unreadable case. Plus an end-to-end test that writes a `CLAUDE.md`, observes, edits it, and asserts the edit is detectable and then settles.

**Verification**
```
cargo test -p agentmux-srv   → 3263 passed, 0 failed
```

Next: export carrying `components.projectInstructions` with the owner discriminator, surfaced on import and never applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
