### PR TITLE
Manoz@Area54: ci: add a tsc --noEmit gate to the frontend job

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -167,5 +167,16 @@ jobs:
           node-version: '24'
           cache: npm
       - run: npm ci
+      # Runs BEFORE vitest, and is not redundant with it: vitest transpiles
+      # per-file without typechecking, so a type error compiles away and the
+      # suite goes green. Two reached main this way (a `#[ts(optional)]`-shaped
+      # mistake, and a test passing fields the action type does not declare —
+      # ignored at runtime, so the test was still valid and still passed while
+      # not compiling). Neither was catchable by any gate that existed.
+      #
+      # Cheap: no build, just the checker, on an install the next step needs
+      # anyway.
+      - name: tsc --noEmit
+        run: npx tsc --noEmit -p tsconfig.json
       - name: vitest run
         run: npx vitest run

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -176,7 +176,12 @@ jobs:
       #
       # Cheap: no build, just the checker, on an install the next step needs
       # anyway.
+      #
+      # tsconfig.citypecheck.json, not tsconfig.json: the build config includes
+      # only frontend/**, while vitest below also runs test/contract/* and
+      # test/e2e/*. Checking the narrower set would have left the same hole in
+      # a different directory (reagent P2 on #3166).
       - name: tsc --noEmit
-        run: npx tsc --noEmit -p tsconfig.json
+        run: npx tsc --noEmit -p tsconfig.citypecheck.json
       - name: vitest run
         run: npx vitest run

--- a/tsconfig.citypecheck.json
+++ b/tsconfig.citypecheck.json
@@ -1,0 +1,15 @@
+{
+    // Typecheck-only config for the CI gate. Extends the build config and
+    // widens `include` to everything vitest actually runs.
+    //
+    // tsconfig.json's own `include` is ["frontend/**/*"], but vitest discovers
+    // and executes `test/contract/*` and `test/e2e/*` too — so a type error in
+    // those files would still compile away under vitest's per-file
+    // transpilation and go undetected, which is precisely the hole the gate
+    // exists to close (reagent P2 on #3166).
+    //
+    // Separate file rather than widening tsconfig.json: that one drives the
+    // build and the editor, and test sources have no business in either.
+    "extends": "./tsconfig.json",
+    "include": ["frontend/**/*", "test/**/*"]
+}


### PR DESCRIPTION
## Why

**vitest transpiles per-file without typechecking**, so a type error compiles away and the suite goes green. Nothing in CI reads types today — the frontend jobs are `vitest` and the doc/grep gates.

Two got through that hole in a single day:

- **#3158** — a test passed `{ type: "TurnEnd", at, outcome }` when `TurnEnd` declares only `stats`. The extra properties were ignored at runtime, so the test was genuinely valid and genuinely passing *while not compiling*. Fixed in #3164.
- Earlier the same session, a `#[ts(optional)]`-shaped mistake with the identical signature: green suite, broken types.

Neither was catchable by any gate that existed. Both would have been caught here in seconds.

## Placement

Before `vitest`, in the same job — it needs the `npm ci` that step already runs, and failing on types first is a clearer signal than a wall of suite output. No build, just the checker.

## Sequencing

Deliberately landed **after #3164**. Adding this while main still carried that type error would have red-lined every open PR, including the one fixing it.

Verified against `origin/main` after #3164 merged: `npx tsc --noEmit` is clean, so this gate passes on the current tree rather than arriving already-red. That check is the whole reason it's a separate PR.

## Note on required checks

This adds a step to the existing `vitest` job rather than a new job, so it inherits that job's required-check status automatically — no branch-protection change needed. If you'd rather it be independently visible in the checks list, it should be its own job instead; say so and I'll split it.

<!-- agentmux:agent_id=manoz -->