### PR TITLE
Manoz@Area54: chore: release v0.55.41

### DIFF
--- a/.changesets/1788855717-feat-zoom-ctrl-shift-scroll-zooms-every-pane-in-the-window-a-79bh.md
+++ b/.changesets/1788855717-feat-zoom-ctrl-shift-scroll-zooms-every-pane-in-the-window-a-79bh.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(zoom): Ctrl+Shift+Scroll zooms every pane in the window at once

--- a/.changesets/1788928077-feat-lan-peers-report-which-agents-they-host-s58f.md
+++ b/.changesets/1788928077-feat-lan-peers-report-which-agents-they-host-s58f.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(lan): peers report which agents they host

--- a/.changesets/1788928478-docs-cef-decide-on-staged-per-platform-rollout-for-the-152-u-0f5l.md
+++ b/.changesets/1788928478-docs-cef-decide-on-staged-per-platform-rollout-for-the-152-u-0f5l.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(cef): decide on staged per-platform rollout for the 152 upgrade

--- a/.changesets/1788928643-refactor-srv-migrate-agentdefcreatefromtemplate-and-forkagen-mg8t.md
+++ b/.changesets/1788928643-refactor-srv-migrate-agentdefcreatefromtemplate-and-forkagen-mg8t.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(srv): migrate agentdefcreatefromtemplate and forkagentdefinitionsuggest to register_typed — 4 more RPC types generated and gated

--- a/.changesets/1788929003-fix-session-flush-the-session-snapshot-on-os-shutdown-wm-que-qda9.md
+++ b/.changesets/1788929003-fix-session-flush-the-session-snapshot-on-os-shutdown-wm-que-qda9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(session): flush the session snapshot on OS shutdown (WM_QUERYENDSESSION/WM_ENDSESSION)

--- a/.changesets/1788931415-refactor-srv-migrate-deleteagentinstance-hidenamedagent-to-r-mbov.md
+++ b/.changesets/1788931415-refactor-srv-migrate-deleteagentinstance-hidenamedagent-to-r-mbov.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(srv): migrate deleteagentinstance + hidenamedagent to register_typed — 4 more RPC types generated and gated, two new named response types replace anonymous json! shapes

--- a/.changesets/1788933053-refactor-srv-migrate-deletememory-deletesystemmemory-to-regi-dc2m.md
+++ b/.changesets/1788933053-refactor-srv-migrate-deletememory-deletesystemmemory-to-regi-dc2m.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(srv): migrate deletememory + deletesystemmemory to register_typed — 2 more RPC types generated and gated, shared response type mirrors the existing shared request type

--- a/.changesets/1788933817-docs-rename-claudius-narko-in-live-references-sud7.md
+++ b/.changesets/1788933817-docs-rename-claudius-narko-in-live-references-sud7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: rename claudius -> narko in live references

--- a/.changesets/1788960406-fix-cef-macos-build-broken-native-window-visible-referenced--7okv.md
+++ b/.changesets/1788960406-fix-cef-macos-build-broken-native-window-visible-referenced--7okv.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(cef): macOS build broken — native_window_visible referenced Arc<AppState> without an import on macOS

--- a/.changesets/1788960467-fix-cef-linux-userns-sandbox-probe-false-positives-on-apparm-o68w.md
+++ b/.changesets/1788960467-fix-cef-linux-userns-sandbox-probe-false-positives-on-apparm-o68w.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(cef): linux userns-sandbox probe false-positives on AppArmor hosts

--- a/.changesets/1788960693-fix-build-fail-bundle-loudly-on-stub-angle-gl-libraries-inst-noly.md
+++ b/.changesets/1788960693-fix-build-fail-bundle-loudly-on-stub-angle-gl-libraries-inst-noly.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(build): fail bundle:* loudly on stub ANGLE GL libraries instead of shipping a broken GFX-off build

--- a/.changesets/1788961597-fix-srv-jekt-notifications-for-a-renamed-agent-s-stable-agen-lmfg.md
+++ b/.changesets/1788961597-fix-srv-jekt-notifications-for-a-renamed-agent-s-stable-agen-lmfg.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(srv): jekt notifications for a renamed agent's stable AGENTMUX_AGENT_ID now resolve

--- a/.changesets/1788964010-docs-cef-branch-model-upgrade-practice-for-the-cef-fork-all--iqa5.md
+++ b/.changesets/1788964010-docs-cef-branch-model-upgrade-practice-for-the-cef-fork-all--iqa5.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(cef): branch model + upgrade practice for the CEF fork, all three platforms

--- a/.changesets/1788966810-fix-floating-pane-require-a-real-500ms-hover-before-a-floati-qve5.md
+++ b/.changesets/1788966810-fix-floating-pane-require-a-real-500ms-hover-before-a-floati-qve5.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(floating-pane): require a real 500ms hover before a floating pane redocks

--- a/.changesets/1788974763-docs-qr-pairing-correct-stale-mdns-parity-claim-in-hostpopov-8ye3.md
+++ b/.changesets/1788974763-docs-qr-pairing-correct-stale-mdns-parity-claim-in-hostpopov-8ye3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(qr-pairing): correct stale mDNS-parity claim in HostPopover

--- a/.changesets/1788976172-fix-ci-drop-the-unused-google-chrome-apt-source-so-a-bad-ind-jmcs.md
+++ b/.changesets/1788976172-fix-ci-drop-the-unused-google-chrome-apt-source-so-a-bad-ind-jmcs.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ci): drop the unused Google Chrome apt source so a bad index cannot fail Linux CI

--- a/.changesets/1788991931-fix-floating-pane-retune-the-redock-dwell-to-300ms-o36m.md
+++ b/.changesets/1788991931-fix-floating-pane-retune-the-redock-dwell-to-300ms-o36m.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(floating-pane): retune the redock dwell to 300ms

--- a/.changesets/1788997039-refactor-srv-armory-naming-phase-1-rename-memory-bundle-bund-g3mx.md
+++ b/.changesets/1788997039-refactor-srv-armory-naming-phase-1-rename-memory-bundle-bund-g3mx.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(srv): armory naming Phase 1 — rename Memory->Bundle, bundle_memory_*->bundle_*, memory_bundles->bundles; split rpc_types/memory.rs

--- a/.changesets/1788997152-refactor-layout-add-inert-nodemodel-activeblockid-groundwork-o2iz.md
+++ b/.changesets/1788997152-refactor-layout-add-inert-nodemodel-activeblockid-groundwork-o2iz.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(layout): add inert NodeModel.activeBlockId groundwork for pane chrome-stability fix

--- a/.changesets/1788997373-refactor-block-blockframe-header-endicons-take-a-reactive-bl-iiw9.md
+++ b/.changesets/1788997373-refactor-block-blockframe-header-endicons-take-a-reactive-bl-iiw9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(block): BlockFrame_Header/EndIcons take a reactive blockId accessor

--- a/.changesets/1788998545-refactor-frontend-armory-naming-phase-1-view-memory-view-bun-c591.md
+++ b/.changesets/1788998545-refactor-frontend-armory-naming-phase-1-view-memory-view-bun-c591.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor(frontend): armory naming Phase 1 — view/memory->view/bundle, type Memory->Bundle, BundleApi/NativeMemoryApi split, bundleId locals

--- a/.changesets/1789000090-fix-agent-stop-the-pane-header-tab-strip-flash-when-switchin-u0r3.md
+++ b/.changesets/1789000090-fix-agent-stop-the-pane-header-tab-strip-flash-when-switchin-u0r3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): stop the pane header/tab-strip flash when switching Agent <-> History tabs

--- a/.changesets/1789013957-ui-armory-rename-the-abf-tab-to-bundles-abf-stays-the-name-o-1d6a.md
+++ b/.changesets/1789013957-ui-armory-rename-the-abf-tab-to-bundles-abf-stays-the-name-o-1d6a.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-ui(armory): rename the ABF tab to Bundles; ABF stays the name of the import/export format

--- a/.changesets/1789014195-refactor-armory-naming-phase-2-retire-brain-on-the-bundle-si-uxve.md
+++ b/.changesets/1789014195-refactor-armory-naming-phase-2-retire-brain-on-the-bundle-si-uxve.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-refactor: armory naming Phase 2 — retire 'brain' on the bundle side (format_global_bundle_block, view/global-bundle, GlobalBundleViewModel)

--- a/.changesets/1789015007-fix-net-lan-listeners-macos-bind-conflict-assumption-was-wro-heoo.md
+++ b/.changesets/1789015007-fix-net-lan-listeners-macos-bind-conflict-assumption-was-wro-heoo.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(net): lan_listeners macOS bind-conflict assumption was wrong — groups with Windows, not Linux

--- a/.changesets/1789016663-fix-cef-move-the-cef-carry-set-gates-into-tested-scripts-2uu7.md
+++ b/.changesets/1789016663-fix-cef-move-the-cef-carry-set-gates-into-tested-scripts-2uu7.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(cef): move the CEF carry-set gates into tested scripts

--- a/.changesets/1789016766-fix-agent-pane-bind-the-working-indicators-to-one-predicate--k79z.md
+++ b/.changesets/1789016766-fix-agent-pane-bind-the-working-indicators-to-one-predicate--k79z.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): bind the working indicators to one predicate so they cannot disagree

--- a/.changesets/1789018616-fix-srv-integration-tests-no-longer-trigger-a-real-macos-key-bm6w.md
+++ b/.changesets/1789018616-fix-srv-integration-tests-no-longer-trigger-a-real-macos-key-bm6w.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(srv): integration tests no longer trigger a real macOS Keychain prompt

--- a/.changesets/1789018629-fix-cef-ship-the-macos-26-renderer-fix-bump-the-macos-cef-pi-b4pu.md
+++ b/.changesets/1789018629-fix-cef-ship-the-macos-26-renderer-fix-bump-the-macos-cef-pi-b4pu.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(cef): ship the macOS 26 renderer fix — bump the macOS CEF pin to 148.23.25

--- a/.changesets/1789018698-feat-srv-armory-portability-phase-1-2-bundle-export-announce-m9er.md
+++ b/.changesets/1789018698-feat-srv-armory-portability-phase-1-2-bundle-export-announce-m9er.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): armory portability Phase 1+2 — bundle.export announces memory it cannot carry; history registered in the ABF manifest

--- a/.changesets/1789021692-fix-cef-stop-verify-cef-framework-darwin-calling-a-stripped--7jex.md
+++ b/.changesets/1789021692-fix-cef-stop-verify-cef-framework-darwin-calling-a-stripped--7jex.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(cef): stop verify-cef-framework-darwin calling a stripped framework UNPATCHED

--- a/.changesets/1789021699-fix-agent-restore-the-pane-tab-strip-and-header-layout-after-ttg6.md
+++ b/.changesets/1789021699-fix-agent-restore-the-pane-tab-strip-and-header-layout-after-ttg6.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent): restore the pane tab strip and header layout after chrome hoisting

--- a/.changesets/1789022722-fix-srv-bundle-exports-now-carry-the-skills-and-mcp-servers--e638.md
+++ b/.changesets/1789022722-fix-srv-bundle-exports-now-carry-the-skills-and-mcp-servers--e638.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(srv): bundle exports now carry the skills and MCP servers actually bound to the bundle, with a migration carrying existing inline data across

--- a/.changesets/1789024994-fix-srv-deleting-a-bundle-purges-its-component-refs-bundle-v-5z1d.md
+++ b/.changesets/1789024994-fix-srv-deleting-a-bundle-purges-its-component-refs-bundle-v-5z1d.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(srv): deleting a bundle purges its component refs; bundle.validate checks the bound components rather than the retired inline columns

--- a/.changesets/1789026221-feat-srv-provider-registry-records-every-instruction-file-a--a1fy.md
+++ b/.changesets/1789026221-feat-srv-provider-registry-records-every-instruction-file-a--a1fy.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): provider registry records every instruction file a provider reads, not just the one AgentMux writes

--- a/.changesets/1789026385-docs-cef-chromium-152-needs-the-metal-toolchain-component-on-gqgp.md
+++ b/.changesets/1789026385-docs-cef-chromium-152-needs-the-metal-toolchain-component-on-gqgp.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs(cef): Chromium 152 needs the Metal Toolchain component on macOS

--- a/.changesets/1789027537-feat-srv-agent-project-instructions-reports-every-file-an-ag-jf0d.md
+++ b/.changesets/1789027537-feat-srv-agent-project-instructions-reports-every-file-an-ag-jf0d.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): agent.project_instructions reports every file an agent will read as instructions, with a content hash and an agentmux/foreign owner

--- a/.changesets/1789029506-fix-ci-bootstrap-the-winget-identifier-as-agentmux-ai-distin-9jo9.md
+++ b/.changesets/1789029506-fix-ci-bootstrap-the-winget-identifier-as-agentmux-ai-distin-9jo9.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ci): bootstrap the WinGet identifier as AgentMux.AI, distinct from the published MSIX identity

--- a/.changesets/1789029661-fix-term-stop-the-terminal-pane-header-tab-strip-flash-on-sh-23ty.md
+++ b/.changesets/1789029661-fix-term-stop-the-terminal-pane-header-tab-strip-flash-on-sh-23ty.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(term): stop the terminal pane header/tab-strip flash on shell-tab switch

--- a/.changesets/1789029739-fix-agent-pane-background-shell-output-no-longer-pins-a-fini-2je4.md
+++ b/.changesets/1789029739-fix-agent-pane-background-shell-output-no-longer-pins-a-fini-2je4.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): background shell output no longer pins a finished turn in Working

--- a/.changesets/1789031080-feat-srv-track-what-each-agent-reads-as-project-instructions-rfl0.md
+++ b/.changesets/1789031080-feat-srv-track-what-each-agent-reads-as-project-instructions-rfl0.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): track what each agent reads as project instructions, so a repository file changing between launches is detectable

--- a/.changesets/1789033084-feat-srv-exported-bundles-carry-the-project-instructions-the-5y54.md
+++ b/.changesets/1789033084-feat-srv-exported-bundles-carry-the-project-instructions-the-5y54.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): exported bundles carry the project instructions their agent was reading, recorded read-only and never installed on import

--- a/.changesets/1789033627-fix-agent-pane-fix-a-type-error-that-a-missing-tsc-gate-let--d7v8.md
+++ b/.changesets/1789033627-fix-agent-pane-fix-a-type-error-that-a-missing-tsc-gate-let--d7v8.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): fix a type error that a missing tsc gate let through

--- a/.changesets/1789037143-feat-agent-pane-narrate-backgrounded-tasks-into-the-conversa-ljh5.md
+++ b/.changesets/1789037143-feat-agent-pane-narrate-backgrounded-tasks-into-the-conversa-ljh5.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(agent-pane): narrate backgrounded tasks into the conversation

--- a/.changesets/1789049561-fix-cef-build-set-use-static-angle-false-for-windows-cef-152-5n4o.md
+++ b/.changesets/1789049561-fix-cef-build-set-use-static-angle-false-for-windows-cef-152-5n4o.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(cef-build): set use_static_angle=false for Windows CEF 152 — fixes a silent GPU regression

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.40"
+version = "0.55.41"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.40"
+version = "0.55.41"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.40"
+version = "0.55.41"
 dependencies = [
  "base64",
  "dirs 5.0.1",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.40"
+version = "0.55.41"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.40"
+version = "0.55.41"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.40"
+version = "0.55.41"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.40"
+version = "0.55.41"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,53 @@
 # AgentMux Version History
 
+## 0.55.41 — 2026-09-10
+
+- feat(zoom): Ctrl+Shift+Scroll zooms every pane in the window at once
+- feat(lan): peers report which agents they host
+- docs(cef): decide on staged per-platform rollout for the 152 upgrade
+- refactor(srv): migrate agentdefcreatefromtemplate and forkagentdefinitionsuggest to register_typed — 4 more RPC types generated and gated
+- fix(session): flush the session snapshot on OS shutdown (WM_QUERYENDSESSION/WM_ENDSESSION)
+- refactor(srv): migrate deleteagentinstance + hidenamedagent to register_typed — 4 more RPC types generated and gated, two new named response types replace anonymous json! shapes
+- refactor(srv): migrate deletememory + deletesystemmemory to register_typed — 2 more RPC types generated and gated, shared response type mirrors the existing shared request type
+- docs: rename claudius -> narko in live references
+- fix(cef): macOS build broken — native_window_visible referenced Arc<AppState> without an import on macOS
+- fix(cef): linux userns-sandbox probe false-positives on AppArmor hosts
+- fix(build): fail bundle:* loudly on stub ANGLE GL libraries instead of shipping a broken GFX-off build
+- fix(srv): jekt notifications for a renamed agent's stable AGENTMUX_AGENT_ID now resolve
+- docs(cef): branch model + upgrade practice for the CEF fork, all three platforms
+- fix(floating-pane): require a real 500ms hover before a floating pane redocks
+- docs(qr-pairing): correct stale mDNS-parity claim in HostPopover
+- fix(ci): drop the unused Google Chrome apt source so a bad index cannot fail Linux CI
+- fix(floating-pane): retune the redock dwell to 300ms
+- refactor(srv): armory naming Phase 1 — rename Memory->Bundle, bundle_memory_*->bundle_*, memory_bundles->bundles; split rpc_types/memory.rs
+- refactor(layout): add inert NodeModel.activeBlockId groundwork for pane chrome-stability fix
+- refactor(block): BlockFrame_Header/EndIcons take a reactive blockId accessor
+- refactor(frontend): armory naming Phase 1 — view/memory->view/bundle, type Memory->Bundle, BundleApi/NativeMemoryApi split, bundleId locals
+- fix(agent): stop the pane header/tab-strip flash when switching Agent <-> History tabs
+- ui(armory): rename the ABF tab to Bundles; ABF stays the name of the import/export format
+- refactor: armory naming Phase 2 — retire 'brain' on the bundle side (format_global_bundle_block, view/global-bundle, GlobalBundleViewModel)
+- fix(net): lan_listeners macOS bind-conflict assumption was wrong — groups with Windows, not Linux
+- fix(cef): move the CEF carry-set gates into tested scripts
+- fix(agent-pane): bind the working indicators to one predicate so they cannot disagree
+- fix(srv): integration tests no longer trigger a real macOS Keychain prompt
+- fix(cef): ship the macOS 26 renderer fix — bump the macOS CEF pin to 148.23.25
+- feat(srv): armory portability Phase 1+2 — bundle.export announces memory it cannot carry; history registered in the ABF manifest
+- fix(cef): stop verify-cef-framework-darwin calling a stripped framework UNPATCHED
+- fix(agent): restore the pane tab strip and header layout after chrome hoisting
+- fix(srv): bundle exports now carry the skills and MCP servers actually bound to the bundle, with a migration carrying existing inline data across
+- fix(srv): deleting a bundle purges its component refs; bundle.validate checks the bound components rather than the retired inline columns
+- feat(srv): provider registry records every instruction file a provider reads, not just the one AgentMux writes
+- docs(cef): Chromium 152 needs the Metal Toolchain component on macOS
+- feat(srv): agent.project_instructions reports every file an agent will read as instructions, with a content hash and an agentmux/foreign owner
+- fix(ci): bootstrap the WinGet identifier as AgentMux.AI, distinct from the published MSIX identity
+- fix(term): stop the terminal pane header/tab-strip flash on shell-tab switch
+- fix(agent-pane): background shell output no longer pins a finished turn in Working
+- feat(srv): track what each agent reads as project instructions, so a repository file changing between launches is detectable
+- feat(srv): exported bundles carry the project instructions their agent was reading, recorded read-only and never installed on import
+- fix(agent-pane): fix a type error that a missing tsc gate let through
+- feat(agent-pane): narrate backgrounded tasks into the conversation
+- fix(cef-build): set use_static_angle=false for Windows CEF 152 — fixes a silent GPU regression
+
 ## 0.55.40 — 2026-09-08
 
 - fix(window): reveal a cold-path window even when CEF Views misreports it visible

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.40",
+  "version": "0.55.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.40",
+      "version": "0.55.41",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.40",
+  "version": "0.55.41",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Forced patch release (`task release -- --as patch`) consuming 46 pending changesets.

**WARNING acknowledged:** the computed bump from the pending changesets was `minor` (several `feat:` entries, e.g. LAN peer agent reporting, provider-registry instruction tracking, ambient narration). Forcing `--as patch` per the explicit ask ships that minor-level work under a patch version number — the changelog is unaffected, every entry still lands, only the version number is lower than the changesets alone would have computed.

## Release-consistency invariant

All five locations verified to agree at `0.55.41`:
- `VERSION_HISTORY.md` top section
- `package.json`
- `Cargo.toml [workspace.package].version`
- `Cargo.lock` workspace-member versions
- `package-lock.json` root version

## Note on the release tooling

`@a5af/bump-cli`'s global npm install was corrupted on this machine — `npm ls -g` showed the package registered with an empty version and no `dist/cli.js` on disk, so `task release` failed on the first attempt with `MODULE_NOT_FOUND`. Reinstalled with `npm install -g @a5af/bump-cli` (now `0.2.1`) before retrying; the release itself completed cleanly on the second attempt with no other changes.

## Verification

- `git diff --staged` reviewed before committing — only the changeset deletions (46, all consumed) and the 5 version-location files changed.
- Changelog entry count (46) matches changesets consumed.

<!-- agentmux:agent_id=manoz -->