### PR TITLE
Manoz@Area54: ci: note how to actually verify the tsc gate locally

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -181,6 +181,17 @@ jobs:
       # only frontend/**, while vitest below also runs test/contract/* and
       # test/e2e/*. Checking the narrower set would have left the same hole in
       # a different directory (reagent P2 on #3166).
+      #
+      # IF YOU ARE HERE BECAUSE THIS STEP FAILED AND YOU BELIEVE YOU RAN IT
+      # LOCALLY: check how you read the result, not just that you ran it. Both
+      # errors this gate was built for got past a local run that LOOKED clean.
+      #   - `npx tsc ... | head -5` / `| tail -5` hides errors outside the
+      #     window you printed. tsc lists every error; a truncated view is not
+      #     a verdict.
+      #   - `npx tsc ... | tail -4; echo $?` reports TAIL's exit status, not
+      #     tsc's. A pipeline exits with its LAST command. That reads as a
+      #     confident green while the checker was failing.
+      # Run it bare and read the exit code:  npx tsc --noEmit -p tsconfig.citypecheck.json; echo $?
       - name: tsc --noEmit
         run: npx tsc --noEmit -p tsconfig.citypecheck.json
       - name: vitest run


### PR DESCRIPTION
Follow-up reagent asked for on #3169.

The gate added in #3166 exists to catch what a contributor *believes* they already checked — so the failure mode of that belief belongs written next to it, rather than left as a lesson one person happened to learn.

Both errors the gate was built for got past a local run that **looked** clean, and in both cases the mistake was in reading the result rather than in running it:

- **`npx tsc ... | head -5`** hides errors outside the printed window. tsc lists *every* error; a truncated view is not a verdict. This is exactly how the TS1378 in #3169 reached CI — the run happened, the error scrolled past above what I read, and I reported it clean.
- **`npx tsc ... | tail -4; echo $?`** reports **tail's** exit status. A pipeline exits with its last command, so that reads as a confident green while the checker was failing.

The note tells you to run it bare and read the exit code.

Comment only — no behaviour change, and the gate itself is untouched.

<!-- agentmux:agent_id=manoz -->