### PR TITLE
feat(srv): Phase 3 — carry project instructions in the export, never install them

### DIFF
--- a/.changesets/1789033084-feat-srv-exported-bundles-carry-the-project-instructions-the-5y54.md
+++ b/.changesets/1789033084-feat-srv-exported-bundles-carry-the-project-instructions-the-5y54.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(srv): exported bundles carry the project instructions their agent was reading, recorded read-only and never installed on import

--- a/agentmux-srv/src/backend/bundle_import.rs
+++ b/agentmux-srv/src/backend/bundle_import.rs
@@ -1007,29 +1007,47 @@ pub fn parse_bundle_import_with_budget(
                     let str_field = |k: &str| {
                         obj.get(k).and_then(|v| v.as_str()).unwrap_or_default().to_string()
                     };
-                    let file_path = str_field("file");
-                    if file_path.is_empty() {
+                    let raw_file = str_field("file");
+                    if raw_file.is_empty() {
                         warnings.push(
                             "components.projectInstructions: entry has no \"file\"; skipped"
                                 .to_string(),
                         );
                         continue;
                     }
+                    // Normalize the manifest's OWN reference the same way
+                    // `by_path`'s keys are normalized, exactly as every other
+                    // manifest-reference lookup in this file does (codex P2,
+                    // PR #2379 round 4; reagent P2, round 6; reagent P2 again
+                    // on PR #3163 — this is the third component to need it).
+                    // Without it a valid non-canonical spelling
+                    // (`./instructions/project/CLAUDE.md`, backslashes) misses
+                    // the lookup and gets reported as "not found" even though
+                    // the content is right there.
+                    let Some(file_path) = sanitize_context_relative_path(&raw_file) else {
+                        warnings.push(format!(
+                            "components.projectInstructions: \"{raw_file}\" is not a \
+                             safe path; skipped"
+                        ));
+                        continue;
+                    };
                     // The accounts/ allowlist applies here for the same reason
                     // it applies to components.instructions: a manifest is not
                     // a trustworthy inventory of its own bundle, and a
                     // projectInstructions entry must not become a second way to
                     // read accounts/requirements.json back out as content.
+                    // Checked on the NORMALIZED path so a non-canonical
+                    // spelling can't slip past it either.
                     if is_requirements_json(&file_path) {
                         warnings.push(format!(
-                            "components.projectInstructions: \"{file_path}\" is the \
+                            "components.projectInstructions: \"{raw_file}\" is the \
                              accounts/ requirements file; not readable as instructions"
                         ));
                         continue;
                     }
                     let Some(content) = by_path.get(file_path.as_str()) else {
                         warnings.push(format!(
-                            "components.projectInstructions: \"{file_path}\" not found \
+                            "components.projectInstructions: \"{raw_file}\" not found \
                              among the bundle's files; skipped"
                         ));
                         continue;
@@ -1800,6 +1818,53 @@ mod tests {
                 }],
             }))),
             file("accounts/requirements.json", "[{\"id\":\"x\",\"credentialProvider\":\"y\"}]"),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+
+        assert!(result.project_instructions.is_empty());
+        assert!(result
+            .warnings
+            .iter()
+            .any(|w| w.contains("projectInstructions") && w.contains("requirements file")));
+    }
+
+    #[test]
+    fn a_non_canonical_project_instruction_reference_still_resolves() {
+        // reagent P2, PR #3163 — the third component to need this (codex P2,
+        // PR #2379 round 4 for instructions; reagent P2 round 6 for
+        // accounts/requirements.json). A bundle not produced by this exact
+        // exporter can spell the reference differently; reporting it "not
+        // found" when the content is present defeats the whole point.
+        let files = manifest_with_project_instructions(serde_json::json!([{
+            "path": "CLAUDE.md",
+            "file": ".\\instructions\\project\\.\\CLAUDE.md",
+            "owner": "foreign",
+        }]));
+        let result = parse_bundle_import(&files).unwrap();
+
+        assert_eq!(
+            result.project_instructions.len(),
+            1,
+            "a non-canonical spelling must resolve, got warnings: {:?}",
+            result.warnings
+        );
+        assert_eq!(result.project_instructions[0].file, "instructions/project/CLAUDE.md");
+        assert!(result.project_instructions[0].content.contains("House rules"));
+    }
+
+    #[test]
+    fn a_non_canonical_accounts_reference_is_still_rejected_from_project_instructions() {
+        // The allowlist is checked on the normalized path, so normalizing the
+        // reference above can't become a way around it.
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "projectInstructions": [{
+                    "path": "CLAUDE.md",
+                    "file": "./accounts/./requirements.json",
+                    "owner": "foreign",
+                }],
+            }))),
+            file("accounts/requirements.json", "{\"requirements\":[]}"),
         ];
         let result = parse_bundle_import(&files).unwrap();
 

--- a/agentmux-srv/src/backend/bundle_import.rs
+++ b/agentmux-srv/src/backend/bundle_import.rs
@@ -264,6 +264,40 @@ pub struct ImportedContextFile {
     pub content: String,
 }
 
+/// One `components.projectInstructions` entry, read back out of the bundle.
+///
+/// Phase 3 of `SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md`. This is
+/// a **record of what the SOURCE agent was reading**, not content to install:
+/// no import path writes these files, and `owner` is the field that says why
+/// (a `foreign` entry belongs to the source repository, and writing it into
+/// the importing one is exactly what
+/// `SPEC_CLAUDE_MD_OWNERSHIP_PROTECTION_2026_08_22.md` exists to prevent).
+///
+/// Carried through the parser rather than being reduced to a warning because
+/// "surfaced" has to mean readable to be worth anything: `agent.
+/// project_instructions` scans the IMPORTING agent's working directory, so it
+/// is structurally unable to show what the source machine had (Codex P1,
+/// PR #3163). Without this the import flow could tell you the component
+/// existed and nothing more.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ImportedProjectInstruction {
+    /// Working-directory-relative path on the SOURCE machine, e.g. `CLAUDE.md`.
+    pub path: String,
+    /// Where the snapshot lives inside the bundle (`instructions/project/...`).
+    pub file: String,
+    /// SHA-256 the exporter recorded for the source bytes. Kept verbatim and
+    /// never recomputed here — a mismatch against `content` is itself
+    /// information about the bundle, not something to paper over.
+    pub content_hash: String,
+    /// `"agentmux"` or `"foreign"`, verbatim from the manifest. Not parsed
+    /// into an enum: an unrecognized value from a future/hand-written bundle
+    /// must survive to the UI as-is rather than being silently coerced to
+    /// `foreign`, which would understate AgentMux's own authorship.
+    pub owner: String,
+    /// The snapshot's content, resolved from the bundle's files.
+    pub content: String,
+}
+
 /// Parsed, validated bundle content ready for the RPC handler to resolve
 /// accounts against and write to the Store. `mcp_servers` still contains
 /// whatever `${VAR}`-style placeholders the exporter's redaction left in
@@ -294,6 +328,10 @@ pub struct ParsedBundleImport {
     pub skills: Vec<ParsedSkill>,
     pub skipped_skills: Vec<String>,
     pub requirements: Vec<AccountRequirement>,
+    /// What the SOURCE agent was reading as project instructions. Read-only —
+    /// see [`ImportedProjectInstruction`]. No caller writes these anywhere;
+    /// `PROJECT_INSTRUCTIONS_NOT_APPLIED_WARNING` rides alongside them.
+    pub project_instructions: Vec<ImportedProjectInstruction>,
     pub warnings: Vec<String>,
 }
 
@@ -443,6 +481,15 @@ const MAX_INSTRUCTION_PROVIDER_VARIANTS: usize = 32;
 /// therefore unconditional and permanent, not a "use the other RPC" pointer.
 pub(crate) const PROJECT_INSTRUCTIONS_NOT_APPLIED_WARNING: &str =
     "components.projectInstructions: recorded for reference, never installed — these files belong to the importing repository, not to the bundle. Inspect them with agent.project_instructions and apply anything you want deliberately";
+
+/// Cap on how many `components.projectInstructions` entries are read back.
+///
+/// Matches `project_instructions::MAX_SCANNED_INSTRUCTION_FILES`, which is the
+/// most AgentMux's own exporter can ever produce — so this can only ever bite
+/// a hand-written or hostile bundle, where refusing to allocate unboundedly is
+/// the point. Overflow warns rather than truncating silently, same rule the
+/// rest of this parser follows.
+pub const MAX_IMPORTED_PROJECT_INSTRUCTIONS: usize = 200;
 
 pub(crate) const MEMORY_COMPONENT_IGNORED_WARNING: &str =
     "components.memory: present but ignored — memory requires an agent-scoped import (bundle.import_for_agent), not bundle.import";
@@ -930,8 +977,76 @@ pub fn parse_bundle_import_with_budget(
     // would be exactly what SPEC_CLAUDE_MD_OWNERSHIP_PROTECTION_2026_08_22.md
     // exists to prevent — a portability feature turning into a back door
     // (SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md §5.2).
-    if components.and_then(|c| c.get("projectInstructions")).is_some() {
+    //
+    // The entries themselves ARE read back (Codex P1, PR #3163): a warning
+    // saying "this bundle recorded some instructions" with no way to see them
+    // is not surfacing anything, and `agent.project_instructions` can't fill
+    // the gap because it scans the IMPORTING agent's working directory.
+    // Reading is not applying — nothing downstream writes these.
+    let mut project_instructions: Vec<ImportedProjectInstruction> = Vec::new();
+    if let Some(raw) = components.and_then(|c| c.get("projectInstructions")) {
         warnings.push(PROJECT_INSTRUCTIONS_NOT_APPLIED_WARNING.to_string());
+        match raw.as_array() {
+            Some(entries) => {
+                if entries.len() > MAX_IMPORTED_PROJECT_INSTRUCTIONS {
+                    warnings.push(format!(
+                        "components.projectInstructions: {} entries exceeds the \
+                         {MAX_IMPORTED_PROJECT_INSTRUCTIONS}-entry cap; only the \
+                         first {MAX_IMPORTED_PROJECT_INSTRUCTIONS} were read",
+                        entries.len()
+                    ));
+                }
+                for entry in entries.iter().take(MAX_IMPORTED_PROJECT_INSTRUCTIONS) {
+                    let Some(obj) = entry.as_object() else {
+                        warnings.push(
+                            "components.projectInstructions: non-object entry skipped"
+                                .to_string(),
+                        );
+                        continue;
+                    };
+                    let str_field = |k: &str| {
+                        obj.get(k).and_then(|v| v.as_str()).unwrap_or_default().to_string()
+                    };
+                    let file_path = str_field("file");
+                    if file_path.is_empty() {
+                        warnings.push(
+                            "components.projectInstructions: entry has no \"file\"; skipped"
+                                .to_string(),
+                        );
+                        continue;
+                    }
+                    // The accounts/ allowlist applies here for the same reason
+                    // it applies to components.instructions: a manifest is not
+                    // a trustworthy inventory of its own bundle, and a
+                    // projectInstructions entry must not become a second way to
+                    // read accounts/requirements.json back out as content.
+                    if is_requirements_json(&file_path) {
+                        warnings.push(format!(
+                            "components.projectInstructions: \"{file_path}\" is the \
+                             accounts/ requirements file; not readable as instructions"
+                        ));
+                        continue;
+                    }
+                    let Some(content) = by_path.get(file_path.as_str()) else {
+                        warnings.push(format!(
+                            "components.projectInstructions: \"{file_path}\" not found \
+                             among the bundle's files; skipped"
+                        ));
+                        continue;
+                    };
+                    project_instructions.push(ImportedProjectInstruction {
+                        path: str_field("path"),
+                        file: file_path,
+                        content_hash: str_field("contentHash"),
+                        owner: str_field("owner"),
+                        content: content.to_string(),
+                    });
+                }
+            }
+            None => warnings.push(
+                "components.projectInstructions: not an array; ignored".to_string(),
+            ),
+        }
     }
 
     Ok(ParsedBundleImport {
@@ -946,6 +1061,7 @@ pub fn parse_bundle_import_with_budget(
         skills,
         skipped_skills,
         requirements,
+        project_instructions,
         warnings: warnings.into_vec(),
     })
 }
@@ -1600,6 +1716,116 @@ mod tests {
         ];
         let result = parse_bundle_import(&files).unwrap();
         assert!(!result.warnings.iter().any(|w| w.contains("components.memory")));
+    }
+
+    fn manifest_with_project_instructions(entries: Value) -> Vec<BundleImportFile> {
+        vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "instructions": ["instructions/AGENTS.md"],
+                "projectInstructions": entries,
+            }))),
+            file("instructions/AGENTS.md", "Be concise."),
+            file("instructions/project/CLAUDE.md", "# House rules\n"),
+        ]
+    }
+
+    #[test]
+    fn project_instructions_are_readable_after_import() {
+        // Codex P1, PR #3163: the warning alone told you a component existed
+        // and nothing else, and `agent.project_instructions` can't fill the
+        // gap — it scans the IMPORTING agent's working directory, not the
+        // source machine's. Reading is not applying.
+        let files = manifest_with_project_instructions(serde_json::json!([{
+            "path": "CLAUDE.md",
+            "file": "instructions/project/CLAUDE.md",
+            "contentHash": "abc123",
+            "owner": "foreign",
+        }]));
+        let result = parse_bundle_import(&files).unwrap();
+
+        assert_eq!(result.project_instructions.len(), 1);
+        let entry = &result.project_instructions[0];
+        assert_eq!(entry.path, "CLAUDE.md");
+        assert_eq!(entry.owner, "foreign");
+        assert_eq!(entry.content_hash, "abc123");
+        assert!(entry.content.contains("House rules"), "the content must be readable");
+
+        // Readable, still not applied: the warning stays, and nothing about
+        // this entry leaks into the fields an import actually writes.
+        assert!(result
+            .warnings
+            .iter()
+            .any(|w| w == PROJECT_INSTRUCTIONS_NOT_APPLIED_WARNING));
+        assert!(
+            !result.instructions.contains("House rules"),
+            "a project instruction must never become the bundle's own instructions"
+        );
+        assert!(
+            !result.context_files.iter().any(|cf| cf.content.contains("House rules")),
+            "nor a context file"
+        );
+    }
+
+    #[test]
+    fn project_instruction_entries_are_capped_and_report_the_overflow() {
+        let entries: Vec<Value> = (0..MAX_IMPORTED_PROJECT_INSTRUCTIONS + 5)
+            .map(|i| serde_json::json!({
+                "path": format!("CLAUDE{i}.md"),
+                "file": "instructions/project/CLAUDE.md",
+                "owner": "foreign",
+            }))
+            .collect();
+        let files = manifest_with_project_instructions(serde_json::json!(entries));
+        let result = parse_bundle_import(&files).unwrap();
+
+        assert_eq!(result.project_instructions.len(), MAX_IMPORTED_PROJECT_INSTRUCTIONS);
+        assert!(
+            result.warnings.iter().any(|w| w.contains("exceeds the")),
+            "truncating a list silently is what the rest of this parser refuses to do: {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn a_project_instruction_cannot_read_the_accounts_requirements_file() {
+        // The same allowlist components.instructions is held to: a manifest is
+        // not a trustworthy inventory of its own bundle, so this must not
+        // become a second route to read accounts/requirements.json back out.
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "projectInstructions": [{
+                    "path": "CLAUDE.md",
+                    "file": "accounts/requirements.json",
+                    "owner": "foreign",
+                }],
+            }))),
+            file("accounts/requirements.json", "[{\"id\":\"x\",\"credentialProvider\":\"y\"}]"),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+
+        assert!(result.project_instructions.is_empty());
+        assert!(result
+            .warnings
+            .iter()
+            .any(|w| w.contains("projectInstructions") && w.contains("requirements file")));
+    }
+
+    #[test]
+    fn a_project_instruction_referencing_a_missing_file_warns_rather_than_vanishing() {
+        let files = vec![file("armory.json", &minimal_manifest(serde_json::json!({
+            "projectInstructions": [{
+                "path": "CLAUDE.md",
+                "file": "instructions/project/GONE.md",
+                "owner": "foreign",
+            }],
+        })))];
+        let result = parse_bundle_import(&files).unwrap();
+
+        assert!(result.project_instructions.is_empty());
+        assert!(result
+            .warnings
+            .iter()
+            .any(|w| w.contains("GONE.md") && w.contains("not found")));
     }
 
     #[test]

--- a/agentmux-srv/src/backend/bundle_import.rs
+++ b/agentmux-srv/src/backend/bundle_import.rs
@@ -429,6 +429,21 @@ const MAX_INSTRUCTION_PROVIDER_VARIANTS: usize = 32;
 /// so the two can never drift apart: if this message ever changes, the
 /// filter in `bundle.rs` keeps working because it references the same
 /// constant, not a copy of the string.
+/// Warning for an ABF carrying `components.projectInstructions`.
+///
+/// Phase 3 of `SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md`. These
+/// entries record what the *source* agent was reading. They are surfaced and
+/// never installed — the files they describe belong to whatever repository the
+/// bundle is being imported into, and an import that wrote them would be doing
+/// what `SPEC_CLAUDE_MD_OWNERSHIP_PROTECTION_2026_08_22.md` exists to prevent.
+///
+/// Unlike [`MEMORY_COMPONENT_IGNORED_WARNING`] this has no filter site: memory
+/// warns only on the agent-less path because `bundle.import_for_agent` really
+/// does install it, whereas no import path installs these. The warning is
+/// therefore unconditional and permanent, not a "use the other RPC" pointer.
+pub(crate) const PROJECT_INSTRUCTIONS_NOT_APPLIED_WARNING: &str =
+    "components.projectInstructions: recorded for reference, never installed — these files belong to the importing repository, not to the bundle. Inspect them with agent.project_instructions and apply anything you want deliberately";
+
 pub(crate) const MEMORY_COMPONENT_IGNORED_WARNING: &str =
     "components.memory: present but ignored — memory requires an agent-scoped import (bundle.import_for_agent), not bundle.import";
 
@@ -907,6 +922,16 @@ pub fn parse_bundle_import_with_budget(
     // literal, so the push site and the filter site can't drift apart).
     if components.and_then(|c| c.get("memory")).is_some() {
         warnings.push(MEMORY_COMPONENT_IGNORED_WARNING.to_string());
+    }
+
+    // Unlike memory, this warning has no filter site anywhere: NO import path
+    // installs project instructions, agent-scoped or not. Those files belong
+    // to the repository the bundle is being imported INTO, and writing them
+    // would be exactly what SPEC_CLAUDE_MD_OWNERSHIP_PROTECTION_2026_08_22.md
+    // exists to prevent — a portability feature turning into a back door
+    // (SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md §5.2).
+    if components.and_then(|c| c.get("projectInstructions")).is_some() {
+        warnings.push(PROJECT_INSTRUCTIONS_NOT_APPLIED_WARNING.to_string());
     }
 
     Ok(ParsedBundleImport {
@@ -1506,6 +1531,46 @@ mod tests {
         ];
         let result = parse_bundle_import(&files).unwrap();
         assert!(result.warnings.iter().any(|w| w.contains("provider variants exceeds the limit")));
+    }
+
+    #[test]
+    fn project_instructions_are_surfaced_and_never_installed() {
+        // Phase 3 §5.2. These entries describe what the SOURCE agent read.
+        // The files they name belong to whatever repository this bundle is
+        // being imported into, so no import path may write them — unlike
+        // memory, there is no agent-scoped variant that does.
+        let files = vec![
+            file("armory.json", &minimal_manifest(serde_json::json!({
+                "instructions": ["instructions/AGENTS.md"],
+                "projectInstructions": [{
+                    "path": "CLAUDE.md",
+                    "file": "instructions/project/CLAUDE.md",
+                    "contentHash": "abc123",
+                    "owner": "foreign",
+                }],
+            }))),
+            file("instructions/AGENTS.md", "Be concise."),
+            file("instructions/project/CLAUDE.md", "someone else's house rules"),
+        ];
+        let result = parse_bundle_import(&files).unwrap();
+
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("components.projectInstructions") && w.contains("never installed")),
+            "the import must say it is not applying them: {:?}",
+            result.warnings
+        );
+        // And nothing about them reaches the bundle that gets written.
+        assert!(
+            !result.instructions.contains("house rules"),
+            "another repository's instructions must not become this bundle's"
+        );
+        assert!(
+            !result.context_files.iter().any(|cf| cf.content.contains("house rules")),
+            "nor arrive as a context file"
+        );
     }
 
     #[test]

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -829,7 +829,12 @@ fn bound_agent_has_native_memory(
         .unwrap_or(false)
 }
 
-/// Register `paths` under `components.<key>` in the export's `armory.json`.
+/// Register `entries` under `components.<key>` in the export's `armory.json`.
+///
+/// Takes JSON values rather than paths: most components are a list of archive
+/// paths, but `projectInstructions` carries an object per file, because a bare
+/// path could not express the `owner` discriminator that keeps import from
+/// installing somebody else's instructions.
 ///
 /// The manifest is built as an inline `json!` literal in `bundle_export.rs`
 /// with no struct behind it (`bundle_export.rs:615`), so every agent-aware
@@ -843,9 +848,9 @@ fn bound_agent_has_native_memory(
 fn set_manifest_component(
     export: &mut crate::backend::bundle_export::BundleExport,
     key: &str,
-    paths: Vec<String>,
+    entries: Vec<serde_json::Value>,
 ) -> Result<(), String> {
-    if paths.is_empty() {
+    if entries.is_empty() {
         return Ok(());
     }
     let manifest_idx = export
@@ -855,7 +860,7 @@ fn set_manifest_component(
         .ok_or_else(|| "bundle export is missing armory.json".to_string())?;
     let mut manifest: serde_json::Value = serde_json::from_str(&export.files[manifest_idx].content)
         .map_err(|e| format!("armory.json: {e}"))?;
-    manifest["components"][key] = json!(paths);
+    manifest["components"][key] = json!(entries);
     export.files[manifest_idx].content =
         serde_json::to_string_pretty(&manifest).map_err(|e| e.to_string())?;
     Ok(())
@@ -874,7 +879,7 @@ fn splice_history_component(
     export: &mut crate::backend::bundle_export::BundleExport,
     history_paths: Vec<String>,
 ) -> Result<(), String> {
-    set_manifest_component(export, "history", history_paths)
+    set_manifest_component(export, "history", history_paths.into_iter().map(|p| json!(p)).collect())
 }
 
 /// Splice native-memory files into an already-built bundle export's
@@ -889,6 +894,60 @@ fn splice_history_component(
 /// component category. A no-op when `memory_files` is empty — matches the
 /// existing omit-empty-components convention used elsewhere in the
 /// manifest.
+/// Carry the agent's project instructions into the export as
+/// `components.projectInstructions`.
+///
+/// Phase 3 of `SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md`. Files
+/// land under `instructions/project/<sanitized-path>`, and each manifest entry
+/// carries its original `path`, a `contentHash`, and an `owner`.
+///
+/// **`owner` is the load-bearing field.** It is what stops this from becoming a
+/// way to install one repository's instructions into another: an importer that
+/// treated a `foreign` entry as content to write would be doing precisely what
+/// `SPEC_CLAUDE_MD_OWNERSHIP_PROTECTION_2026_08_22.md` exists to prevent.
+/// Import surfaces these and never applies them (spec §5.2), so an operator who
+/// wants them acts deliberately.
+///
+/// Only files that exist and were readable are carried — there is nothing to
+/// put in an archive otherwise. Their absence from the manifest is therefore
+/// not a claim that the source agent had none; `agent.project_instructions` is
+/// where the fuller picture, including absent and unreadable files, lives.
+///
+/// Paths go through the same sanitizer the exporter uses for context files, so
+/// a scanned path can never write outside the archive's own tree.
+fn splice_project_instructions_component(
+    export: &mut crate::backend::bundle_export::BundleExport,
+    files: &[crate::backend::project_instructions::ProjectInstructionFile],
+) -> Result<(), String> {
+    use crate::backend::project_instructions::InstructionOwner;
+
+    let mut entries: Vec<serde_json::Value> = Vec::new();
+    for file in files {
+        if !file.exists || file.content.is_empty() {
+            continue;
+        }
+        let Some(safe) = crate::backend::bundle_export::sanitize_context_relative_path(&file.path)
+        else {
+            continue;
+        };
+        let out_path = format!("instructions/project/{safe}");
+        export.files.push(crate::backend::bundle_export::BundleExportFile {
+            path: out_path.clone(),
+            content: file.content.clone(),
+        });
+        entries.push(json!({
+            "path": file.path,
+            "file": out_path,
+            "contentHash": file.content_hash,
+            "owner": match file.owner {
+                InstructionOwner::Agentmux => "agentmux",
+                InstructionOwner::Foreign => "foreign",
+            },
+        }));
+    }
+    set_manifest_component(export, "projectInstructions", entries)
+}
+
 fn splice_memory_component(
     export: &mut crate::backend::bundle_export::BundleExport,
     memory_files: &[(String, String)],
@@ -911,7 +970,7 @@ fn splice_memory_component(
         });
         manifest_memory.push(out_path);
     }
-    set_manifest_component(export, "memory", manifest_memory)
+    set_manifest_component(export, "memory", manifest_memory.into_iter().map(|p| json!(p)).collect())
 }
 
 /// `bundle.export_for_agent` — ABF v0.2 §2.3. The only export path that
@@ -1025,6 +1084,21 @@ async fn build_export_for_agent(
         Err(e) => handler_warnings.push(format!("native memory: failed to list: {e}")),
     }
     splice_memory_component(&mut export, &memory_files).map_err(|e| format!("{err_prefix}: {e}"))?;
+
+    // Project instructions — carried as a record of what the source agent was
+    // reading, not as content to install. The working directory is resolved
+    // the same way launch resolves it, so the export describes the directory
+    // the agent actually runs in.
+    let work_dir = crate::backend::project_instructions::effective_working_dir(
+        &agent.working_directory,
+        &agent.name,
+    );
+    let instructions = crate::backend::project_instructions::resolve_project_instructions(
+        &agent.provider,
+        &work_dir,
+    );
+    splice_project_instructions_component(&mut export, &instructions)
+        .map_err(|e| format!("{err_prefix}: {e}"))?;
 
     let mut all_warnings = export.warnings.clone();
     all_warnings.append(&mut handler_warnings);
@@ -3398,6 +3472,49 @@ mod export_import_for_agent_tests {
                 && i["message"].as_str().unwrap_or("").contains("broken")),
             "the issue must name the server: {issues:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn export_carries_project_instructions_with_their_owner() {
+        // The last piece of Phase 3: an exported bundle records what the
+        // source agent was reading, with enough to tell whose file each was.
+        let state = test_state();
+        let work = tempfile::tempdir().unwrap();
+        let config_dir = tempfile::tempdir().unwrap();
+        make_agent(&state, "agent-1", work.path().to_str().unwrap(), config_dir.path());
+        make_bundle(&state, "bundle-1", "Be helpful.");
+
+        std::fs::write(work.path().join("CLAUDE.md"), "# House rules\n\nBe careful.\n").unwrap();
+
+        let result = bundle_export_for_agent_impl(
+            &state.id_store,
+            &state.wstore,
+            ExportForAgentReq {
+                bundle_id: "bundle-1".to_string(),
+                agent_id: "agent-1".to_string(),
+                format: String::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let files = result["files"].as_array().unwrap();
+        let carried = files
+            .iter()
+            .find(|f| f["path"] == "instructions/project/CLAUDE.md")
+            .expect("the repository's own CLAUDE.md must be carried");
+        assert!(carried["content"].as_str().unwrap().contains("House rules"));
+
+        let manifest_file = files.iter().find(|f| f["path"] == "armory.json").unwrap();
+        let manifest: serde_json::Value =
+            serde_json::from_str(manifest_file["content"].as_str().unwrap()).unwrap();
+        let entries = manifest["components"]["projectInstructions"].as_array().unwrap();
+        let entry = entries.iter().find(|e| e["path"] == "CLAUDE.md").unwrap();
+        assert_eq!(
+            entry["owner"], "foreign",
+            "an unmarked repository file is the repository's — this field is what keeps import from installing it"
+        );
+        assert!(!entry["contentHash"].as_str().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -913,6 +913,12 @@ fn splice_history_component(
 /// not a claim that the source agent had none; `agent.project_instructions` is
 /// where the fuller picture, including absent and unreadable files, lives.
 ///
+/// "Readable" is decided by `error`/`truncated`, NOT by whether the content is
+/// empty (Codex P2, PR #3163). A real, readable, zero-byte `CLAUDE.md` is a
+/// fact about the source agent — dropping it would make the export
+/// indistinguishable from one where the file was absent, which is the exact
+/// kind of quiet lie this component exists to remove.
+///
 /// Paths go through the same sanitizer the exporter uses for context files, so
 /// a scanned path can never write outside the archive's own tree.
 fn splice_project_instructions_component(
@@ -920,17 +926,43 @@ fn splice_project_instructions_component(
     files: &[crate::backend::project_instructions::ProjectInstructionFile],
 ) -> Result<(), String> {
     use crate::backend::project_instructions::InstructionOwner;
+    use std::collections::HashSet;
 
     let mut entries: Vec<serde_json::Value> = Vec::new();
+    // Case-INSENSITIVE, for the same reason the context-file loop in
+    // `bundle_export.rs` is (reagent P2, PR #2333): a case-sensitive source
+    // filesystem can hold `.github/instructions/A.md` and `.../a.md`, and the
+    // scan in `project_instructions.rs` will find both — but they collide on
+    // extraction on Windows/macOS, where one snapshot silently overwrites the
+    // other. Scanned directories make this reachable here in a way it isn't
+    // for the fixed registry paths (Codex P2, PR #3163). The written path
+    // keeps its original case; only the check is folded.
+    let mut used_paths: HashSet<String> = HashSet::new();
     for file in files {
-        if !file.exists || file.content.is_empty() {
+        if !file.exists || file.error.is_some() || file.truncated {
             continue;
         }
         let Some(safe) = crate::backend::bundle_export::sanitize_context_relative_path(&file.path)
         else {
+            // Warn rather than dropping in silence — a backup tool that loses
+            // an input without saying so defeats its own purpose (reagent P1,
+            // PR #2333, on the context-file equivalent).
+            export.warnings.push(format!(
+                "projectInstructions: \"{}\" could not be sanitized into an \
+                 archive-relative path; skipped",
+                file.path
+            ));
             continue;
         };
         let out_path = format!("instructions/project/{safe}");
+        if !used_paths.insert(out_path.to_lowercase()) {
+            export.warnings.push(format!(
+                "projectInstructions: \"{}\" normalizes to the same path as an \
+                 earlier entry ({out_path}); skipped to avoid overwriting it",
+                file.path
+            ));
+            continue;
+        }
         export.files.push(crate::backend::bundle_export::BundleExportFile {
             path: out_path.clone(),
             content: file.content.clone(),
@@ -2126,6 +2158,15 @@ fn preview_commit_warning_budget() -> crate::backend::bundle_import::WarningBudg
 /// already individually bounded; concatenating two independently-bounded
 /// lists can still exceed either bound alone, so one more pass caps the
 /// combined total before it's ever serialized).
+/// Per-entry content cap for `project_instructions` in an import preview.
+///
+/// Deliberately far below `MAX_INSTRUCTIONS_PREVIEW_CHARS` (50k): that cap
+/// applies to ONE field, whereas a preview can carry up to
+/// `MAX_IMPORTED_PROJECT_INSTRUCTIONS` (200) of these, so the same number
+/// would put a 10 MB ceiling on a single response. 4k is enough to recognize a
+/// file and see how it opens; the untruncated bytes are in the archive itself.
+const MAX_PROJECT_INSTRUCTION_PREVIEW_CHARS: usize = 4_000;
+
 fn bound_warnings_for_response(warnings: Vec<String>) -> (Vec<String>, bool) {
     const MAX_COMBINED_WARNINGS: usize = 200;
     if warnings.len() <= MAX_COMBINED_WARNINGS {
@@ -2291,9 +2332,40 @@ async fn bundle_import_preview_impl(
         .collect();
     let name_collision = existing_names.contains(&parsed.name);
 
+    // Phase 3, Codex P1 on PR #3163. Read-only: this is what the SOURCE agent
+    // was reading, and `bundle.import.commit` has no counterpart field — the
+    // entries exist to be looked at, never to be written into the importing
+    // repository (spec §5.2). Each content is bounded the same way
+    // `instructions_preview` is, since a snapshot can be an arbitrarily large
+    // repository file and the response carries up to
+    // MAX_IMPORTED_PROJECT_INSTRUCTIONS of them.
+    let project_instructions_json: Vec<serde_json::Value> = parsed
+        .project_instructions
+        .iter()
+        .map(|pi| {
+            let total_chars = pi.content.chars().count();
+            let truncated = total_chars > MAX_PROJECT_INSTRUCTION_PREVIEW_CHARS;
+            let preview: String = if truncated {
+                pi.content.chars().take(MAX_PROJECT_INSTRUCTION_PREVIEW_CHARS).collect()
+            } else {
+                pi.content.clone()
+            };
+            json!({
+                "path": bounded_display(&pi.path),
+                "file": bounded_display(&pi.file),
+                "content_hash": bounded_display(&pi.content_hash),
+                "owner": bounded_display(&pi.owner),
+                "content_preview": preview,
+                "content_truncated": truncated,
+                "content_total_chars": total_chars,
+            })
+        })
+        .collect();
+
     let (warnings, warnings_truncated) = bound_warnings_for_response(all_warnings);
 
     Ok(json!({
+        "project_instructions": project_instructions_json,
         "name": parsed.name,
         "description": bounded_display(&parsed.description),
         "instructions_preview": instructions_preview,
@@ -3515,6 +3587,128 @@ mod export_import_for_agent_tests {
             "an unmarked repository file is the repository's — this field is what keeps import from installing it"
         );
         assert!(!entry["contentHash"].as_str().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn export_carries_a_readable_but_empty_instruction_file() {
+        // Codex P2 on #3163: skipping on `content.is_empty()` conflated "the
+        // file is there and says nothing" with "there is no file", which is
+        // the exact ambiguity this component exists to remove. An empty
+        // CLAUDE.md is a real fact about what the agent reads.
+        let state = test_state();
+        let work = tempfile::tempdir().unwrap();
+        let config_dir = tempfile::tempdir().unwrap();
+        make_agent(&state, "agent-1", work.path().to_str().unwrap(), config_dir.path());
+        make_bundle(&state, "bundle-1", "Be helpful.");
+
+        std::fs::write(work.path().join("CLAUDE.md"), "").unwrap();
+
+        let result = bundle_export_for_agent_impl(
+            &state.id_store,
+            &state.wstore,
+            ExportForAgentReq {
+                bundle_id: "bundle-1".to_string(),
+                agent_id: "agent-1".to_string(),
+                format: String::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let files = result["files"].as_array().unwrap();
+        assert!(
+            files.iter().any(|f| f["path"] == "instructions/project/CLAUDE.md"),
+            "an empty-but-present CLAUDE.md must still be recorded"
+        );
+        let manifest_file = files.iter().find(|f| f["path"] == "armory.json").unwrap();
+        let manifest: serde_json::Value =
+            serde_json::from_str(manifest_file["content"].as_str().unwrap()).unwrap();
+        let entries = manifest["components"]["projectInstructions"].as_array().unwrap();
+        assert!(
+            entries.iter().any(|e| e["path"] == "CLAUDE.md"),
+            "present-and-empty must be distinguishable from absent, got: {entries:?}"
+        );
+    }
+
+    /// Build a resolver result by hand. The two conditions below (a
+    /// case-only path collision, and unreadable/oversized files) are not
+    /// reachable through the filesystem on this repo's own dev platform —
+    /// Windows folds case, so the collision cannot be staged at all — so the
+    /// splice function is exercised directly rather than not at all.
+    fn instruction_file(
+        path: &str,
+        content: &str,
+    ) -> crate::backend::project_instructions::ProjectInstructionFile {
+        crate::backend::project_instructions::ProjectInstructionFile {
+            path: path.to_string(),
+            exists: true,
+            size_bytes: content.len() as u64,
+            content_hash: "hash".to_string(),
+            owner: crate::backend::project_instructions::InstructionOwner::Foreign,
+            content: content.to_string(),
+            truncated: false,
+            error: None,
+        }
+    }
+
+    fn empty_export() -> crate::backend::bundle_export::BundleExport {
+        crate::backend::bundle_export::BundleExport {
+            root_slug: "b".to_string(),
+            files: vec![crate::backend::bundle_export::BundleExportFile {
+                path: "armory.json".to_string(),
+                content: "{\"components\":{}}".to_string(),
+            }],
+            skipped_skills: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn case_only_different_instruction_paths_do_not_overwrite_each_other() {
+        // Codex P2 on #3163. Scanned directories (Copilot's
+        // `.github/instructions/`) make two paths differing only in case
+        // reachable on a case-sensitive source filesystem; extracted on
+        // Windows or macOS one silently clobbers the other.
+        let mut export = empty_export();
+        let files = vec![
+            instruction_file(".github/instructions/A.instructions.md", "first"),
+            instruction_file(".github/instructions/a.instructions.md", "second"),
+        ];
+        splice_project_instructions_component(&mut export, &files).unwrap();
+
+        let carried: Vec<_> = export
+            .files
+            .iter()
+            .filter(|f| f.path.to_lowercase().starts_with("instructions/project/"))
+            .collect();
+        assert_eq!(carried.len(), 1, "the second must be skipped, not written alongside");
+        assert!(
+            export.warnings.iter().any(|w| w.contains("normalizes to the same path")),
+            "the skip must be reported, not silent: {:?}",
+            export.warnings
+        );
+    }
+
+    #[test]
+    fn unreadable_and_truncated_instruction_files_are_not_exported() {
+        // The other half of the empty-file fix: `content.is_empty()` was doing
+        // two jobs, and only one of them was correct. These are the cases that
+        // genuinely have nothing to archive.
+        let mut export = empty_export();
+        let mut unreadable = instruction_file("CLAUDE.md", "");
+        unreadable.error = Some("permission denied".to_string());
+        let mut oversized = instruction_file("AGENTS.md", "");
+        oversized.truncated = true;
+        let mut absent = instruction_file("GEMINI.md", "");
+        absent.exists = false;
+
+        splice_project_instructions_component(&mut export, &[unreadable, oversized, absent])
+            .unwrap();
+
+        assert!(
+            !export.files.iter().any(|f| f.path.starts_with("instructions/project/")),
+            "nothing readable means nothing to carry"
+        );
     }
 
     #[tokio::test]

--- a/docs/specs/SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md
+++ b/docs/specs/SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md
@@ -331,6 +331,14 @@ import the entries are **surfaced, never applied** — the same warning shape as
 §5.1, naming what the source machine's agent was reading. An operator who wants
 those instructions applies them deliberately; AgentMux does not decide that.
 
+"Surfaced" means *readable*, not merely *announced*: the importer parses the
+entries back out (path, hash, owner, content) and returns them on
+`bundle.import.preview`. A warning alone would not have been enough, because
+`agent.project_instructions` scans the **importing** agent's working directory
+and so is structurally unable to show what the source machine held (Codex P1,
+PR #3163). Reading is not applying — no import path writes these, and
+`bundle.import.commit` has no field that could select them.
+
 The `owner` field is what keeps this honest. A re-import that silently merged a
 foreign `CLAUDE.md` into a new machine's repo would be the exact failure the
 ownership spec exists to prevent.


### PR DESCRIPTION
The last piece of Phase 3 of `SPEC_INSTRUCTION_AND_MEMORY_PORTABILITY_2026_09_09.md`, and where the original ask lands: an exported bundle now records what its agent was actually reading. Builds on #3156 and #3162. Tracking: #3148.

**Export.** Files land under `instructions/project/<sanitized-path>`; each `components.projectInstructions` entry carries the original `path`, a `contentHash`, and an `owner`.

**`owner` is the load-bearing field.** It is what stops this becoming a way to install one repository's instructions into another. An importer treating a `foreign` entry as content to write would be doing precisely what `SPEC_CLAUDE_MD_OWNERSHIP_PROTECTION_2026_08_22.md` exists to prevent — the whole reason a foreign `CLAUDE.md` is never overwritten in the first place.

**Import surfaces them and never applies them** (spec §5.2). An operator who wants them acts deliberately.

That warning has **no filter site anywhere**, unlike `MEMORY_COMPONENT_IGNORED_WARNING`. Memory warns only on the agent-less path because `bundle.import_for_agent` genuinely does install it; no import path installs these. So the warning is unconditional and permanent rather than a "use the other RPC" pointer — stated at the constant, because the asymmetry with memory looks like an oversight otherwise.

**Scope, stated so absence is not misread:** only files that exist and were readable are carried, since there is nothing to put in an archive otherwise. Their absence from a manifest is therefore *not* a claim the source agent had none. `agent.project_instructions` remains where the fuller picture lives, including absent, unreadable, oversized, and removed-since-last-launch files.

The working directory is resolved the way launch resolves it, so the export describes the directory the agent actually runs in — the same correction #3156 needed.

`set_manifest_component` now takes JSON values rather than paths. Most components are a list of archive paths; a bare path could not express the owner discriminator. The two existing callers map into it.

**Tests** — 2 new:

| Test | Pins |
|---|---|
| `export_carries_project_instructions_with_their_owner` | the repo's own `CLAUDE.md` is carried, with content, hash, and `owner: foreign` |
| `project_instructions_are_surfaced_and_never_installed` | the warning fires, and the content reaches neither the bundle's instructions nor its context files |

**Verification**
```
cargo test -p agentmux-srv   → 3267 passed, 0 failed
```

With this, Phase 3 is complete: AgentMux can say where every instruction an agent reads came from, what is in it now, whether it changed since last launch, and can move it to another machine without ever writing somebody else's file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
