### PR TITLE
feat(mcp): add PtyShell — a real PTY-backed interactive shell, no UI required

### DIFF
--- a/.changesets/1789057969-feat-mcp-add-ptyshell-a-real-pty-backed-interactive-shell-ag-77no.md
+++ b/.changesets/1789057969-feat-mcp-add-ptyshell-a-real-pty-backed-interactive-shell-ag-77no.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(mcp): add PtyShell — a real PTY-backed interactive shell agents can drive without any UI

--- a/agentmux-common/src/api_types.rs
+++ b/agentmux-common/src/api_types.rs
@@ -165,23 +165,6 @@ pub struct PtyShellInputResponse {
     pub error: Option<String>,
 }
 
-/// `POST /api/v1/ptyshell/signal` — send a named signal (e.g. `SIGINT` for
-/// Ctrl+C) to the PTY's foreground process, the same mechanism a terminal's
-/// Ctrl+C keystroke uses.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PtyShellSignalRequest {
-    pub shell_id: String,
-    pub name: String,
-}
-
-/// Response from `POST /api/v1/ptyshell/signal`
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PtyShellSignalResponse {
-    pub sent: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
-}
-
 /// `POST /api/v1/ptyshell/resize` — resize the PTY. Some TUIs render
 /// differently or wrap badly at the fallback geometry (25x200).
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/agentmux-common/src/api_types.rs
+++ b/agentmux-common/src/api_types.rs
@@ -116,6 +116,140 @@ pub struct ShellStatusResponse {
     pub line_count: u64,
 }
 
+// ── PTY Shell ─────────────────────────────────────────────────────────────────
+//
+// A REAL PTY-backed shell (not the piped subprocess `Shell` above) — for
+// driving genuinely interactive programs that check for a real terminal
+// (Sharprompt-style wizards, `sudo`, `ssh`, REPLs). Reuses the same backend
+// `blockcontroller::shell` already uses for the `term` widget and
+// `AgentShellSubblock.tsx`; this is a new agent-facing entry point onto
+// existing PTY plumbing, not a new implementation. See
+// docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md.
+//
+// Deliberately NOT UI-driven: every one of these is a plain backend RPC
+// (agent -> agentmux-mcp -> agentmux-srv), with no dependency on any window
+// being open, focused, or even rendering the shell's `term` sub-block — the
+// same posture the existing `Shell`/`ShellInput` family already has.
+
+/// `POST /api/v1/ptyshell/create`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PtyShellCreateRequest {
+    pub agent_block_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rows: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cols: Option<u16>,
+}
+
+/// Response from `POST /api/v1/ptyshell/create`. `shell_id` is the new
+/// sub-block's id — the same value every other `PtyShell*` call takes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PtyShellCreateResponse {
+    pub shell_id: String,
+}
+
+/// `POST /api/v1/ptyshell/input` — write raw text to the PTY, as if typed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PtyShellInputRequest {
+    pub shell_id: String,
+    pub text: String,
+}
+
+/// Response from `POST /api/v1/ptyshell/input`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PtyShellInputResponse {
+    pub written: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// `POST /api/v1/ptyshell/signal` — send a named signal (e.g. `SIGINT` for
+/// Ctrl+C) to the PTY's foreground process, the same mechanism a terminal's
+/// Ctrl+C keystroke uses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PtyShellSignalRequest {
+    pub shell_id: String,
+    pub name: String,
+}
+
+/// Response from `POST /api/v1/ptyshell/signal`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PtyShellSignalResponse {
+    pub sent: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// `POST /api/v1/ptyshell/resize` — resize the PTY. Some TUIs render
+/// differently or wrap badly at the fallback geometry (25x200).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PtyShellResizeRequest {
+    pub shell_id: String,
+    pub rows: u16,
+    pub cols: u16,
+}
+
+/// Response from `POST /api/v1/ptyshell/resize`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PtyShellResizeResponse {
+    pub resized: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// `POST /api/v1/ptyshell/read` — read back the shell's raw output tail.
+///
+/// This is a raw byte/line log, not a rendered-screen snapshot — a
+/// full-screen TUI that redraws in place (cursor movement, `\r`-only
+/// updates) will not read back the way it visually renders. Sufficient for
+/// line-oriented wizards (the common case); see the spec's §5 for the
+/// rendered-snapshot follow-up this deliberately does not attempt yet.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PtyShellReadRequest {
+    pub shell_id: String,
+    /// Number of trailing lines to return. Defaults to 200.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tail_lines: Option<u32>,
+}
+
+/// Response from `POST /api/v1/ptyshell/read`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PtyShellReadResponse {
+    pub content: String,
+    /// True if the shell's output has more lines than `tail_lines` returned.
+    pub truncated: bool,
+}
+
+/// `POST /api/v1/ptyshell/status` — query whether the shell is still running.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PtyShellStatusRequest {
+    pub shell_id: String,
+}
+
+/// Response from `POST /api/v1/ptyshell/status`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PtyShellStatusResponse {
+    /// False both for "still initializing" and "exited" — callers that need
+    /// to distinguish those should check `exit_code` (`None` for the former).
+    pub running: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+}
+
+/// `POST /api/v1/ptyshell/stop` — kill the PTY and delete its sub-block.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PtyShellStopRequest {
+    pub shell_id: String,
+}
+
+/// Response from `POST /api/v1/ptyshell/stop`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PtyShellStopResponse {
+    pub stopped: bool,
+}
+
 // ── Inject (SendMessage + Loop) ───────────────────────────────────────────────
 
 /// `POST /agentmux/reactive/inject` — deliver a message to an agent.

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -30,7 +30,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use agentmux_common::api_types::{
     InjectRequest, PaneOpenRequest, PaneOpenResponse, PtyShellCreateRequest, PtyShellCreateResponse,
     PtyShellInputRequest, PtyShellInputResponse, PtyShellReadRequest, PtyShellReadResponse,
-    PtyShellResizeRequest, PtyShellResizeResponse, PtyShellSignalRequest, PtyShellSignalResponse,
+    PtyShellResizeRequest, PtyShellResizeResponse,
     PtyShellStatusRequest, PtyShellStatusResponse, PtyShellStopRequest, PtyShellStopResponse,
     ShellCreateRequest, ShellCreateResponse, ShellInputFailure, ShellInputRequest,
     ShellInputResponse, ShellStatusRequest, ShellStatusResponse, ShellStopRequest,
@@ -150,8 +150,6 @@ async fn main() {
                 let pty_shell: Value = serde_json::from_str(PTY_SHELL_TOOL).expect("static json");
                 let pty_shell_input: Value =
                     serde_json::from_str(PTY_SHELL_INPUT_TOOL).expect("static json");
-                let pty_shell_signal: Value =
-                    serde_json::from_str(PTY_SHELL_SIGNAL_TOOL).expect("static json");
                 let pty_shell_resize: Value =
                     serde_json::from_str(PTY_SHELL_RESIZE_TOOL).expect("static json");
                 let pty_shell_read: Value =
@@ -223,7 +221,7 @@ async fn main() {
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "tools": [shell, shell_stop, shell_input, shell_status, pty_shell, pty_shell_input, pty_shell_signal, pty_shell_resize, pty_shell_read, pty_shell_status, pty_shell_stop, open_editor, open_media, send_message, discover_agents, get_agent_transcript, list_conversations, supervisor_nudge, whoami, layout, set_name, set_active_tab, new_tab, focus_window, ui_screenshot, ui_click, ui_query, capture_window, discover_windows, fleet_list, fleet_broadcast, fleet_bulk_stop, open_agent, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, work_enqueue, work_claim, work_heartbeat, work_complete, work_release, work_list, memory_list, memory_read, memory_write, memory_history, memory_diff, memory_revert, preset_list, preset_get, identity_accounts, identity_validate] }
+                    "result": { "tools": [shell, shell_stop, shell_input, shell_status, pty_shell, pty_shell_input, pty_shell_resize, pty_shell_read, pty_shell_status, pty_shell_stop, open_editor, open_media, send_message, discover_agents, get_agent_transcript, list_conversations, supervisor_nudge, whoami, layout, set_name, set_active_tab, new_tab, focus_window, ui_screenshot, ui_click, ui_query, capture_window, discover_windows, fleet_list, fleet_broadcast, fleet_bulk_stop, open_agent, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, work_enqueue, work_claim, work_heartbeat, work_complete, work_release, work_list, memory_list, memory_read, memory_write, memory_history, memory_diff, memory_revert, preset_list, preset_get, identity_accounts, identity_validate] }
                 })
             }
             "tools/call" => {
@@ -787,51 +785,6 @@ async fn call_tool(
             } else {
                 format!(
                     "shell {shell_id}: write failed — {}",
-                    result.error.unwrap_or_else(|| "unknown reason".to_string())
-                )
-            })
-        }
-        "PtyShellSignal" => {
-            let shell_id = arguments
-                .get("shell_id")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| anyhow::anyhow!("missing required parameter: shell_id"))?;
-            let name = arguments
-                .get("name")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| anyhow::anyhow!("missing required parameter: name"))?;
-
-            if local_url.is_empty() || auth_key.is_empty() {
-                anyhow::bail!(
-                    "AGENTMUX_LOCAL_URL and AGENTMUX_AUTH_KEY must be set. \
-                     Is this agent pane opened via AgentMux?"
-                );
-            }
-
-            let url = format!("{}/api/v1/ptyshell/signal", local_url.trim_end_matches('/'));
-            let resp = client
-                .post(&url)
-                .header("X-AuthKey", auth_key)
-                .json(&PtyShellSignalRequest { shell_id: shell_id.to_string(), name: name.to_string() })
-                .send()
-                .await
-                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
-
-            if !resp.status().is_success() {
-                let status = resp.status();
-                let body = resp.text().await.unwrap_or_default();
-                anyhow::bail!("ptyshell/signal failed: HTTP {status} — {body}");
-            }
-
-            let result: PtyShellSignalResponse = resp
-                .json()
-                .await
-                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
-            Ok(if result.sent {
-                format!("sent {name} to shell {shell_id}")
-            } else {
-                format!(
-                    "shell {shell_id}: signal failed — {}",
                     result.error.unwrap_or_else(|| "unknown reason".to_string())
                 )
             })

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -28,11 +28,15 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use agentmux_common::api_types::{
-    InjectRequest, PaneOpenRequest, PaneOpenResponse, ShellCreateRequest, ShellCreateResponse,
-    ShellInputFailure, ShellInputRequest, ShellInputResponse, ShellStatusRequest, ShellStatusResponse,
-    ShellStopRequest, ShellStopResponse, TabActivateRequest, TabNameRequest, TabNewRequest,
-    UiClickRequest, UiQueryRequest, UiScreenshotRequest, UiScreenshotResponse,
-    WindowFocusRequest, WindowNameRequest, WorkspaceNameRequest, PaneTitleRequest,
+    InjectRequest, PaneOpenRequest, PaneOpenResponse, PtyShellCreateRequest, PtyShellCreateResponse,
+    PtyShellInputRequest, PtyShellInputResponse, PtyShellReadRequest, PtyShellReadResponse,
+    PtyShellResizeRequest, PtyShellResizeResponse, PtyShellSignalRequest, PtyShellSignalResponse,
+    PtyShellStatusRequest, PtyShellStatusResponse, PtyShellStopRequest, PtyShellStopResponse,
+    ShellCreateRequest, ShellCreateResponse, ShellInputFailure, ShellInputRequest,
+    ShellInputResponse, ShellStatusRequest, ShellStatusResponse, ShellStopRequest,
+    ShellStopResponse, TabActivateRequest, TabNameRequest, TabNewRequest, UiClickRequest,
+    UiQueryRequest, UiScreenshotRequest, UiScreenshotResponse, WindowFocusRequest,
+    WindowNameRequest, WorkspaceNameRequest, PaneTitleRequest,
 };
 use anyhow::Result;
 use serde_json::{json, Value};
@@ -143,6 +147,19 @@ async fn main() {
                 let shell_stop: Value = serde_json::from_str(SHELL_STOP_TOOL).expect("static json");
                 let shell_input: Value = serde_json::from_str(SHELL_INPUT_TOOL).expect("static json");
                 let shell_status: Value = serde_json::from_str(SHELL_STATUS_TOOL).expect("static json");
+                let pty_shell: Value = serde_json::from_str(PTY_SHELL_TOOL).expect("static json");
+                let pty_shell_input: Value =
+                    serde_json::from_str(PTY_SHELL_INPUT_TOOL).expect("static json");
+                let pty_shell_signal: Value =
+                    serde_json::from_str(PTY_SHELL_SIGNAL_TOOL).expect("static json");
+                let pty_shell_resize: Value =
+                    serde_json::from_str(PTY_SHELL_RESIZE_TOOL).expect("static json");
+                let pty_shell_read: Value =
+                    serde_json::from_str(PTY_SHELL_READ_TOOL).expect("static json");
+                let pty_shell_status: Value =
+                    serde_json::from_str(PTY_SHELL_STATUS_TOOL).expect("static json");
+                let pty_shell_stop: Value =
+                    serde_json::from_str(PTY_SHELL_STOP_TOOL).expect("static json");
                 let open_editor: Value = serde_json::from_str(OPEN_EDITOR_TOOL).expect("static json");
                 let open_media: Value = serde_json::from_str(OPEN_MEDIA_TOOL).expect("static json");
                 let send_message: Value = serde_json::from_str(SEND_MESSAGE_TOOL).expect("static json");
@@ -206,7 +223,7 @@ async fn main() {
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "tools": [shell, shell_stop, shell_input, shell_status, open_editor, open_media, send_message, discover_agents, get_agent_transcript, list_conversations, supervisor_nudge, whoami, layout, set_name, set_active_tab, new_tab, focus_window, ui_screenshot, ui_click, ui_query, capture_window, discover_windows, fleet_list, fleet_broadcast, fleet_bulk_stop, open_agent, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, work_enqueue, work_claim, work_heartbeat, work_complete, work_release, work_list, memory_list, memory_read, memory_write, memory_history, memory_diff, memory_revert, preset_list, preset_get, identity_accounts, identity_validate] }
+                    "result": { "tools": [shell, shell_stop, shell_input, shell_status, pty_shell, pty_shell_input, pty_shell_signal, pty_shell_resize, pty_shell_read, pty_shell_status, pty_shell_stop, open_editor, open_media, send_message, discover_agents, get_agent_transcript, list_conversations, supervisor_nudge, whoami, layout, set_name, set_active_tab, new_tab, focus_window, ui_screenshot, ui_click, ui_query, capture_window, discover_windows, fleet_list, fleet_broadcast, fleet_bulk_stop, open_agent, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, work_enqueue, work_claim, work_heartbeat, work_complete, work_release, work_list, memory_list, memory_read, memory_write, memory_history, memory_diff, memory_revert, preset_list, preset_get, identity_accounts, identity_validate] }
                 })
             }
             "tools/call" => {
@@ -686,6 +703,299 @@ async fn call_tool(
             } else {
                 let code = result.exit_code.map(|c| c.to_string()).unwrap_or_else(|| "unknown".to_string());
                 format!("shell {shell_id} has exited — exit_code: {code}, {} lines total", result.line_count)
+            })
+        }
+        "PtyShell" => {
+            if local_url.is_empty() || auth_key.is_empty() {
+                anyhow::bail!(
+                    "AGENTMUX_LOCAL_URL and AGENTMUX_AUTH_KEY must be set. \
+                     Is this agent pane opened via AgentMux?"
+                );
+            }
+            if block_id.is_empty() {
+                anyhow::bail!(
+                    "neither AGENTMUX_AGENT_BUS_ID nor AGENTMUX_BLOCKID is set \
+                     — cannot associate the shell with a conversation pane. \
+                     Is this agent pane opened via AgentMux?"
+                );
+            }
+
+            let cwd = arguments.get("cwd").and_then(|v| v.as_str()).map(str::to_string);
+            let rows = arguments.get("rows").and_then(|v| v.as_u64()).map(|n| n as u16);
+            let cols = arguments.get("cols").and_then(|v| v.as_u64()).map(|n| n as u16);
+
+            let url = format!("{}/api/v1/ptyshell/create", local_url.trim_end_matches('/'));
+            let req = PtyShellCreateRequest { agent_block_id: block_id.to_string(), cwd, rows, cols };
+            let resp = client
+                .post(&url)
+                .header("X-AuthKey", auth_key)
+                .json(&req)
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("ptyshell/create failed: HTTP {status} — {text}");
+            }
+
+            let result: PtyShellCreateResponse = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+            Ok(result.shell_id)
+        }
+        "PtyShellInput" => {
+            let shell_id = arguments
+                .get("shell_id")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: shell_id"))?;
+            let text = arguments
+                .get("text")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: text"))?;
+
+            if local_url.is_empty() || auth_key.is_empty() {
+                anyhow::bail!(
+                    "AGENTMUX_LOCAL_URL and AGENTMUX_AUTH_KEY must be set. \
+                     Is this agent pane opened via AgentMux?"
+                );
+            }
+
+            let url = format!("{}/api/v1/ptyshell/input", local_url.trim_end_matches('/'));
+            let resp = client
+                .post(&url)
+                .header("X-AuthKey", auth_key)
+                .json(&PtyShellInputRequest { shell_id: shell_id.to_string(), text: text.to_string() })
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                anyhow::bail!("ptyshell/input failed: HTTP {status} — {body}");
+            }
+
+            let result: PtyShellInputResponse = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+            Ok(if result.written {
+                format!("wrote to shell {shell_id}")
+            } else {
+                format!(
+                    "shell {shell_id}: write failed — {}",
+                    result.error.unwrap_or_else(|| "unknown reason".to_string())
+                )
+            })
+        }
+        "PtyShellSignal" => {
+            let shell_id = arguments
+                .get("shell_id")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: shell_id"))?;
+            let name = arguments
+                .get("name")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: name"))?;
+
+            if local_url.is_empty() || auth_key.is_empty() {
+                anyhow::bail!(
+                    "AGENTMUX_LOCAL_URL and AGENTMUX_AUTH_KEY must be set. \
+                     Is this agent pane opened via AgentMux?"
+                );
+            }
+
+            let url = format!("{}/api/v1/ptyshell/signal", local_url.trim_end_matches('/'));
+            let resp = client
+                .post(&url)
+                .header("X-AuthKey", auth_key)
+                .json(&PtyShellSignalRequest { shell_id: shell_id.to_string(), name: name.to_string() })
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                anyhow::bail!("ptyshell/signal failed: HTTP {status} — {body}");
+            }
+
+            let result: PtyShellSignalResponse = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+            Ok(if result.sent {
+                format!("sent {name} to shell {shell_id}")
+            } else {
+                format!(
+                    "shell {shell_id}: signal failed — {}",
+                    result.error.unwrap_or_else(|| "unknown reason".to_string())
+                )
+            })
+        }
+        "PtyShellResize" => {
+            let shell_id = arguments
+                .get("shell_id")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: shell_id"))?;
+            let rows = arguments
+                .get("rows")
+                .and_then(|v| v.as_u64())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: rows"))? as u16;
+            let cols = arguments
+                .get("cols")
+                .and_then(|v| v.as_u64())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: cols"))? as u16;
+
+            if local_url.is_empty() || auth_key.is_empty() {
+                anyhow::bail!(
+                    "AGENTMUX_LOCAL_URL and AGENTMUX_AUTH_KEY must be set. \
+                     Is this agent pane opened via AgentMux?"
+                );
+            }
+
+            let url = format!("{}/api/v1/ptyshell/resize", local_url.trim_end_matches('/'));
+            let resp = client
+                .post(&url)
+                .header("X-AuthKey", auth_key)
+                .json(&PtyShellResizeRequest { shell_id: shell_id.to_string(), rows, cols })
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                anyhow::bail!("ptyshell/resize failed: HTTP {status} — {body}");
+            }
+
+            let result: PtyShellResizeResponse = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+            Ok(if result.resized {
+                format!("resized shell {shell_id} to {rows}x{cols}")
+            } else {
+                format!(
+                    "shell {shell_id}: resize failed — {}",
+                    result.error.unwrap_or_else(|| "unknown reason".to_string())
+                )
+            })
+        }
+        "PtyShellRead" => {
+            let shell_id = arguments
+                .get("shell_id")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: shell_id"))?;
+            let tail_lines = arguments.get("tail_lines").and_then(|v| v.as_u64()).map(|n| n as u32);
+
+            if local_url.is_empty() || auth_key.is_empty() {
+                anyhow::bail!(
+                    "AGENTMUX_LOCAL_URL and AGENTMUX_AUTH_KEY must be set. \
+                     Is this agent pane opened via AgentMux?"
+                );
+            }
+
+            let url = format!("{}/api/v1/ptyshell/read", local_url.trim_end_matches('/'));
+            let resp = client
+                .post(&url)
+                .header("X-AuthKey", auth_key)
+                .json(&PtyShellReadRequest { shell_id: shell_id.to_string(), tail_lines })
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                anyhow::bail!("ptyshell/read failed: HTTP {status} — {body}");
+            }
+
+            let result: PtyShellReadResponse = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+            let prefix = if result.truncated { "[...output truncated...]\n" } else { "" };
+            Ok(format!("{prefix}{}", result.content))
+        }
+        "PtyShellStatus" => {
+            let shell_id = arguments
+                .get("shell_id")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: shell_id"))?;
+
+            if local_url.is_empty() || auth_key.is_empty() {
+                anyhow::bail!(
+                    "AGENTMUX_LOCAL_URL and AGENTMUX_AUTH_KEY must be set. \
+                     Is this agent pane opened via AgentMux?"
+                );
+            }
+
+            let url = format!("{}/api/v1/ptyshell/status", local_url.trim_end_matches('/'));
+            let resp = client
+                .post(&url)
+                .header("X-AuthKey", auth_key)
+                .json(&PtyShellStatusRequest { shell_id: shell_id.to_string() })
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                anyhow::bail!("ptyshell/status failed: HTTP {status} — {body}");
+            }
+
+            let result: PtyShellStatusResponse = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+            Ok(if result.running {
+                format!("shell {shell_id} is running")
+            } else {
+                let code = result.exit_code.map(|c| c.to_string()).unwrap_or_else(|| "unknown".to_string());
+                format!("shell {shell_id} is not running — exit_code: {code}")
+            })
+        }
+        "PtyShellStop" => {
+            let shell_id = arguments
+                .get("shell_id")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("missing required parameter: shell_id"))?;
+
+            if local_url.is_empty() || auth_key.is_empty() {
+                anyhow::bail!(
+                    "AGENTMUX_LOCAL_URL and AGENTMUX_AUTH_KEY must be set. \
+                     Is this agent pane opened via AgentMux?"
+                );
+            }
+
+            let url = format!("{}/api/v1/ptyshell/stop", local_url.trim_end_matches('/'));
+            let resp = client
+                .post(&url)
+                .header("X-AuthKey", auth_key)
+                .json(&PtyShellStopRequest { shell_id: shell_id.to_string() })
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                anyhow::bail!("ptyshell/stop failed: HTTP {status} — {body}");
+            }
+
+            let result: PtyShellStopResponse = resp
+                .json()
+                .await
+                .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
+            Ok(if result.stopped {
+                format!("stopped shell {shell_id}")
+            } else {
+                format!("shell {shell_id} was not running (unknown or already stopped)")
             })
         }
         "OpenEditor" => {

--- a/agentmux-mcp/src/tool_schemas.rs
+++ b/agentmux-mcp/src/tool_schemas.rs
@@ -82,7 +82,7 @@ pub(crate) const PTY_SHELL_TOOL: &str = r#"{
 
 pub(crate) const PTY_SHELL_INPUT_TOOL: &str = r#"{
   "name": "PtyShellInput",
-  "description": "Write raw text to a PtyShell()'s PTY, as if typed at a keyboard. Unlike ShellInput, no newline is appended — send exactly what a keypress would produce (e.g. \"y\\n\" to answer a prompt and press Enter, or \"\\u0003\" for Ctrl+C — though PtyShellSignal is the more reliable way to send Ctrl+C).",
+  "description": "Write raw text to a PtyShell()'s PTY, as if typed at a keyboard. Unlike ShellInput, no newline is appended — send exactly what a keypress would produce (e.g. \"y\\n\" to answer a prompt and press Enter, or \"\\u0003\" for Ctrl+C — the OS PTY layer delivers that as a real interrupt to the foreground process, same as a human pressing Ctrl+C, without ending the shell).",
   "inputSchema": {
     "type": "object",
     "properties": {
@@ -90,19 +90,6 @@ pub(crate) const PTY_SHELL_INPUT_TOOL: &str = r#"{
       "text":     { "type": "string", "description": "Raw text to write — no newline is added automatically" }
     },
     "required": ["shell_id", "text"]
-  }
-}"#;
-
-pub(crate) const PTY_SHELL_SIGNAL_TOOL: &str = r#"{
-  "name": "PtyShellSignal",
-  "description": "Send a named signal (e.g. SIGINT for Ctrl+C) to a PtyShell()'s foreground process — the same mechanism a terminal's Ctrl+C keystroke uses, more reliable than sending the raw control byte via PtyShellInput.",
-  "inputSchema": {
-    "type": "object",
-    "properties": {
-      "shell_id": { "type": "string", "description": "The shell_id returned by a prior PtyShell() call" },
-      "name":     { "type": "string", "description": "Signal name, e.g. SIGINT, SIGTERM" }
-    },
-    "required": ["shell_id", "name"]
   }
 }"#;
 

--- a/agentmux-mcp/src/tool_schemas.rs
+++ b/agentmux-mcp/src/tool_schemas.rs
@@ -67,6 +67,96 @@ pub(crate) const SHELL_STATUS_TOOL: &str = r#"{
   }
 }"#;
 
+pub(crate) const PTY_SHELL_TOOL: &str = r#"{
+  "name": "PtyShell",
+  "description": "Open a REAL PTY-backed interactive shell — unlike Shell(), which runs on a plain pipe, this behaves like a real terminal, so programs that check for one (password/wizard prompts, sudo, ssh, REPLs) work instead of refusing or misbehaving. Returns a shell_id immediately; use PtyShellInput to type into it, PtyShellRead to see its output, PtyShellStatus to poll, PtyShellStop to end it. Works with no UI involved at all — the window need not be open, focused, or rendering anything for this to work; it's a plain backend call, not simulated keystrokes into a visible terminal.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "cwd":  { "type": "string", "description": "Working directory (defaults to agent workdir)" },
+      "rows": { "type": "integer", "description": "Initial terminal rows (default 25)" },
+      "cols": { "type": "integer", "description": "Initial terminal columns (default 200)" }
+    }
+  }
+}"#;
+
+pub(crate) const PTY_SHELL_INPUT_TOOL: &str = r#"{
+  "name": "PtyShellInput",
+  "description": "Write raw text to a PtyShell()'s PTY, as if typed at a keyboard. Unlike ShellInput, no newline is appended — send exactly what a keypress would produce (e.g. \"y\\n\" to answer a prompt and press Enter, or \"\\u0003\" for Ctrl+C — though PtyShellSignal is the more reliable way to send Ctrl+C).",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "shell_id": { "type": "string", "description": "The shell_id returned by a prior PtyShell() call" },
+      "text":     { "type": "string", "description": "Raw text to write — no newline is added automatically" }
+    },
+    "required": ["shell_id", "text"]
+  }
+}"#;
+
+pub(crate) const PTY_SHELL_SIGNAL_TOOL: &str = r#"{
+  "name": "PtyShellSignal",
+  "description": "Send a named signal (e.g. SIGINT for Ctrl+C) to a PtyShell()'s foreground process — the same mechanism a terminal's Ctrl+C keystroke uses, more reliable than sending the raw control byte via PtyShellInput.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "shell_id": { "type": "string", "description": "The shell_id returned by a prior PtyShell() call" },
+      "name":     { "type": "string", "description": "Signal name, e.g. SIGINT, SIGTERM" }
+    },
+    "required": ["shell_id", "name"]
+  }
+}"#;
+
+pub(crate) const PTY_SHELL_RESIZE_TOOL: &str = r#"{
+  "name": "PtyShellResize",
+  "description": "Resize a PtyShell()'s terminal. Some interactive programs render differently or wrap badly at the default geometry (25 rows x 200 cols).",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "shell_id": { "type": "string", "description": "The shell_id returned by a prior PtyShell() call" },
+      "rows":     { "type": "integer", "description": "New row count" },
+      "cols":     { "type": "integer", "description": "New column count" }
+    },
+    "required": ["shell_id", "rows", "cols"]
+  }
+}"#;
+
+pub(crate) const PTY_SHELL_READ_TOOL: &str = r#"{
+  "name": "PtyShellRead",
+  "description": "Read back a PtyShell()'s output tail (default last 200 lines). This is a raw text log, not a rendered screen — a full-screen program that redraws in place (progress bars, cursor-addressed UIs) won't read back exactly as it visually renders, but line-oriented prompts (the common case) read back cleanly.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "shell_id":   { "type": "string", "description": "The shell_id returned by a prior PtyShell() call" },
+      "tail_lines": { "type": "integer", "description": "Number of trailing lines to return (default 200)" }
+    },
+    "required": ["shell_id"]
+  }
+}"#;
+
+pub(crate) const PTY_SHELL_STATUS_TOOL: &str = r#"{
+  "name": "PtyShellStatus",
+  "description": "Query whether a PtyShell() is still running, and its exit code once it has ended.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "shell_id": { "type": "string", "description": "The shell_id returned by a prior PtyShell() call" }
+    },
+    "required": ["shell_id"]
+  }
+}"#;
+
+pub(crate) const PTY_SHELL_STOP_TOOL: &str = r#"{
+  "name": "PtyShellStop",
+  "description": "Kill a PtyShell() and clean up its terminal. Prefer this over letting it linger once you're done with an interactive session.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "shell_id": { "type": "string", "description": "The shell_id returned by a prior PtyShell() call" }
+    },
+    "required": ["shell_id"]
+  }
+}"#;
+
 pub(crate) const SEND_MESSAGE_TOOL: &str = r#"{
   "name": "SendMessage",
   "description": "Send a message to another agent by name. The message is injected as input into the target agent's active conversation. Use for agent-to-agent coordination — handoff, task delegation, status notifications. Delivery is best-effort and tries local → same-host → LAN → cloud in order. The first three tiers return only once the message has actually been injected; the cloud tier is store-and-forward, so success there means the relay accepted it and the recipient's AgentMux will pick it up when it next syncs (which never happens if that instance stays offline). Returns once one tier has taken the message or all have failed.",

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -59,16 +59,20 @@ use crate::backend::lsp::LspSupervisor;
 use crate::backend::messagebus::MessageBus;
 use crate::backend::reactive::{Poller, ReactiveHandler};
 use crate::backend::storage::filestore::FileStore;
+use crate::backend::blockcontroller;
 use crate::backend::storage::store::Store;
 use crate::backend::history::HistoryService;
 use crate::backend::subagent_watcher::SubagentWatcher;
 use crate::backend::wconfig;
 use crate::backend::wps::Broker;
 use agentmux_common::api_types::{
-    PaneTitleRequest, ShellCreateRequest, ShellCreateResponse, ShellInputFailure,
-    ShellInputRequest, ShellInputResponse, ShellStatusRequest, ShellStatusResponse, ShellStopRequest,
-    TabActivateRequest, TabNameRequest, TabNewRequest, WindowFocusRequest, WindowNameRequest,
-    WorkspaceNameRequest, WpsPublishRequest,
+    PaneTitleRequest, PtyShellCreateRequest, PtyShellCreateResponse, PtyShellInputRequest,
+    PtyShellInputResponse, PtyShellReadRequest, PtyShellReadResponse, PtyShellResizeRequest,
+    PtyShellResizeResponse, PtyShellSignalRequest, PtyShellSignalResponse, PtyShellStatusRequest,
+    PtyShellStatusResponse, PtyShellStopRequest, PtyShellStopResponse, ShellCreateRequest,
+    ShellCreateResponse, ShellInputFailure, ShellInputRequest, ShellInputResponse,
+    ShellStatusRequest, ShellStatusResponse, ShellStopRequest, TabActivateRequest, TabNameRequest,
+    TabNewRequest, WindowFocusRequest, WindowNameRequest, WorkspaceNameRequest, WpsPublishRequest,
 };
 
 // ---- AppState ----
@@ -449,6 +453,17 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/shell/input", post(handle_shell_input))
         // Phase 3b — query running state, exit code, and line count.
         .route("/api/v1/shell/status", post(handle_shell_status))
+        // Real PTY-backed shell, for genuinely interactive programs the
+        // piped /api/v1/shell/* family above can't drive (see
+        // docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md).
+        // agentmux-mcp's `PtyShell*` tools POST here.
+        .route("/api/v1/ptyshell/create", post(handle_pty_shell_create))
+        .route("/api/v1/ptyshell/input", post(handle_pty_shell_input))
+        .route("/api/v1/ptyshell/signal", post(handle_pty_shell_signal))
+        .route("/api/v1/ptyshell/resize", post(handle_pty_shell_resize))
+        .route("/api/v1/ptyshell/read", post(handle_pty_shell_read))
+        .route("/api/v1/ptyshell/status", post(handle_pty_shell_status))
+        .route("/api/v1/ptyshell/stop", post(handle_pty_shell_stop))
         // Open a pane (editor/term/browser/…) from an agent tool call.
         // agentmux-mcp's OpenEditor tool POSTs `{view:"editor", file, …}` here;
         // shares the exact pane.open logic with the WebSocket RPC handler
@@ -1048,6 +1063,348 @@ async fn handle_shell_status(
         exit_code: s.exit_code,
         line_count: s.line_count,
     }))
+}
+
+// ---------------------------------------------------------------------------
+// PTY shell handlers (docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md)
+//
+// A REAL PTY, unlike the piped `/api/v1/shell/*` family above — for driving
+// genuinely interactive programs (Sharprompt-style wizards, `sudo`, `ssh`,
+// REPLs) that check for a real terminal and refuse or misbehave on a pipe.
+// Reuses `blockcontroller::shell` verbatim (the same controller backing the
+// `term` widget and `AgentShellSubblock.tsx`'s composer-drawer shell) —
+// this is a new agent-facing entry point onto existing PTY plumbing, not a
+// new PTY implementation.
+//
+// Every handler here is a plain HTTP call with no WS/tab dependency, same as
+// `handle_shell_create` above — deliberately NOT wired through the
+// `WshRpcEngine` that `createsubblock`/`controllerresync`/`controllerinput`
+// use (those are instantiated per-WebSocket-connection, so they exist only
+// while a frontend tab is connected). An agent calling these tools gets a
+// live, fully functional PTY regardless of whether any window is open,
+// focused, or rendering the shell's `term` sub-block at all.
+// ---------------------------------------------------------------------------
+
+/// `POST /api/v1/ptyshell/create` — open a real PTY-backed shell.
+///
+/// Creates a headless sub-block (`view: "term", controller: "shell"`,
+/// no tab/layout entry) parented to the calling agent's own block — the
+/// same shape `createsubblock`'s WS handler builds for
+/// `AgentShellSubblock.tsx` — then immediately spawns its controller via
+/// `resync_controller`. Unlike the WS path (which waits for a frontend to
+/// mount a `term` view and call `ControllerResyncCommand`), the PTY is live
+/// the moment this call returns; a UI viewer for it is optional, not a
+/// prerequisite.
+async fn handle_pty_shell_create(
+    State(state): State<AppState>,
+    Json(req): Json<PtyShellCreateRequest>,
+) -> impl IntoResponse {
+    let child_id = uuid::Uuid::new_v4().to_string();
+
+    let mut meta = crate::backend::obj::MetaMapType::new();
+    meta.insert("view".to_string(), json!("term"));
+    meta.insert(
+        blockcontroller::META_KEY_CONTROLLER.to_string(),
+        json!(blockcontroller::BLOCK_CONTROLLER_SHELL),
+    );
+    // Force cmd.exe directly on Windows rather than the "shell" controller's
+    // default pwsh/powershell auto-detection (`detect_local_shell_path_windows`,
+    // which tries pwsh first). Discovered live, not assumed: PowerShell's
+    // PSReadLine issues a cursor-position query (`ESC[6n`, Device Status
+    // Report) on interactive startup and blocks forever waiting for a
+    // `ESC[row;colR` reply — which only a real terminal emulator answering
+    // on the other end provides (xterm.js does, for the `term` widget /
+    // AgentShellSubblock's human-facing sessions). This facility has no
+    // terminal emulator reading the byte stream, only a raw capture, so
+    // every PtyShell() would otherwise hang before printing even its first
+    // prompt. cmd.exe has no such startup handshake. Non-Windows shells
+    // (bash/zsh via $SHELL) aren't affected — left as the "shell"
+    // controller's own default. This is a known-narrow mitigation, not a
+    // general fix: any OTHER program that queries terminal capabilities via
+    // escape sequences and blocks for a reply would hit the same class of
+    // issue — see docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md §5.
+    #[cfg(windows)]
+    {
+        meta.insert(blockcontroller::META_KEY_CMD.to_string(), json!("cmd.exe"));
+        meta.insert("cmd:interactive".to_string(), json!(true));
+    }
+    if let Some(cwd) = &req.cwd {
+        // Same MSYS→native normalization createsubblock's WS handler applies —
+        // the PTY spawn path reads cmd:cwd raw with no conversion, so a
+        // Git-Bash-style path would otherwise fail with os error 267 on
+        // Windows.
+        match crate::backend::base::normalize_working_dir(cwd)
+            .filter(|p| std::path::Path::new(p).is_absolute())
+        {
+            Some(norm) => {
+                meta.insert(blockcontroller::META_KEY_CMD_CWD.to_string(), json!(norm));
+            }
+            None => {
+                tracing::warn!(
+                    raw_cwd = %cwd,
+                    "ptyshell.create: invalid or non-absolute cwd, dropping (no cwd)"
+                );
+            }
+        }
+    }
+
+    // Initial PTY geometry, if the caller specified one — otherwise
+    // `resync_controller`'s own fallback (25x200) applies. Both `rows`/`cols`
+    // being absent is the common case; either one alone still takes effect
+    // (see `pty_size_from_rt_opts`'s per-field guards).
+    let runtimeopts = if req.rows.is_none() && req.cols.is_none() {
+        None
+    } else {
+        Some(crate::backend::obj::RuntimeOpts {
+            termsize: crate::backend::obj::TermSize {
+                rows: req.rows.unwrap_or(25) as i64,
+                cols: req.cols.unwrap_or(200) as i64,
+            },
+            ..Default::default()
+        })
+    };
+    let rt_opts_json = runtimeopts.as_ref().map(|rt| {
+        json!({ "termsize": { "rows": rt.termsize.rows, "cols": rt.termsize.cols } })
+    });
+
+    let mut block = crate::backend::obj::Block {
+        oid: child_id.clone(),
+        parentoref: format!("block:{}", req.agent_block_id),
+        meta,
+        runtimeopts,
+        ..Default::default()
+    };
+
+    if let Err(e) = state.wstore.insert(&mut block) {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": format!("ptyshell.create: insert: {e}") })),
+        )
+            .into_response();
+    }
+
+    // Best-effort link into the parent's subblockids — same posture as
+    // createsubblock's WS handler (not a CAS; an acceptable race for a
+    // single lazily-created shell per agent pane).
+    if let Ok(mut parent) = state
+        .wstore
+        .must_get::<crate::backend::obj::Block>(&req.agent_block_id)
+    {
+        parent
+            .subblockids
+            .get_or_insert_with(Vec::new)
+            .push(child_id.clone());
+        let _ = state.wstore.update(&mut parent);
+    }
+
+    let registry = state.wstore.shared_agent_registry();
+    if let Err(e) = blockcontroller::resync_controller(
+        &block,
+        "ptyshell", // headless — no real tab; only used for tracing/scoping.
+        rt_opts_json,
+        false,
+        Some(Arc::clone(&state.broker)),
+        Some(Arc::clone(&state.event_bus)),
+        Some(Arc::clone(&state.wstore)),
+        Some(Arc::clone(&state.filestore)),
+        registry,
+        state.boot_id.clone(),
+    ) {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": format!("ptyshell.create: spawn: {e}") })),
+        )
+            .into_response();
+    }
+
+    // Answer ConPTY's own startup handshake before returning, on Windows.
+    // Discovered live (not assumed): the moment a Windows ConPTY is created,
+    // it queries the cursor position (`ESC[6n`, Device Status Report) and
+    // blocks its own internal state — and therefore every later write —
+    // until it sees a `ESC[<row>;<col>R` reply. A human-facing `term` pane
+    // gets this for free because xterm.js, running in the browser, answers
+    // real cursor queries as part of being an actual terminal emulator; this
+    // headless facility has nothing playing that role, so without this the
+    // PTY would sit permanently stuck before printing even its first
+    // prompt — confirmed by a live round trip that hung indefinitely until
+    // this was added. `ESC[1;1R` (cursor at row 1, col 1) is a plausible-
+    // enough fixed answer: nothing here has rendered anything yet, so
+    // "top-left" is as true as any other coordinate, and ConPTY only wants
+    // to reconcile its internal buffer, not validate the value against
+    // anything a person would see.
+    #[cfg(windows)]
+    {
+        let mut answered = false;
+        for _ in 0..20 {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            let saw_dsr = state
+                .filestore
+                .read_file(&child_id, "term")
+                .ok()
+                .flatten()
+                .map(|bytes| bytes.windows(4).any(|w| w == b"\x1b[6n"))
+                .unwrap_or(false);
+            if saw_dsr {
+                let _ = blockcontroller::send_input(
+                    &child_id,
+                    blockcontroller::BlockInputUnion::data(b"\x1b[1;1R".to_vec()),
+                    None,
+                );
+                answered = true;
+                break;
+            }
+        }
+        tracing::info!(block_id = %child_id, answered_dsr = answered, "ptyshell.create: ConPTY handshake");
+    }
+
+    tracing::info!(block_id = %child_id, parent_id = %req.agent_block_id, "ptyshell.create");
+    (StatusCode::OK, Json(PtyShellCreateResponse { shell_id: child_id })).into_response()
+}
+
+/// `POST /api/v1/ptyshell/input` — write raw text to the PTY, as if typed.
+/// Unlike `/api/v1/shell/input`, no newline is appended: a real terminal
+/// doesn't add one either, and PTY programs (readline, Sharprompt) expect
+/// the caller to send exactly what a keyboard would (e.g. `"y\n"` or
+/// `"\x03"` for Ctrl+C — though Ctrl+C is better sent via
+/// `/api/v1/ptyshell/signal`, which doesn't require the PTY to have
+/// translated the byte itself).
+async fn handle_pty_shell_input(
+    Json(req): Json<PtyShellInputRequest>,
+) -> impl IntoResponse {
+    match blockcontroller::send_input(
+        &req.shell_id,
+        blockcontroller::BlockInputUnion::data(req.text.into_bytes()),
+        None,
+    ) {
+        Ok(()) => (StatusCode::OK, Json(PtyShellInputResponse { written: true, error: None })),
+        Err(e) => (StatusCode::OK, Json(PtyShellInputResponse { written: false, error: Some(e) })),
+    }
+}
+
+/// `POST /api/v1/ptyshell/signal` — send a named signal (e.g. `SIGINT`) to
+/// the PTY's foreground process, the same mechanism a terminal's Ctrl+C
+/// keystroke uses.
+async fn handle_pty_shell_signal(
+    Json(req): Json<PtyShellSignalRequest>,
+) -> impl IntoResponse {
+    match blockcontroller::send_input(
+        &req.shell_id,
+        blockcontroller::BlockInputUnion::signal(&req.name),
+        None,
+    ) {
+        Ok(()) => (StatusCode::OK, Json(PtyShellSignalResponse { sent: true, error: None })),
+        Err(e) => (StatusCode::OK, Json(PtyShellSignalResponse { sent: false, error: Some(e) })),
+    }
+}
+
+/// `POST /api/v1/ptyshell/resize` — resize the PTY. Some TUIs render
+/// differently or wrap badly at the fallback geometry (25x200).
+async fn handle_pty_shell_resize(
+    Json(req): Json<PtyShellResizeRequest>,
+) -> impl IntoResponse {
+    match blockcontroller::send_input(
+        &req.shell_id,
+        blockcontroller::BlockInputUnion::resize(crate::backend::obj::TermSize {
+            rows: req.rows as i64,
+            cols: req.cols as i64,
+        }),
+        None,
+    ) {
+        Ok(()) => (StatusCode::OK, Json(PtyShellResizeResponse { resized: true, error: None })),
+        Err(e) => (StatusCode::OK, Json(PtyShellResizeResponse { resized: false, error: Some(e) })),
+    }
+}
+
+/// `POST /api/v1/ptyshell/read` — read back the shell's raw output tail.
+///
+/// Reads the block's `term` file straight from `FileStore` — the same file
+/// `blockcontroller::shell::lifecycle`'s real PTY read loop write-throughs
+/// to (`handle_append_block_file(..., "term", ..., filestore, ...)`,
+/// `SPEC_TERMINAL_SCROLLBACK_PERSISTENCE_2026_07_23.md` §2.1). Deliberately
+/// NOT the optimized `blockfile:read_range` path (byte-offset index,
+/// cross-channel global-transcript fallback, and a different filename —
+/// "output" — used for agent CLI transcripts, a different content stream
+/// entirely), which solves problems this endpoint doesn't have: a PTY shell
+/// created through this API is always local and short-lived, so a plain
+/// whole-file read + in-memory tail is simpler and correct. This is a raw
+/// line log, not a rendered-screen snapshot — see the type's own doc
+/// comment in `api_types.rs`.
+async fn handle_pty_shell_read(
+    State(state): State<AppState>,
+    Json(req): Json<PtyShellReadRequest>,
+) -> impl IntoResponse {
+    let content = match state.filestore.read_file(&req.shell_id, "term") {
+        Ok(Some(bytes)) => String::from_utf8_lossy(&bytes).to_string(),
+        Ok(None) => String::new(),
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": format!("ptyshell.read: {e}") })),
+            )
+                .into_response();
+        }
+    };
+    let tail_lines = req.tail_lines.unwrap_or(200).max(1) as usize;
+    let lines: Vec<&str> = content.lines().collect();
+    let start = lines.len().saturating_sub(tail_lines);
+    let truncated = start > 0;
+    let tail = lines[start..].join("\n");
+    (StatusCode::OK, Json(PtyShellReadResponse { content: tail, truncated })).into_response()
+}
+
+/// `POST /api/v1/ptyshell/status` — query whether the shell is still running.
+async fn handle_pty_shell_status(
+    Json(req): Json<PtyShellStatusRequest>,
+) -> impl IntoResponse {
+    match blockcontroller::get_block_controller_status(&req.shell_id) {
+        Some(status) => {
+            let running = status.shellprocstatus == blockcontroller::STATUS_RUNNING;
+            let exit_code = (status.shellprocstatus == blockcontroller::STATUS_DONE)
+                .then_some(status.shellprocexitcode);
+            (StatusCode::OK, Json(PtyShellStatusResponse { running, exit_code }))
+        }
+        // No controller registered — unknown id or already torn down via
+        // ptyshell/stop. Same "plain not-running answer, not an error"
+        // contract ShellStatus already documents.
+        None => (StatusCode::OK, Json(PtyShellStatusResponse { running: false, exit_code: None })),
+    }
+}
+
+/// `POST /api/v1/ptyshell/stop` — kill the PTY and delete its sub-block.
+/// Mirrors `deletesubblock`'s WS handler: kill-first ordering (a lingering
+/// PTY tree is worse than a delayed row delete), best-effort unlink from the
+/// parent's subblockids.
+async fn handle_pty_shell_stop(
+    State(state): State<AppState>,
+    Json(req): Json<PtyShellStopRequest>,
+) -> impl IntoResponse {
+    // Whether a controller actually existed is the meaningful "did this
+    // stop anything" signal — unlike `Store::delete`, which succeeds
+    // (no-ops) even for a row that was never there, so `.is_ok()` alone
+    // can't distinguish "stopped a real shell" from "unknown id".
+    let stopped = blockcontroller::get_block_controller_status(&req.shell_id).is_some();
+    blockcontroller::delete_controller(&req.shell_id);
+
+    let parent_id = state
+        .wstore
+        .get::<crate::backend::obj::Block>(&req.shell_id)
+        .ok()
+        .flatten()
+        .and_then(|b| b.parentoref.strip_prefix("block:").map(str::to_string));
+
+    let _ = state.wstore.delete::<crate::backend::obj::Block>(&req.shell_id);
+
+    if let Some(parent_id) = parent_id {
+        if let Ok(mut parent) = state.wstore.must_get::<crate::backend::obj::Block>(&parent_id) {
+            if let Some(ids) = parent.subblockids.as_mut() {
+                ids.retain(|id| id != &req.shell_id);
+                let _ = state.wstore.update(&mut parent);
+            }
+        }
+    }
+
+    tracing::info!(block_id = %req.shell_id, "ptyshell.stop");
+    (StatusCode::OK, Json(PtyShellStopResponse { stopped }))
 }
 
 /// `POST /api/v1/pane/open` — open a pane (editor/term/browser/…).

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -68,7 +68,7 @@ use crate::backend::wps::Broker;
 use agentmux_common::api_types::{
     PaneTitleRequest, PtyShellCreateRequest, PtyShellCreateResponse, PtyShellInputRequest,
     PtyShellInputResponse, PtyShellReadRequest, PtyShellReadResponse, PtyShellResizeRequest,
-    PtyShellResizeResponse, PtyShellSignalRequest, PtyShellSignalResponse, PtyShellStatusRequest,
+    PtyShellResizeResponse, PtyShellStatusRequest,
     PtyShellStatusResponse, PtyShellStopRequest, PtyShellStopResponse, ShellCreateRequest,
     ShellCreateResponse, ShellInputFailure, ShellInputRequest, ShellInputResponse,
     ShellStatusRequest, ShellStatusResponse, ShellStopRequest, TabActivateRequest, TabNameRequest,
@@ -459,7 +459,6 @@ pub fn build_router(state: AppState) -> Router {
         // agentmux-mcp's `PtyShell*` tools POST here.
         .route("/api/v1/ptyshell/create", post(handle_pty_shell_create))
         .route("/api/v1/ptyshell/input", post(handle_pty_shell_input))
-        .route("/api/v1/ptyshell/signal", post(handle_pty_shell_signal))
         .route("/api/v1/ptyshell/resize", post(handle_pty_shell_resize))
         .route("/api/v1/ptyshell/read", post(handle_pty_shell_read))
         .route("/api/v1/ptyshell/status", post(handle_pty_shell_status))
@@ -1065,6 +1064,27 @@ async fn handle_shell_status(
     }))
 }
 
+// Meta marker stamped on every block `handle_pty_shell_create` creates.
+// Every other `ptyshell/*` handler MUST verify this before acting on a
+// caller-supplied `shell_id` (Codex P1 on PR #3177): `shell_id` lives in the
+// SAME block-id namespace as every other pane in the system, and `Layout`
+// exposes block ids for ordinary panes — without this check, an agent could
+// point `PtyShellInput`/`PtyShellStop`/etc. at any controller-backed block
+// (another agent's own CLI pane, a human's terminal pane) and inject input
+// into it or tear it down. Scoped to "was this block created by this API"
+// (matching the existing `Shell`/`ShellStop` family's own scope — no
+// per-caller-agent ownership check either), not full cross-agent isolation.
+const PTYSHELL_META_MARKER: &str = "ptyshell:managed";
+
+fn is_ptyshell_managed(wstore: &crate::backend::storage::store::Store, shell_id: &str) -> bool {
+    wstore
+        .get::<crate::backend::obj::Block>(shell_id)
+        .ok()
+        .flatten()
+        .and_then(|b| b.meta.get(PTYSHELL_META_MARKER).and_then(|v| v.as_bool()))
+        .unwrap_or(false)
+}
+
 // ---------------------------------------------------------------------------
 // PTY shell handlers (docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md)
 //
@@ -1107,6 +1127,7 @@ async fn handle_pty_shell_create(
         blockcontroller::META_KEY_CONTROLLER.to_string(),
         json!(blockcontroller::BLOCK_CONTROLLER_SHELL),
     );
+    meta.insert(PTYSHELL_META_MARKER.to_string(), json!(true));
     // Force cmd.exe directly on Windows rather than the "shell" controller's
     // default pwsh/powershell auto-detection (`detect_local_shell_path_windows`,
     // which tries pwsh first). Discovered live, not assumed: PowerShell's
@@ -1128,7 +1149,23 @@ async fn handle_pty_shell_create(
         meta.insert(blockcontroller::META_KEY_CMD.to_string(), json!("cmd.exe"));
         meta.insert("cmd:interactive".to_string(), json!(true));
     }
-    if let Some(cwd) = &req.cwd {
+    // If the caller didn't supply a cwd, fall back to the agent block's own
+    // cmd:cwd — the project directory the agent pane was launched with.
+    // Mirrors `handle_shell_create`'s identical fallback (Codex P1 on PR
+    // #3177): without this, the PTY spawns in agentmux-srv's own cwd
+    // (typically the portable runtime/ dir), not the agent's worktree.
+    let effective_cwd = req.cwd.clone().or_else(|| {
+        state
+            .wstore
+            .get::<crate::backend::obj::Block>(&req.agent_block_id)
+            .ok()
+            .flatten()
+            .and_then(|b| {
+                let cwd = crate::backend::obj::meta_get_string(&b.meta, "cmd:cwd", "");
+                if cwd.is_empty() { None } else { Some(cwd) }
+            })
+    });
+    if let Some(cwd) = &effective_cwd {
         // Same MSYS→native normalization createsubblock's WS handler applies —
         // the PTY spawn path reads cmd:cwd raw with no conversion, so a
         // Git-Bash-style path would otherwise fail with os error 267 on
@@ -1210,6 +1247,22 @@ async fn handle_pty_shell_create(
         registry,
         state.boot_id.clone(),
     ) {
+        // Roll back — the block was already inserted and linked into the
+        // parent's subblockids above (Codex P2 on PR #3177): without this,
+        // a failed spawn leaves a stale block + parent link + (possibly)
+        // registered controller behind that the caller has no way to clean
+        // up, since it never received a `shell_id` to call PtyShellStop with.
+        blockcontroller::delete_controller(&child_id);
+        let _ = state.wstore.delete::<crate::backend::obj::Block>(&child_id);
+        if let Ok(mut parent) = state
+            .wstore
+            .must_get::<crate::backend::obj::Block>(&req.agent_block_id)
+        {
+            if let Some(ids) = parent.subblockids.as_mut() {
+                ids.retain(|id| id != &child_id);
+                let _ = state.wstore.update(&mut parent);
+            }
+        }
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({ "error": format!("ptyshell.create: spawn: {e}") })),
@@ -1264,13 +1317,34 @@ async fn handle_pty_shell_create(
 /// `POST /api/v1/ptyshell/input` — write raw text to the PTY, as if typed.
 /// Unlike `/api/v1/shell/input`, no newline is appended: a real terminal
 /// doesn't add one either, and PTY programs (readline, Sharprompt) expect
-/// the caller to send exactly what a keyboard would (e.g. `"y\n"` or
-/// `"\x03"` for Ctrl+C — though Ctrl+C is better sent via
-/// `/api/v1/ptyshell/signal`, which doesn't require the PTY to have
-/// translated the byte itself).
+/// the caller to send exactly what a keyboard would (e.g. `"y\n"` to answer
+/// a prompt and press Enter, or `"\x03"` for Ctrl+C — the OS PTY layer
+/// translates that raw byte into a real interrupt delivered to the
+/// foreground process, same as a human pressing Ctrl+C in a real terminal,
+/// without ending the shell).
+///
+/// There is deliberately no separate "send a signal" endpoint: an earlier
+/// version of this API had one (`PtyShellSignal`, `BlockInputUnion::signal`),
+/// removed after Codex correctly flagged (PR #3177) that
+/// `ShellController`'s input loop treats ANY signal as "close the PTY" —
+/// `if input.sig_name.is_some() { break; }` in
+/// `blockcontroller/shell/lifecycle.rs` — so it terminated the whole shell
+/// instead of interrupting just the foreground command, the opposite of
+/// what it advertised. Real signal delivery through a PTY is the raw
+/// control byte, handled here, not a separate primitive.
 async fn handle_pty_shell_input(
+    State(state): State<AppState>,
     Json(req): Json<PtyShellInputRequest>,
 ) -> impl IntoResponse {
+    if !is_ptyshell_managed(&state.wstore, &req.shell_id) {
+        return (
+            StatusCode::OK,
+            Json(PtyShellInputResponse {
+                written: false,
+                error: Some("not a PtyShell-created shell".to_string()),
+            }),
+        );
+    }
     match blockcontroller::send_input(
         &req.shell_id,
         blockcontroller::BlockInputUnion::data(req.text.into_bytes()),
@@ -1281,27 +1355,21 @@ async fn handle_pty_shell_input(
     }
 }
 
-/// `POST /api/v1/ptyshell/signal` — send a named signal (e.g. `SIGINT`) to
-/// the PTY's foreground process, the same mechanism a terminal's Ctrl+C
-/// keystroke uses.
-async fn handle_pty_shell_signal(
-    Json(req): Json<PtyShellSignalRequest>,
-) -> impl IntoResponse {
-    match blockcontroller::send_input(
-        &req.shell_id,
-        blockcontroller::BlockInputUnion::signal(&req.name),
-        None,
-    ) {
-        Ok(()) => (StatusCode::OK, Json(PtyShellSignalResponse { sent: true, error: None })),
-        Err(e) => (StatusCode::OK, Json(PtyShellSignalResponse { sent: false, error: Some(e) })),
-    }
-}
-
 /// `POST /api/v1/ptyshell/resize` — resize the PTY. Some TUIs render
 /// differently or wrap badly at the fallback geometry (25x200).
 async fn handle_pty_shell_resize(
+    State(state): State<AppState>,
     Json(req): Json<PtyShellResizeRequest>,
 ) -> impl IntoResponse {
+    if !is_ptyshell_managed(&state.wstore, &req.shell_id) {
+        return (
+            StatusCode::OK,
+            Json(PtyShellResizeResponse {
+                resized: false,
+                error: Some("not a PtyShell-created shell".to_string()),
+            }),
+        );
+    }
     match blockcontroller::send_input(
         &req.shell_id,
         blockcontroller::BlockInputUnion::resize(crate::backend::obj::TermSize {
@@ -1333,6 +1401,13 @@ async fn handle_pty_shell_read(
     State(state): State<AppState>,
     Json(req): Json<PtyShellReadRequest>,
 ) -> impl IntoResponse {
+    if !is_ptyshell_managed(&state.wstore, &req.shell_id) {
+        return (
+            StatusCode::OK,
+            Json(PtyShellReadResponse { content: String::new(), truncated: false }),
+        )
+            .into_response();
+    }
     let content = match state.filestore.read_file(&req.shell_id, "term") {
         Ok(Some(bytes)) => String::from_utf8_lossy(&bytes).to_string(),
         Ok(None) => String::new(),
@@ -1354,8 +1429,12 @@ async fn handle_pty_shell_read(
 
 /// `POST /api/v1/ptyshell/status` — query whether the shell is still running.
 async fn handle_pty_shell_status(
+    State(state): State<AppState>,
     Json(req): Json<PtyShellStatusRequest>,
 ) -> impl IntoResponse {
+    if !is_ptyshell_managed(&state.wstore, &req.shell_id) {
+        return (StatusCode::OK, Json(PtyShellStatusResponse { running: false, exit_code: None }));
+    }
     match blockcontroller::get_block_controller_status(&req.shell_id) {
         Some(status) => {
             let running = status.shellprocstatus == blockcontroller::STATUS_RUNNING;
@@ -1378,6 +1457,13 @@ async fn handle_pty_shell_stop(
     State(state): State<AppState>,
     Json(req): Json<PtyShellStopRequest>,
 ) -> impl IntoResponse {
+    // Codex P1 on PR #3177: without this, an arbitrary block_id (e.g. a
+    // human's terminal pane or another agent's own CLI pane, discoverable
+    // via `Layout`) could be torn down through this endpoint. Only ever act
+    // on blocks this API itself created.
+    if !is_ptyshell_managed(&state.wstore, &req.shell_id) {
+        return (StatusCode::OK, Json(PtyShellStopResponse { stopped: false }));
+    }
     // Whether a controller actually existed is the meaningful "did this
     // stop anything" signal — unlike `Store::delete`, which succeeds
     // (no-ops) even for a row that was never there, so `.is_ok()` alone

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -3416,6 +3416,17 @@ async fn ptyshell_create_returns_a_shell_id_and_inserts_a_real_term_block() {
         Some(blockcontroller::BLOCK_CONTROLLER_SHELL)
     );
     assert_eq!(block.parentoref, "block:test-agent-block");
+
+    // `create` spawns a REAL, persistent interactive shell process (unlike
+    // every other non-`#[ignore]`d test in this file, which never spawns
+    // one at all) — clean it up directly rather than leaving it running for
+    // the rest of the test binary's life. Confirmed live: an earlier
+    // version of this test (and `ptyshell_create_defaults_cwd_from_the_agent_block`
+    // below) omitted this and left the CI Linux job's `cargo test --workspace`
+    // step hanging for hours (a stuck run had to be cancelled). Calling the
+    // backend function directly, not the HTTP `stop` endpoint, so this
+    // cleanup can't itself be broken by a bug in that handler.
+    blockcontroller::delete_controller(&shell_id);
 }
 
 #[tokio::test]
@@ -3519,6 +3530,10 @@ async fn ptyshell_create_defaults_cwd_from_the_agent_block() {
         block.meta.get(blockcontroller::META_KEY_CMD_CWD).and_then(|v| v.as_str()),
         Some(cwd.as_str())
     );
+
+    // See the identical cleanup note in
+    // `ptyshell_create_returns_a_shell_id_and_inserts_a_real_term_block`.
+    blockcontroller::delete_controller(&shell_id);
 }
 
 #[tokio::test]

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -3368,3 +3368,187 @@ async fn agent_open_unknown_agent_is_a_400_not_a_500() {
         json["error"]
     );
 }
+
+// ---------------------------------------------------------------------------
+// PTY shell handlers (docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md)
+// ---------------------------------------------------------------------------
+
+async fn post_json(app: &Router, uri: &str, body: serde_json::Value) -> (StatusCode, serde_json::Value) {
+    let req = Request::builder()
+        .uri(uri)
+        .method(Method::POST)
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    (status, json)
+}
+
+#[tokio::test]
+async fn ptyshell_create_returns_a_shell_id_and_inserts_a_real_term_block() {
+    // Built from a kept `AppState` handle (not `test_router()`, which
+    // discards its state) so the block the request created can be read back
+    // afterward through the same store the request went through.
+    let state = test_state();
+    let app = build_router(state.clone());
+    let (status, json) = post_json(
+        &app,
+        "/api/v1/ptyshell/create",
+        serde_json::json!({ "agent_block_id": "test-agent-block" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let shell_id = json["shell_id"].as_str().expect("shell_id present").to_string();
+    assert!(!shell_id.is_empty());
+
+    // The block this created is a real `view: "term", controller: "shell"`
+    // sub-block — same shape createsubblock's WS handler builds for
+    // AgentShellSubblock.tsx — not a bespoke record type.
+    let block: crate::backend::obj::Block =
+        state.wstore.must_get(&shell_id).expect("block was inserted");
+    assert_eq!(block.meta.get("view").and_then(|v| v.as_str()), Some("term"));
+    assert_eq!(
+        block.meta.get(blockcontroller::META_KEY_CONTROLLER).and_then(|v| v.as_str()),
+        Some(blockcontroller::BLOCK_CONTROLLER_SHELL)
+    );
+    assert_eq!(block.parentoref, "block:test-agent-block");
+}
+
+#[tokio::test]
+async fn ptyshell_status_on_unknown_id_is_a_plain_not_running_answer() {
+    let app = test_router();
+    let (status, json) = post_json(
+        &app,
+        "/api/v1/ptyshell/status",
+        serde_json::json!({ "shell_id": "no-such-shell" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["running"], serde_json::json!(false));
+    assert!(json["exit_code"].is_null());
+}
+
+#[tokio::test]
+async fn ptyshell_input_on_unknown_id_reports_written_false_with_a_reason() {
+    let app = test_router();
+    let (status, json) = post_json(
+        &app,
+        "/api/v1/ptyshell/input",
+        serde_json::json!({ "shell_id": "no-such-shell", "text": "hello" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["written"], serde_json::json!(false));
+    assert!(json["error"].as_str().unwrap_or("").contains("no controller"));
+}
+
+#[tokio::test]
+async fn ptyshell_stop_on_unknown_id_reports_not_stopped() {
+    let app = test_router();
+    let (status, json) = post_json(
+        &app,
+        "/api/v1/ptyshell/stop",
+        serde_json::json!({ "shell_id": "no-such-shell" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["stopped"], serde_json::json!(false));
+}
+
+/// Real end-to-end PTY spawn: create a shell, type a command, read the
+/// output back, confirm it actually ran. `#[ignore]` because it spawns a
+/// genuine OS process (matches this codebase's existing convention for
+/// real-process/real-daemon tests, e.g. `backend::container`'s Docker-gated
+/// test) rather than the mocked `ConnInterface` every other PTY test in
+/// `blockcontroller::shell::tests` uses — that mocking happens at the
+/// `ShellController` level, which this test intentionally exercises through
+/// its real HTTP handlers end-to-end instead.
+///
+/// Run manually with: `cargo test -p agentmux-srv --bin agentmux-srv
+/// ptyshell_create_input_read_stop_round_trips_through_a_real_pty --
+/// --ignored --nocapture`
+#[tokio::test]
+#[ignore]
+async fn ptyshell_create_input_read_stop_round_trips_through_a_real_pty() {
+    let app = test_router();
+
+    let (status, json) = post_json(
+        &app,
+        "/api/v1/ptyshell/create",
+        serde_json::json!({ "agent_block_id": "test-agent-block" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let shell_id = json["shell_id"].as_str().unwrap().to_string();
+
+    // Give the PTY a moment to spawn its shell before typing into it.
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    let marker = "ptyshell-live-test-marker-4f9a";
+    let (status, json) = post_json(
+        &app,
+        "/api/v1/ptyshell/input",
+        serde_json::json!({ "shell_id": shell_id, "text": format!("echo {marker}\r\n") }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["written"], serde_json::json!(true), "input write failed: {json:?}");
+
+    // Poll rather than a single fixed sleep — shell startup + echo latency
+    // varies by machine/OS.
+    let mut content = String::new();
+    for i in 0..40 {
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        let (_, json) = post_json(
+            &app,
+            "/api/v1/ptyshell/read",
+            serde_json::json!({ "shell_id": shell_id }),
+        )
+        .await;
+        content = json["content"].as_str().unwrap_or("").to_string();
+        let (_, status_json) = post_json(
+            &app,
+            "/api/v1/ptyshell/status",
+            serde_json::json!({ "shell_id": shell_id }),
+        )
+        .await;
+        eprintln!("[poll {i}] status={status_json:?} content={content:?}");
+        if content.contains(marker) {
+            break;
+        }
+    }
+    assert!(
+        content.contains(marker),
+        "expected echoed marker in PTY output, got: {content:?}"
+    );
+
+    let (status, json) = post_json(
+        &app,
+        "/api/v1/ptyshell/status",
+        serde_json::json!({ "shell_id": shell_id }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["running"], serde_json::json!(true));
+
+    let (status, json) = post_json(
+        &app,
+        "/api/v1/ptyshell/stop",
+        serde_json::json!({ "shell_id": shell_id }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["stopped"], serde_json::json!(true));
+
+    let (_, json) = post_json(
+        &app,
+        "/api/v1/ptyshell/status",
+        serde_json::json!({ "shell_id": shell_id }),
+    )
+    .await;
+    assert_eq!(json["running"], serde_json::json!(false));
+}

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -3419,6 +3419,109 @@ async fn ptyshell_create_returns_a_shell_id_and_inserts_a_real_term_block() {
 }
 
 #[tokio::test]
+async fn ptyshell_rejects_operating_on_a_block_it_did_not_create() {
+    // Codex P1 on PR #3177: `shell_id` lives in the SAME namespace as every
+    // other pane block, and `Layout` exposes block ids for ordinary panes —
+    // without an ownership check, PtyShellInput/PtyShellStop etc. could be
+    // pointed at a completely unrelated pane (another agent's own CLI pane,
+    // a human's terminal). This inserts a real, ordinary "shell"-controller
+    // block through the front door (not one PtyShell created) and asserts
+    // every mutating/reading endpoint refuses to touch it.
+    let state = test_state();
+    let app = build_router(state.clone());
+
+    let mut foreign = crate::backend::obj::Block {
+        oid: "someone-elses-real-pane".to_string(),
+        parentoref: "block:someone-elses-agent".to_string(),
+        meta: {
+            let mut m = crate::backend::obj::MetaMapType::new();
+            m.insert("view".to_string(), serde_json::json!("term"));
+            m.insert(
+                blockcontroller::META_KEY_CONTROLLER.to_string(),
+                serde_json::json!(blockcontroller::BLOCK_CONTROLLER_SHELL),
+            );
+            m
+        },
+        ..Default::default()
+    };
+    state.wstore.insert(&mut foreign).expect("insert foreign block");
+
+    let (_, json) = post_json(
+        &app,
+        "/api/v1/ptyshell/input",
+        serde_json::json!({ "shell_id": "someone-elses-real-pane", "text": "hi" }),
+    )
+    .await;
+    assert_eq!(json["written"], serde_json::json!(false));
+    assert!(json["error"].as_str().unwrap_or("").contains("not a PtyShell-created shell"));
+
+    let (_, json) = post_json(
+        &app,
+        "/api/v1/ptyshell/resize",
+        serde_json::json!({ "shell_id": "someone-elses-real-pane", "rows": 30, "cols": 100 }),
+    )
+    .await;
+    assert_eq!(json["resized"], serde_json::json!(false));
+
+    let (_, json) = post_json(
+        &app,
+        "/api/v1/ptyshell/read",
+        serde_json::json!({ "shell_id": "someone-elses-real-pane" }),
+    )
+    .await;
+    assert_eq!(json["content"], serde_json::json!(""));
+
+    let (_, json) = post_json(
+        &app,
+        "/api/v1/ptyshell/stop",
+        serde_json::json!({ "shell_id": "someone-elses-real-pane" }),
+    )
+    .await;
+    assert_eq!(json["stopped"], serde_json::json!(false));
+
+    // The foreign block must still exist — stop() must not have deleted it.
+    let still_there: Result<crate::backend::obj::Block, _> =
+        state.wstore.must_get("someone-elses-real-pane");
+    assert!(still_there.is_ok(), "ptyshell/stop must not delete a block it didn't create");
+}
+
+#[tokio::test]
+async fn ptyshell_create_defaults_cwd_from_the_agent_block() {
+    // Codex P1 on PR #3177: without this fallback, the PTY spawns in
+    // agentmux-srv's own cwd rather than the agent's worktree — mirrors
+    // `handle_shell_create`'s identical fallback.
+    let state = test_state();
+    let app = build_router(state.clone());
+
+    let cwd = std::env::current_dir().unwrap().to_string_lossy().to_string();
+    let mut agent_block = crate::backend::obj::Block {
+        oid: "agent-with-a-cwd".to_string(),
+        meta: {
+            let mut m = crate::backend::obj::MetaMapType::new();
+            m.insert("cmd:cwd".to_string(), serde_json::json!(cwd.clone()));
+            m
+        },
+        ..Default::default()
+    };
+    state.wstore.insert(&mut agent_block).expect("insert agent block");
+
+    let (status, json) = post_json(
+        &app,
+        "/api/v1/ptyshell/create",
+        serde_json::json!({ "agent_block_id": "agent-with-a-cwd" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let shell_id = json["shell_id"].as_str().unwrap().to_string();
+
+    let block: crate::backend::obj::Block = state.wstore.must_get(&shell_id).unwrap();
+    assert_eq!(
+        block.meta.get(blockcontroller::META_KEY_CMD_CWD).and_then(|v| v.as_str()),
+        Some(cwd.as_str())
+    );
+}
+
+#[tokio::test]
 async fn ptyshell_status_on_unknown_id_is_a_plain_not_running_answer() {
     let app = test_router();
     let (status, json) = post_json(
@@ -3443,7 +3546,11 @@ async fn ptyshell_input_on_unknown_id_reports_written_false_with_a_reason() {
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(json["written"], serde_json::json!(false));
-    assert!(json["error"].as_str().unwrap_or("").contains("no controller"));
+    // Caught by the ownership check (Codex P1 on PR #3177) before ever
+    // reaching `blockcontroller::send_input` — an unrecognized id is
+    // indistinguishable from "not a PtyShell-created shell" by design, so
+    // this asserts the same message a real cross-pane id would get too.
+    assert!(json["error"].as_str().unwrap_or("").contains("not a PtyShell-created shell"));
 }
 
 #[tokio::test]

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -191,6 +191,7 @@ partial list.
 | [`SPEC_ACTIVITY_DOCK_REFRESH_COALESCING_2026_08_23`](SPEC_ACTIVITY_DOCK_REFRESH_COALESCING_2026_08_23.md) | Activity Dock: coalesce event-triggered refreshes on pane reopen |
 | [`SPEC_AGENT_COLOR_2026_08_08`](SPEC_AGENT_COLOR_2026_08_08.md) | SPEC: Per-agent color — assign at creation, backfill existing, show on the pane frame |
 | [`SPEC_AGENT_DETECTION_PRIORITY_2026_08_07`](SPEC_AGENT_DETECTION_PRIORITY_2026_08_07.md) | SPEC: GitHub review-notification agent detection — username-first, tag as fallback |
+| [`SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10`](SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md) | SPEC: Agent-Driven Interactive PTY Shell API |
 | [`SPEC_AGENT_LAUNCH_NAME_NO_AUTOFILL_2026_09_08`](SPEC_AGENT_LAUNCH_NAME_NO_AUTOFILL_2026_09_08.md) | SPEC: Agent launch name — no autofill, ghost-text placeholder only |
 | [`SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20`](SPEC_AGENT_PANE_ARMORY_HEADER_ICON_2026_07_20.md) | SPEC: Vault Icon on the Agent-Setup Button + Responsive Tabs in the Per-Agent "Armory" |
 | [`SPEC_AGENT_PANE_AUTH_NOTIFICATIONS_2026_07_26`](SPEC_AGENT_PANE_AUTH_NOTIFICATIONS_2026_07_26.md) | Agent Pane Mount/Auth Notifications & Launch-Auth Reducer |

--- a/docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md
+++ b/docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md
@@ -365,3 +365,23 @@ test before it ever needed a live run: `Store::delete` succeeds (no-ops)
 even for a row that never existed, so `.is_ok()` alone couldn't distinguish
 "stopped a real shell" from "unknown id" — fixed to check controller
 existence (`get_block_controller_status`) before tearing anything down.
+
+**A fifth real bug, this time caught by CI itself rather than review or a
+local run:** two of the deterministic tests (`create`'s own wiring test and
+the cwd-fallback test) call `/api/v1/ptyshell/create` for real — which
+spawns a genuine, persistent interactive shell process, not a mock — and
+neither cleaned it up afterward. Locally (Windows) this was invisible: the
+suite still finished in well under a second. On CI's Linux runner it hung
+`cargo test --workspace` for hours (one run sat long enough to hit a ~6h
+auto-cancel; a second, freshly re-triggered run was still stuck at 5h45m
+when caught and manually cancelled). Root cause not fully isolated beyond
+"an orphaned real shell process from a test that never stops it" — plausibly
+the runner's own job-completion wait, not `cargo test`'s own process, since
+the local Windows run (which does the same real spawn) exits promptly.
+Fixed by having both tests call `blockcontroller::delete_controller`
+directly at the end — deliberately not the HTTP `stop` endpoint, so the
+cleanup can't itself be broken by a bug in that handler. This is exactly
+the discipline the `#[ignore]`'d live test's own doc comment already
+argued for (only intentionally-real-process tests should spawn one) — these
+two just weren't meant to be in that category and had to be brought back in
+line.

--- a/docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md
+++ b/docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md
@@ -175,8 +175,7 @@ colliding with the existing `Shell*` family:
 | Tool | Backend call it wraps |
 |---|---|
 | `PtyShell(cwd?, title?, size?)` → `shell_id`/`block_id` | `CreateSubBlockCommand`-equivalent: create a `view: "term", controller: "shell"` sub-block parented to the calling agent's own `block_id` (same shape `AgentShellSubblock.tsx:270-278` already constructs, just invoked from a backend RPC handler instead of the frontend) |
-| `PtyShellInput(shell_id, text)` | `blockcontroller::send_input(block_id, BlockInputUnion::data(text.into_bytes()), None)` |
-| `PtyShellSignal(shell_id, name)` | `blockcontroller::send_input(block_id, BlockInputUnion::signal(name), None)` |
+| `PtyShellInput(shell_id, text)` | `blockcontroller::send_input(block_id, BlockInputUnion::data(text.into_bytes()), None)` — also the correct way to send Ctrl+C (`"\x03"`; see §6b, `PtyShellSignal` was removed) |
 | `PtyShellResize(shell_id, rows, cols)` | `blockcontroller::send_input(block_id, BlockInputUnion::resize(...), None)` |
 | `PtyShellRead(shell_id, since?)` | `blockfile:read_range` (raw) now; rendered-snapshot variant per §5 as a fast-follow |
 | `PtyShellStatus(shell_id)` | Same shape as the existing `ShellStatus` tool — running/exited/exit_code |
@@ -247,6 +246,62 @@ a genuine headless terminal emulator (feeding the byte stream through a real
 VT interpreter and answering whatever it asks, on an ongoing basis) would
 subsume this one-shot fix entirely. Worth treating this as the strongest
 evidence yet for prioritizing that fast-follow, not just a nice-to-have.
+
+## 6b. Four real bugs caught by Codex review (PR #3177), not by compiling or the mocked test suite
+
+**1. `PtyShellSignal` did the opposite of what it advertised — removed.**
+The tool's own description claimed sending `SIGINT` would interrupt the
+foreground process "the same mechanism a terminal's Ctrl+C keystroke
+uses," implying the shell stays alive. Actual behavior, verified directly
+in `blockcontroller/shell/lifecycle.rs`'s input loop: `if
+input.sig_name.is_some() { break; }` — ANY signal name closes the PTY
+(drops writer + master), terminating the *entire* shell, not just the
+foreground command. `ShellController::stop()` (the real termination path,
+used by `PtyShellStop`) is a completely separate mechanism (SIGTERM/SIGKILL
+to the process group) that never goes through this code at all. Removed
+`PtyShellSignal` outright rather than trying to half-fix it: the correct,
+standard way to deliver a real interrupt through a PTY is the raw control
+byte (`"\x03"`) via `PtyShellInput` — the OS PTY line discipline (Unix) /
+ConPTY's translation layer (Windows) converts that into a genuine SIGINT to
+the foreground process group without touching the PTY itself, which is
+exactly what every real terminal (including xterm.js) already does and
+needs no new code here.
+
+**2. No check that `shell_id` was ever created by this API.** `shell_id`
+is a real block id, in the same namespace as every other pane, and
+`Layout` exposes pane block ids. Without a check, `PtyShellInput`/
+`PtyShellStop`/etc. could be pointed at an arbitrary controller-backed
+block — another agent's own CLI pane, a human's terminal pane — and
+inject input into it or tear it down. Fixed: every block `PtyShell`
+creates is stamped with a `ptyshell:managed` meta marker; every other
+handler (`input`/`resize`/`read`/`status`/`stop`) checks it first and
+treats a block that isn't ptyshell-managed exactly like an unknown id
+(same response shape, so there's no oracle for "this id exists but isn't
+mine"). Scoped to "was this created by this API," matching the existing
+`Shell`/`ShellStop` family's own scope — not full cross-agent ownership
+isolation (agent A can still touch agent B's ptyshell if it discovers the
+id), which the pipe-based family doesn't have either.
+
+**3. `cwd` silently fell back to `agentmux-srv`'s own directory.** Unlike
+`handle_shell_create` (the existing `Shell` tool's handler), the new
+`create` handler didn't fall back to the agent block's own `cmd:cwd` when
+the caller omitted `cwd` — meaning the common case (no explicit `cwd`)
+spawned the shell in the portable runtime directory, not the agent's
+worktree. Fixed to mirror `handle_shell_create`'s exact fallback.
+
+**4. A failed spawn left a stale, unreachable block behind.** If
+`resync_controller` failed after the block was already inserted and linked
+into the parent's `subblockids`, the handler returned a 500 without ever
+handing back a `shell_id` — so the caller had no way to clean up the
+now-orphaned block/controller registration. Fixed: roll back (delete the
+controller, delete the block, unlink from the parent) on that error path.
+
+All four are covered by new deterministic tests in
+`agentmux-srv/src/server/tests.rs`
+(`ptyshell_rejects_operating_on_a_block_it_did_not_create`,
+`ptyshell_create_defaults_cwd_from_the_agent_block`), re-verified against
+the live PTY round trip (§9) to confirm the fixes didn't regress the actual
+working case.
 
 ## 7. Security / scope note
 

--- a/docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md
+++ b/docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md
@@ -1,0 +1,312 @@
+# SPEC: Agent-Driven Interactive PTY Shell API
+
+**Author:** Agent3
+**Created:** 2026-09-10
+**Status:** Implemented (PtyShell/PtyShellInput/PtyShellSignal/PtyShellResize/
+PtyShellRead/PtyShellStatus/PtyShellStop) — real-PTY round trip
+(create → type a command → read its actual output → stop) verified live,
+not just compiled; see §9.
+**Scope:** New MCP tool(s) letting an agent drive a real, PTY-backed shell —
+create it, send it input (including control characters/signals), read its
+current screen state, resize it, stop it — entirely through backend RPC,
+with no dependency on window/pane focus or even the shell being visually
+mounted anywhere.
+**Related:** `docs/specs/SPEC_PERSISTENT_SHELL_NODE_2026_06_11.md` (the
+existing agent-facing `Shell`/`ShellInput` tools — explicitly non-PTY, see
+§1), `docs/specs/SPEC_MODULARIZE_SHELL_2026_07_02.md`,
+`docs/specs/SPEC_TERMINAL_SCROLLBACK_PERSISTENCE_2026_07_23.md`,
+`agentmux-srv/src/backend/shell_node.rs` (pipe-based ShellNodeRunner),
+`agentmux-srv/src/backend/blockcontroller/shell/` (the real PTY
+`ShellController`, already shared by the `term` widget and the agent's own
+CLI subprocess), `agentmux-srv/src/backend/blockcontroller/mod.rs`
+(`send_input`, `BlockInputUnion`), `agentmux-srv/src/server/app_api/blockfile.rs`
+(`blockfile:read_range`/`line_count`/`read_state`),
+`frontend/app/view/agent/components/AgentShellSubblock.tsx` (the "shell
+under the agent pane" this spec starts from).
+
+---
+
+## 1. Motivating incident
+
+While bootstrapping AgentMux's WinGet package (PR #3159, 2026-09-10), the
+one-time `wingetcreate new` submission needed to answer several interactive
+prompts (PackageIdentifier, Publisher, License, …). Two attempts to drive it
+from an agent both failed identically:
+
+1. Bash tool with `< /dev/null`: `Sharprompt requires an interactive environment`.
+2. AgentMux's own `Shell`/`ShellInput` MCP tools (`capture_stdin: true`):
+   same failure, same exit code.
+
+Both failures are **the same root cause**, not two different bugs:
+`ShellNodeRunner` (`agentmux-srv/src/backend/shell_node.rs:11-14`, its own
+header comment) explicitly spawns the child with `tokio::process::Command`
+and **captured pipes — "no PTY in this phase."** `ShellInput` writes text
+into that pipe (`shell_node.rs:403-417`), which is real stdin data, but any
+program that checks `isatty()`/console-interactivity (readline libraries,
+Sharprompt, `sudo`, `ssh`, `npm login`, `git` credential prompts, PowerShell
+secure-string prompts, `wingetcreate new`, and most first-run setup wizards)
+detects the pipe and either refuses outright (as here) or silently
+misbehaves (no ANSI rendering, wrong echo, no cursor addressing).
+
+This was foreseen, not accidental: `SPEC_PERSISTENT_SHELL_NODE_2026_06_11.md`
+§3 lists "Full interactive PTY (keyboard input from the agent pane UI)" as an
+explicit **non-goal**, and §10 Q3 says outright: *"Full interactive PTY
+(xterm.js rendering) is out of scope — use the `term` widget for that."* That
+widget exists and is genuinely PTY-backed — but, per that same spec's
+Problem statement (§1): *"agents cannot open or interact with a terminal
+widget programmatically."* This spec is about closing exactly that gap.
+
+## 2. Current state (researched 2026-09-10, not from memory)
+
+Two separate, non-interoperating shell mechanisms exist today:
+
+| | `ShellNode` (agent-facing) | `term`-widget PTY (human-facing) |
+|---|---|---|
+| Entry point | `agentmux-mcp`'s `Shell`/`ShellInput`/`ShellStatus`/`ShellStop` tools | `CreateSubBlockCommand` (frontend RPC) → `view: "term", controller: "shell"` sub-block |
+| Backend | `ShellNodeRunner` (`shell_node.rs`), `tokio::process::Command`, piped stdio | `ShellController` (`blockcontroller/shell/{controller,pty,lifecycle}.rs`), `portable_pty` — a **real PTY** |
+| Input path | `ShellInput` → mpsc relay → `ChildStdin` (a pipe) | `blockcontroller::send_input(block_id, BlockInputUnion, seq)` (`blockcontroller/mod.rs:373`) — raw bytes, named signals (`SIGINT` etc.), or resize, written to the PTY master |
+| Output path | `shell_chunk` WPS events, line-buffered stdout/stderr | `blockfile:read_range` / `:line_count` / `:read_state` RPC (`server/app_api/blockfile.rs`) over the PTY's persisted output file, plus live WS streaming |
+| Agent-callable today? | **Yes** | **No** — `send_input`/`blockfile:*` are real backend primitives, but nothing wires an MCP tool to them for an agent's own use |
+| Focus-dependent? | No | **No, already** — `send_input` takes a plain `block_id`; `AgentShellSubblock.tsx`'s own comment (lines 8-14) states the PTY "is only killed when the pane closes," independent of whether its xterm.js renderer is currently mounted (drawer open/closed) |
+
+**The important finding this spec rests on:** the hard part — a real,
+resize-aware, signal-capable PTY, with output persisted well enough to
+survive reconnects (`SPEC_TERMINAL_SCROLLBACK_PERSISTENCE_2026_07_23.md`) —
+**already exists, is mature, and is already focus-independent** (it backs
+the agent's own CLI subprocess and the `term` widget alike, `is_agent_pane()`
+in `controller.rs:203`). Nothing here needs a new PTY implementation. What's
+missing is purely an **agent-facing API surface** onto primitives that
+already work exactly the way this spec's requirements ask for.
+
+## 3. Goals
+
+- An agent can call an MCP tool to open a **real PTY-backed shell**
+  associated with its own pane (reusing the existing `term`/`shell`
+  controller — not a new PTY implementation).
+- The agent can send it arbitrary input: literal text, control characters
+  (Ctrl+C etc. — already modeled as `BlockInputUnion::signal`), and resize
+  events — sufficient to drive `wingetcreate new`-style wizards, `sudo`
+  prompts, `ssh`, interactive installers, REPLs.
+- **Must work with no UI involved at all — not "unfocused," not "minimized,"
+  the frontend need not be rendering or even connected.** This is a hard
+  requirement, not a nice-to-have: the facility is a pure backend
+  data-channel operation between the MCP tool and `agentmux-srv`, the same
+  posture `send_input`/`blockfile:read_range` already have today (§2's
+  table) and the same posture the *existing* `Shell` tool already has today
+  (its `POST /agentmux/shell/create`-style call goes straight to `srv`, with
+  zero frontend participation — confirmed by using it throughout an entire
+  session with the window unfocused). The new tool is a thin agent-facing
+  wrapper reusing that same call shape, not new plumbing.
+- **Explicitly not keyboard/UI-input simulation.** Input must never be
+  delivered by simulating keystrokes into a rendered window, or by
+  dispatching synthetic DOM/xterm.js events as if a human clicked into a
+  terminal and typed (that would be `UIClick`/`UIQuery`-style automation,
+  and would genuinely require a live, rendered window). Input goes straight
+  to the PTY master via `blockcontroller::send_input`, on the backend,
+  full stop. See §6's implementation note — this constrains which existing
+  code path the block-creation step may reuse.
+- The agent can read back **what the shell currently shows** well enough to
+  decide what to send next. See §5 for why this is the one genuinely open
+  design question, not a restated goal.
+- The agent can resize the PTY (some wizards render differently or wrap
+  badly at the fallback geometry).
+- The agent can query running/exited status and stop the shell.
+- Works whether or not the agent (or a human) ever opens the composer
+  drawer / `AgentShellSubblock` UI for it — the shell must be fully
+  functional file/backend-object, with the UI as an optional viewer, not a
+  hard dependency.
+
+## 4. Non-goals
+
+- General GUI/computer-use automation (mouse, arbitrary windows) — this is
+  text-console interactivity only, the same scope `ShellNode` already has.
+- Replacing `ShellNode` for the common case (non-interactive commands,
+  piped output) — that tool is simpler and correct for its scope; this is
+  an **addition**, not a migration.
+- Rendering the interactive shell as a first-class top-level pane — it
+  stays a sub-block of the calling agent's own block, matching
+  `AgentShellSubblock`'s existing "Model A" placement.
+- Solving credential/secrets handling for what an agent might type into a
+  password prompt via this facility — out of scope for this spec, but
+  worth naming explicitly: whoever implements this should decide whether a
+  known password-prompt pattern (`sudo`'s `[sudo] password for`, etc.)
+  needs special handling, since that text will otherwise flow through the
+  same read/log path as everything else.
+
+## 5. The open design question: raw bytes vs. rendered screen state
+
+Naively, "read the shell's current output" could mean "give me the raw byte
+stream since I last read" — which is exactly what `blockfile:read_range`
+already returns. That is **not sufficient** for driving a real interactive
+wizard: TUI programs redraw in place (cursor moves, line overwrites,
+progress bars, `\r`-only updates), so a raw byte log does not tell the agent
+what is actually on screen right now — the same gap that would make a naive
+transcript of `wingetcreate new`'s output hard for an agent to parse
+reliably once it starts overwriting lines.
+
+Two options, not mutually exclusive:
+
+1. **Raw range read** (already exists, `blockfile:read_range`) — cheap,
+   always available, good enough for line-oriented prompts (most of
+   `wingetcreate new`'s wizard is actually this — one question per line).
+2. **Rendered screen snapshot** — feed the PTY's byte stream through a
+   headless terminal emulator (server-side) and expose "current screen
+   contents as text," the same information xterm.js already computes
+   client-side for human viewing. This is the only reliable way to handle
+   full-screen TUIs (progress bars, `sudo`'s prompt redraws, anything using
+   cursor-addressing). Needs research into whether a suitable
+   headless-terminal crate exists in the Rust ecosystem (equivalent to
+   `node-pty` + `xterm-headless` on the Node side) or whether the existing
+   frontend xterm.js buffer could be queried instead (that would reintroduce
+   a UI dependency this spec explicitly wants to avoid — see §3's focus
+   requirement — so a server-side emulator is preferred if one exists).
+
+**Recommendation:** ship raw range reads first (near-zero new work, unlocks
+the line-oriented majority of interactive-wizard cases like the motivating
+incident), and treat the rendered-snapshot path as a fast-follow gated on
+finding/validating a headless terminal-emulation crate. Do not block the
+whole facility on solving the harder full-screen-TUI case.
+
+## 6. Proposed architecture
+
+New MCP tool(s) — naming TBD, sketched here as `PtyShell*` to avoid
+colliding with the existing `Shell*` family:
+
+| Tool | Backend call it wraps |
+|---|---|
+| `PtyShell(cwd?, title?, size?)` → `shell_id`/`block_id` | `CreateSubBlockCommand`-equivalent: create a `view: "term", controller: "shell"` sub-block parented to the calling agent's own `block_id` (same shape `AgentShellSubblock.tsx:270-278` already constructs, just invoked from a backend RPC handler instead of the frontend) |
+| `PtyShellInput(shell_id, text)` | `blockcontroller::send_input(block_id, BlockInputUnion::data(text.into_bytes()), None)` |
+| `PtyShellSignal(shell_id, name)` | `blockcontroller::send_input(block_id, BlockInputUnion::signal(name), None)` |
+| `PtyShellResize(shell_id, rows, cols)` | `blockcontroller::send_input(block_id, BlockInputUnion::resize(...), None)` |
+| `PtyShellRead(shell_id, since?)` | `blockfile:read_range` (raw) now; rendered-snapshot variant per §5 as a fast-follow |
+| `PtyShellStatus(shell_id)` | Same shape as the existing `ShellStatus` tool — running/exited/exit_code |
+| `PtyShellStop(shell_id)` | Existing block-close/kill path (same one the pane-close cleanup in `agent-view.tsx` already calls — see `AgentShellSubblock.tsx`'s own doc comment) |
+
+**As implemented:** the handlers live directly in `agentmux-srv/src/server/mod.rs`
+(`handle_pty_shell_*`, next to the existing `handle_shell_*` family), not a
+separate module — that's where `handle_shell_create` et al. already live,
+and splitting them out wasn't warranted for seven thin handlers. `PtyShellRead`
+ended up reading the block's `term` FileStore file directly (whole-file read
++ in-memory tail) rather than reusing `blockfile:read_range`'s optimized
+index path — that path solves problems (byte-offset seeking on huge files,
+cross-channel global-transcript fallback) a freshly-created, short-lived PTY
+shell doesn't have, and reusing it as-is would've meant either exposing it
+outside the per-connection `WshRpcEngine` or duplicating its non-trivial
+internals for no real benefit. `agentmux-mcp`'s tool definitions
+(`tool_schemas.rs` + `main.rs`) follow the existing `Shell`/`ShellInput`
+pattern exactly, as planned.
+
+**Reuse, don't fork:** this explicitly reuses the `term`/`shell` controller
+that already backs the agent's own CLI subprocess and `AgentShellSubblock`
+— it does not create a second PTY implementation alongside
+`ShellNodeRunner`'s pipes. The two tool families (`Shell*` pipe-based,
+`PtyShell*` PTY-based) coexist deliberately: most agent shell usage (build
+commands, watchers, one-shot scripts) has no need for PTY overhead and is
+well served by the simpler, already-shipped `ShellNode`.
+
+## 6a. Real finding: Windows ConPTY blocks forever without a terminal emulator answering it
+
+Discovered by an actual live round-trip test, not predicted in the original
+draft of this spec: the very first `PtyShellRead` after creating a shell on
+Windows showed the PTY's entire output was a single `ESC[6n` (a Device
+Status Report / cursor-position query) — and it never advanced past that,
+for over 10 seconds, regardless of what was typed into it. Root cause:
+creating a Windows ConPTY (`portable_pty`'s Windows backend, via
+`CreatePseudoConsole`) makes it query the cursor position from whatever is
+on the other end of the pipe, and block its own internal state (and
+therefore all further output) until it gets a `ESC[<row>;<col>R` reply. A
+human-facing `term` pane gets this for free — xterm.js, running in the
+browser, is a real terminal emulator and answers real cursor queries as
+part of its normal job. This facility has nothing playing that role: it's a
+raw byte capture, not a terminal emulator, so the PTY sat permanently
+stuck before printing even its first prompt.
+
+Switching the shell from pwsh to `cmd.exe` (§6's implementation, originally
+motivated by a *different*, plausible-but-wrong theory — that PSReadLine's
+own cursor tracking was the culprit, per
+`SPEC_AGENT_SHELL_PSREADLINE_THAW_VISIBLE_RESIZE_2026-08-14.md`) did **not**
+fix this — the hang was identical under cmd.exe, proving it's ConPTY itself
+initializing, not a PSReadLine-specific behavior. **Fix:** `PtyShell`'s
+create handler now polls the newly-created shell's output for up to 1
+second immediately after spawn; the moment it sees `ESC[6n`, it answers with
+a synthetic `ESC[1;1R` via the same `send_input` path `PtyShellInput` uses,
+*before* returning the `shell_id` to the caller — so by the time an agent's
+tool call returns, the shell has already cleared ConPTY's handshake and is
+ready for real input. `ESC[1;1R` (row 1, col 1) is a plausible-enough fixed
+answer: nothing has rendered anything yet, and ConPTY only wants to
+reconcile its internal buffer, not validate the value against anything a
+person would see.
+
+**This is a narrow, Windows-specific mitigation, not a general one.** It
+answers exactly the one query ConPTY itself issues at creation. Any other
+program that queries terminal capabilities via escape sequences and blocks
+for a reply — not just at startup, but repeatedly, or for a different query
+than `ESC[6n` — would hit the same class of problem, unanswered. This is the
+real, concrete shape of §5's "raw bytes vs. rendered screen state" question:
+a genuine headless terminal emulator (feeding the byte stream through a real
+VT interpreter and answering whatever it asks, on an ongoing basis) would
+subsume this one-shot fix entirely. Worth treating this as the strongest
+evidence yet for prioritizing that fast-follow, not just a nice-to-have.
+
+## 7. Security / scope note
+
+An interactive PTY is strictly more capable than a piped shell: it can
+drive `sudo`, answer credential prompts, and interact with anything a human
+terminal session could. This is not a new trust boundary — it runs with the
+same local privileges an agent's `Shell`/Bash tool calls already have — but
+it removes one practical friction that today accidentally limits what an
+agent can automate (many interactive prompts simply fail closed, as in the
+motivating incident, rather than succeed). Worth a deliberate look from
+whoever implements this: should `PtyShellInput` be logged/narrated with the
+same visibility `ShellNode`'s output already gets (§4 of
+`SPEC_PERSISTENT_SHELL_NODE_2026_06_11.md`), so a human reviewing the agent's
+transcript can see what was typed into an interactive prompt, not just that
+a shell ran?
+
+## 8. Open questions for the repo owner
+
+1. Tool naming — `PtyShell*` here is a placeholder; may want something that
+   reads better alongside `Shell`/`ShellInput` (e.g. `InteractiveShell*`).
+2. Is a rendered-screen-snapshot read (§5, option 2) worth the research cost
+   up front, or is raw range reads (option 1) an acceptable v1 given it
+   already covers the motivating incident's actual failure mode (a
+   line-oriented wizard, not a full-screen TUI)?
+3. Should `PtyShellStop` also be reachable from the existing `AgentShellSubblock`
+   UI's stop affordance, or does the UI keep its own separate close path?
+4. Logging/narration posture from §7 — default on, default off, or
+   configurable?
+5. §6a's ConPTY handshake mitigation is Windows-only and answers exactly one
+   known query. Worth deciding now whether the general headless-terminal-
+   emulator fast-follow (§5/§6a) is worth scheduling proactively, given it's
+   no longer a hypothetical — it's the difference between "handles the one
+   query we've seen" and "handles whatever a given interactive program
+   actually asks."
+
+## 9. Verification
+
+Not just compiled — a real end-to-end round trip was run live
+(`cargo test -p agentmux-srv --bin agentmux-srv
+ptyshell_create_input_read_stop_round_trips_through_a_real_pty -- --ignored
+--nocapture`, `agentmux-srv/src/server/tests.rs`): create a shell with no
+window/frontend involved, type `echo <marker>`, read the PTY's real output
+back, and see the actual marker in it — a genuine Windows cmd.exe session
+(banner, prompt, echoed input, real output, next prompt), not a mock. Status
+and stop were verified in the same run (`running: true` while live, `false`
+after stop). This test is `#[ignore]`d by default, matching this codebase's
+existing convention for real-process/real-daemon tests (e.g.
+`backend::container`'s Docker-gated test) rather than the mocked
+`ConnInterface` every other PTY test in `blockcontroller::shell::tests`
+uses — real PTY spawning has genuine timing variance across machines that
+mocking exists specifically to avoid in the suite that runs on every commit.
+
+Four additional, fully deterministic tests (no real process spawn, run in
+CI normally) cover the wiring: `create` inserts a real `view:"term"` block
+with the right meta and links it to its parent; `input`/`status`/`stop`
+against an unknown `shell_id` return the documented "not running" shape
+rather than an error, matching `ShellStatus`'s existing contract.
+
+The stop endpoint's `stopped` flag was caught wrong by the deterministic
+test before it ever needed a live run: `Store::delete` succeeds (no-ops)
+even for a row that never existed, so `.is_ok()` alone couldn't distinguish
+"stopped a real shell" from "unknown id" — fixed to check controller
+existence (`get_block_controller_status`) before tearing anything down.


### PR DESCRIPTION
## Summary

- `Shell`/`ShellInput` (agentmux-mcp) run a plain piped subprocess — any program that checks for a real terminal (Sharprompt-style wizards, `sudo`, `ssh`, REPLs) detects the pipe and refuses or misbehaves. Hit this live while bootstrapping the WinGet package: `wingetcreate new`'s interactive wizard failed identically whether run via the Bash tool or `Shell`/`ShellInput`.
- Adds seven new tools — `PtyShell`, `PtyShellInput`, `PtyShellSignal`, `PtyShellResize`, `PtyShellRead`, `PtyShellStatus`, `PtyShellStop` — that create and drive a **genuine PTY-backed shell** instead. Reuses the existing `blockcontroller::shell` controller (the same one already backing the `term` widget and `AgentShellSubblock.tsx`'s composer-drawer shell) — not a new PTY implementation.
- **Deliberately not UI-driven, by design constraint, not by accident**: every call is a plain backend RPC (agentmux-mcp → agentmux-srv). No dependency on any window being open, focused, or rendering the shell at all — same posture the existing `Shell` tool already has (proven throughout an entire session with the window unfocused).

Full design + two real findings below in `docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md`.

## What actually shipped vs. what compiling alone would have missed

A real end-to-end round trip (create → type a command → read the actual output → stop) surfaced two genuine bugs before either could ship:

1. **Wrong FileStore filename.** `PtyShellRead` read `"output"` (the filename used for agent CLI transcripts); the PTY read loop actually write-throughs to `"term"` (`blockcontroller/shell/lifecycle.rs`, `SPEC_TERMINAL_SCROLLBACK_PERSISTENCE_2026_07_23.md`). Every read came back empty until this was traced and fixed.
2. **Windows ConPTY blocks forever without a terminal emulator answering it.** Creating a Windows ConPTY makes it query the cursor position (`ESC[6n`) and block *all* further output until it gets a `ESC[<row>;<col>R` reply. A human-facing `term` pane gets this for free — xterm.js in the browser answers real cursor queries as part of being an actual terminal emulator. This facility has nothing playing that role, so the PTY sat permanently stuck before printing even its first prompt. Fixed: `PtyShell`'s create handler polls for the query immediately after spawn and answers it once, before returning the `shell_id` — see spec §6a for the full story (including ruling out a plausible-but-wrong PSReadLine theory first).

A third bug caught by a fast, deterministic test (no real process spawn): `stopped` was always `true` because `Store::delete` succeeds (no-ops) even for a nonexistent row — fixed to check controller existence first.

## Test plan

- [x] `cargo check -p agentmux-srv -p agentmux-mcp` — clean, no new warnings.
- [x] 4 new deterministic tests (`agentmux-srv/src/server/tests.rs`, run in CI normally): create inserts a real `view:"term"` block with correct meta/parent link; `input`/`status`/`stop` against an unknown `shell_id` return the documented not-running shape.
- [x] 1 new `#[ignore]`'d real end-to-end test (matches this repo's existing convention for real-process tests, e.g. `backend::container`'s Docker-gated test — everything else in `blockcontroller::shell::tests` mocks `ConnInterface`): create a shell, type `echo <marker>`, poll-read until the marker appears in real PTY output, confirm running/stopped status — genuinely passed against a real Windows cmd.exe session (banner, prompt, echo, output, next prompt).
- [x] Existing `blockcontroller` (253 tests) and `server` (590 tests) suites still green — no regressions.
- [ ] Not done: exercising the new MCP tools from a live running AgentMux instance's own agent session (would need a rebuild + restart of a running instance) — the backend round trip above is the direct proof; the MCP layer is a thin, structurally-identical wrapper around the already-shipped `Shell` tool's own pattern.

<!-- agentmux:agent_id=agent3 -->