### PR TITLE
feat(srv): redirect skill/MCP-server catalog reads and writes to identity_store

### DIFF
--- a/.changesets/1789075390-feat-srv-redirect-skill-mcp-server-catalog-reads-and-writes--haz0.md
+++ b/.changesets/1789075390-feat-srv-redirect-skill-mcp-server-catalog-reads-and-writes--haz0.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(srv): redirect skill/MCP-server catalog reads and writes to the identity store

--- a/agentmux-srv/src/backend/mcp_seed.rs
+++ b/agentmux-srv/src/backend/mcp_seed.rs
@@ -123,7 +123,9 @@ fn reject_duplicate_names(manifest: &[StarterMcpServer]) -> Result<(), StoreErro
 pub(crate) fn any_starter_mcp_server_name_exists(wstore: &Arc<Store>) -> Result<bool, StoreError> {
     let manifest: Vec<StarterMcpServer> = serde_json::from_str(STARTER_MCP_SERVERS_JSON)
         .map_err(|e| StoreError::Other(format!("mcp server seed: parse manifest: {e}")))?;
-    let existing = wstore.mcp_server_list_global()?;
+    // Pre-dates Phase 2 of SPEC_DURABLE_BINDINGS_2026_09_10.md's catalog
+    // redirect — see skill_seed.rs's identical note.
+    let existing = wstore.mcp_server_list_global(wstore)?;
     Ok(manifest
         .iter()
         .any(|entry| existing.iter().any(|item| item.server.name == entry.name)))
@@ -170,7 +172,7 @@ pub(crate) fn seed_starter_mcp_servers(wstore: &Arc<Store>) -> Result<McpServerS
         };
         if let Err(e) = wstore.mcp_server_upsert_unique_global(&server) {
             for id in &inserted_ids {
-                if let Err(cleanup_err) = wstore.mcp_server_delete(id) {
+                if let Err(cleanup_err) = wstore.mcp_server_delete(wstore, id) {
                     tracing::error!(
                         "mcp server seed: cleanup after partial failure could not remove {id}: {cleanup_err}"
                     );
@@ -222,13 +224,13 @@ mod tests {
         seed_starter_mcp_servers(&store_b).unwrap();
 
         let mut ids_a: Vec<(String, String)> = store_a
-            .mcp_server_list_global()
+            .mcp_server_list_global(&store_a)
             .unwrap()
             .into_iter()
             .map(|item| (item.server.name, item.server.id))
             .collect();
         let mut ids_b: Vec<(String, String)> = store_b
-            .mcp_server_list_global()
+            .mcp_server_list_global(&store_b)
             .unwrap()
             .into_iter()
             .map(|item| (item.server.name, item.server.id))
@@ -255,12 +257,12 @@ mod tests {
     #[test]
     fn seeds_six_mcp_servers_into_an_empty_catalog() {
         let wstore = Arc::new(Store::open_in_memory().unwrap());
-        assert!(wstore.mcp_server_list_global().unwrap().is_empty());
+        assert!(wstore.mcp_server_list_global(&wstore).unwrap().is_empty());
 
         let report = seed_starter_mcp_servers(&wstore).unwrap();
 
         assert_eq!(report.created, 6);
-        let after = wstore.mcp_server_list_global().unwrap();
+        let after = wstore.mcp_server_list_global(&wstore).unwrap();
         assert_eq!(after.len(), 6, "all six starter MCP servers should be seeded");
         assert!(after.iter().all(|item| item.server.is_global));
         assert!(
@@ -274,7 +276,7 @@ mod tests {
         let wstore = Arc::new(Store::open_in_memory().unwrap());
         seed_starter_mcp_servers(&wstore).unwrap();
 
-        let after = wstore.mcp_server_list_global().unwrap();
+        let after = wstore.mcp_server_list_global(&wstore).unwrap();
         let git = after
             .iter()
             .find(|item| item.server.name == "git")
@@ -317,7 +319,7 @@ mod tests {
         let result = seed_starter_mcp_servers(&wstore);
         assert!(result.is_err(), "seeding must fail when a name collides");
 
-        let after = wstore.mcp_server_list_global().unwrap();
+        let after = wstore.mcp_server_list_global(&wstore).unwrap();
         assert_eq!(
             after.len(),
             1,
@@ -348,7 +350,7 @@ mod tests {
 
         assert!(any_starter_mcp_server_name_exists(&wstore).unwrap());
         assert_eq!(
-            wstore.mcp_server_list_global().unwrap().len(),
+            wstore.mcp_server_list_global(&wstore).unwrap().len(),
             1,
             "the check itself must not insert anything"
         );

--- a/agentmux-srv/src/backend/skill_seed.rs
+++ b/agentmux-srv/src/backend/skill_seed.rs
@@ -164,7 +164,12 @@ fn reject_duplicate_triggers(manifest: &[StarterSkill]) -> Result<(), StoreError
 pub(crate) fn any_starter_skill_name_exists(wstore: &Arc<Store>) -> Result<bool, StoreError> {
     let manifest: Vec<StarterSkill> = serde_json::from_str(STARTER_SKILLS_JSON)
         .map_err(|e| StoreError::Other(format!("skill seed: parse manifest: {e}")))?;
-    let existing = wstore.skill_list_global()?;
+    // Pre-dates Phase 2 of SPEC_DURABLE_BINDINGS_2026_09_10.md's catalog
+    // redirect — this migration always operated on one store's own
+    // db_skills, so `wstore` plays both the ref-owner and catalog role here
+    // (the later carry-across migration, m0031, is what moves these rows
+    // into identity_store).
+    let existing = wstore.skill_list_global(wstore)?;
     Ok(manifest
         .iter()
         .any(|entry| existing.iter().any(|item| item.skill.name == entry.name)))
@@ -211,7 +216,7 @@ pub(crate) fn seed_starter_skills(wstore: &Arc<Store>) -> Result<SkillSeedReport
         };
         if let Err(e) = wstore.skill_upsert_unique_global(&skill) {
             for id in &inserted_ids {
-                if let Err(cleanup_err) = wstore.skill_delete(id) {
+                if let Err(cleanup_err) = wstore.skill_delete(wstore, id) {
                     tracing::error!(
                         "skill seed: cleanup after partial failure could not remove {id}: {cleanup_err}"
                     );
@@ -276,13 +281,13 @@ mod tests {
         seed_starter_skills(&store_b).unwrap();
 
         let mut ids_a: Vec<(String, String)> = store_a
-            .skill_list_global()
+            .skill_list_global(&store_a)
             .unwrap()
             .into_iter()
             .map(|item| (item.skill.name, item.skill.id))
             .collect();
         let mut ids_b: Vec<(String, String)> = store_b
-            .skill_list_global()
+            .skill_list_global(&store_b)
             .unwrap()
             .into_iter()
             .map(|item| (item.skill.name, item.skill.id))
@@ -312,12 +317,12 @@ mod tests {
     #[test]
     fn seeds_six_skills_into_an_empty_catalog() {
         let wstore = Arc::new(Store::open_in_memory().unwrap());
-        assert!(wstore.skill_list_global().unwrap().is_empty());
+        assert!(wstore.skill_list_global(&wstore).unwrap().is_empty());
 
         let report = seed_starter_skills(&wstore).unwrap();
 
         assert_eq!(report.created, 6);
-        let after = wstore.skill_list_global().unwrap();
+        let after = wstore.skill_list_global(&wstore).unwrap();
         assert_eq!(after.len(), 6, "all six starter skills should be seeded");
         assert!(after.iter().all(|item| item.skill.is_global));
     }
@@ -358,7 +363,7 @@ mod tests {
         let result = seed_starter_skills(&wstore);
         assert!(result.is_err(), "seeding must fail when a name collides");
 
-        let after = wstore.skill_list_global().unwrap();
+        let after = wstore.skill_list_global(&wstore).unwrap();
         assert_eq!(
             after.len(),
             1,

--- a/agentmux-srv/src/backend/storage/managed.rs
+++ b/agentmux-srv/src/backend/storage/managed.rs
@@ -21,6 +21,33 @@
 //! never from runtime input — so the generated statements are exactly as
 //! fixed as the literals they replace. Values still go through `?N`
 //! parameters.
+//!
+//! ## `self` vs `catalog` (Phase 2 of SPEC_DURABLE_BINDINGS_2026_09_10.md)
+//!
+//! As of Phase 2's application-layer redirect (§5.4), `self` and the
+//! catalog table's store are no longer guaranteed to be the same physical
+//! SQLite file: `db_skills`/`db_mcp_servers` are authoritatively
+//! `identity_store` now, while `db_agent_skills_ref`/`db_bundle_skills_ref`
+//! (and the MCP equivalents) stay on `self` (`wstore`) until Phase 3/6
+//! promotes them too. Every method that used to join the catalog table
+//! against a ref table in one SQL statement now takes an explicit
+//! `catalog: &Store` parameter and does two queries composed in Rust
+//! instead — fetch the relevant ref ids from `self`, fetch the relevant
+//! catalog rows from `catalog`, combine and sort in memory. This is not a
+//! new pattern — `managed_bind_bundle`/`managed_upsert_unique_for_bundle`
+//! already took an `id_store: &Store` parameter for bundle-existence checks,
+//! for the identical reason. `managed_get` needs no such change — it is
+//! genuinely single-table, so callers invoke it directly on whichever store
+//! actually owns the table (`catalog` for a Skill/McpServer row).
+//!
+//! `managed_upsert_unique` additionally loses single-transaction atomicity
+//! by this same split: the catalog insert and the ref-table bind are now two
+//! separate connections, so they can't share a `rusqlite::Transaction`. This
+//! is a documented, accepted interim gap (§5.4) — narrowed by a best-effort
+//! compensating delete on the catalog row if the ref-bind fails, so a failed
+//! bind cannot leave a permanent, undiscoverable orphan catalog row behind.
+
+use std::collections::{HashMap, HashSet};
 
 use rusqlite::{params, params_from_iter, types::Value, Row};
 
@@ -58,6 +85,13 @@ pub trait ManagedResource: Sized {
     fn values(&self) -> Vec<Value>;
     fn id(&self) -> &str;
     fn name(&self) -> &str;
+    /// Whether this row is a global (catalog-wide) row. Needed by
+    /// `managed_list`'s in-memory sort, now that combining a global set with
+    /// a private set can no longer happen inside one `ORDER BY` (Phase 2 of
+    /// SPEC_DURABLE_BINDINGS_2026_09_10.md).
+    fn is_global(&self) -> bool;
+    /// Last-updated timestamp, for the same in-memory sort as `is_global`.
+    fn updated_at(&self) -> i64;
 }
 
 /// Which ref table a scoped query is keyed on.
@@ -88,16 +122,16 @@ impl Owner {
     }
 }
 
-fn aliased_cols<R: ManagedResource>(alias: &str) -> String {
-    R::COLUMNS
-        .iter()
-        .map(|c| format!("{alias}.{c}"))
-        .collect::<Vec<_>>()
-        .join(", ")
-}
-
+/// `?1, ?2, ... ?n`.
 fn placeholders(n: usize) -> String {
     (1..=n).map(|i| format!("?{i}")).collect::<Vec<_>>().join(", ")
+}
+
+/// `?{start}, ?{start+1}, ... ?{start+n-1}` — for a `?N` list that must
+/// continue numbering after some earlier bound parameters (`managed_upsert_unique`'s
+/// dup-check binds `name`/`id` at `?1`/`?2` before any owner-bound ids).
+fn placeholders_from(start: usize, n: usize) -> String {
+    (start..start + n).map(|i| format!("?{i}")).collect::<Vec<_>>().join(", ")
 }
 
 fn update_set<R: ManagedResource>() -> String {
@@ -123,28 +157,122 @@ fn values_with_global<R: ManagedResource>(row: &R, force_global: Option<bool>) -
 }
 
 impl Store {
+    // ── Cross-store helpers (Phase 2 of SPEC_DURABLE_BINDINGS_2026_09_10.md) ──
+    // Small building blocks the rewritten methods below compose. Split out so
+    // each one locks exactly one connection for exactly as long as it needs
+    // to — important because `self` and `catalog` (or `id_store`) may be the
+    // SAME `Store` (test_state() aliases them; even in production `id_store`
+    // and `identity_store` can coincide with `wstore` in a degraded-mode
+    // fallback), and `Mutex<Connection>` is not reentrant. A method that
+    // locked `self` and then called into `catalog` while still holding that
+    // lock would deadlock the moment they aliased.
+
+    /// The ref ids `owner_id` holds for one primitive, on `self`.
+    fn managed_bound_ids<R: ManagedResource>(&self, owner: Owner, owner_id: &str) -> Result<HashSet<String>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let sql = format!(
+            "SELECT {refc} FROM {reft} WHERE {key} = ?1",
+            refc = R::REF_COL,
+            reft = owner.ref_table::<R>(),
+            key = owner.key_col(),
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(params![owner_id], |row| row.get::<_, String>(0))?;
+        let mut out = HashSet::new();
+        for r in rows {
+            out.insert(r?);
+        }
+        Ok(out)
+    }
+
+    /// `REF_COL -> count` across every agent-level ref row, on `self`.
+    fn managed_bound_counts<R: ManagedResource>(&self) -> Result<HashMap<String, i64>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let sql = format!(
+            "SELECT {refc}, COUNT(*) FROM {reft} GROUP BY {refc}",
+            refc = R::REF_COL,
+            reft = R::AGENT_REF_TABLE,
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)))?;
+        let mut out = HashMap::new();
+        for r in rows {
+            let (id, count) = r?;
+            out.insert(id, count);
+        }
+        Ok(out)
+    }
+
+    /// Every global row of a primitive, on `self` acting as the CATALOG
+    /// store — newest first.
+    fn managed_catalog_global<R: ManagedResource>(&self) -> Result<Vec<R>, StoreError> {
+        let sql = format!(
+            "SELECT {cols} FROM {table} WHERE is_global = 1 ORDER BY updated_at DESC",
+            cols = R::COLUMNS.join(", "),
+            table = R::TABLE,
+        );
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map([], |row| R::from_row(row))?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    /// Every global row, plus (if `ids` is non-empty) every row in `ids` —
+    /// global or private — on `self` acting as the CATALOG store. Unordered;
+    /// callers sort as needed.
+    fn managed_catalog_global_and_ids<R: ManagedResource>(&self, ids: &HashSet<String>) -> Result<Vec<R>, StoreError> {
+        let sql = if ids.is_empty() {
+            format!(
+                "SELECT {cols} FROM {table} WHERE is_global = 1",
+                cols = R::COLUMNS.join(", "),
+                table = R::TABLE,
+            )
+        } else {
+            format!(
+                "SELECT {cols} FROM {table} WHERE is_global = 1 OR id IN ({ph})",
+                cols = R::COLUMNS.join(", "),
+                table = R::TABLE,
+                ph = placeholders(ids.len()),
+            )
+        };
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(&sql)?;
+        let bind: Vec<Value> = ids.iter().map(|s| Value::Text(s.clone())).collect();
+        let rows = stmt.query_map(params_from_iter(bind), |row| R::from_row(row))?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    // ── Public-to-crate managed-primitive operations ──────────────────────
+
     /// Rows visible to `owner_id` — its own referenced rows plus every global
     /// row — each paired with whether this owner holds the ref. Global rows
     /// first, newest first.
     pub(super) fn managed_list<R: ManagedResource>(
         &self,
+        catalog: &Store,
         owner: Owner,
         owner_id: &str,
     ) -> Result<Vec<(R, bool)>, StoreError> {
-        let sql = format!(
-            "SELECT {cols},
-                    EXISTS(SELECT 1 FROM {reft} r WHERE r.{refc} = s.id AND r.{key} = ?1) AS bound
-             FROM {table} s
-             WHERE s.is_global = 1
-                OR s.id IN (SELECT {refc} FROM {reft} WHERE {key} = ?1)
-             ORDER BY s.is_global DESC, s.updated_at DESC",
-            cols = aliased_cols::<R>("s"),
-            reft = owner.ref_table::<R>(),
-            refc = R::REF_COL,
-            key = owner.key_col(),
-            table = R::TABLE,
-        );
-        self.managed_rows_with_flag::<R>(&sql, owner_id)
+        let bound_ids = self.managed_bound_ids::<R>(owner, owner_id)?;
+        let mut rows = catalog.managed_catalog_global_and_ids::<R>(&bound_ids)?;
+        // A global row this owner ALSO directly refs is still "bound" — the
+        // flag reflects ownership of the ref row, not visibility.
+        rows.sort_by(|a, b| b.is_global().cmp(&a.is_global()).then_with(|| b.updated_at().cmp(&a.updated_at())));
+        Ok(rows
+            .into_iter()
+            .map(|row| {
+                let bound = bound_ids.contains(row.id());
+                (row, bound)
+            })
+            .collect())
     }
 
     /// Global rows only, each paired with whether `agent_id` holds the
@@ -153,66 +281,36 @@ impl Store {
     /// use this (reagentx P0 on PR #2329).
     pub(super) fn managed_list_global_for_agent<R: ManagedResource>(
         &self,
+        catalog: &Store,
         agent_id: &str,
     ) -> Result<Vec<(R, bool)>, StoreError> {
-        let sql = format!(
-            "SELECT {cols},
-                    EXISTS(SELECT 1 FROM {reft} r WHERE r.{refc} = s.id AND r.agent_id = ?1) AS bound
-             FROM {table} s
-             WHERE s.is_global = 1
-             ORDER BY s.updated_at DESC",
-            cols = aliased_cols::<R>("s"),
-            reft = R::AGENT_REF_TABLE,
-            refc = R::REF_COL,
-            table = R::TABLE,
-        );
-        self.managed_rows_with_flag::<R>(&sql, agent_id)
-    }
-
-    fn managed_rows_with_flag<R: ManagedResource>(
-        &self,
-        sql: &str,
-        key: &str,
-    ) -> Result<Vec<(R, bool)>, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(sql)?;
-        let flag_idx = R::COLUMNS.len();
-        let rows = stmt.query_map(params![key], |row| {
-            Ok((R::from_row(row)?, row.get::<_, i64>(flag_idx)? != 0))
-        })?;
-        let mut out = Vec::new();
-        for row in rows {
-            out.push(row?);
-        }
-        Ok(out)
+        let globals = catalog.managed_catalog_global::<R>()?;
+        let bound_ids = self.managed_bound_ids::<R>(Owner::Agent, agent_id)?;
+        Ok(globals
+            .into_iter()
+            .map(|row| {
+                let bound = bound_ids.contains(row.id());
+                (row, bound)
+            })
+            .collect())
     }
 
     /// Global rows with how many agents hold an agent-level ref to each —
     /// the Armory catalog's "used by N agents". Newest first.
-    pub(super) fn managed_list_global<R: ManagedResource>(&self) -> Result<Vec<(R, i64)>, StoreError> {
-        let sql = format!(
-            "SELECT {cols},
-                    (SELECT COUNT(*) FROM {reft} r WHERE r.{refc} = s.id) AS bound_count
-             FROM {table} s
-             WHERE s.is_global = 1
-             ORDER BY s.updated_at DESC",
-            cols = aliased_cols::<R>("s"),
-            reft = R::AGENT_REF_TABLE,
-            refc = R::REF_COL,
-            table = R::TABLE,
-        );
-        let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(&sql)?;
-        let count_idx = R::COLUMNS.len();
-        let rows = stmt.query_map([], |row| Ok((R::from_row(row)?, row.get::<_, i64>(count_idx)?)))?;
-        let mut out = Vec::new();
-        for row in rows {
-            out.push(row?);
-        }
-        Ok(out)
+    pub(super) fn managed_list_global<R: ManagedResource>(&self, catalog: &Store) -> Result<Vec<(R, i64)>, StoreError> {
+        let globals = catalog.managed_catalog_global::<R>()?;
+        let counts = self.managed_bound_counts::<R>()?;
+        Ok(globals
+            .into_iter()
+            .map(|row| {
+                let count = counts.get(row.id()).copied().unwrap_or(0);
+                (row, count)
+            })
+            .collect())
     }
 
-    /// One row by id.
+    /// One row by id. Genuinely single-table — callers invoke this directly
+    /// on whichever store owns `R::TABLE` (`catalog` for Skill/McpServer).
     pub(super) fn managed_get<R: ManagedResource>(&self, id: &str) -> Result<Option<R>, StoreError> {
         let sql = format!(
             "SELECT {cols} FROM {table} WHERE id = ?1",
@@ -227,18 +325,15 @@ impl Store {
         }
     }
 
-    /// Delete a row and purge its agent- and bundle-level refs explicitly
-    /// (FK cascades may be off on some builds). True if a row was deleted.
-    pub(super) fn managed_delete<R: ManagedResource>(&self, id: &str) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            &format!("DELETE FROM {} WHERE {} = ?1", R::AGENT_REF_TABLE, R::REF_COL),
-            params![id],
-        )?;
-        conn.execute(
-            &format!("DELETE FROM {} WHERE {} = ?1", R::BUNDLE_REF_TABLE, R::REF_COL),
-            params![id],
-        )?;
+    /// Purge `id`'s ref rows on `self`, then delete the catalog row on
+    /// `catalog`. True if a catalog row was deleted.
+    pub(super) fn managed_delete<R: ManagedResource>(&self, catalog: &Store, id: &str) -> Result<bool, StoreError> {
+        {
+            let conn = self.conn.lock().unwrap();
+            conn.execute(&format!("DELETE FROM {} WHERE {} = ?1", R::AGENT_REF_TABLE, R::REF_COL), params![id])?;
+            conn.execute(&format!("DELETE FROM {} WHERE {} = ?1", R::BUNDLE_REF_TABLE, R::REF_COL), params![id])?;
+        }
+        let conn = catalog.conn.lock().unwrap();
         let rows = conn.execute(&format!("DELETE FROM {} WHERE id = ?1", R::TABLE), params![id])?;
         Ok(rows > 0)
     }
@@ -271,29 +366,50 @@ impl Store {
     }
 
     /// Insert the agent-level ref (idempotent). Errors if `agent_id` is not
-    /// a LOCAL agent: the ref table's FK would otherwise swallow
-    /// the `INSERT OR IGNORE` silently for a cross-channel agent, which is
-    /// indistinguishable by row count from "already bound" (reagentx P1 on
-    /// PR #2315; REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md).
+    /// a LOCAL agent: the ref table's `agent_id → db_agents` FK would
+    /// otherwise swallow the `INSERT OR IGNORE` silently for a cross-channel
+    /// agent, which is indistinguishable by row count from "already bound"
+    /// (reagentx P1 on PR #2315; REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md).
     ///
     /// Checks `db_agents`, not `db_agent_definitions`: `R::AGENT_REF_TABLE`'s
     /// FK targets `db_agents` as of Phase 3c (#3088), so checking the legacy
     /// table here would reject a bind for any agent that exists ONLY as a
     /// `db_agents` row (a template launch), even though the FK the INSERT
     /// below actually depends on would accept it.
-    pub(super) fn managed_bind_agent<R: ManagedResource>(&self, agent_id: &str, id: &str) -> Result<(), StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let agent_exists: bool = conn.query_row(
-            "SELECT EXISTS(SELECT 1 FROM db_agents WHERE id = ?1)",
-            params![agent_id],
-            |row| row.get(0),
-        )?;
+    ///
+    /// Additionally errors if `id` has no row in `catalog` — Part A of
+    /// SPEC_DURABLE_BINDINGS_2026_09_10.md §5.4 drops the ref table's
+    /// `skill_id`/`mcp_id → db_skills`/`db_mcp_servers` FK entirely (it used
+    /// to target THIS channel's local, now-stale catalog copy), so the
+    /// existence check that FK used to provide is now explicit here instead
+    /// — mirroring `managed_bind_bundle`'s existing `id_store` check.
+    pub(super) fn managed_bind_agent<R: ManagedResource>(
+        &self,
+        catalog: &Store,
+        agent_id: &str,
+        id: &str,
+    ) -> Result<(), StoreError> {
+        let agent_exists: bool = {
+            let conn = self.conn.lock().unwrap();
+            conn.query_row(
+                "SELECT EXISTS(SELECT 1 FROM db_agents WHERE id = ?1)",
+                params![agent_id],
+                |row| row.get(0),
+            )?
+        };
         if !agent_exists {
             return Err(StoreError::Other(format!(
                 "agent {agent_id} not found in this channel's local registry — cross-channel {} binding is not supported",
                 R::KIND
             )));
         }
+        if catalog.managed_get::<R>(id)?.is_none() {
+            return Err(StoreError::Other(format!(
+                "{} {id} not found — cannot bind it to agent {agent_id}",
+                R::NAME_NOUN
+            )));
+        }
+        let conn = self.conn.lock().unwrap();
         conn.execute(
             &format!(
                 "INSERT OR IGNORE INTO {} (agent_id, {}) VALUES (?1, ?2)",
@@ -309,8 +425,20 @@ impl Store {
     /// in `id_store`, not `self` — bundles are authoritatively written through
     /// the shared store, and `self`'s local `db_bundles` copy is essentially
     /// always empty in production (reagentx P0 on PR #2639).
+    ///
+    /// Also checks `id` exists in `catalog` — same Part A FK-removal reason
+    /// as `managed_bind_agent`'s new check (`db_bundle_skills_ref`/
+    /// `db_bundle_mcp_ref` also lost their `skill_id`/`mcp_id` FK, and this
+    /// table never had a `bundle_id` FK at all — see `migrations.rs`'s own
+    /// comment on these tables). Added now for the same reason as the
+    /// agent-level check, even though `bundle_skill_bind`/`bundle_mcp_bind`'s
+    /// current call sites already pre-check existence via `skill_get`/
+    /// `mcp_server_get` before calling — see this crate's report for why
+    /// this is still worth doing as a second line of defense at the store
+    /// layer rather than trusting every call site forever.
     pub(super) fn managed_bind_bundle<R: ManagedResource>(
         &self,
+        catalog: &Store,
         id_store: &Store,
         bundle_id: &str,
         id: &str,
@@ -319,6 +447,12 @@ impl Store {
             return Err(StoreError::Other(format!(
                 "bundle {bundle_id} not found — cannot bind {} to a nonexistent bundle",
                 R::ARTICLE_NOUN
+            )));
+        }
+        if catalog.managed_get::<R>(id)?.is_none() {
+            return Err(StoreError::Other(format!(
+                "{} {id} not found — cannot bind it to bundle {bundle_id}",
+                R::NAME_NOUN
             )));
         }
         let conn = self.conn.lock().unwrap();
@@ -362,37 +496,53 @@ impl Store {
         Ok(rows > 0)
     }
 
-    /// Atomically upsert `row` enforcing owner-scoped name uniqueness (no
+    /// Upsert `row` into `catalog` enforcing owner-scoped name uniqueness (no
     /// other row visible to the owner — bound or global — may share the
-    /// name), and bind it when `bind_new`, in one transaction so concurrent
-    /// upserts of the same name can't both pass the check. `force_global`
-    /// overrides the row's own `is_global` on INSERT: the bundle-scoped
-    /// upsert always creates PRIVATE rows (`Some(false)`), the agent-scoped
-    /// one keeps the row's value (`None`).
+    /// name), and bind it into `self` when `bind_new`.
+    ///
+    /// **No longer atomic** (Phase 2 of SPEC_DURABLE_BINDINGS_2026_09_10.md
+    /// §5.4, accepted interim gap): the catalog insert and the ref-table bind
+    /// are two separate connections now, so a narrow same-name race between
+    /// two concurrent upserts for a brand-new name is possible (single-owner,
+    /// single-submit UI flows are not a realistic multi-writer scenario — not
+    /// closed until Phase 3/6 restores single-connection atomicity). What
+    /// this DOES still guarantee: if the ref-bind fails after the catalog
+    /// insert already committed, a best-effort COMPENSATING DELETE removes
+    /// the just-inserted catalog row before the bind error propagates, so the
+    /// caller's failure and the durable state agree ("nothing was created")
+    /// instead of leaving a permanent, undiscoverable orphan catalog row (no
+    /// ordinary list/access/delete path can find a row that is neither bound
+    /// nor global). The compensating delete's own failure is logged, never
+    /// allowed to mask the original bind error.
     pub(super) fn managed_upsert_unique<R: ManagedResource>(
         &self,
+        catalog: &Store,
         owner: Owner,
         owner_id: &str,
         row: &R,
         bind_new: bool,
         force_global: Option<bool>,
     ) -> Result<(), StoreError> {
-        let mut conn = self.conn.lock().unwrap();
-        let tx = conn.transaction()?;
-        let dup: i64 = tx.query_row(
-            &format!(
-                "SELECT COUNT(*) FROM {table}
-                 WHERE name = ?1 AND id <> ?2 AND (is_global = 1 OR id IN (
-                   SELECT {refc} FROM {reft} WHERE {key} = ?3
-                 ))",
+        let bound_ids = self.managed_bound_ids::<R>(owner, owner_id)?;
+
+        let dup_sql = if bound_ids.is_empty() {
+            format!(
+                "SELECT COUNT(*) FROM {table} WHERE name = ?1 AND id <> ?2 AND is_global = 1",
                 table = R::TABLE,
-                refc = R::REF_COL,
-                reft = owner.ref_table::<R>(),
-                key = owner.key_col(),
-            ),
-            params![row.name(), row.id(), owner_id],
-            |r| r.get(0),
-        )?;
+            )
+        } else {
+            format!(
+                "SELECT COUNT(*) FROM {table} WHERE name = ?1 AND id <> ?2 AND (is_global = 1 OR id IN ({ph}))",
+                table = R::TABLE,
+                ph = placeholders_from(3, bound_ids.len()),
+            )
+        };
+        let dup: i64 = {
+            let conn = catalog.conn.lock().unwrap();
+            let mut bind: Vec<Value> = vec![Value::Text(row.name().to_string()), Value::Text(row.id().to_string())];
+            bind.extend(bound_ids.iter().map(|s| Value::Text(s.clone())));
+            conn.query_row(&dup_sql, params_from_iter(bind), |r| r.get(0))?
+        };
         if dup > 0 {
             return Err(StoreError::Other(format!(
                 "{} name '{}' already bound to this {}",
@@ -401,19 +551,40 @@ impl Store {
                 owner.word()
             )));
         }
-        tx.execute(&insert_sql::<R>(), params_from_iter(values_with_global(row, force_global)))?;
-        if bind_new {
-            tx.execute(
-                &format!(
-                    "INSERT OR IGNORE INTO {} ({}, {}) VALUES (?1, ?2)",
-                    owner.ref_table::<R>(),
-                    owner.key_col(),
-                    R::REF_COL
-                ),
-                params![owner_id, row.id()],
-            )?;
+
+        {
+            let conn = catalog.conn.lock().unwrap();
+            conn.execute(&insert_sql::<R>(), params_from_iter(values_with_global(row, force_global)))?;
         }
-        tx.commit()?;
+
+        if bind_new {
+            let bind_result = {
+                let conn = self.conn.lock().unwrap();
+                conn.execute(
+                    &format!(
+                        "INSERT OR IGNORE INTO {} ({}, {}) VALUES (?1, ?2)",
+                        owner.ref_table::<R>(),
+                        owner.key_col(),
+                        R::REF_COL
+                    ),
+                    params![owner_id, row.id()],
+                )
+            };
+            if let Err(bind_err) = bind_result {
+                let conn = catalog.conn.lock().unwrap();
+                if let Err(compensate_err) =
+                    conn.execute(&format!("DELETE FROM {} WHERE id = ?1", R::TABLE), params![row.id()])
+                {
+                    tracing::warn!(
+                        id = row.id(),
+                        bind_error = %bind_err,
+                        compensate_error = %compensate_err,
+                        "managed_upsert_unique: compensating delete failed after a bind error — a durable orphan catalog row may remain"
+                    );
+                }
+                return Err(bind_err.into());
+            }
+        }
         Ok(())
     }
 
@@ -427,6 +598,7 @@ impl Store {
     /// that has never belonged to anyone else (reagentx P1 on PR #2639).
     pub(super) fn managed_upsert_unique_for_bundle<R: ManagedResource>(
         &self,
+        catalog: &Store,
         id_store: &Store,
         bundle_id: &str,
         row: &R,
@@ -438,12 +610,15 @@ impl Store {
                 R::ARTICLE_NOUN
             )));
         }
-        self.managed_upsert_unique(Owner::Bundle, bundle_id, row, bind_new, Some(false))
+        self.managed_upsert_unique(catalog, Owner::Bundle, bundle_id, row, bind_new, Some(false))
     }
 
     /// Atomically upsert a GLOBAL row enforcing catalog-wide name uniqueness
     /// among every global row (not just those visible to one owner). Forces
     /// `is_global = 1` on INSERT; the caller is expected to have set it too.
+    ///
+    /// Pure single-table operation — callers invoke this directly on
+    /// whichever store owns `R::TABLE` (`identity_store` in production).
     pub(super) fn managed_upsert_unique_global<R: ManagedResource>(&self, row: &R) -> Result<(), StoreError> {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
@@ -467,34 +642,50 @@ impl Store {
         Ok(())
     }
 
-    /// True when the row is global or the owner holds a ref to it — the
-    /// read/mutation access check.
+    /// True when the row is global (in `catalog`) or the owner holds a ref
+    /// to it (in `self`) — the read/mutation access check.
     pub(super) fn managed_is_accessible_to<R: ManagedResource>(
         &self,
+        catalog: &Store,
         owner: Owner,
         owner_id: &str,
         id: &str,
     ) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let count: i64 = conn.query_row(
-            &format!(
-                "SELECT COUNT(*) FROM {table}
-                 WHERE id = ?1 AND (is_global = 1 OR id IN (
-                   SELECT {refc} FROM {reft} WHERE {key} = ?2
-                 ))",
-                table = R::TABLE,
-                refc = R::REF_COL,
-                reft = owner.ref_table::<R>(),
-                key = owner.key_col(),
-            ),
-            params![id, owner_id],
-            |r| r.get(0),
-        )?;
-        Ok(count > 0)
+        let is_global: Option<bool> = {
+            let conn = catalog.conn.lock().unwrap();
+            match conn.query_row(
+                &format!("SELECT is_global FROM {} WHERE id = ?1", R::TABLE),
+                params![id],
+                |r| r.get::<_, i64>(0),
+            ) {
+                Ok(v) => Some(v != 0),
+                Err(rusqlite::Error::QueryReturnedNoRows) => None,
+                Err(e) => return Err(e.into()),
+            }
+        };
+        match is_global {
+            None => Ok(false),
+            Some(true) => Ok(true),
+            Some(false) => {
+                let conn = self.conn.lock().unwrap();
+                let count: i64 = conn.query_row(
+                    &format!(
+                        "SELECT COUNT(*) FROM {} WHERE {} = ?1 AND {} = ?2",
+                        owner.ref_table::<R>(),
+                        owner.key_col(),
+                        R::REF_COL
+                    ),
+                    params![owner_id, id],
+                    |r| r.get(0),
+                )?;
+                Ok(count > 0)
+            }
+        }
     }
 
     /// True when the owner holds a direct ref to the row (global rows are
-    /// not implied) — the ownership check for edit/delete.
+    /// not implied) — the ownership check for edit/delete. Pure ref-table
+    /// operation on `self`.
     pub(super) fn managed_is_bound_to<R: ManagedResource>(
         &self,
         owner: Owner,
@@ -521,11 +712,16 @@ impl Store {
     /// bundle-level refs would be exactly as inert at launch as the bundle's
     /// old inline JSON columns were (GH issue #2024 item 3). Silent on
     /// lookup failure, like the two callers it was lifted from.
-    pub(super) fn managed_union_bundle_refs<R: ManagedResource>(&self, agent_id: &str, visible: &mut Vec<R>) {
+    pub(super) fn managed_union_bundle_refs<R: ManagedResource>(
+        &self,
+        catalog: &Store,
+        agent_id: &str,
+        visible: &mut Vec<R>,
+    ) {
         if let Ok(Some(def)) = self.agent_def_get(agent_id) {
             if !def.memory_id.is_empty() {
                 for (row, _) in self
-                    .managed_list::<R>(Owner::Bundle, &def.memory_id)
+                    .managed_list::<R>(catalog, Owner::Bundle, &def.memory_id)
                     .unwrap_or_default()
                 {
                     if !visible.iter().any(|s| s.id() == row.id()) {
@@ -582,6 +778,12 @@ mod tests {
         fn name(&self) -> &str {
             "n"
         }
+        fn is_global(&self) -> bool {
+            false
+        }
+        fn updated_at(&self) -> i64 {
+            2
+        }
     }
 
     #[test]
@@ -609,5 +811,244 @@ mod tests {
         assert_eq!(Owner::Bundle.ref_table::<Probe>(), "db_bundle_probe_ref");
         assert_eq!(Owner::Agent.key_col(), "agent_id");
         assert_eq!(Owner::Bundle.key_col(), "bundle_id");
+    }
+
+    #[test]
+    fn placeholders_from_continues_numbering_past_earlier_bound_params() {
+        assert_eq!(placeholders_from(3, 0), "");
+        assert_eq!(placeholders_from(3, 1), "?3");
+        assert_eq!(placeholders_from(3, 3), "?3, ?4, ?5");
+    }
+
+    // ── Cross-store integration tests (Phase 2 of SPEC_DURABLE_BINDINGS_2026_09_10.md) ──
+    //
+    // Use the REAL `Skill` primitive against two genuinely separate
+    // `Store::open_in_memory()` instances — one acting as the ref-owning
+    // `wstore`, one as `catalog` (with the identity schema applied) — so a
+    // bug that only shows up when the two stores are NOT the same connection
+    // (e.g. accidentally querying `self` for a catalog row, or vice versa)
+    // cannot hide the way it would if both roles resolved to one aliased
+    // store (as `test_state()` does elsewhere in this codebase).
+
+    use crate::backend::storage::skills::Skill;
+
+    fn wstore() -> Store {
+        Store::open_in_memory().unwrap()
+    }
+
+    fn catalog_store() -> Store {
+        let store = Store::open_in_memory().unwrap();
+        store.apply_identity_schema_for_tests().unwrap();
+        store
+    }
+
+    fn skill(id: &str, name: &str, is_global: bool, updated_at: i64) -> Skill {
+        Skill {
+            id: id.to_string(),
+            name: name.to_string(),
+            trigger: String::new(),
+            skill_type: "prompt".to_string(),
+            description: String::new(),
+            content: "c".to_string(),
+            is_global,
+            created_at: updated_at,
+            updated_at,
+        }
+    }
+
+    fn insert_agent(store: &Store, id: &str) {
+        store
+            .conn()
+            .lock()
+            .unwrap()
+            .execute("INSERT INTO db_agents (id, name, provider) VALUES (?1, 'A', 'claude')", params![id])
+            .unwrap();
+    }
+
+    fn insert_bundle(store: &Store, id: &str) {
+        store
+            .conn()
+            .lock()
+            .unwrap()
+            .execute(
+                "INSERT INTO db_bundles (id, name, created_at, updated_at) VALUES (?1, ?1, 0, 0)",
+                params![id],
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn managed_list_combines_global_and_bound_private_rows_from_two_distinct_stores() {
+        let wstore = wstore();
+        let catalog = catalog_store();
+        insert_agent(&wstore, "agent-1");
+        catalog.managed_upsert_unique_global(&skill("global-1", "Global", true, 200)).unwrap();
+        catalog.managed_upsert_unique_global(&skill("global-2", "Unrelated Global", true, 100)).unwrap();
+        // A private row that exists in the catalog but is NOT referenced by
+        // agent-1 — must not appear.
+        {
+            let conn = catalog.conn().lock().unwrap();
+            conn.execute(
+                "INSERT INTO db_skills (id, name, is_global, created_at, updated_at) VALUES ('private-other', 'Someone Else', 0, 50, 50)",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO db_skills (id, name, is_global, created_at, updated_at) VALUES ('private-mine', 'Mine', 0, 150, 150)",
+                [],
+            )
+            .unwrap();
+        }
+        wstore.skill_bind(&catalog, "agent-1", "private-mine").unwrap();
+
+        let list = wstore.managed_list::<Skill>(&catalog, Owner::Agent, "agent-1").unwrap();
+        let ids: Vec<&str> = list.iter().map(|(s, _)| s.id.as_str()).collect();
+        assert_eq!(ids, vec!["global-1", "global-2", "private-mine"], "globals first (newest first), then the bound private row");
+        assert!(!list.iter().any(|(s, _)| s.id == "private-other"), "an unbound private row from another owner must not appear");
+
+        let bound: std::collections::HashMap<&str, bool> = list.iter().map(|(s, b)| (s.id.as_str(), *b)).collect();
+        assert!(!bound["global-1"], "a global the owner has not directly bound is visible but not 'bound'");
+        assert!(bound["private-mine"]);
+    }
+
+    #[test]
+    fn managed_list_global_reports_bound_count_from_the_wstore_side() {
+        let wstore = wstore();
+        let catalog = catalog_store();
+        insert_agent(&wstore, "agent-1");
+        insert_agent(&wstore, "agent-2");
+        catalog.managed_upsert_unique_global(&skill("global-1", "Global", true, 100)).unwrap();
+        wstore.skill_bind(&catalog, "agent-1", "global-1").unwrap();
+        wstore.skill_bind(&catalog, "agent-2", "global-1").unwrap();
+
+        let list = wstore.managed_list_global::<Skill>(&catalog).unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].1, 2, "bound_count must come from wstore's ref table, not catalog");
+    }
+
+    #[test]
+    fn managed_list_global_for_agent_never_returns_private_rows() {
+        let wstore = wstore();
+        let catalog = catalog_store();
+        insert_agent(&wstore, "agent-1");
+        catalog.managed_upsert_unique_global(&skill("global-1", "Global", true, 100)).unwrap();
+        {
+            let conn = catalog.conn().lock().unwrap();
+            conn.execute(
+                "INSERT INTO db_skills (id, name, is_global, created_at, updated_at) VALUES ('private-1', 'Private', 0, 50, 50)",
+                [],
+            )
+            .unwrap();
+        }
+        wstore.skill_bind(&catalog, "agent-1", "global-1").unwrap();
+
+        let list = wstore.managed_list_global_for_agent::<Skill>(&catalog, "agent-1").unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].0.id, "global-1");
+        assert!(list[0].1);
+    }
+
+    #[test]
+    fn managed_is_accessible_to_checks_globality_in_catalog_and_binding_in_wstore() {
+        let wstore = wstore();
+        let catalog = catalog_store();
+        insert_agent(&wstore, "agent-1");
+        catalog.managed_upsert_unique_global(&skill("global-1", "Global", true, 100)).unwrap();
+        {
+            let conn = catalog.conn().lock().unwrap();
+            conn.execute(
+                "INSERT INTO db_skills (id, name, is_global, created_at, updated_at) VALUES ('private-1', 'Private', 0, 50, 50)",
+                [],
+            )
+            .unwrap();
+        }
+
+        assert!(wstore.managed_is_accessible_to::<Skill>(&catalog, Owner::Agent, "agent-1", "global-1").unwrap());
+        assert!(!wstore.managed_is_accessible_to::<Skill>(&catalog, Owner::Agent, "agent-1", "private-1").unwrap());
+        wstore.skill_bind(&catalog, "agent-1", "private-1").unwrap();
+        assert!(wstore.managed_is_accessible_to::<Skill>(&catalog, Owner::Agent, "agent-1", "private-1").unwrap());
+        assert!(!wstore.managed_is_accessible_to::<Skill>(&catalog, Owner::Agent, "agent-1", "no-such-id").unwrap());
+    }
+
+    #[test]
+    fn managed_upsert_unique_detects_a_duplicate_name_in_the_catalog_store() {
+        let wstore = wstore();
+        let catalog = catalog_store();
+        insert_agent(&wstore, "agent-1");
+        catalog.managed_upsert_unique_global(&skill("global-1", "Deploy", true, 100)).unwrap();
+
+        let result = wstore.managed_upsert_unique(&catalog, Owner::Agent, "agent-1", &skill("new-1", "Deploy", false, 200), true, None);
+        assert!(result.is_err(), "a name already used by a visible global row must be rejected");
+        // The catalog must not have gained a row from the rejected attempt.
+        assert!(catalog.managed_get::<Skill>("new-1").unwrap().is_none());
+    }
+
+    #[test]
+    fn managed_upsert_unique_compensates_by_deleting_the_catalog_row_when_the_bind_fails() {
+        let wstore = wstore();
+        let catalog = catalog_store();
+        insert_agent(&wstore, "agent-1");
+        // Force the ref-insert to fail deterministically: drop the ref table
+        // out from under it (a stand-in for the "lock contention / disk
+        // full / a channel-local constraint" failures the doc comment
+        // describes — `INSERT OR IGNORE` swallows an agent_id FK violation
+        // silently rather than erroring, so a missing db_agents row can't be
+        // used to exercise this path; a missing TABLE is a real, unignored
+        // SQL error).
+        wstore.conn().lock().unwrap().execute_batch("DROP TABLE db_agent_skills_ref;").unwrap();
+
+        let result = wstore.managed_upsert_unique(&catalog, Owner::Agent, "agent-1", &skill("new-1", "Deploy", false, 200), true, None);
+        assert!(result.is_err(), "the bind must fail now that its table is gone");
+        assert!(
+            catalog.managed_get::<Skill>("new-1").unwrap().is_none(),
+            "the catalog insert must be compensated away, leaving no orphan row"
+        );
+    }
+
+    #[test]
+    fn managed_upsert_unique_leaves_the_catalog_row_when_bind_new_is_false() {
+        let wstore = wstore();
+        let catalog = catalog_store();
+        wstore.managed_upsert_unique(&catalog, Owner::Agent, "agent-1", &skill("new-1", "Deploy", false, 200), false, None).unwrap();
+        assert!(catalog.managed_get::<Skill>("new-1").unwrap().is_some());
+    }
+
+    #[test]
+    fn managed_delete_purges_wstore_refs_and_removes_the_catalog_row() {
+        let wstore = wstore();
+        let catalog = catalog_store();
+        insert_agent(&wstore, "agent-1");
+        insert_bundle(&wstore, "bundle-1");
+        catalog.managed_upsert_unique_global(&skill("global-1", "Global", true, 100)).unwrap();
+        wstore.skill_bind(&catalog, "agent-1", "global-1").unwrap();
+        wstore.bundle_skill_bind(&catalog, &wstore, "bundle-1", "global-1").unwrap();
+
+        let deleted = wstore.managed_delete::<Skill>(&catalog, "global-1").unwrap();
+        assert!(deleted);
+        assert!(catalog.managed_get::<Skill>("global-1").unwrap().is_none());
+        assert!(!wstore.skill_is_bound_to("agent-1", "global-1").unwrap());
+        assert!(!wstore.bundle_skill_is_bound_to("bundle-1", "global-1").unwrap());
+    }
+
+    #[test]
+    fn managed_bind_agent_succeeds_when_the_catalog_row_exists_in_the_separate_store() {
+        let wstore = wstore();
+        let catalog = catalog_store();
+        insert_agent(&wstore, "agent-1");
+        catalog.managed_upsert_unique_global(&skill("global-1", "Global", true, 100)).unwrap();
+
+        wstore.skill_bind(&catalog, "agent-1", "global-1").unwrap();
+        assert!(wstore.skill_is_bound_to("agent-1", "global-1").unwrap());
+    }
+
+    #[test]
+    fn managed_bind_agent_rejects_a_catalog_row_that_does_not_exist_anywhere() {
+        let wstore = wstore();
+        let catalog = catalog_store();
+        insert_agent(&wstore, "agent-1");
+
+        let result = wstore.skill_bind(&catalog, "agent-1", "no-such-skill");
+        assert!(result.is_err(), "binding an id with no row in catalog must error, not silently no-op");
+        assert!(!wstore.skill_is_bound_to("agent-1", "no-such-skill").unwrap());
     }
 }

--- a/agentmux-srv/src/backend/storage/mcp_servers.rs
+++ b/agentmux-srv/src/backend/storage/mcp_servers.rs
@@ -126,6 +126,7 @@ impl Store {
     /// Returns `(created, warnings)`.
     pub fn bundle_mcp_bind_inline_entries(
         &self,
+        catalog: &Store,
         id_store: &Store,
         bundle_id: &str,
         entries: &[serde_json::Value],
@@ -138,7 +139,7 @@ impl Store {
 
         // What is already bound, captured BEFORE the loop so a duplicate
         // inside `entries` is not mistaken for a previous run.
-        let bound = match self.bundle_mcp_list(bundle_id) {
+        let bound = match self.bundle_mcp_list(catalog, bundle_id) {
             Ok(items) => items
                 .into_iter()
                 .filter(|i| i.bound_to_bundle)
@@ -192,7 +193,7 @@ impl Store {
                     continue;
                 }
                 server.name = candidate.clone();
-                match self.bundle_mcp_upsert_unique(id_store, bundle_id, &server, true) {
+                match self.bundle_mcp_upsert_unique(catalog, id_store, bundle_id, &server, true) {
                     Ok(()) => {
                         if candidate != base {
                             // Not a loss, but the operator should know the
@@ -274,6 +275,12 @@ impl ManagedResource for McpServer {
     fn name(&self) -> &str {
         &self.name
     }
+    fn is_global(&self) -> bool {
+        self.is_global
+    }
+    fn updated_at(&self) -> i64 {
+        self.updated_at
+    }
 }
 
 /// `mcp_server_list`'s response shape: the server plus whether the requesting
@@ -313,9 +320,9 @@ pub struct McpServerBundleListItem {
 impl Store {
     /// List all MCP servers visible to an agent: own (referenced) + global,
     /// each annotated with whether this specific agent holds the bind ref.
-    pub fn mcp_server_list(&self, agent_id: &str) -> Result<Vec<McpServerListItem>, StoreError> {
+    pub fn mcp_server_list(&self, catalog: &Store, agent_id: &str) -> Result<Vec<McpServerListItem>, StoreError> {
         Ok(self
-            .managed_list::<McpServer>(Owner::Agent, agent_id)?
+            .managed_list::<McpServer>(catalog, Owner::Agent, agent_id)?
             .into_iter()
             .map(|(server, bound_to_agent)| McpServerListItem { server, bound_to_agent })
             .collect())
@@ -330,14 +337,14 @@ impl Store {
     /// always was. Deduped by id. Single source of truth for
     /// `write_agent_config_files` — mirrors `effective_skills`'s own
     /// same-source-of-truth requirement (see its doc comment).
-    pub fn effective_mcp_servers(&self, agent_id: &str) -> Vec<McpServer> {
+    pub fn effective_mcp_servers(&self, catalog: &Store, agent_id: &str) -> Vec<McpServer> {
         let mut visible: Vec<McpServer> = self
-            .mcp_server_list(agent_id)
+            .mcp_server_list(catalog, agent_id)
             .unwrap_or_default()
             .into_iter()
             .map(|item| item.server)
             .collect();
-        self.managed_union_bundle_refs(agent_id, &mut visible);
+        self.managed_union_bundle_refs(catalog, agent_id, &mut visible);
         visible
     }
 
@@ -348,9 +355,9 @@ impl Store {
     /// Each row carries `bound_count` — how many agents currently hold a
     /// `db_agent_mcp_ref` to it — per SPEC_V1_MCP_SKILLS_PRIMITIVES_2026_06_30.md
     /// §8 ("used by N agents"), tracked as gap #2 of #1960.
-    pub fn mcp_server_list_global(&self) -> Result<Vec<McpServerCatalogItem>, StoreError> {
+    pub fn mcp_server_list_global(&self, catalog: &Store) -> Result<Vec<McpServerCatalogItem>, StoreError> {
         Ok(self
-            .managed_list_global::<McpServer>()?
+            .managed_list_global::<McpServer>(catalog)?
             .into_iter()
             .map(|(server, bound_count)| McpServerCatalogItem { server, bound_count })
             .collect())
@@ -369,9 +376,9 @@ impl Store {
     /// `mcp_server_list_global` (the Armory catalog) — so exposing them
     /// alongside a caller-chosen agent's bind status is safe.
     /// reagentx P0 on PR #2329.
-    pub fn mcp_server_list_global_for_agent(&self, agent_id: &str) -> Result<Vec<McpServerListItem>, StoreError> {
+    pub fn mcp_server_list_global_for_agent(&self, catalog: &Store, agent_id: &str) -> Result<Vec<McpServerListItem>, StoreError> {
         Ok(self
-            .managed_list_global_for_agent::<McpServer>(agent_id)?
+            .managed_list_global_for_agent::<McpServer>(catalog, agent_id)?
             .into_iter()
             .map(|(server, bound_to_agent)| McpServerListItem { server, bound_to_agent })
             .collect())
@@ -385,8 +392,8 @@ impl Store {
     /// Delete a standalone MCP server and purge ref rows (both agent- and
     /// bundle-level — FK cascades may be off on some builds, same reasoning
     /// as `skill_delete`). Returns true if deleted.
-    pub fn mcp_server_delete(&self, id: &str) -> Result<bool, StoreError> {
-        self.managed_delete::<McpServer>(id)
+    pub fn mcp_server_delete(&self, catalog: &Store, id: &str) -> Result<bool, StoreError> {
+        self.managed_delete::<McpServer>(catalog, id)
     }
 
     /// Bind an MCP server to an agent (insert ref row). Idempotent —
@@ -404,8 +411,8 @@ impl Store {
     /// case — reporting success while creating nothing. Same fix as
     /// skill_bind — see
     /// docs/reports/REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md.
-    pub fn mcp_server_bind(&self, agent_id: &str, mcp_id: &str) -> Result<(), StoreError> {
-        self.managed_bind_agent::<McpServer>(agent_id, mcp_id)
+    pub fn mcp_server_bind(&self, catalog: &Store, agent_id: &str, mcp_id: &str) -> Result<(), StoreError> {
+        self.managed_bind_agent::<McpServer>(catalog, agent_id, mcp_id)
     }
 
     /// Unbind an MCP server from an agent. Returns true if a row was removed.
@@ -420,11 +427,12 @@ impl Store {
     /// the agent (bound or global) already uses the name.
     pub fn mcp_server_upsert_unique(
         &self,
+        catalog: &Store,
         agent_id: &str,
         server: &McpServer,
         bind_new: bool,
     ) -> Result<(), StoreError> {
-        self.managed_upsert_unique(Owner::Agent, agent_id, server, bind_new, None)
+        self.managed_upsert_unique(catalog, Owner::Agent, agent_id, server, bind_new, None)
     }
 
     /// Atomically upsert a GLOBAL MCP server enforcing catalog-wide name
@@ -533,8 +541,8 @@ impl Store {
 
     /// Return true if the given MCP server is accessible to the agent (global or bound).
     /// Used for read and mutation access checks.
-    pub fn mcp_server_is_accessible_to(&self, agent_id: &str, mcp_id: &str) -> Result<bool, StoreError> {
-        self.managed_is_accessible_to::<McpServer>(Owner::Agent, agent_id, mcp_id)
+    pub fn mcp_server_is_accessible_to(&self, catalog: &Store, agent_id: &str, mcp_id: &str) -> Result<bool, StoreError> {
+        self.managed_is_accessible_to::<McpServer>(catalog, Owner::Agent, agent_id, mcp_id)
     }
 
     /// Return true if the agent has a direct ref binding to this MCP server.
@@ -554,9 +562,9 @@ impl Store {
     /// Bundle-level sibling of `mcp_server_list` — this bundle's own
     /// (referenced) + global servers, each annotated with whether this
     /// specific bundle holds the `db_bundle_mcp_ref` row.
-    pub fn bundle_mcp_list(&self, bundle_id: &str) -> Result<Vec<McpServerBundleListItem>, StoreError> {
+    pub fn bundle_mcp_list(&self, catalog: &Store, bundle_id: &str) -> Result<Vec<McpServerBundleListItem>, StoreError> {
         Ok(self
-            .managed_list::<McpServer>(Owner::Bundle, bundle_id)?
+            .managed_list::<McpServer>(catalog, Owner::Bundle, bundle_id)?
             .into_iter()
             .map(|(server, bound_to_bundle)| McpServerBundleListItem { server, bound_to_bundle })
             .collect())
@@ -576,8 +584,8 @@ impl Store {
     /// with no possible cross-database FK to it — same "check at the
     /// application layer, not via FK" pattern as
     /// `identity::resolver::resolve_account`'s cross-store lookups.
-    pub fn bundle_mcp_bind(&self, id_store: &Store, bundle_id: &str, mcp_id: &str) -> Result<(), StoreError> {
-        self.managed_bind_bundle::<McpServer>(id_store, bundle_id, mcp_id)
+    pub fn bundle_mcp_bind(&self, catalog: &Store, id_store: &Store, bundle_id: &str, mcp_id: &str) -> Result<(), StoreError> {
+        self.managed_bind_bundle::<McpServer>(catalog, id_store, bundle_id, mcp_id)
     }
 
     /// Atomically create a NEW, PRIVATE (never global) MCP server scoped
@@ -597,12 +605,13 @@ impl Store {
     /// isn't already visible to every other agent.
     pub fn bundle_mcp_upsert_unique(
         &self,
+        catalog: &Store,
         id_store: &Store,
         bundle_id: &str,
         server: &McpServer,
         bind_new: bool,
     ) -> Result<(), StoreError> {
-        self.managed_upsert_unique_for_bundle(id_store, bundle_id, server, bind_new)
+        self.managed_upsert_unique_for_bundle(catalog, id_store, bundle_id, server, bind_new)
     }
 
     /// Unbind an MCP server from a bundle. Returns true if a row was removed.
@@ -612,8 +621,8 @@ impl Store {
 
     /// Return true if the given MCP server is accessible to the bundle
     /// (global or bundle-bound). Mirrors `mcp_server_is_accessible_to`.
-    pub fn bundle_mcp_is_accessible_to(&self, bundle_id: &str, mcp_id: &str) -> Result<bool, StoreError> {
-        self.managed_is_accessible_to::<McpServer>(Owner::Bundle, bundle_id, mcp_id)
+    pub fn bundle_mcp_is_accessible_to(&self, catalog: &Store, bundle_id: &str, mcp_id: &str) -> Result<bool, StoreError> {
+        self.managed_is_accessible_to::<McpServer>(catalog, Owner::Bundle, bundle_id, mcp_id)
     }
 
     /// Return true if the bundle has a direct ref binding to this MCP
@@ -677,15 +686,15 @@ mod bundle_ref_tests {
         // A private (non-global) server, upserted without any agent bind —
         // simulates a server that exists but this bundle hasn't referenced.
         store
-            .mcp_server_upsert_unique("some-other-agent-context", &server("srv-private", "Private", false), false)
+            .mcp_server_upsert_unique(&store, "some-other-agent-context", &server("srv-private", "Private", false), false)
             .unwrap_or(());
 
-        let before = store.bundle_mcp_list("bundle-1").unwrap();
+        let before = store.bundle_mcp_list(&store, "bundle-1").unwrap();
         assert_eq!(before.len(), 1, "only the global server should be visible before any bind: {before:?}");
         assert!(!before[0].bound_to_bundle, "global server isn't bundle-bound yet");
 
-        store.bundle_mcp_bind(&store, "bundle-1", "srv-private").unwrap();
-        let after = store.bundle_mcp_list("bundle-1").unwrap();
+        store.bundle_mcp_bind(&store, &store, "bundle-1", "srv-private").unwrap();
+        let after = store.bundle_mcp_list(&store, "bundle-1").unwrap();
         assert_eq!(after.len(), 2, "private server must now be visible after binding: {after:?}");
         let private_item = after.iter().find(|i| i.server.id == "srv-private").expect("private server present");
         assert!(private_item.bound_to_bundle);
@@ -697,11 +706,11 @@ mod bundle_ref_tests {
         insert_bundle(&store, "bundle-1");
         insert_bundle(&store, "bundle-2");
         store
-            .mcp_server_upsert_unique("some-other-agent-context", &server("srv-private", "Private", false), false)
+            .mcp_server_upsert_unique(&store, "some-other-agent-context", &server("srv-private", "Private", false), false)
             .unwrap_or(());
-        store.bundle_mcp_bind(&store, "bundle-1", "srv-private").unwrap();
+        store.bundle_mcp_bind(&store, &store, "bundle-1", "srv-private").unwrap();
 
-        let bundle2_list = store.bundle_mcp_list("bundle-2").unwrap();
+        let bundle2_list = store.bundle_mcp_list(&store, "bundle-2").unwrap();
         assert!(
             bundle2_list.is_empty(),
             "a private server bound to bundle-1 must not leak into bundle-2's list: {bundle2_list:?}"
@@ -712,7 +721,7 @@ mod bundle_ref_tests {
     fn bind_errors_when_the_bundle_does_not_exist() {
         let store = make_store();
         store.mcp_server_upsert_unique_global(&server("srv-1", "S", true)).unwrap();
-        let result = store.bundle_mcp_bind(&store, "no-such-bundle", "srv-1");
+        let result = store.bundle_mcp_bind(&store, &store, "no-such-bundle", "srv-1");
         assert!(result.is_err(), "binding to a nonexistent bundle must error, not silently no-op");
     }
 
@@ -721,13 +730,13 @@ mod bundle_ref_tests {
         let store = make_store();
         insert_bundle(&store, "bundle-1");
         store
-            .mcp_server_upsert_unique("ctx", &server("srv-private", "Private", false), false)
+            .mcp_server_upsert_unique(&store, "ctx", &server("srv-private", "Private", false), false)
             .unwrap_or(());
-        store.bundle_mcp_bind(&store, "bundle-1", "srv-private").unwrap();
+        store.bundle_mcp_bind(&store, &store, "bundle-1", "srv-private").unwrap();
 
         let removed = store.bundle_mcp_unbind("bundle-1", "srv-private").unwrap();
         assert!(removed);
-        assert!(store.bundle_mcp_list("bundle-1").unwrap().is_empty());
+        assert!(store.bundle_mcp_list(&store, "bundle-1").unwrap().is_empty());
 
         let removed_again = store.bundle_mcp_unbind("bundle-1", "srv-private").unwrap();
         assert!(!removed_again, "unbinding an already-unbound pair returns false, not an error");
@@ -738,14 +747,14 @@ mod bundle_ref_tests {
         let store = make_store();
         insert_bundle(&store, "bundle-1");
         store
-            .mcp_server_upsert_unique("ctx", &server("srv-private", "Private", false), false)
+            .mcp_server_upsert_unique(&store, "ctx", &server("srv-private", "Private", false), false)
             .unwrap_or(());
-        store.bundle_mcp_bind(&store, "bundle-1", "srv-private").unwrap();
-        assert_eq!(store.bundle_mcp_list("bundle-1").unwrap().len(), 1);
+        store.bundle_mcp_bind(&store, &store, "bundle-1", "srv-private").unwrap();
+        assert_eq!(store.bundle_mcp_list(&store, "bundle-1").unwrap().len(), 1);
 
-        store.mcp_server_delete("srv-private").unwrap();
+        store.mcp_server_delete(&store, "srv-private").unwrap();
         assert!(
-            store.bundle_mcp_list("bundle-1").unwrap().is_empty(),
+            store.bundle_mcp_list(&store, "bundle-1").unwrap().is_empty(),
             "the bundle ref row must be purged when the underlying server is deleted"
         );
     }
@@ -763,7 +772,7 @@ mod bundle_ref_tests {
         insert_bundle(&id_store, "bundle-1");
         wstore.mcp_server_upsert_unique_global(&server("srv-1", "S", true)).unwrap();
 
-        let result = wstore.bundle_mcp_bind(&id_store, "bundle-1", "srv-1");
+        let result = wstore.bundle_mcp_bind(&wstore, &id_store, "bundle-1", "srv-1");
         assert!(result.is_ok(), "must check bundle existence against id_store, not self: {result:?}");
     }
 
@@ -781,7 +790,7 @@ mod bundle_ref_tests {
         insert_bundle(&wstore, "bundle-1"); // wrong store — simulates the pre-fix bug's mirror image
         wstore.mcp_server_upsert_unique_global(&server("srv-1", "S", true)).unwrap();
 
-        let result = wstore.bundle_mcp_bind(&id_store, "bundle-1", "srv-1");
+        let result = wstore.bundle_mcp_bind(&wstore, &id_store, "bundle-1", "srv-1");
         assert!(
             result.is_err(),
             "a bundle only present in self's non-authoritative copy must not satisfy the id_store check: {result:?}"
@@ -801,13 +810,14 @@ mod bundle_ref_tests {
         store
             .bundle_mcp_upsert_unique(
                 &store,
+                &store,
                 "bundle-1",
                 &server("new-srv", "Bundle-Only Tool", true), // is_global: true here is IGNORED
                 true,
             )
             .unwrap();
 
-        let list = store.bundle_mcp_list("bundle-1").unwrap();
+        let list = store.bundle_mcp_list(&store, "bundle-1").unwrap();
         let item = list.iter().find(|i| i.server.id == "new-srv").expect("newly created server present");
         assert!(item.bound_to_bundle);
         assert!(!item.server.is_global, "upsert_unique must force is_global=false regardless of the input struct");
@@ -817,9 +827,9 @@ mod bundle_ref_tests {
     fn upsert_unique_rejects_a_duplicate_name_already_bound_to_the_bundle() {
         let store = make_store();
         insert_bundle(&store, "bundle-1");
-        store.bundle_mcp_upsert_unique(&store, "bundle-1", &server("srv-a", "Dup Name", true), true).unwrap();
+        store.bundle_mcp_upsert_unique(&store, &store, "bundle-1", &server("srv-a", "Dup Name", true), true).unwrap();
 
-        let result = store.bundle_mcp_upsert_unique(&store, "bundle-1", &server("srv-b", "Dup Name", true), true);
+        let result = store.bundle_mcp_upsert_unique(&store, &store, "bundle-1", &server("srv-b", "Dup Name", true), true);
         assert!(result.is_err(), "a second server with the same name bound to the same bundle must be rejected");
     }
 
@@ -829,13 +839,13 @@ mod bundle_ref_tests {
         insert_bundle(&store, "bundle-1");
         store.mcp_server_upsert_unique_global(&server("srv-global", "Global", true)).unwrap();
         store
-            .mcp_server_upsert_unique("ctx", &server("srv-private", "Private", false), false)
+            .mcp_server_upsert_unique(&store, "ctx", &server("srv-private", "Private", false), false)
             .unwrap_or(());
 
-        assert!(store.bundle_mcp_is_accessible_to("bundle-1", "srv-global").unwrap());
-        assert!(!store.bundle_mcp_is_accessible_to("bundle-1", "srv-private").unwrap());
-        store.bundle_mcp_bind(&store, "bundle-1", "srv-private").unwrap();
-        assert!(store.bundle_mcp_is_accessible_to("bundle-1", "srv-private").unwrap());
+        assert!(store.bundle_mcp_is_accessible_to(&store, "bundle-1", "srv-global").unwrap());
+        assert!(!store.bundle_mcp_is_accessible_to(&store, "bundle-1", "srv-private").unwrap());
+        store.bundle_mcp_bind(&store, &store, "bundle-1", "srv-private").unwrap();
+        assert!(store.bundle_mcp_is_accessible_to(&store, "bundle-1", "srv-private").unwrap());
     }
 
     fn insert_agent_with_bundle(store: &Store, id: &str, memory_id: &str) {
@@ -885,11 +895,11 @@ mod bundle_ref_tests {
         insert_bundle(&store, "bundle-1");
         insert_agent_with_bundle(&store, "agent-1", "bundle-1");
         store
-            .mcp_server_upsert_unique("some-other-context", &server("bundle-srv", "Bundle Server", false), false)
+            .mcp_server_upsert_unique(&store, "some-other-context", &server("bundle-srv", "Bundle Server", false), false)
             .unwrap_or(());
-        store.bundle_mcp_bind(&store, "bundle-1", "bundle-srv").unwrap();
+        store.bundle_mcp_bind(&store, &store, "bundle-1", "bundle-srv").unwrap();
 
-        let effective = store.effective_mcp_servers("agent-1");
+        let effective = store.effective_mcp_servers(&store, "agent-1");
         let names: Vec<&str> = effective.iter().map(|s| s.name.as_str()).collect();
         assert!(
             names.contains(&"Bundle Server"),
@@ -909,10 +919,10 @@ mod bundle_ref_tests {
         insert_agent_with_bundle(&store, "agent-1", "bundle-1");
 
         store
-            .bundle_mcp_upsert_unique(&store, "bundle-1", &server("bundle-own-tool", "Bundle-Owned Tool", false), true)
+            .bundle_mcp_upsert_unique(&store, &store, "bundle-1", &server("bundle-own-tool", "Bundle-Owned Tool", false), true)
             .unwrap();
 
-        let effective = store.effective_mcp_servers("agent-1");
+        let effective = store.effective_mcp_servers(&store, "agent-1");
         let names: Vec<&str> = effective.iter().map(|s| s.name.as_str()).collect();
         assert!(
             names.contains(&"Bundle-Owned Tool"),
@@ -927,7 +937,7 @@ mod bundle_ref_tests {
         insert_agent_with_bundle(&store, "agent-1", "bundle-1");
         store.mcp_server_upsert_unique_global(&server("global-1", "Global Server", true)).unwrap();
 
-        let effective = store.effective_mcp_servers("agent-1");
+        let effective = store.effective_mcp_servers(&store, "agent-1");
         let matches: Vec<_> = effective.iter().filter(|s| s.name == "Global Server").collect();
         assert_eq!(matches.len(), 1, "a global server visible via both the agent and its bundle must not be duplicated: {effective:?}");
     }
@@ -970,7 +980,7 @@ mod bundle_ref_tests {
         store.agent_def_insert(&mut def).unwrap();
         store.mcp_server_upsert_unique_global(&server("global-1", "Global Server", true)).unwrap();
 
-        let effective = store.effective_mcp_servers("agent-no-bundle");
+        let effective = store.effective_mcp_servers(&store, "agent-no-bundle");
         assert_eq!(effective.len(), 1, "an agent with no bundle still sees globals, unaffected by the new union logic: {effective:?}");
     }
 }

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -357,7 +357,25 @@ pub const SHARED_STORE_SCHEMA_VERSION: i64 = 9;
 ///
 ///        Purely additive: nothing reads it at launch, and an agent with no
 ///        row simply has no prior observation to compare against.
-pub const OBJECT_SCHEMA_VERSION: i64 = 33;
+///   v34 — `db_agent_skills_ref` / `db_agent_mcp_ref` / `db_bundle_skills_ref`
+///        / `db_bundle_mcp_ref` drop their `skill_id`/`mcp_id` FK to this
+///        store's LOCAL `db_skills`/`db_mcp_servers`. Phase 2 of
+///        `SPEC_DURABLE_BINDINGS_2026_09_10.md` §5.4 (Codex P1, PR #3182):
+///        once catalog writes redirect to `identity_store`, this channel's
+///        local catalog copies stop gaining new rows, so binding a
+///        post-redirect skill/server would otherwise hit a hard `FOREIGN KEY
+///        constraint failed` (`PRAGMA foreign_keys=ON` in production, see
+///        `Store::configure_and_migrate`). The `agent_id → db_agents` FK on
+///        the agent-level pair is kept verbatim — only the catalog-pointing
+///        FK is dropped. Same shape `db_bundle_skills_ref`/`db_bundle_mcp_ref`
+///        already used for `db_bundles` (see those tables' own doc comment
+///        below): existence moves to the application layer
+///        (`managed_bind_agent`/`managed_bind_bundle`'s new `catalog: &Store`
+///        check). SQLite has no `ALTER TABLE ... DROP CONSTRAINT`, so an
+///        existing store's four tables are rebuilt by
+///        `m0032_drop_catalog_fk_from_ref_tables`; a fresh install gets the
+///        trimmed FK directly from the CREATE TABLE statements below.
+pub const OBJECT_SCHEMA_VERSION: i64 = 34;
 /// `user_version` value stamped into `filestore.db`.
 pub const FILESTORE_SCHEMA_VERSION: i64 = 1;
 /// `user_version` value stamped into `sagas.db`.
@@ -714,22 +732,24 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
         );
         CREATE INDEX IF NOT EXISTS idx_mcp_servers_is_global ON db_mcp_servers(is_global);
 
+        -- v34: skill_id's FK to this store's LOCAL db_skills is gone — see
+        -- OBJECT_SCHEMA_VERSION's v34 doc comment above. agent_id's FK to
+        -- db_agents (v30) is unchanged.
         CREATE TABLE IF NOT EXISTS db_agent_skills_ref (
             agent_id TEXT NOT NULL,
             skill_id TEXT NOT NULL,
             PRIMARY KEY (agent_id, skill_id),
-            -- v30: see OBJECT_SCHEMA_VERSION's v30 doc comment above.
-            FOREIGN KEY (agent_id) REFERENCES db_agents(id) ON DELETE CASCADE,
-            FOREIGN KEY (skill_id) REFERENCES db_skills(id) ON DELETE CASCADE
+            FOREIGN KEY (agent_id) REFERENCES db_agents(id) ON DELETE CASCADE
         );
 
+        -- v34: mcp_id's FK to this store's LOCAL db_mcp_servers is gone —
+        -- see OBJECT_SCHEMA_VERSION's v34 doc comment above. agent_id's FK
+        -- to db_agents (v30) is unchanged.
         CREATE TABLE IF NOT EXISTS db_agent_mcp_ref (
             agent_id TEXT NOT NULL,
             mcp_id   TEXT NOT NULL,
             PRIMARY KEY (agent_id, mcp_id),
-            -- v30: see OBJECT_SCHEMA_VERSION's v30 doc comment above.
-            FOREIGN KEY (agent_id) REFERENCES db_agents(id) ON DELETE CASCADE,
-            FOREIGN KEY (mcp_id)   REFERENCES db_mcp_servers(id) ON DELETE CASCADE
+            FOREIGN KEY (agent_id) REFERENCES db_agents(id) ON DELETE CASCADE
         );
 
         -- v23: Bundle-level MCP/skill references (composable model v2,
@@ -747,26 +767,34 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
         -- shared store in a normal production install — see
         -- `bundle.rs::register_bundle_upsert`), not `wstore`/objects.db,
         -- where this table lives (it must live here to FK to
-        -- db_mcp_servers/db_skills, which ARE wstore-local). wstore's own
-        -- copy of db_bundles is a schema-compatible but essentially always-
+        -- db_mcp_servers/db_skills, which used to be wstore-local too (now
+        -- authoritatively identity_store as of Phase 2 — see
+        -- OBJECT_SCHEMA_VERSION's v34 doc comment). wstore's own copy of
+        -- db_bundles is a schema-compatible but essentially always-
         -- empty local mirror in that case — an FK against it would make
         -- every real bind fail. Same no-FK-to-a-table-living-in-the-wrong-
         -- store reasoning as `db_agent_identity_links.account_id`'s
         -- deliberate lack of an account FK (see that table's own doc
         -- comment). Existence is checked at the application layer instead
         -- — see `Store::bundle_mcp_bind`'s `id_store` parameter.
+        --
+        -- v34: skill_id's FK to db_skills is ALSO gone now (it was
+        -- wstore-local before v34; see OBJECT_SCHEMA_VERSION's v34 doc
+        -- comment) — this table has never had a bundle_id FK, so it is now
+        -- FK-free entirely, existence checked purely at the application
+        -- layer for both columns.
         CREATE TABLE IF NOT EXISTS db_bundle_skills_ref (
             bundle_id TEXT NOT NULL,
             skill_id  TEXT NOT NULL,
-            PRIMARY KEY (bundle_id, skill_id),
-            FOREIGN KEY (skill_id) REFERENCES db_skills(id) ON DELETE CASCADE
+            PRIMARY KEY (bundle_id, skill_id)
         );
 
+        -- v34: mcp_id's FK to db_mcp_servers is gone — see the
+        -- db_bundle_skills_ref comment above; same reasoning, MCP side.
         CREATE TABLE IF NOT EXISTS db_bundle_mcp_ref (
             bundle_id TEXT NOT NULL,
             mcp_id    TEXT NOT NULL,
-            PRIMARY KEY (bundle_id, mcp_id),
-            FOREIGN KEY (mcp_id) REFERENCES db_mcp_servers(id) ON DELETE CASCADE
+            PRIMARY KEY (bundle_id, mcp_id)
         );
 
         -- v7: MuxBus cloud connectivity — global singleton PKCE token store.
@@ -1473,7 +1501,22 @@ pub fn run_shared_store_schema(conn: &Connection) -> Result<(), StoreError> {
 ///        to arbitrate the race (Codex P1, PR #3181). The migration's
 ///        insert now handles the resulting `UNIQUE constraint failed` by
 ///        re-querying for whichever row actually won.
-pub const IDENTITY_STORE_SCHEMA_VERSION: i64 = 7;
+///   v8 — `idx_ids_skills_global_name` replaces `idx_ids_skills_global_name_type`:
+///        narrows the skill global-uniqueness index from `(name, skill_type)`
+///        to `name` alone, matching the invariant `skill_upsert_unique_global`'s
+///        own dup-check has always enforced (`WHERE name = ?1 AND id <> ?2
+///        AND is_global = 1` — no `skill_type` filter). Codex P2, PR #3182,
+///        `SPEC_DURABLE_BINDINGS_2026_09_10.md` §5.4: the v7 index was
+///        narrower than the invariant it was meant to back, so a
+///        same-name-different-`skill_type` race between two channels could
+///        insert two rows the application itself considers duplicates. MCP
+///        servers don't have this mismatch — `idx_ids_mcp_servers_global_name`
+///        is already name-only — so this bump is skills-only.
+///        `m0033_narrow_skill_global_uniqueness_index` defensively collapses
+///        any existing same-name/different-type pair `m0031`'s own
+///        `(name, skill_type)`-keyed dedup may already have produced, to the
+///        earlier-`created_at` row, before the new index is created.
+pub const IDENTITY_STORE_SCHEMA_VERSION: i64 = 8;
 
 /// Initialize (or re-validate) the `~/.agentmux/shared/identity-store.db`
 /// schema — the permanently-global store introduced by
@@ -1720,12 +1763,14 @@ pub fn run_identity_store_schema(conn: &Connection) -> Result<(), StoreError> {
             updated_at  INTEGER NOT NULL DEFAULT 0
         );
         CREATE INDEX IF NOT EXISTS idx_ids_skills_is_global ON db_skills(is_global);
-        -- v7: see this constant's v7 doc comment — arbitrates the
-        -- concurrent-carry race at the database level, since an
-        -- application-level check-then-insert can't be atomic across two
-        -- separate processes/connections.
-        CREATE UNIQUE INDEX IF NOT EXISTS idx_ids_skills_global_name_type
-            ON db_skills(name, skill_type) WHERE is_global = 1;
+        -- v8: name-only, matching skill_upsert_unique_global's own dup-check
+        -- — see this constant's v8 doc comment. Replaces
+        -- idx_ids_skills_global_name_type (dropped just below for an
+        -- existing store; a fresh store never creates it in the first
+        -- place, since this whole batch runs as one execute_batch).
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_ids_skills_global_name
+            ON db_skills(name) WHERE is_global = 1;
+        DROP INDEX IF EXISTS idx_ids_skills_global_name_type;
 
         CREATE TABLE IF NOT EXISTS db_mcp_servers (
             id          TEXT PRIMARY KEY,

--- a/agentmux-srv/src/backend/storage/skills.rs
+++ b/agentmux-srv/src/backend/storage/skills.rs
@@ -272,6 +272,12 @@ impl ManagedResource for Skill {
     fn name(&self) -> &str {
         &self.name
     }
+    fn is_global(&self) -> bool {
+        self.is_global
+    }
+    fn updated_at(&self) -> i64 {
+        self.updated_at
+    }
 }
 
 /// `skill_list`'s response shape: the skill plus whether the requesting agent
@@ -309,9 +315,11 @@ pub struct SkillBundleListItem {
 impl Store {
     /// List all skills visible to an agent: own (referenced) + global, each
     /// annotated with whether this specific agent holds the bind ref.
-    pub fn skill_list(&self, agent_id: &str) -> Result<Vec<SkillListItem>, StoreError> {
+    /// `catalog` is where `db_skills` is authoritative — `identity_store` in
+    /// production (Phase 2 of SPEC_DURABLE_BINDINGS_2026_09_10.md §5.4).
+    pub fn skill_list(&self, catalog: &Store, agent_id: &str) -> Result<Vec<SkillListItem>, StoreError> {
         Ok(self
-            .managed_list::<Skill>(Owner::Agent, agent_id)?
+            .managed_list::<Skill>(catalog, Owner::Agent, agent_id)?
             .into_iter()
             .map(|(skill, bound_to_agent)| SkillListItem { skill, bound_to_agent })
             .collect())
@@ -338,10 +346,10 @@ impl Store {
     /// agent connection could (reagent P0 on PR #2322 — the launch UI is not
     /// an authenticated agent connection, so it was never able to reach the
     /// standalone Skill primitive via the RPC layer at all).
-    pub fn effective_skills(&self, agent_id: &str) -> Vec<AgentSkill> {
+    pub fn effective_skills(&self, catalog: &Store, agent_id: &str) -> Vec<AgentSkill> {
         let legacy_skills = self.agent_skill_list(agent_id).unwrap_or_default();
         let mut visible_skills: Vec<Skill> = self
-            .skill_list(agent_id)
+            .skill_list(catalog, agent_id)
             .unwrap_or_default()
             .into_iter()
             .map(|item| item.skill)
@@ -365,7 +373,7 @@ impl Store {
         // `bundle_skill_list` below. Happens AFTER the has_own decision —
         // bundle-referenced skills still appear in the final list, they
         // just never trigger the "discard legacy" path on their own.
-        self.managed_union_bundle_refs(agent_id, &mut visible_skills);
+        self.managed_union_bundle_refs(catalog, agent_id, &mut visible_skills);
         if has_own_skill_refs {
             crate::backend::agent_config::skills_to_agent_skills(&visible_skills, agent_id)
         } else {
@@ -383,9 +391,9 @@ impl Store {
     /// `db_agent_skills_ref` to it — per
     /// SPEC_V1_MCP_SKILLS_PRIMITIVES_2026_06_30.md §8 ("used by N agents"),
     /// tracked as gap #2 of #1960.
-    pub fn skill_list_global(&self) -> Result<Vec<SkillCatalogItem>, StoreError> {
+    pub fn skill_list_global(&self, catalog: &Store) -> Result<Vec<SkillCatalogItem>, StoreError> {
         Ok(self
-            .managed_list_global::<Skill>()?
+            .managed_list_global::<Skill>(catalog)?
             .into_iter()
             .map(|(skill, bound_count)| SkillCatalogItem { skill, bound_count })
             .collect())
@@ -403,9 +411,9 @@ impl Store {
     /// they're already fully visible via `skill_list_global` (the Armory
     /// catalog) — so exposing them alongside a caller-chosen agent's bind
     /// status is safe. reagentx P0 on PR #2329.
-    pub fn skill_list_global_for_agent(&self, agent_id: &str) -> Result<Vec<SkillListItem>, StoreError> {
+    pub fn skill_list_global_for_agent(&self, catalog: &Store, agent_id: &str) -> Result<Vec<SkillListItem>, StoreError> {
         Ok(self
-            .managed_list_global_for_agent::<Skill>(agent_id)?
+            .managed_list_global_for_agent::<Skill>(catalog, agent_id)?
             .into_iter()
             .map(|(skill, bound_to_agent)| SkillListItem { skill, bound_to_agent })
             .collect())
@@ -418,8 +426,8 @@ impl Store {
 
     /// Delete a standalone skill and purge its ref rows (both agent- and
     /// bundle-level). Returns true if deleted.
-    pub fn skill_delete(&self, id: &str) -> Result<bool, StoreError> {
-        self.managed_delete::<Skill>(id)
+    pub fn skill_delete(&self, catalog: &Store, id: &str) -> Result<bool, StoreError> {
+        self.managed_delete::<Skill>(catalog, id)
     }
 
     /// Bind a skill to an agent (insert ref row). Idempotent — binding an
@@ -436,8 +444,8 @@ impl Store {
     /// affected-row-count alone, from the equally-silent "already bound"
     /// case — reporting success while creating nothing. reagentx P1, PR
     /// #2315.
-    pub fn skill_bind(&self, agent_id: &str, skill_id: &str) -> Result<(), StoreError> {
-        self.managed_bind_agent::<Skill>(agent_id, skill_id)
+    pub fn skill_bind(&self, catalog: &Store, agent_id: &str, skill_id: &str) -> Result<(), StoreError> {
+        self.managed_bind_agent::<Skill>(catalog, agent_id, skill_id)
     }
 
     /// Unbind a skill from an agent. Returns true if a row was removed.
@@ -453,11 +461,12 @@ impl Store {
     /// global) already uses the name.
     pub fn skill_upsert_unique(
         &self,
+        catalog: &Store,
         agent_id: &str,
         skill: &Skill,
         bind_new: bool,
     ) -> Result<(), StoreError> {
-        self.managed_upsert_unique(Owner::Agent, agent_id, skill, bind_new, None)
+        self.managed_upsert_unique(catalog, Owner::Agent, agent_id, skill, bind_new, None)
     }
 
     /// Atomically upsert a GLOBAL skill enforcing catalog-wide name
@@ -606,8 +615,8 @@ impl Store {
 
     /// Return true if the given skill is accessible to the agent (global or bound).
     /// Used for read and delete access checks.
-    pub fn skill_is_accessible_to(&self, agent_id: &str, skill_id: &str) -> Result<bool, StoreError> {
-        self.managed_is_accessible_to::<Skill>(Owner::Agent, agent_id, skill_id)
+    pub fn skill_is_accessible_to(&self, catalog: &Store, agent_id: &str, skill_id: &str) -> Result<bool, StoreError> {
+        self.managed_is_accessible_to::<Skill>(catalog, Owner::Agent, agent_id, skill_id)
     }
 
     /// Return true if the agent has a direct ref binding to this skill (for delete/mutation).
@@ -624,9 +633,9 @@ impl Store {
     /// Bundle-level sibling of `skill_list` — this bundle's own (referenced)
     /// and global skills, each annotated with whether this specific bundle
     /// holds the `db_bundle_skills_ref` row.
-    pub fn bundle_skill_list(&self, bundle_id: &str) -> Result<Vec<SkillBundleListItem>, StoreError> {
+    pub fn bundle_skill_list(&self, catalog: &Store, bundle_id: &str) -> Result<Vec<SkillBundleListItem>, StoreError> {
         Ok(self
-            .managed_list::<Skill>(Owner::Bundle, bundle_id)?
+            .managed_list::<Skill>(catalog, Owner::Bundle, bundle_id)?
             .into_iter()
             .map(|(skill, bound_to_bundle)| SkillBundleListItem { skill, bound_to_bundle })
             .collect())
@@ -636,9 +645,13 @@ impl Store {
     ///
     /// `id_store` (NOT `self`) is where bundle existence is checked — see
     /// `Store::bundle_mcp_bind`'s doc comment (mcp_servers.rs) for the full
-    /// reasoning (reagentx P0 review on PR #2639).
-    pub fn bundle_skill_bind(&self, id_store: &Store, bundle_id: &str, skill_id: &str) -> Result<(), StoreError> {
-        self.managed_bind_bundle::<Skill>(id_store, bundle_id, skill_id)
+    /// reasoning (reagentx P0 review on PR #2639). `catalog` is where
+    /// `db_skills` is authoritative — see `managed_bind_bundle`'s doc
+    /// comment for why it now ALSO checks skill existence there (Part A of
+    /// SPEC_DURABLE_BINDINGS_2026_09_10.md §5.4 dropped this table's
+    /// `skill_id` FK).
+    pub fn bundle_skill_bind(&self, catalog: &Store, id_store: &Store, bundle_id: &str, skill_id: &str) -> Result<(), StoreError> {
+        self.managed_bind_bundle::<Skill>(catalog, id_store, bundle_id, skill_id)
     }
 
     /// Atomically create a NEW, PRIVATE (never global) skill scoped and
@@ -648,12 +661,13 @@ impl Store {
     /// the full reasoning (reagentx P1 review on PR #2639).
     pub fn bundle_skill_upsert_unique(
         &self,
+        catalog: &Store,
         id_store: &Store,
         bundle_id: &str,
         skill: &Skill,
         bind_new: bool,
     ) -> Result<(), StoreError> {
-        self.managed_upsert_unique_for_bundle(id_store, bundle_id, skill, bind_new)
+        self.managed_upsert_unique_for_bundle(catalog, id_store, bundle_id, skill, bind_new)
     }
 
     /// Unbind a skill from a bundle. Returns true if a row was removed.
@@ -663,8 +677,8 @@ impl Store {
 
     /// Return true if the given skill is accessible to the bundle (global or
     /// bundle-bound). Mirrors `skill_is_accessible_to`.
-    pub fn bundle_skill_is_accessible_to(&self, bundle_id: &str, skill_id: &str) -> Result<bool, StoreError> {
-        self.managed_is_accessible_to::<Skill>(Owner::Bundle, bundle_id, skill_id)
+    pub fn bundle_skill_is_accessible_to(&self, catalog: &Store, bundle_id: &str, skill_id: &str) -> Result<bool, StoreError> {
+        self.managed_is_accessible_to::<Skill>(catalog, Owner::Bundle, bundle_id, skill_id)
     }
 
     /// Return true if the bundle has a direct ref binding to this skill
@@ -754,7 +768,7 @@ mod effective_skills_tests {
         store.skill_upsert_unique_global(&global_skill("global-1", "Global Skill")).unwrap();
         // Not bound to agent-1 -- has_own_skill_refs must stay false.
 
-        let effective = store.effective_skills("agent-1");
+        let effective = store.effective_skills(&store, "agent-1");
         let names: Vec<&str> = effective.iter().map(|s| s.name.as_str()).collect();
         assert_eq!(names.len(), 2, "expected legacy + global, got: {names:?}");
         assert!(names.contains(&"Legacy Skill"));
@@ -792,9 +806,9 @@ mod effective_skills_tests {
             created_at: 1_700_000_000_000,
             updated_at: 1_700_000_000_000,
         };
-        store.skill_upsert_unique("agent-1", &own_skill, true).unwrap();
+        store.skill_upsert_unique(&store, "agent-1", &own_skill, true).unwrap();
 
-        let effective = store.effective_skills("agent-1");
+        let effective = store.effective_skills(&store, "agent-1");
         let names: Vec<&str> = effective.iter().map(|s| s.name.as_str()).collect();
         assert_eq!(names.len(), 2, "expected own + global, legacy discarded, got: {names:?}");
         assert!(names.contains(&"Own Skill"));
@@ -822,9 +836,9 @@ mod effective_skills_tests {
             created_at: 1_700_000_000_000,
             updated_at: 1_700_000_000_000,
         };
-        store.skill_upsert_unique("agent-1", &own_skill, true).unwrap();
+        store.skill_upsert_unique(&store, "agent-1", &own_skill, true).unwrap();
 
-        let effective = store.effective_skills("agent-1");
+        let effective = store.effective_skills(&store, "agent-1");
         assert_eq!(effective.len(), 1);
         assert_eq!(effective[0].skill_type, "agent-skill");
     }
@@ -915,10 +929,10 @@ mod effective_skills_tests {
         // Upserted under an unrelated agent context, then bound to the
         // BUNDLE (not to agent-1 directly) — simulates a skill added via
         // the bundle editor, not the agent's own Stash.
-        store.skill_upsert_unique("some-other-context", &bundle_skill, false).unwrap();
-        store.bundle_skill_bind(&store, "bundle-1", "bundle-skill-1").unwrap();
+        store.skill_upsert_unique(&store, "some-other-context", &bundle_skill, false).unwrap();
+        store.bundle_skill_bind(&store, &store, "bundle-1", "bundle-skill-1").unwrap();
 
-        let effective = store.effective_skills("agent-1");
+        let effective = store.effective_skills(&store, "agent-1");
         let names: Vec<&str> = effective.iter().map(|s| s.name.as_str()).collect();
         assert!(
             names.contains(&"Bundle Skill"),
@@ -947,9 +961,9 @@ mod effective_skills_tests {
             created_at: 1_700_000_000_000,
             updated_at: 1_700_000_000_000,
         };
-        store.bundle_skill_upsert_unique(&store, "bundle-1", &bundle_skill, true).unwrap();
+        store.bundle_skill_upsert_unique(&store, &store, "bundle-1", &bundle_skill, true).unwrap();
 
-        let effective = store.effective_skills("agent-1");
+        let effective = store.effective_skills(&store, "agent-1");
         let names: Vec<&str> = effective.iter().map(|s| s.name.as_str()).collect();
         assert!(
             names.contains(&"Bundle-Owned Skill"),
@@ -995,11 +1009,11 @@ mod effective_skills_tests {
             created_at: 1_700_000_000_000,
             updated_at: 1_700_000_000_000,
         };
-        store.skill_upsert_unique("some-other-context", &bundle_private_skill, false).unwrap();
-        store.bundle_skill_bind(&store, "bundle-1", "bundle-private-1").unwrap();
+        store.skill_upsert_unique(&store, "some-other-context", &bundle_private_skill, false).unwrap();
+        store.bundle_skill_bind(&store, &store, "bundle-1", "bundle-private-1").unwrap();
         // agent-1 itself has NO own db_skills ref — only its bundle does.
 
-        let effective = store.effective_skills("agent-1");
+        let effective = store.effective_skills(&store, "agent-1");
         let names: Vec<&str> = effective.iter().map(|s| s.name.as_str()).collect();
         assert!(
             names.contains(&"Legacy Skill"),
@@ -1018,7 +1032,7 @@ mod effective_skills_tests {
         insert_agent_with_bundle(&store, "agent-1", "bundle-1");
         store.skill_upsert_unique_global(&global_skill("global-1", "Global Skill")).unwrap();
 
-        let effective = store.effective_skills("agent-1");
+        let effective = store.effective_skills(&store, "agent-1");
         let matches: Vec<_> = effective.iter().filter(|s| s.name == "Global Skill").collect();
         assert_eq!(matches.len(), 1, "a global skill visible via both the agent and its bundle must not be duplicated: {effective:?}");
     }
@@ -1076,14 +1090,14 @@ mod bundle_ref_tests {
         insert_bundle(&store, "bundle-1");
         store.skill_upsert_unique_global(&skill("skill-global", "Global", true)).unwrap();
         store
-            .skill_upsert_unique("some-other-agent-context", &skill("skill-private", "Private", false), false)
+            .skill_upsert_unique(&store, "some-other-agent-context", &skill("skill-private", "Private", false), false)
             .unwrap_or(());
 
-        let before = store.bundle_skill_list("bundle-1").unwrap();
+        let before = store.bundle_skill_list(&store, "bundle-1").unwrap();
         assert_eq!(before.len(), 1, "only the global skill should be visible before any bind: {before:?}");
 
-        store.bundle_skill_bind(&store, "bundle-1", "skill-private").unwrap();
-        let after = store.bundle_skill_list("bundle-1").unwrap();
+        store.bundle_skill_bind(&store, &store, "bundle-1", "skill-private").unwrap();
+        let after = store.bundle_skill_list(&store, "bundle-1").unwrap();
         assert_eq!(after.len(), 2, "private skill must now be visible after binding: {after:?}");
         let private_item = after.iter().find(|i| i.skill.id == "skill-private").expect("private skill present");
         assert!(private_item.bound_to_bundle);
@@ -1095,11 +1109,11 @@ mod bundle_ref_tests {
         insert_bundle(&store, "bundle-1");
         insert_bundle(&store, "bundle-2");
         store
-            .skill_upsert_unique("ctx", &skill("skill-private", "Private", false), false)
+            .skill_upsert_unique(&store, "ctx", &skill("skill-private", "Private", false), false)
             .unwrap_or(());
-        store.bundle_skill_bind(&store, "bundle-1", "skill-private").unwrap();
+        store.bundle_skill_bind(&store, &store, "bundle-1", "skill-private").unwrap();
 
-        let bundle2_list = store.bundle_skill_list("bundle-2").unwrap();
+        let bundle2_list = store.bundle_skill_list(&store, "bundle-2").unwrap();
         assert!(
             bundle2_list.is_empty(),
             "a private skill bound to bundle-1 must not leak into bundle-2's list: {bundle2_list:?}"
@@ -1110,7 +1124,7 @@ mod bundle_ref_tests {
     fn bind_errors_when_the_bundle_does_not_exist() {
         let store = make_store();
         store.skill_upsert_unique_global(&skill("skill-1", "S", true)).unwrap();
-        let result = store.bundle_skill_bind(&store, "no-such-bundle", "skill-1");
+        let result = store.bundle_skill_bind(&store, &store, "no-such-bundle", "skill-1");
         assert!(result.is_err(), "binding to a nonexistent bundle must error, not silently no-op");
     }
 
@@ -1119,13 +1133,13 @@ mod bundle_ref_tests {
         let store = make_store();
         insert_bundle(&store, "bundle-1");
         store
-            .skill_upsert_unique("ctx", &skill("skill-private", "Private", false), false)
+            .skill_upsert_unique(&store, "ctx", &skill("skill-private", "Private", false), false)
             .unwrap_or(());
-        store.bundle_skill_bind(&store, "bundle-1", "skill-private").unwrap();
+        store.bundle_skill_bind(&store, &store, "bundle-1", "skill-private").unwrap();
 
         let removed = store.bundle_skill_unbind("bundle-1", "skill-private").unwrap();
         assert!(removed);
-        assert!(store.bundle_skill_list("bundle-1").unwrap().is_empty());
+        assert!(store.bundle_skill_list(&store, "bundle-1").unwrap().is_empty());
 
         let removed_again = store.bundle_skill_unbind("bundle-1", "skill-private").unwrap();
         assert!(!removed_again, "unbinding an already-unbound pair returns false, not an error");
@@ -1136,14 +1150,14 @@ mod bundle_ref_tests {
         let store = make_store();
         insert_bundle(&store, "bundle-1");
         store
-            .skill_upsert_unique("ctx", &skill("skill-private", "Private", false), false)
+            .skill_upsert_unique(&store, "ctx", &skill("skill-private", "Private", false), false)
             .unwrap_or(());
-        store.bundle_skill_bind(&store, "bundle-1", "skill-private").unwrap();
-        assert_eq!(store.bundle_skill_list("bundle-1").unwrap().len(), 1);
+        store.bundle_skill_bind(&store, &store, "bundle-1", "skill-private").unwrap();
+        assert_eq!(store.bundle_skill_list(&store, "bundle-1").unwrap().len(), 1);
 
-        store.skill_delete("skill-private").unwrap();
+        store.skill_delete(&store, "skill-private").unwrap();
         assert!(
-            store.bundle_skill_list("bundle-1").unwrap().is_empty(),
+            store.bundle_skill_list(&store, "bundle-1").unwrap().is_empty(),
             "the bundle ref row must be purged when the underlying skill is deleted"
         );
     }
@@ -1158,7 +1172,7 @@ mod bundle_ref_tests {
         insert_bundle(&id_store, "bundle-1");
         wstore.skill_upsert_unique_global(&skill("skill-1", "S", true)).unwrap();
 
-        let result = wstore.bundle_skill_bind(&id_store, "bundle-1", "skill-1");
+        let result = wstore.bundle_skill_bind(&wstore, &id_store, "bundle-1", "skill-1");
         assert!(result.is_ok(), "must check bundle existence against id_store, not self: {result:?}");
     }
 
@@ -1169,7 +1183,7 @@ mod bundle_ref_tests {
         insert_bundle(&wstore, "bundle-1");
         wstore.skill_upsert_unique_global(&skill("skill-1", "S", true)).unwrap();
 
-        let result = wstore.bundle_skill_bind(&id_store, "bundle-1", "skill-1");
+        let result = wstore.bundle_skill_bind(&wstore, &id_store, "bundle-1", "skill-1");
         assert!(
             result.is_err(),
             "a bundle only present in self's non-authoritative copy must not satisfy the id_store check: {result:?}"
@@ -1184,10 +1198,10 @@ mod bundle_ref_tests {
         insert_bundle(&store, "bundle-1");
 
         store
-            .bundle_skill_upsert_unique(&store, "bundle-1", &skill("new-skill", "Bundle-Only Skill", true), true)
+            .bundle_skill_upsert_unique(&store, &store, "bundle-1", &skill("new-skill", "Bundle-Only Skill", true), true)
             .unwrap();
 
-        let list = store.bundle_skill_list("bundle-1").unwrap();
+        let list = store.bundle_skill_list(&store, "bundle-1").unwrap();
         let item = list.iter().find(|i| i.skill.id == "new-skill").expect("newly created skill present");
         assert!(item.bound_to_bundle);
         assert!(!item.skill.is_global, "upsert_unique must force is_global=false regardless of the input struct");
@@ -1197,9 +1211,9 @@ mod bundle_ref_tests {
     fn upsert_unique_rejects_a_duplicate_name_already_bound_to_the_bundle() {
         let store = make_store();
         insert_bundle(&store, "bundle-1");
-        store.bundle_skill_upsert_unique(&store, "bundle-1", &skill("skill-a", "Dup Name", true), true).unwrap();
+        store.bundle_skill_upsert_unique(&store, &store, "bundle-1", &skill("skill-a", "Dup Name", true), true).unwrap();
 
-        let result = store.bundle_skill_upsert_unique(&store, "bundle-1", &skill("skill-b", "Dup Name", true), true);
+        let result = store.bundle_skill_upsert_unique(&store, &store, "bundle-1", &skill("skill-b", "Dup Name", true), true);
         assert!(result.is_err(), "a second skill with the same name bound to the same bundle must be rejected");
     }
 
@@ -1209,12 +1223,12 @@ mod bundle_ref_tests {
         insert_bundle(&store, "bundle-1");
         store.skill_upsert_unique_global(&skill("skill-global", "Global", true)).unwrap();
         store
-            .skill_upsert_unique("ctx", &skill("skill-private", "Private", false), false)
+            .skill_upsert_unique(&store, "ctx", &skill("skill-private", "Private", false), false)
             .unwrap_or(());
 
-        assert!(store.bundle_skill_is_accessible_to("bundle-1", "skill-global").unwrap());
-        assert!(!store.bundle_skill_is_accessible_to("bundle-1", "skill-private").unwrap());
-        store.bundle_skill_bind(&store, "bundle-1", "skill-private").unwrap();
-        assert!(store.bundle_skill_is_accessible_to("bundle-1", "skill-private").unwrap());
+        assert!(store.bundle_skill_is_accessible_to(&store, "bundle-1", "skill-global").unwrap());
+        assert!(!store.bundle_skill_is_accessible_to(&store, "bundle-1", "skill-private").unwrap());
+        store.bundle_skill_bind(&store, &store, "bundle-1", "skill-private").unwrap();
+        assert!(store.bundle_skill_is_accessible_to(&store, "bundle-1", "skill-private").unwrap());
     }
 }

--- a/agentmux-srv/src/migrations/m0015_seed_starter_skills.rs
+++ b/agentmux-srv/src/migrations/m0015_seed_starter_skills.rs
@@ -79,7 +79,7 @@ mod tests {
         M0015SeedStarterSkills.up(&ctx_for(tmp.path())).unwrap();
 
         let wstore = Store::open(tmp.path()).unwrap();
-        assert_eq!(wstore.skill_list_global().unwrap().len(), 6);
+        assert_eq!(wstore.skill_list_global(&wstore).unwrap().len(), 6);
     }
 
     #[test]
@@ -93,12 +93,12 @@ mod tests {
 
         M0015SeedStarterSkills.up(&ctx).unwrap();
         wstore.migration_mark_applied("0015_seed_starter_skills", "channel", 0).unwrap();
-        assert_eq!(wstore.skill_list_global().unwrap().len(), 6);
+        assert_eq!(wstore.skill_list_global(&wstore).unwrap().len(), 6);
 
-        for item in wstore.skill_list_global().unwrap() {
-            wstore.skill_delete(&item.skill.id).unwrap();
+        for item in wstore.skill_list_global(&wstore).unwrap() {
+            wstore.skill_delete(&wstore, &item.skill.id).unwrap();
         }
-        assert!(wstore.skill_list_global().unwrap().is_empty());
+        assert!(wstore.skill_list_global(&wstore).unwrap().is_empty());
 
         // The real runner (runner.rs) never calls `up()` again once
         // `migration_is_applied` is true — assert that precondition holds,
@@ -139,7 +139,7 @@ mod tests {
 
         M0015SeedStarterSkills.up(&ctx).unwrap();
 
-        let after = wstore.skill_list_global().unwrap();
+        let after = wstore.skill_list_global(&wstore).unwrap();
         assert_eq!(
             after.len(),
             1,

--- a/agentmux-srv/src/migrations/m0016_seed_starter_mcp_servers.rs
+++ b/agentmux-srv/src/migrations/m0016_seed_starter_mcp_servers.rs
@@ -77,7 +77,7 @@ mod tests {
         M0016SeedStarterMcpServers.up(&ctx_for(tmp.path())).unwrap();
 
         let wstore = Store::open(tmp.path()).unwrap();
-        assert_eq!(wstore.mcp_server_list_global().unwrap().len(), 6);
+        assert_eq!(wstore.mcp_server_list_global(&wstore).unwrap().len(), 6);
     }
 
     #[test]
@@ -91,12 +91,12 @@ mod tests {
 
         M0016SeedStarterMcpServers.up(&ctx).unwrap();
         wstore.migration_mark_applied("0016_seed_starter_mcp_servers", "channel", 0).unwrap();
-        assert_eq!(wstore.mcp_server_list_global().unwrap().len(), 6);
+        assert_eq!(wstore.mcp_server_list_global(&wstore).unwrap().len(), 6);
 
-        for item in wstore.mcp_server_list_global().unwrap() {
-            wstore.mcp_server_delete(&item.server.id).unwrap();
+        for item in wstore.mcp_server_list_global(&wstore).unwrap() {
+            wstore.mcp_server_delete(&wstore, &item.server.id).unwrap();
         }
-        assert!(wstore.mcp_server_list_global().unwrap().is_empty());
+        assert!(wstore.mcp_server_list_global(&wstore).unwrap().is_empty());
 
         // The real runner (runner.rs) never calls `up()` again once
         // `migration_is_applied` is true — assert that precondition holds,
@@ -131,7 +131,7 @@ mod tests {
 
         M0016SeedStarterMcpServers.up(&ctx).unwrap();
 
-        let after = wstore.mcp_server_list_global().unwrap();
+        let after = wstore.mcp_server_list_global(&wstore).unwrap();
         assert_eq!(
             after.len(),
             1,

--- a/agentmux-srv/src/migrations/m0030_backfill_bundle_component_refs.rs
+++ b/agentmux-srv/src/migrations/m0030_backfill_bundle_component_refs.rs
@@ -14,14 +14,22 @@
 //! **Ships in the same release as the read switch.** Export reading refs
 //! before this has run would make every pre-existing bundle export empty.
 //!
-//! Two stores, deliberately. `db_bundles` lives in the shared store
-//! (`run_shared_store_schema`), while `db_skills`, `db_mcp_servers` and both
-//! ref tables live in the channel store (`run_object_schema`,
-//! `migrations.rs:742`/`:749`) — the ref tables must sit next to the catalog
-//! tables they carry foreign keys to, which is also why they have no FK to
-//! `db_bundles` (`migrations.rs:721-741`). So this reads bundles from the
-//! shared store and writes refs into the channel store, resolving the former
-//! exactly the way `m0021` does.
+//! Two stores, deliberately, as of when this migration was written.
+//! `db_bundles` lives in the shared store (`run_shared_store_schema`), while
+//! `db_skills`/`db_mcp_servers` and both ref tables lived in the channel
+//! store alone (`run_object_schema`, `migrations.rs:742`/`:749`) — the ref
+//! tables had to sit next to the catalog tables they carried foreign keys
+//! to, which is also why they never had an FK to `db_bundles`
+//! (`migrations.rs:721-741`). So this reads bundles from the shared store
+//! and writes refs into the channel store, resolving the former exactly the
+//! way `m0021` does. **Now stale in one respect** (Phase 2 of
+//! `SPEC_DURABLE_BINDINGS_2026_09_10.md`, `m0032_drop_catalog_fk_from_ref_tables`):
+//! `db_skills`/`db_mcp_servers` are authoritatively `identity_store` and the
+//! ref tables no longer carry the FK described above at all — this
+//! migration itself is unaffected (it ran, or runs, entirely within the
+//! world this comment describes, since it always operated on `wstore`'s own
+//! local catalog copy) and is left as a historical record of why the two
+//! stores were split, not a claim about the current schema.
 //!
 //! Idempotent three times over: `INSERT OR IGNORE` on the ref tables, name
 //! uniqueness on the MCP catalog rows, and a per-bundle skip when nothing is
@@ -93,7 +101,13 @@ fn backfill_one_bundle(
                 // the ref tables cannot represent it and the export could
                 // never have rendered it either.
                 match wstore.skill_get(&id) {
-                    Ok(Some(_)) => match wstore.bundle_skill_bind(bundle_store, bundle_id, &id) {
+                    // `wstore` also serves as `catalog` here: this migration
+                    // pre-dates Phase 2 of SPEC_DURABLE_BINDINGS_2026_09_10.md's
+                    // catalog redirect, back when `db_skills` genuinely lived
+                    // on the channel store alone — see this module's own doc
+                    // comment on why `db_skills` lives here and `db_bundles`
+                    // lives in `bundle_store`.
+                    Ok(Some(_)) => match wstore.bundle_skill_bind(wstore, bundle_store, bundle_id, &id) {
                         Ok(()) => skills_bound += 1,
                         Err(e) => tracing::warn!(
                             bundle_id, skill_id = %id, error = %e,
@@ -128,7 +142,7 @@ fn backfill_one_bundle(
             // end up identical — including how duplicate names are kept apart
             // and how a re-run decides it has nothing to do.
             let (created, warnings) =
-                wstore.bundle_mcp_bind_inline_entries(bundle_store, bundle_id, &entries, now_ms());
+                wstore.bundle_mcp_bind_inline_entries(wstore, bundle_store, bundle_id, &entries, now_ms());
             mcp_bound += created;
             for w in warnings {
                 tracing::warn!(bundle_id, warning = %w, "backfill_bundle_component_refs");
@@ -287,7 +301,7 @@ mod tests {
         assert_eq!((sk, mc), (1, 1));
 
         let bound_skills: Vec<_> = s
-            .bundle_skill_list("bundle-1")
+            .bundle_skill_list(&s, "bundle-1")
             .unwrap()
             .into_iter()
             .filter(|i| i.bound_to_bundle)
@@ -295,7 +309,7 @@ mod tests {
         assert_eq!(bound_skills.len(), 1, "skill must be bound to the bundle");
 
         let bound_mcp: Vec<_> = s
-            .bundle_mcp_list("bundle-1")
+            .bundle_mcp_list(&s, "bundle-1")
             .unwrap()
             .into_iter()
             .filter(|i| i.bound_to_bundle)
@@ -326,7 +340,7 @@ mod tests {
         assert_eq!(second.1, 0, "a second pass must not create a second server");
 
         let bound_mcp = s
-            .bundle_mcp_list("bundle-1")
+            .bundle_mcp_list(&s, "bundle-1")
             .unwrap()
             .into_iter()
             .filter(|i| i.bound_to_bundle)
@@ -367,7 +381,7 @@ mod tests {
         assert_eq!(mc, 2, "both entries must survive the backfill");
 
         let names: Vec<String> = s
-            .bundle_mcp_list("bundle-1")
+            .bundle_mcp_list(&s, "bundle-1")
             .unwrap()
             .into_iter()
             .filter(|i| i.bound_to_bundle)
@@ -402,14 +416,14 @@ mod tests {
             created_at: 1,
             updated_at: 1,
         };
-        s.bundle_mcp_upsert_unique(&s, "bundle-1", &armory, true).unwrap();
+        s.bundle_mcp_upsert_unique(&s, &s, "bundle-1", &armory, true).unwrap();
 
         let mcp = r#"[{"name":"github","command":"gh-mcp"}]"#;
         let (_, mc) = backfill_one_bundle(&s, &s, "bundle-1", "[]", mcp);
         assert_eq!(mc, 1, "the inline entry must be carried across, not swallowed");
 
         let bound: Vec<_> = s
-            .bundle_mcp_list("bundle-1")
+            .bundle_mcp_list(&s, "bundle-1")
             .unwrap()
             .into_iter()
             .filter(|i| i.bound_to_bundle)
@@ -440,7 +454,7 @@ mod tests {
         backfill_one_bundle(&s, &s, "bundle-1", "[]", mcp);
 
         let bound: Vec<_> = s
-            .bundle_mcp_list("bundle-1")
+            .bundle_mcp_list(&s, "bundle-1")
             .unwrap()
             .into_iter()
             .filter(|i| i.bound_to_bundle)
@@ -456,7 +470,7 @@ mod tests {
         assert_eq!(mc, 2, "two nameless entries must not collide on name");
 
         let names: Vec<String> = s
-            .bundle_mcp_list("bundle-1")
+            .bundle_mcp_list(&s, "bundle-1")
             .unwrap()
             .into_iter()
             .filter(|i| i.bound_to_bundle)

--- a/agentmux-srv/src/migrations/m0031_carry_skills_and_mcp_servers_to_identity_store.rs
+++ b/agentmux-srv/src/migrations/m0031_carry_skills_and_mcp_servers_to_identity_store.rs
@@ -396,8 +396,18 @@ fn carry_skills(wstore: &Store, identity_store: &Store, channel_salt: &str) -> R
                     .map_err(|e| format!("rewrite refs for skill {}: {e}", to_insert.name))
             },
             |old| {
+                // Compile-only accommodation for Part D of
+                // SPEC_DURABLE_BINDINGS_2026_09_10.md's redirect
+                // (`skill_delete` gained a `catalog` parameter) — no change
+                // to this migration's own frozen logic. This deletes the
+                // STALE LOCAL row under the superseded id from `wstore`'s
+                // own db_skills mirror — it must never touch
+                // `identity_store` (the new local copy under the final id
+                // was already inserted separately above), so `wstore` is
+                // passed as `catalog` too, reproducing the pre-split
+                // single-store behavior exactly.
                 wstore
-                    .skill_delete(old)
+                    .skill_delete(wstore, old)
                     .map_err(|e| format!("delete superseded local skill row {old}: {e}"))
             },
         )?;
@@ -521,8 +531,10 @@ fn carry_mcp_servers(wstore: &Store, identity_store: &Store, channel_salt: &str)
                     .map_err(|e| format!("rewrite refs for mcp server {}: {e}", to_insert.name))
             },
             |old| {
+                // See the identical compile-only note on the skill_delete
+                // call above (Part D of SPEC_DURABLE_BINDINGS_2026_09_10.md).
                 wstore
-                    .mcp_server_delete(old)
+                    .mcp_server_delete(wstore, old)
                     .map_err(|e| format!("delete superseded local mcp server row {old}: {e}"))
             },
         )?;
@@ -753,7 +765,14 @@ mod tests {
             "INSERT INTO db_agents (id, name, provider) VALUES ('agent-1', 'A', 'claude')",
             [],
         ).unwrap();
-        wstore.skill_bind("agent-1", "legacy-random-id").unwrap();
+        // Compile-only accommodation for Part C of
+        // SPEC_DURABLE_BINDINGS_2026_09_10.md's redirect (`skill_bind` gained
+        // a `catalog` parameter) — no change to this migration's own frozen
+        // logic. `wstore` itself already holds this row locally (inserted
+        // above via `skill_insert_raw`), so passing it as `catalog` too
+        // satisfies the new existence check exactly as it always implicitly
+        // did before the split.
+        wstore.skill_bind(&wstore, "agent-1", "legacy-random-id").unwrap();
 
         let identity_dir = tempfile::tempdir().unwrap();
         let identity_store = Store::open_identity_store(&identity_dir.path().join("identity-store.db")).unwrap();
@@ -875,7 +894,9 @@ mod tests {
             "INSERT INTO db_agents (id, name, provider) VALUES ('agent-1', 'A', 'claude')",
             [],
         ).unwrap();
-        wstore.skill_bind("agent-1", "collided-id").unwrap();
+        // See the identical compile-only note on the earlier skill_bind call
+        // in this file (Part C of SPEC_DURABLE_BINDINGS_2026_09_10.md).
+        wstore.skill_bind(&wstore, "agent-1", "collided-id").unwrap();
 
         let (carried, rewritten) = carry_skills(&wstore, &identity_store, "channel").unwrap();
         assert_eq!(carried, 1, "the fresh-id insert must still succeed even though the first attempt lost the race");

--- a/agentmux-srv/src/migrations/m0032_drop_catalog_fk_from_ref_tables.rs
+++ b/agentmux-srv/src/migrations/m0032_drop_catalog_fk_from_ref_tables.rs
@@ -1,0 +1,403 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Drop the `skill_id`/`mcp_id` foreign key from all four skill/MCP ref
+//! tables (`db_agent_skills_ref`, `db_agent_mcp_ref`, `db_bundle_skills_ref`,
+//! `db_bundle_mcp_ref`), leaving every other constraint verbatim (the
+//! agent-level pair's `agent_id → db_agents` FK, every `PRIMARY KEY`, all
+//! column types).
+//!
+//! Part A of Phase 2's application-layer redirect,
+//! `SPEC_DURABLE_BINDINGS_2026_09_10.md` §5.4 (Codex P1, PR #3182). Once
+//! catalog reads/writes redirect to `identity_store`, this channel's LOCAL
+//! `db_skills`/`db_mcp_servers` stop gaining new rows — but
+//! `PRAGMA foreign_keys=ON` is set on every production connection
+//! (`Store::configure_and_migrate`), and the four ref tables' declared FK
+//! targeted exactly those local tables (`OBJECT_SCHEMA_VERSION` v10/v23,
+//! pre-v34). Binding any catalog row created after the redirect ships would
+//! hit a hard `FOREIGN KEY constraint failed`, not just read stale data —
+//! this is a **write**-path bug the read-side redirect does nothing for.
+//!
+//! `db_bundle_skills_ref`/`db_bundle_mcp_ref` already solved the identical
+//! problem for `db_bundles` (their own doc comment in `storage/migrations.rs`
+//! explains why they carry no FK to it at all) — this migration applies the
+//! same shape one layer over: existence moves to the application layer
+//! (`Store::managed_bind_agent`/`managed_bind_bundle`'s new `catalog: &Store`
+//! parameter, see `storage/managed.rs`).
+//!
+//! SQLite has no `ALTER TABLE ... DROP CONSTRAINT`, so each table is rebuilt:
+//! rename, recreate with the trimmed FK set, copy every row verbatim (no
+//! filtering needed — every existing row already satisfies the LOOSER new
+//! schema, unlike `m0028`'s FK-retarget which could orphan rows), drop the
+//! renamed original. `PRAGMA foreign_keys=OFF` for the swap, `foreign_keys=ON`
+//! restored afterward, with a `PRAGMA foreign_key_check` before commit —
+//! mirrors `m0028_agent_child_tables_repoint_fk`'s rebuild-and-swap exactly.
+//!
+//! Tolerates a table that already lacks the catalog FK (a fresh install:
+//! `run_object_schema` creates all four tables with the trimmed FK set
+//! directly as of `OBJECT_SCHEMA_VERSION` v34, so this migration has nothing
+//! to do there) and a channel store that does not exist yet. Idempotent.
+
+use rusqlite::Connection;
+
+use crate::backend::storage::store::Store;
+
+use super::{Migration, MigrationContext, MigrationError, MigrationScope, VerifyOutcome};
+
+pub struct M0032DropCatalogFkFromRefTables;
+
+/// One ref table this migration may need to rebuild.
+struct TableSpec {
+    name: &'static str,
+    /// The ref column that used to FK to a catalog table (`skill_id` or
+    /// `mcp_id`) — checked via `PRAGMA foreign_key_list` to decide whether a
+    /// rebuild is still needed.
+    ref_col: &'static str,
+    /// The catalog table the ref column used to point at, for the same check.
+    catalog_table: &'static str,
+    create_sql: &'static str,
+}
+
+const TABLES: &[TableSpec] = &[
+    TableSpec {
+        name: "db_agent_skills_ref",
+        ref_col: "skill_id",
+        catalog_table: "db_skills",
+        create_sql: "CREATE TABLE db_agent_skills_ref (
+            agent_id TEXT NOT NULL,
+            skill_id TEXT NOT NULL,
+            PRIMARY KEY (agent_id, skill_id),
+            FOREIGN KEY (agent_id) REFERENCES db_agents(id) ON DELETE CASCADE
+        )",
+    },
+    TableSpec {
+        name: "db_agent_mcp_ref",
+        ref_col: "mcp_id",
+        catalog_table: "db_mcp_servers",
+        create_sql: "CREATE TABLE db_agent_mcp_ref (
+            agent_id TEXT NOT NULL,
+            mcp_id   TEXT NOT NULL,
+            PRIMARY KEY (agent_id, mcp_id),
+            FOREIGN KEY (agent_id) REFERENCES db_agents(id) ON DELETE CASCADE
+        )",
+    },
+    TableSpec {
+        name: "db_bundle_skills_ref",
+        ref_col: "skill_id",
+        catalog_table: "db_skills",
+        create_sql: "CREATE TABLE db_bundle_skills_ref (
+            bundle_id TEXT NOT NULL,
+            skill_id  TEXT NOT NULL,
+            PRIMARY KEY (bundle_id, skill_id)
+        )",
+    },
+    TableSpec {
+        name: "db_bundle_mcp_ref",
+        ref_col: "mcp_id",
+        catalog_table: "db_mcp_servers",
+        create_sql: "CREATE TABLE db_bundle_mcp_ref (
+            bundle_id TEXT NOT NULL,
+            mcp_id    TEXT NOT NULL,
+            PRIMARY KEY (bundle_id, mcp_id)
+        )",
+    },
+];
+
+/// True if `table` no longer has an FK from `ref_col` to `catalog_table` —
+/// either this migration already rebuilt it, or it's a fresh install whose
+/// base schema already declares the trimmed FK set. `Ok(true)` for a missing
+/// table too: nothing to rebuild is the same as already done.
+fn already_dropped(conn: &Connection, spec: &TableSpec) -> Result<bool, String> {
+    let exists: bool = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1)",
+            [spec.name],
+            |row| row.get(0),
+        )
+        .map_err(|e| format!("probe {}: {e}", spec.name))?;
+    if !exists {
+        return Ok(true);
+    }
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA foreign_key_list({})", spec.name))
+        .map_err(|e| format!("foreign_key_list {}: {e}", spec.name))?;
+    // Columns: id, seq, table, from, to, on_update, on_delete, match.
+    let fks: Vec<(String, String)> = stmt
+        .query_map([], |row| Ok((row.get::<_, String>(3)?, row.get::<_, String>(2)?)))
+        .and_then(|rows| rows.collect::<Result<Vec<_>, _>>())
+        .map_err(|e| format!("foreign_key_list {}: {e}", spec.name))?;
+    Ok(!fks.iter().any(|(from, table)| from == spec.ref_col && table == spec.catalog_table))
+}
+
+/// Rebuild one table so its catalog-pointing FK is gone, preserving every
+/// other constraint and every row verbatim.
+fn rebuild_table(conn: &Connection, spec: &TableSpec) -> Result<(), String> {
+    let old_name = format!("{}_pre_drop_catalog_fk", spec.name);
+    conn.execute_batch("PRAGMA foreign_keys=OFF;")
+        .map_err(|e| format!("{}: foreign_keys off: {e}", spec.name))?;
+    let result: Result<(), String> = (|| {
+        conn.execute_batch("BEGIN;").map_err(|e| format!("{}: begin: {e}", spec.name))?;
+        conn.execute(&format!("ALTER TABLE {} RENAME TO {old_name}", spec.name), [])
+            .map_err(|e| format!("{}: rename: {e}", spec.name))?;
+        conn.execute(spec.create_sql, [])
+            .map_err(|e| format!("{}: recreate: {e}", spec.name))?;
+        let columns: String = {
+            let mut stmt = conn
+                .prepare(&format!("PRAGMA table_info({old_name})"))
+                .map_err(|e| format!("{}: table_info: {e}", spec.name))?;
+            let cols: Vec<String> = stmt
+                .query_map([], |row| row.get::<_, String>(1))
+                .and_then(|rows| rows.collect::<Result<Vec<_>, _>>())
+                .map_err(|e| format!("{}: table_info: {e}", spec.name))?;
+            cols.join(", ")
+        };
+        // No filtering: every row satisfies the new (looser) schema — this
+        // rebuild only REMOVES a constraint, unlike m0028's FK-retarget
+        // which could orphan a row against the NEW target.
+        conn.execute(&format!("INSERT INTO {} ({columns}) SELECT {columns} FROM {old_name}", spec.name), [])
+            .map_err(|e| format!("{}: copy: {e}", spec.name))?;
+        conn.execute(&format!("DROP TABLE {old_name}"), [])
+            .map_err(|e| format!("{}: drop old: {e}", spec.name))?;
+        let mut check_stmt = conn
+            .prepare(&format!("PRAGMA foreign_key_check({})", spec.name))
+            .map_err(|e| format!("{}: foreign_key_check: {e}", spec.name))?;
+        let violations = check_stmt
+            .query_map([], |_| Ok(()))
+            .map_err(|e| format!("{}: foreign_key_check: {e}", spec.name))?
+            .count();
+        if violations > 0 {
+            return Err(format!("{}: {violations} foreign key violation(s) after rebuild", spec.name));
+        }
+        conn.execute_batch("COMMIT;").map_err(|e| format!("{}: commit: {e}", spec.name))?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = conn.execute_batch("ROLLBACK;");
+    }
+    conn.execute_batch("PRAGMA foreign_keys=ON;")
+        .map_err(|e| format!("{}: foreign_keys on: {e}", spec.name))?;
+    result
+}
+
+pub(super) fn drop_catalog_fks(conn: &Connection) -> Result<usize, String> {
+    let mut rebuilt = 0usize;
+    for spec in TABLES {
+        if already_dropped(conn, spec)? {
+            continue;
+        }
+        rebuild_table(conn, spec)?;
+        rebuilt += 1;
+    }
+    Ok(rebuilt)
+}
+
+impl Migration for M0032DropCatalogFkFromRefTables {
+    fn id(&self) -> &'static str {
+        "0032_drop_catalog_fk_from_ref_tables"
+    }
+
+    fn scope(&self) -> MigrationScope {
+        MigrationScope::Channel
+    }
+
+    fn description(&self) -> &'static str {
+        "Drop db_agent_skills_ref/db_agent_mcp_ref/db_bundle_skills_ref/db_bundle_mcp_ref's skill_id/mcp_id FK to this channel's local catalog tables"
+    }
+
+    fn up(&self, ctx: &MigrationContext) -> Result<(), MigrationError> {
+        if !ctx.channel_store_path.exists() {
+            return Ok(());
+        }
+        // Store::open lays down the base schema (fresh tables already carry
+        // the trimmed FK set as of OBJECT_SCHEMA_VERSION v34) before the raw
+        // connection below touches anything.
+        drop(
+            Store::open(&ctx.channel_store_path)
+                .map_err(|e| MigrationError(format!("drop_catalog_fk_from_ref_tables: open wstore: {e}")))?,
+        );
+        let conn = Connection::open(&ctx.channel_store_path)
+            .map_err(|e| MigrationError(format!("drop_catalog_fk_from_ref_tables: open: {e}")))?;
+        let rebuilt =
+            drop_catalog_fks(&conn).map_err(|e| MigrationError(format!("drop_catalog_fk_from_ref_tables: {e}")))?;
+        tracing::info!(rebuilt, "m0032_drop_catalog_fk_from_ref_tables: complete");
+        Ok(())
+    }
+
+    fn verify(&self, ctx: &MigrationContext) -> VerifyOutcome {
+        let conn = match super::runner::open_readonly(&ctx.channel_store_path) {
+            Ok(Some(c)) => c,
+            Ok(None) => return VerifyOutcome::Ok("no channel store on this data dir".into()),
+            Err(e) => return VerifyOutcome::Error(e),
+        };
+        for spec in TABLES {
+            match already_dropped(&conn, spec) {
+                Ok(true) => {}
+                Ok(false) => {
+                    return VerifyOutcome::Mismatch(format!(
+                        "{} still has a {} FK to {}",
+                        spec.name, spec.ref_col, spec.catalog_table
+                    ))
+                }
+                Err(e) => return VerifyOutcome::Error(e),
+            }
+        }
+        VerifyOutcome::Ok("every ref table's catalog-pointing FK is gone".into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx_for(channel_path: &std::path::Path) -> MigrationContext {
+        MigrationContext {
+            home: std::env::temp_dir(),
+            data_dir: std::env::temp_dir(),
+            shared_store_path: std::env::temp_dir().join("unused-shared-store.db"),
+            channel_store_path: channel_path.to_path_buf(),
+        }
+    }
+
+    #[test]
+    fn a_fresh_store_already_has_the_trimmed_fk_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("objects.db");
+        drop(Store::open(&path).unwrap());
+        let conn = Connection::open(&path).unwrap();
+        for spec in TABLES {
+            assert!(already_dropped(&conn, spec).unwrap(), "{} should already lack the catalog FK", spec.name);
+        }
+        assert_eq!(drop_catalog_fks(&conn).unwrap(), 0, "nothing to rebuild on a fresh store");
+    }
+
+    /// Simulates a pre-v34 store: the four tables still declare the catalog
+    /// FK. Rebuild must preserve every row and end up with no catalog FK.
+    fn legacy_store() -> (tempfile::TempDir, Connection) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("objects.db");
+        drop(Store::open(&path).unwrap());
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "PRAGMA foreign_keys=OFF;
+             DROP TABLE db_agent_skills_ref;
+             DROP TABLE db_agent_mcp_ref;
+             DROP TABLE db_bundle_skills_ref;
+             DROP TABLE db_bundle_mcp_ref;
+             CREATE TABLE db_agent_skills_ref (
+                agent_id TEXT NOT NULL, skill_id TEXT NOT NULL,
+                PRIMARY KEY (agent_id, skill_id),
+                FOREIGN KEY (agent_id) REFERENCES db_agents(id) ON DELETE CASCADE,
+                FOREIGN KEY (skill_id) REFERENCES db_skills(id) ON DELETE CASCADE
+             );
+             CREATE TABLE db_agent_mcp_ref (
+                agent_id TEXT NOT NULL, mcp_id TEXT NOT NULL,
+                PRIMARY KEY (agent_id, mcp_id),
+                FOREIGN KEY (agent_id) REFERENCES db_agents(id) ON DELETE CASCADE,
+                FOREIGN KEY (mcp_id) REFERENCES db_mcp_servers(id) ON DELETE CASCADE
+             );
+             CREATE TABLE db_bundle_skills_ref (
+                bundle_id TEXT NOT NULL, skill_id TEXT NOT NULL,
+                PRIMARY KEY (bundle_id, skill_id),
+                FOREIGN KEY (skill_id) REFERENCES db_skills(id) ON DELETE CASCADE
+             );
+             CREATE TABLE db_bundle_mcp_ref (
+                bundle_id TEXT NOT NULL, mcp_id TEXT NOT NULL,
+                PRIMARY KEY (bundle_id, mcp_id),
+                FOREIGN KEY (mcp_id) REFERENCES db_mcp_servers(id) ON DELETE CASCADE
+             );
+             PRAGMA foreign_keys=ON;",
+        )
+        .unwrap();
+        (dir, conn)
+    }
+
+    #[test]
+    fn an_existing_store_with_real_ref_rows_survives_the_rebuild_with_every_row_intact() {
+        let (_dir, conn) = legacy_store();
+        conn.execute_batch(
+            "INSERT INTO db_agents (id, name, provider) VALUES ('agent-1', 'A', 'claude');
+             INSERT INTO db_skills (id, name) VALUES ('skill-1', 'Greet');
+             INSERT INTO db_mcp_servers (id, name) VALUES ('mcp-1', 'Server');
+             INSERT INTO db_agent_skills_ref (agent_id, skill_id) VALUES ('agent-1', 'skill-1');
+             INSERT INTO db_agent_mcp_ref (agent_id, mcp_id) VALUES ('agent-1', 'mcp-1');
+             INSERT INTO db_bundle_skills_ref (bundle_id, skill_id) VALUES ('bundle-1', 'skill-1');
+             INSERT INTO db_bundle_mcp_ref (bundle_id, mcp_id) VALUES ('bundle-1', 'mcp-1');",
+        )
+        .unwrap();
+
+        assert_eq!(drop_catalog_fks(&conn).unwrap(), 4, "all four tables need a rebuild");
+
+        for spec in TABLES {
+            assert!(already_dropped(&conn, spec).unwrap(), "{} must have no catalog FK after rebuild", spec.name);
+        }
+        let counts: Vec<i64> = [
+            "db_agent_skills_ref",
+            "db_agent_mcp_ref",
+            "db_bundle_skills_ref",
+            "db_bundle_mcp_ref",
+        ]
+        .iter()
+        .map(|t| conn.query_row(&format!("SELECT COUNT(*) FROM {t}"), [], |r| r.get(0)).unwrap())
+        .collect();
+        assert_eq!(counts, vec![1, 1, 1, 1], "every row must survive the rebuild");
+
+        // agent_id's FK to db_agents must still be enforced on the two
+        // agent-level tables — only the catalog FK was dropped.
+        let agent_fk_err = conn.execute(
+            "INSERT INTO db_agent_skills_ref (agent_id, skill_id) VALUES ('no-such-agent', 'skill-1')",
+            [],
+        );
+        assert!(agent_fk_err.is_err(), "agent_id FK to db_agents must still be enforced");
+    }
+
+    /// The whole point of Part A: binding a skill_id with NO local db_skills
+    /// row (the post-redirect state, once catalog writes move to
+    /// identity_store) must succeed once the FK is gone.
+    #[test]
+    fn binding_a_skill_id_with_no_local_catalog_row_succeeds_after_the_rebuild() {
+        let (_dir, conn) = legacy_store();
+        conn.execute("INSERT INTO db_agents (id, name, provider) VALUES ('agent-1', 'A', 'claude')", [])
+            .unwrap();
+        drop_catalog_fks(&conn).unwrap();
+
+        // No db_skills/db_mcp_servers row exists locally for these ids at
+        // all — simulating a catalog row that only ever lived in
+        // identity_store post-redirect.
+        conn.execute(
+            "INSERT INTO db_agent_skills_ref (agent_id, skill_id) VALUES ('agent-1', 'identity-store-only-skill')",
+            [],
+        )
+        .expect("binding a skill with no local catalog row must succeed once the FK is dropped");
+        conn.execute(
+            "INSERT INTO db_agent_mcp_ref (agent_id, mcp_id) VALUES ('agent-1', 'identity-store-only-mcp')",
+            [],
+        )
+        .expect("binding an mcp server with no local catalog row must succeed once the FK is dropped");
+        conn.execute(
+            "INSERT INTO db_bundle_skills_ref (bundle_id, skill_id) VALUES ('bundle-1', 'identity-store-only-skill')",
+            [],
+        )
+        .expect("bundle-level skill bind with no local catalog row must succeed once the FK is dropped");
+        conn.execute(
+            "INSERT INTO db_bundle_mcp_ref (bundle_id, mcp_id) VALUES ('bundle-1', 'identity-store-only-mcp')",
+            [],
+        )
+        .expect("bundle-level mcp bind with no local catalog row must succeed once the FK is dropped");
+    }
+
+    #[test]
+    fn a_non_existent_channel_store_is_a_no_op() {
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = ctx_for(&dir.path().join("does-not-exist.db"));
+        assert!(M0032DropCatalogFkFromRefTables.up(&ctx).is_ok());
+    }
+
+    #[test]
+    fn re_running_after_a_rebuild_is_idempotent() {
+        let (_dir, conn) = legacy_store();
+        conn.execute("INSERT INTO db_agents (id, name, provider) VALUES ('agent-1', 'A', 'claude')", [])
+            .unwrap();
+        assert_eq!(drop_catalog_fks(&conn).unwrap(), 4);
+        assert_eq!(drop_catalog_fks(&conn).unwrap(), 0, "a second pass must find nothing left to rebuild");
+    }
+}

--- a/agentmux-srv/src/migrations/m0033_narrow_skill_global_uniqueness_index.rs
+++ b/agentmux-srv/src/migrations/m0033_narrow_skill_global_uniqueness_index.rs
@@ -1,0 +1,481 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Narrow the global skill uniqueness index from `(name, skill_type)` to
+//! `name` alone, matching the invariant `skill_upsert_unique_global`'s own
+//! dup-check has always enforced — with a defensive dedup pass for any
+//! existing same-name/different-type pair the OLD, wider index let through.
+//!
+//! Part B of Phase 2's application-layer redirect,
+//! `SPEC_DURABLE_BINDINGS_2026_09_10.md` §5.4 (Codex P2, PR #3182).
+//! `idx_ids_skills_global_name_type` (`IDENTITY_STORE_SCHEMA_VERSION` v7) is
+//! narrower than what the application actually promises ("a global skill's
+//! name is unique, full stop, regardless of type" — see
+//! `managed_upsert_unique_global`'s error message). MCP servers don't have
+//! this mismatch (`idx_ids_mcp_servers_global_name` is already name-only) —
+//! this migration is skills-specific.
+//!
+//! Because `m0031_carry_skills_and_mcp_servers_to_identity_store`'s own dedup
+//! key is `(name, skill_type)`, a store that already ran that migration (in
+//! an earlier release) may already hold two global `db_skills` rows sharing
+//! a name with different types — exactly the pair the OLD index allowed and
+//! the NEW one would reject outright. This migration detects any such
+//! group (not assuming exactly two), collapses to the earliest-`created_at`
+//! row (ties broken by id), rewrites refs, deletes the loser(s), and only
+//! THEN creates the new index — in that order, since creating a UNIQUE
+//! index over still-colliding data would fail.
+//!
+//! ## Cross-channel ref cleanup is intentionally partial
+//!
+//! `db_agent_skills_ref`/`db_bundle_skills_ref` live in EACH CHANNEL's own
+//! `wstore`, not in the identity store this migration (Global-scoped) opens.
+//! A single global migration run cannot reach every channel's ref rows the
+//! way `m0022_identity_store_links_backfill` reads multiple sources —
+//! reaching in and WRITING to a sibling channel's live `objects.db` from a
+//! process that isn't running that channel is the same unnecessary risk
+//! `m0031`'s own doc comment already declines to take. So this migration
+//! rewrites only the CURRENT channel's refs (the one whose `objects.db` is
+//! in `MigrationContext`); any other channel's ref rows still pointing at a
+//! collapsed-away loser id are left dangling until that channel's own next
+//! boot runs this same migration and would have to reconcile them itself —
+//! except this migration is Global-scoped and runs exactly ONCE across every
+//! channel, so a sibling channel never gets a second pass. This mirrors the
+//! already-accepted "cross-channel dangling refs on catalog delete" gap
+//! §5.4 documents elsewhere (a dangling ref degrades gracefully: `skill_get`
+//! against a superseded id returns `None`, which every read path already
+//! handles as "this bound skill no longer exists"), not a new regression —
+//! but it is a real, acknowledged incompleteness worth a second look.
+
+use rusqlite::Connection;
+
+use crate::backend::storage::store::Store;
+use crate::registry;
+
+use super::{Migration, MigrationContext, MigrationError, MigrationScope, VerifyOutcome};
+
+pub struct M0033NarrowSkillGlobalUniquenessIndex;
+
+/// One global skill row's identity, for grouping/collapsing.
+struct GlobalSkillRow {
+    id: String,
+    name: String,
+    created_at: i64,
+}
+
+/// Collapse every group of global `db_skills` rows sharing a `name` (however
+/// large) to the earliest-`created_at` row (ties broken by `id`, for
+/// determinism), rewriting `channel_wstore`'s own ref rows (if given) and
+/// deleting the loser(s) from `identity_conn`'s `db_skills` — then swaps the
+/// uniqueness index. Returns the number of rows collapsed away.
+///
+/// Takes explicit connections/stores rather than resolving paths itself so
+/// it can be exercised directly in tests without depending on
+/// `registry::resolve_identity_store_path`'s env-var-driven resolution (the
+/// same reason `m0031`'s `carry_skills`/`carry_mcp_servers` take explicit
+/// `Store` params instead of opening their own).
+fn collapse_and_reindex(identity_conn: &Connection, channel_wstore: Option<&Store>) -> Result<usize, String> {
+    let mut stmt = identity_conn
+        .prepare("SELECT id, name, created_at FROM db_skills WHERE is_global = 1 ORDER BY name, created_at ASC, id ASC")
+        .map_err(|e| format!("prepare global skills scan: {e}"))?;
+    let rows: Vec<GlobalSkillRow> = stmt
+        .query_map([], |row| {
+            Ok(GlobalSkillRow {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                created_at: row.get(2)?,
+            })
+        })
+        .and_then(|rows| rows.collect::<Result<Vec<_>, _>>())
+        .map_err(|e| format!("read global skills: {e}"))?;
+    drop(stmt);
+
+    // Group by name, preserving the query's own (name, created_at, id)
+    // order within each group — first element is already the survivor.
+    let mut groups: std::collections::BTreeMap<String, Vec<GlobalSkillRow>> = std::collections::BTreeMap::new();
+    for row in rows {
+        groups.entry(row.name.clone()).or_default().push(row);
+    }
+
+    let mut collapsed = 0usize;
+    for (_, mut members) in groups {
+        if members.len() < 2 {
+            continue;
+        }
+        // Deterministic survivor: earliest created_at, ties broken by id.
+        // The SELECT's ORDER BY already sorted this way, but sort again
+        // explicitly so this function's correctness doesn't depend on the
+        // query staying in sync with this comment.
+        members.sort_by(|a, b| a.created_at.cmp(&b.created_at).then_with(|| a.id.cmp(&b.id)));
+        let survivor_id = members[0].id.clone();
+        for loser in &members[1..] {
+            if let Some(wstore) = channel_wstore {
+                wstore
+                    .skill_rewrite_ref_id(&loser.id, &survivor_id)
+                    .map_err(|e| format!("rewrite refs for collapsed skill {}: {e}", loser.id))?;
+            }
+            identity_conn
+                .execute("DELETE FROM db_skills WHERE id = ?1", [&loser.id])
+                .map_err(|e| format!("delete collapsed skill {}: {e}", loser.id))?;
+            collapsed += 1;
+        }
+    }
+
+    // Only safe to create the narrower index AFTER every collision has been
+    // collapsed above — a UNIQUE index over still-colliding data fails.
+    identity_conn
+        .execute_batch(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_ids_skills_global_name
+                ON db_skills(name) WHERE is_global = 1;
+             DROP INDEX IF EXISTS idx_ids_skills_global_name_type;",
+        )
+        .map_err(|e| format!("swap uniqueness index: {e}"))?;
+
+    Ok(collapsed)
+}
+
+impl Migration for M0033NarrowSkillGlobalUniquenessIndex {
+    fn id(&self) -> &'static str {
+        "0033_narrow_skill_global_uniqueness_index"
+    }
+
+    fn scope(&self) -> MigrationScope {
+        MigrationScope::Global
+    }
+
+    fn description(&self) -> &'static str {
+        "Collapse any global skill rows sharing a name across skill_type, then narrow the global-uniqueness index to name alone"
+    }
+
+    fn up(&self, ctx: &MigrationContext) -> Result<(), MigrationError> {
+        let Some(path) = registry::resolve_identity_store_path() else {
+            // No resolvable identity store (CI / unusual env, same
+            // treat-as-no-op posture as m0031's own resolution failures).
+            return Ok(());
+        };
+        if !path.exists() {
+            // Nothing carried yet — a fresh store gets the new index
+            // directly from run_identity_store_schema, no dedup needed.
+            return Ok(());
+        }
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| MigrationError(format!("narrow_skill_global_uniqueness_index: create dir: {e}")))?;
+        }
+        let conn = Connection::open(&path)
+            .map_err(|e| MigrationError(format!("narrow_skill_global_uniqueness_index: open identity store: {e}")))?;
+        let has_table: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'db_skills')",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| MigrationError(format!("narrow_skill_global_uniqueness_index: probe db_skills: {e}")))?;
+        if !has_table {
+            // Older-than-v6 store: db_skills doesn't exist yet. Nothing to
+            // dedup or reindex; a later boot creates it fresh (new index
+            // included) once it's actually populated.
+            return Ok(());
+        }
+
+        let channel_wstore = if ctx.channel_store_path.exists() {
+            Some(
+                Store::open(&ctx.channel_store_path)
+                    .map_err(|e| MigrationError(format!("narrow_skill_global_uniqueness_index: open wstore: {e}")))?,
+            )
+        } else {
+            None
+        };
+
+        let collapsed = collapse_and_reindex(&conn, channel_wstore.as_ref())
+            .map_err(|e| MigrationError(format!("narrow_skill_global_uniqueness_index: {e}")))?;
+        tracing::info!(collapsed, "m0033_narrow_skill_global_uniqueness_index: complete");
+        Ok(())
+    }
+
+    fn verify(&self, _ctx: &MigrationContext) -> VerifyOutcome {
+        let Some(path) = registry::resolve_identity_store_path() else {
+            return VerifyOutcome::Ok("identity store path unresolved".to_string());
+        };
+        let conn = match super::runner::open_readonly(&path) {
+            Ok(Some(c)) => c,
+            Ok(None) => return VerifyOutcome::Ok("identity store not yet created".to_string()),
+            Err(e) => return VerifyOutcome::Error(e),
+        };
+        let dupes: i64 = match conn.query_row(
+            "SELECT COUNT(*) FROM (
+                SELECT name FROM db_skills WHERE is_global = 1 GROUP BY name HAVING COUNT(*) > 1
+             )",
+            [],
+            |row| row.get(0),
+        ) {
+            Ok(n) => n,
+            Err(rusqlite::Error::SqliteFailure(_, Some(msg))) if msg.contains("no such table") => 0,
+            Err(e) => return VerifyOutcome::Error(format!("count duplicate global skill names: {e}")),
+        };
+        if dupes > 0 {
+            return VerifyOutcome::Mismatch(format!("{dupes} global skill name(s) still have more than one row"));
+        }
+        VerifyOutcome::Ok("no duplicate global skill names remain".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A pre-v8 identity store shape: `db_skills` with the OLD
+    /// `(name, skill_type)` index, not the new name-only one — the state a
+    /// real upgrading store is in before this migration runs. Deliberately
+    /// NOT built via `Store::open_identity_store` (which would already lay
+    /// down the NEW index from this binary's own `run_identity_store_schema`
+    /// and refuse to create a colliding fixture in the first place).
+    fn legacy_identity_conn() -> (tempfile::TempDir, Connection) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("identity-store.db");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE db_skills (
+                id          TEXT PRIMARY KEY,
+                name        TEXT NOT NULL,
+                trigger     TEXT NOT NULL DEFAULT '',
+                skill_type  TEXT NOT NULL DEFAULT 'prompt',
+                description TEXT NOT NULL DEFAULT '',
+                content     TEXT NOT NULL DEFAULT '',
+                is_global   INTEGER NOT NULL DEFAULT 0,
+                created_at  INTEGER NOT NULL DEFAULT 0,
+                updated_at  INTEGER NOT NULL DEFAULT 0
+             );
+             CREATE UNIQUE INDEX idx_ids_skills_global_name_type
+                ON db_skills(name, skill_type) WHERE is_global = 1;",
+        )
+        .unwrap();
+        (dir, conn)
+    }
+
+    fn insert_skill(conn: &Connection, id: &str, name: &str, skill_type: &str, created_at: i64) {
+        conn.execute(
+            "INSERT INTO db_skills (id, name, skill_type, is_global, created_at, updated_at)
+             VALUES (?1, ?2, ?3, 1, ?4, ?4)",
+            rusqlite::params![id, name, skill_type, created_at],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn two_colliding_global_skills_are_collapsed_to_the_earliest_created_at_row() {
+        let (_dir, conn) = legacy_identity_conn();
+        insert_skill(&conn, "newer", "Deploy", "prompt", 200);
+        insert_skill(&conn, "older", "Deploy", "agent-skill", 100);
+
+        let collapsed = collapse_and_reindex(&conn, None).unwrap();
+        assert_eq!(collapsed, 1);
+
+        let remaining: Vec<String> = {
+            let mut stmt = conn.prepare("SELECT id FROM db_skills").unwrap();
+            stmt.query_map([], |r| r.get::<_, String>(0)).unwrap().map(|r| r.unwrap()).collect()
+        };
+        assert_eq!(remaining, vec!["older".to_string()], "the earliest created_at row must survive");
+    }
+
+    #[test]
+    fn a_larger_group_of_collisions_collapses_to_one_survivor() {
+        let (_dir, conn) = legacy_identity_conn();
+        insert_skill(&conn, "c", "Deploy", "prompt", 300);
+        insert_skill(&conn, "a", "Deploy", "agent-skill", 100);
+        insert_skill(&conn, "b", "Deploy", "shell", 200);
+
+        let collapsed = collapse_and_reindex(&conn, None).unwrap();
+        assert_eq!(collapsed, 2, "must not assume exactly two colliding rows");
+
+        let remaining: i64 = conn.query_row("SELECT COUNT(*) FROM db_skills", [], |r| r.get(0)).unwrap();
+        assert_eq!(remaining, 1);
+        let survivor: String = conn.query_row("SELECT id FROM db_skills", [], |r| r.get(0)).unwrap();
+        assert_eq!(survivor, "a");
+    }
+
+    #[test]
+    fn ties_in_created_at_are_broken_deterministically_by_id() {
+        let (_dir, conn) = legacy_identity_conn();
+        insert_skill(&conn, "zzz", "Deploy", "prompt", 100);
+        insert_skill(&conn, "aaa", "Deploy", "agent-skill", 100);
+
+        collapse_and_reindex(&conn, None).unwrap();
+        let survivor: String = conn.query_row("SELECT id FROM db_skills", [], |r| r.get(0)).unwrap();
+        assert_eq!(survivor, "aaa", "the lexicographically smaller id must win a created_at tie");
+    }
+
+    #[test]
+    fn the_current_channels_ref_rows_are_rewritten_to_the_survivor() {
+        let (_dir, conn) = legacy_identity_conn();
+        insert_skill(&conn, "loser", "Deploy", "prompt", 200);
+        insert_skill(&conn, "winner", "Deploy", "agent-skill", 100);
+
+        let wstore = Store::open_in_memory().unwrap();
+        // Insert the ref row directly rather than through `skill_bind` — the
+        // catalog row lives only in the raw identity `conn` above (not
+        // wrapped as a `Store`), and `skill_bind` now checks catalog
+        // existence (Part C of SPEC_DURABLE_BINDINGS_2026_09_10.md). This
+        // test is only exercising `skill_rewrite_ref_id`'s effect on the ref
+        // table, same as m0031's own tests seed ref rows directly.
+        {
+            let raw = wstore.conn().lock().unwrap();
+            raw.execute("INSERT INTO db_agents (id, name, provider) VALUES ('agent-1', 'A', 'claude')", [])
+                .unwrap();
+            raw.execute("INSERT INTO db_agent_skills_ref (agent_id, skill_id) VALUES ('agent-1', 'loser')", [])
+                .unwrap();
+        }
+
+        collapse_and_reindex(&conn, Some(&wstore)).unwrap();
+
+        assert!(wstore.skill_is_bound_to("agent-1", "winner").unwrap(), "the ref must now point at the survivor");
+        assert!(!wstore.skill_is_bound_to("agent-1", "loser").unwrap());
+    }
+
+    #[test]
+    fn the_new_index_rejects_a_fresh_same_name_insert_after_the_swap() {
+        let (_dir, conn) = legacy_identity_conn();
+        insert_skill(&conn, "existing", "Deploy", "prompt", 100);
+
+        collapse_and_reindex(&conn, None).unwrap();
+
+        let result = conn.execute(
+            "INSERT INTO db_skills (id, name, skill_type, is_global, created_at, updated_at)
+             VALUES ('new-one', 'Deploy', 'agent-skill', 1, 200, 200)",
+            [],
+        );
+        assert!(
+            result.is_err(),
+            "the new name-only index must reject a same-name insert even with a different skill_type"
+        );
+    }
+
+    #[test]
+    fn a_store_with_no_collisions_is_a_clean_no_op() {
+        let (_dir, conn) = legacy_identity_conn();
+        insert_skill(&conn, "s1", "Deploy", "prompt", 100);
+        insert_skill(&conn, "s2", "Review", "prompt", 100);
+
+        let collapsed = collapse_and_reindex(&conn, None).unwrap();
+        assert_eq!(collapsed, 0);
+
+        let remaining: i64 = conn.query_row("SELECT COUNT(*) FROM db_skills", [], |r| r.get(0)).unwrap();
+        assert_eq!(remaining, 2, "no-collision rows must be untouched");
+
+        // The index swap must still have happened even with nothing to
+        // collapse — a fresh-enough store still needs the new index.
+        let has_new_index: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_ids_skills_global_name')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(has_new_index);
+    }
+
+    // ── up()-level tests: these resolve a REAL identity store path via
+    // registry::resolve_identity_store_path(), so — same as
+    // m0022_identity_store_links_backfill's test module — they must pin
+    // AGENTMUX_HOME_OVERRIDE to an isolated temp dir under the shared
+    // process-wide env lock, never run against whatever the test process's
+    // ambient environment happens to resolve to.
+    use crate::test_support::ISOLATED_AUTH_ENV_LOCK as ENV_LOCK;
+
+    fn clear_env() {
+        std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
+        std::env::remove_var("AGENTMUX_SHARED_DIR");
+        std::env::remove_var("AGENTMUX_ISOLATED_AUTH");
+        std::env::remove_var("AGENTMUX_CHANNEL");
+        std::env::remove_var("AGENTMUX_INSTANCE_DIR");
+    }
+
+    #[test]
+    fn a_non_existent_identity_store_path_is_a_no_op() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_env();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", tmp.path());
+
+        let ctx = MigrationContext {
+            home: tmp.path().to_path_buf(),
+            data_dir: tmp.path().join("data"),
+            shared_store_path: tmp.path().join("shared").join("store.db"),
+            channel_store_path: tmp.path().join("data").join("db").join("does-not-exist.db"),
+        };
+        // Nothing has ever created identity-store.db under this fresh home.
+        assert!(M0033NarrowSkillGlobalUniquenessIndex.up(&ctx).is_ok());
+        clear_env();
+    }
+
+    /// End-to-end through `up()` itself: a real identity store (pre-v8
+    /// shape, built the same way `legacy_identity_conn` does but at the
+    /// resolved production path) with a real colliding pair, plus a real
+    /// current-channel `wstore` holding a ref row pointing at the loser —
+    /// after `up()`, the identity store has one row, the ref points at the
+    /// survivor, and the new index is in place.
+    #[test]
+    fn up_end_to_end_collapses_rewrites_refs_and_swaps_the_index() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_env();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", tmp.path());
+
+        let identity_path = registry::resolve_identity_store_path().unwrap();
+        std::fs::create_dir_all(identity_path.parent().unwrap()).unwrap();
+        {
+            let conn = Connection::open(&identity_path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE db_skills (
+                    id TEXT PRIMARY KEY, name TEXT NOT NULL, trigger TEXT NOT NULL DEFAULT '',
+                    skill_type TEXT NOT NULL DEFAULT 'prompt', description TEXT NOT NULL DEFAULT '',
+                    content TEXT NOT NULL DEFAULT '', is_global INTEGER NOT NULL DEFAULT 0,
+                    created_at INTEGER NOT NULL DEFAULT 0, updated_at INTEGER NOT NULL DEFAULT 0
+                 );
+                 CREATE UNIQUE INDEX idx_ids_skills_global_name_type
+                    ON db_skills(name, skill_type) WHERE is_global = 1;",
+            )
+            .unwrap();
+            insert_skill(&conn, "loser", "Deploy", "prompt", 200);
+            insert_skill(&conn, "winner", "Deploy", "agent-skill", 100);
+        }
+
+        let channel_store_path = tmp.path().join("data").join("db").join("objects.db");
+        std::fs::create_dir_all(channel_store_path.parent().unwrap()).unwrap();
+        {
+            let wstore = Store::open(&channel_store_path).unwrap();
+            // Direct ref-row insert, not `skill_bind` — see the identical
+            // note on `the_current_channels_ref_rows_are_rewritten_to_the_survivor`
+            // above.
+            let raw = wstore.conn().lock().unwrap();
+            raw.execute("INSERT INTO db_agents (id, name, provider) VALUES ('agent-1', 'A', 'claude')", [])
+                .unwrap();
+            raw.execute("INSERT INTO db_agent_skills_ref (agent_id, skill_id) VALUES ('agent-1', 'loser')", [])
+                .unwrap();
+        }
+
+        let ctx = MigrationContext {
+            home: tmp.path().to_path_buf(),
+            data_dir: tmp.path().join("data"),
+            shared_store_path: tmp.path().join("shared").join("store.db"),
+            channel_store_path,
+        };
+        M0033NarrowSkillGlobalUniquenessIndex.up(&ctx).unwrap();
+
+        let identity_conn = Connection::open(&identity_path).unwrap();
+        let remaining: i64 = identity_conn.query_row("SELECT COUNT(*) FROM db_skills", [], |r| r.get(0)).unwrap();
+        assert_eq!(remaining, 1, "the loser row must be gone from the identity store");
+        let survivor: String = identity_conn.query_row("SELECT id FROM db_skills", [], |r| r.get(0)).unwrap();
+        assert_eq!(survivor, "winner");
+
+        let wstore = Store::open(&ctx.channel_store_path).unwrap();
+        assert!(wstore.skill_is_bound_to("agent-1", "winner").unwrap(), "the ref must now point at the survivor");
+        assert!(!wstore.skill_is_bound_to("agent-1", "loser").unwrap());
+
+        assert!(
+            matches!(M0033NarrowSkillGlobalUniquenessIndex.verify(&ctx), VerifyOutcome::Ok(_)),
+            "no duplicate names remain, so verify() must pass"
+        );
+
+        clear_env();
+    }
+}

--- a/agentmux-srv/src/migrations/mod.rs
+++ b/agentmux-srv/src/migrations/mod.rs
@@ -76,6 +76,8 @@ mod m0028_agent_child_tables_repoint_fk;
 mod m0029_drop_legacy_agent_tables;
 mod m0030_backfill_bundle_component_refs;
 mod m0031_carry_skills_and_mcp_servers_to_identity_store;
+mod m0032_drop_catalog_fk_from_ref_tables;
+mod m0033_narrow_skill_global_uniqueness_index;
 mod runner;
 #[cfg(test)]
 mod phase5_tests;
@@ -242,4 +244,6 @@ static REGISTRY: &[&(dyn Migration + Sync)] = &[
     &m0029_drop_legacy_agent_tables::M0029DropLegacyAgentTables,
     &m0030_backfill_bundle_component_refs::M0030BackfillBundleComponentRefs,
     &m0031_carry_skills_and_mcp_servers_to_identity_store::M0031CarrySkillsAndMcpServersToIdentityStore,
+    &m0032_drop_catalog_fk_from_ref_tables::M0032DropCatalogFkFromRefTables,
+    &m0033_narrow_skill_global_uniqueness_index::M0033NarrowSkillGlobalUniquenessIndex,
 ];

--- a/agentmux-srv/src/server/agent_handlers/skills.rs
+++ b/agentmux-srv/src/server/agent_handlers/skills.rs
@@ -31,14 +31,16 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
     // silently hiding every standalone/Armory-catalog skill from the actual
     // launch flow (reagent P0 on PR #2322).
     let wstore_lfs = state.wstore.clone();
+    let identity_store_lfs = state.identity_store.clone();
     engine.register_handler(
         COMMAND_LIST_AGENT_SKILLS,
         Box::new(move |data, _ctx| {
             let wstore = wstore_lfs.clone();
+            let identity_store = identity_store_lfs.clone();
             Box::pin(async move {
                 let cmd: CommandListAgentSkillsData = serde_json::from_value(data)
                     .map_err(|e| format!("listagentskills: {e}"))?;
-                let skills = wstore.effective_skills(&cmd.agent_id);
+                let skills = wstore.effective_skills(&identity_store, &cmd.agent_id);
                 Ok(Some(serde_json::to_value(&skills).unwrap_or_default()))
             })
         }),

--- a/agentmux-srv/src/server/app_api/agent_open.rs
+++ b/agentmux-srv/src/server/app_api/agent_open.rs
@@ -662,7 +662,7 @@ pub(crate) async fn open_agent_impl(
                 //    missing and overwrites whatever's there. Same-
                 //    name same-hour launches will share a workdir;
                 //    proper allocation is tracked as a follow-up.
-                write_agent_config_files(&wstore, &app_state.id_store, &agent, routing_id, &work_dir)?;
+                write_agent_config_files(&wstore, &app_state.id_store, &app_state.identity_store, &agent, routing_id, &work_dir)?;
 
                 // 9. Register controller (resync)
                 let block_for_resync = wstore.must_get::<Block>(&block_id)
@@ -728,6 +728,7 @@ pub(crate) async fn open_agent_impl(
 pub(super) fn write_agent_config_files(
     wstore: &Store,
     id_store: &Store,
+    identity_store: &Store,
     agent: &crate::backend::storage::AgentDefinition,
     agent_slug: &str,
     work_dir: &str,
@@ -790,7 +791,7 @@ pub(super) fn write_agent_config_files(
     // db_agent_skills. See Store::effective_skills for the merge algorithm —
     // shared with the `listagentskills` RPC handler so the frontend's
     // pre-launch skill fetch and this materialization path never diverge.
-    let effective_skills = wstore.effective_skills(&agent.id);
+    let effective_skills = wstore.effective_skills(identity_store, &agent.id);
 
     let mut config_files = crate::backend::agent_config::build_config_files(
         &content_map,
@@ -809,7 +810,7 @@ pub(super) fn write_agent_config_files(
     // `effective_mcp_servers` (not the raw `mcp_server_list`) also unions in
     // the agent's bound bundle's own referenced servers — composable model
     // v2, docs/specs/SPEC_BUNDLE_AS_CONTAINER_V2_2026_08_17.md.
-    let visible_mcp: Vec<crate::backend::storage::McpServer> = wstore.effective_mcp_servers(&agent.id); // own refs + bundle refs + globals
+    let visible_mcp: Vec<crate::backend::storage::McpServer> = wstore.effective_mcp_servers(identity_store, &agent.id); // own refs + bundle refs + globals
     // reagentx P1 on PR #2639: has_own_mcp_refs must reflect ONLY the
     // agent's own direct binds, computed from the raw (pre-bundle-union)
     // mcp_server_list — NOT from `visible_mcp` above, which already
@@ -820,7 +821,7 @@ pub(super) fn write_agent_config_files(
     // silently dropped, even though the agent itself never bound anything.
     // Same fix as effective_skills's has_own_skill_refs — see its own
     // comment for the full reasoning.
-    let has_own_mcp_refs = wstore.mcp_server_list(&agent.id)
+    let has_own_mcp_refs = wstore.mcp_server_list(identity_store, &agent.id)
         .unwrap_or_default()
         .iter()
         .any(|item| !item.server.is_global);
@@ -1098,17 +1099,17 @@ mod write_agent_config_files_tests {
 
         let mut agent = make_agent("agent-1", work_dir_str);
         wstore.agent_def_insert(&mut agent).unwrap();
-        wstore.skill_upsert_unique("agent-1", &make_skill("agent-skill"), true).unwrap();
+        wstore.skill_upsert_unique(&wstore, "agent-1", &make_skill("agent-skill"), true).unwrap();
 
-        write_agent_config_files(&wstore, &id_store, &agent, "test-agent", work_dir_str).unwrap();
+        write_agent_config_files(&wstore, &id_store, &wstore, &agent, "test-agent", work_dir_str).unwrap();
         let skill_md = work_dir.path().join(".claude/skills/deploy/SKILL.md");
         assert!(skill_md.exists(), "expected .claude/skills/deploy/SKILL.md to be written");
 
         // Flip the same skill to "prompt" format and relaunch.
         let mut prompt_skill = make_skill("prompt");
         prompt_skill.updated_at = 1_700_000_000_001;
-        wstore.skill_upsert_unique("agent-1", &prompt_skill, true).unwrap();
-        write_agent_config_files(&wstore, &id_store, &agent, "test-agent", work_dir_str).unwrap();
+        wstore.skill_upsert_unique(&wstore, "agent-1", &prompt_skill, true).unwrap();
+        write_agent_config_files(&wstore, &id_store, &wstore, &agent, "test-agent", work_dir_str).unwrap();
 
         let command_md = work_dir.path().join(".claude/commands/deploy.md");
         assert!(command_md.exists(), "expected .claude/commands/deploy.md to be written");
@@ -1139,9 +1140,9 @@ mod write_agent_config_files_tests {
         std::fs::create_dir_all(user_file.parent().unwrap()).unwrap();
         std::fs::write(&user_file, "# hand-authored, not from AgentMux").unwrap();
 
-        wstore.skill_upsert_unique("agent-1", &make_skill("agent-skill"), true).unwrap();
-        write_agent_config_files(&wstore, &id_store, &agent, "test-agent", work_dir_str).unwrap();
-        write_agent_config_files(&wstore, &id_store, &agent, "test-agent", work_dir_str).unwrap();
+        wstore.skill_upsert_unique(&wstore, "agent-1", &make_skill("agent-skill"), true).unwrap();
+        write_agent_config_files(&wstore, &id_store, &wstore, &agent, "test-agent", work_dir_str).unwrap();
+        write_agent_config_files(&wstore, &id_store, &wstore, &agent, "test-agent", work_dir_str).unwrap();
 
         assert!(user_file.exists(), "hand-authored file outside AgentMux's manifest must survive");
     }
@@ -1182,7 +1183,7 @@ mod write_agent_config_files_tests {
 
         // No skills at all this run, so the manifest's one entry is "stale"
         // and would normally be deleted.
-        write_agent_config_files(&wstore, &id_store, &agent, "test-agent", work_dir_str).unwrap();
+        write_agent_config_files(&wstore, &id_store, &wstore, &agent, "test-agent", work_dir_str).unwrap();
 
         assert!(sentinel.exists(), "file outside the working directory must never be deleted");
     }
@@ -1228,6 +1229,7 @@ mod write_agent_config_files_tests {
             .unwrap();
         wstore
             .mcp_server_upsert_unique(
+                &wstore,
                 "some-other-context",
                 &crate::backend::storage::McpServer {
                     id: "bundle-private-server".to_string(),
@@ -1241,7 +1243,7 @@ mod write_agent_config_files_tests {
                 false,
             )
             .unwrap_or(());
-        wstore.bundle_mcp_bind(&wstore, "bundle-1", "bundle-private-server").unwrap();
+        wstore.bundle_mcp_bind(&wstore, &wstore, "bundle-1", "bundle-private-server").unwrap();
         // agent-1 itself has NO own db_mcp_servers ref — only its bundle does.
 
         wstore
@@ -1253,7 +1255,7 @@ mod write_agent_config_files_tests {
             })
             .unwrap();
 
-        write_agent_config_files(&wstore, &id_store, &agent, "test-agent", work_dir_str).unwrap();
+        write_agent_config_files(&wstore, &id_store, &wstore, &agent, "test-agent", work_dir_str).unwrap();
 
         let mcp_json_path = work_dir.path().join(".mcp.json");
         let mcp_json = std::fs::read_to_string(&mcp_json_path).unwrap();

--- a/agentmux-srv/src/server/app_api/bundle.rs
+++ b/agentmux-srv/src/server/app_api/bundle.rs
@@ -110,9 +110,11 @@ fn register_bundle_get(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_bundle_validate(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     let handler: crate::backend::rpc::engine::CommandHandler = Box::new(move |data, _ctx| {
         let wstore = wstore.clone();
-        Box::pin(async move { Ok(Some(bundle_validate_impl(&wstore, data)?)) })
+        let identity_store = identity_store.clone();
+        Box::pin(async move { Ok(Some(bundle_validate_impl(&wstore, &identity_store, data)?)) })
     });
     engine.register_handler(COMMAND_BUNDLE_VALIDATE, handler);
 }
@@ -493,15 +495,17 @@ struct ExportReq {
 fn register_bundle_export(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let id_store = state.id_store.clone();
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     engine.register_handler(
         COMMAND_BUNDLE_EXPORT,
         Box::new(move |data, _ctx| {
             let id_store = id_store.clone();
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             Box::pin(async move {
                 let req: ExportReq = serde_json::from_value(data)
                     .map_err(|e| format!("bundle.export: {e}"))?;
-                bundle_export_impl(&id_store, &wstore, req).map(Some)
+                bundle_export_impl(&id_store, &wstore, &identity_store, req).map(Some)
             })
         }),
     );
@@ -515,6 +519,7 @@ fn register_bundle_export(engine: &Arc<WshRpcEngine>, state: &AppState) {
 fn bundle_export_impl(
     id_store: &crate::backend::storage::store::Store,
     wstore: &crate::backend::storage::store::Store,
+    identity_store: &crate::backend::storage::store::Store,
     req: ExportReq,
 ) -> Result<serde_json::Value, String> {
     let bundle = id_store
@@ -524,7 +529,7 @@ fn bundle_export_impl(
 
     // Components come from the ref tables, which are authoritative for what a
     // bundle contains -- see resolve_bundle_components.
-    let components = resolve_bundle_components(wstore, &bundle.id)
+    let components = resolve_bundle_components(wstore, identity_store, &bundle.id)
         .map_err(|e| format!("bundle.export: {e}"))?;
     let mut handler_warnings = components.warnings;
 
@@ -620,6 +625,7 @@ pub(crate) fn purge_bundle_component_refs(
 fn bind_imported_components(
     wstore: &crate::backend::storage::store::Store,
     id_store: &crate::backend::storage::store::Store,
+    identity_store: &crate::backend::storage::store::Store,
     bundle_id: &str,
     imported_skill_ids: &[String],
     mcp_configs: &[serde_json::Value],
@@ -627,7 +633,7 @@ fn bind_imported_components(
     let mut warnings: Vec<String> = Vec::new();
 
     for skill_id in imported_skill_ids {
-        if let Err(e) = wstore.bundle_skill_bind(id_store, bundle_id, skill_id) {
+        if let Err(e) = wstore.bundle_skill_bind(identity_store, id_store, bundle_id, skill_id) {
             warnings.push(format!(
                 "skills: imported skill {skill_id} could not be bound to the bundle ({e}) — it will not be exported or reach the agent"
             ));
@@ -638,7 +644,7 @@ fn bind_imported_components(
     // import and one recovered from an old inline column end up identical,
     // including duplicate-name handling.
     let (_created, mcp_warnings) =
-        wstore.bundle_mcp_bind_inline_entries(id_store, bundle_id, mcp_configs, now_ms());
+        wstore.bundle_mcp_bind_inline_entries(identity_store, id_store, bundle_id, mcp_configs, now_ms());
     warnings.extend(mcp_warnings);
 
     warnings
@@ -680,10 +686,11 @@ pub(super) struct ResolvedComponents {
 /// is inert, since `PRAGMA foreign_keys` is only ever set ON in tests.
 pub(super) fn resolve_bundle_components(
     wstore: &crate::backend::storage::store::Store,
+    identity_store: &crate::backend::storage::store::Store,
     bundle_id: &str,
 ) -> Result<ResolvedComponents, String> {
     let skills: Vec<crate::backend::storage::Skill> = wstore
-        .bundle_skill_list(bundle_id)
+        .bundle_skill_list(identity_store, bundle_id)
         .map_err(|e| format!("failed to resolve bundle skills: {e}"))?
         .into_iter()
         .filter(|item| item.bound_to_bundle)
@@ -693,7 +700,7 @@ pub(super) fn resolve_bundle_components(
     let mut warnings: Vec<String> = Vec::new();
     let mut mcp_entries: Vec<serde_json::Value> = Vec::new();
     for item in wstore
-        .bundle_mcp_list(bundle_id)
+        .bundle_mcp_list(identity_store, bundle_id)
         .map_err(|e| format!("failed to resolve bundle MCP servers: {e}"))?
         .into_iter()
         .filter(|item| item.bound_to_bundle)
@@ -1044,6 +1051,7 @@ struct ExportForAgentReq {
 async fn build_export_for_agent(
     id_store: &crate::backend::storage::store::Store,
     wstore: &crate::backend::storage::store::Store,
+    identity_store: &crate::backend::storage::store::Store,
     bundle_id: &str,
     agent_id: &str,
     err_prefix: &str,
@@ -1064,7 +1072,7 @@ async fn build_export_for_agent(
 
     // Same resolver as the agent-less path, so the two cannot disagree about
     // what the bundle contains.
-    let components = resolve_bundle_components(wstore, &bundle.id)
+    let components = resolve_bundle_components(wstore, identity_store, &bundle.id)
         .map_err(|e| format!("{err_prefix}: {e}"))?;
     let mut handler_warnings = components.warnings;
     // Always empty now — see the note at the agent-less export path.
@@ -1141,10 +1149,11 @@ async fn build_export_for_agent(
 async fn bundle_export_for_agent_impl(
     id_store: &crate::backend::storage::store::Store,
     wstore: &crate::backend::storage::store::Store,
+    identity_store: &crate::backend::storage::store::Store,
     req: ExportForAgentReq,
 ) -> Result<serde_json::Value, String> {
     let (export, _agent, all_warnings, missing_skill_ids) =
-        build_export_for_agent(id_store, wstore, &req.bundle_id, &req.agent_id, "bundle.export_for_agent").await?;
+        build_export_for_agent(id_store, wstore, identity_store, &req.bundle_id, &req.agent_id, "bundle.export_for_agent").await?;
 
     if req.format == "zip" {
         let zip_bytes = crate::backend::bundle_export::zip_bundle_export(&export)
@@ -1271,6 +1280,7 @@ async fn bundle_export_for_agent_with_history_impl(
     let (export, _agent, all_warnings, missing_skill_ids) = build_export_for_agent(
         &id_store,
         wstore,
+        &identity_store,
         &req.bundle_id,
         &req.agent_id,
         "bundle.export_for_agent_with_history",
@@ -1379,15 +1389,17 @@ async fn bundle_export_for_agent_with_history_impl(
 fn register_bundle_export_for_agent(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let id_store = state.id_store.clone();
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     engine.register_handler(
         COMMAND_BUNDLE_EXPORT_FOR_AGENT,
         Box::new(move |data, _ctx| {
             let id_store = id_store.clone();
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             Box::pin(async move {
                 let req: ExportForAgentReq = serde_json::from_value(data)
                     .map_err(|e| format!("bundle.export_for_agent: {e}"))?;
-                bundle_export_for_agent_impl(&id_store, &wstore, req).await.map(Some)
+                bundle_export_for_agent_impl(&id_store, &wstore, &identity_store, req).await.map(Some)
             })
         }),
     );
@@ -1442,6 +1454,7 @@ struct ImportForAgentReq {
 /// `bundle_import_preview_impl`'s pattern.
 async fn bundle_import_for_agent_impl(
     id_store: &crate::backend::storage::store::Store,
+    identity_store: &crate::backend::storage::store::Store,
     wstore: &crate::backend::storage::store::Store,
     req: ImportForAgentReq,
 ) -> Result<serde_json::Value, String> {
@@ -1545,7 +1558,7 @@ async fn bundle_import_for_agent_impl(
     // the caller to know cleanup may be needed.
     let rollback_skills = |ids: &[String]| -> Vec<String> {
         ids.iter()
-            .filter_map(|id| wstore.skill_delete(id).err().map(|e| format!("{id}: {e}")))
+            .filter_map(|id| wstore.skill_delete(identity_store, id).err().map(|e| format!("{id}: {e}")))
             .collect()
     };
     for skill in &parsed.skills {
@@ -1560,7 +1573,7 @@ async fn bundle_import_for_agent_impl(
             created_at: now,
             updated_at: now,
         };
-        match wstore.skill_upsert_unique_global(&row) {
+        match identity_store.skill_upsert_unique_global(&row) {
             Ok(()) => imported_skill_ids.push(row.id),
             Err(e) if e.to_string().contains("already exists") => {
                 warnings.push(format!("skill \"{}\" already exists; skipped", skill.slug));
@@ -1621,6 +1634,7 @@ async fn bundle_import_for_agent_impl(
     warnings.extend(bind_imported_components(
         wstore,
         id_store,
+        identity_store,
         &bundle_id,
         &imported_skill_ids,
         &parsed.mcp_servers.iter().map(|m| m.config.clone()).collect::<Vec<_>>(),
@@ -1700,16 +1714,18 @@ async fn bundle_import_for_agent_impl(
 
 fn register_bundle_import_for_agent(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let id_store = state.id_store.clone();
+    let identity_store = state.identity_store.clone();
     let wstore = state.wstore.clone();
     engine.register_handler(
         COMMAND_BUNDLE_IMPORT_FOR_AGENT,
         Box::new(move |data, _ctx| {
             let id_store = id_store.clone();
+            let identity_store = identity_store.clone();
             let wstore = wstore.clone();
             Box::pin(async move {
                 let req: ImportForAgentReq = serde_json::from_value(data)
                     .map_err(|e| format!("bundle.import_for_agent: {e}"))?;
-                bundle_import_for_agent_impl(&id_store, &wstore, req).await.map(Some)
+                bundle_import_for_agent_impl(&id_store, &identity_store, &wstore, req).await.map(Some)
             })
         }),
     );
@@ -1814,12 +1830,14 @@ fn bounded_display(s: &str) -> String {
 /// placeholders in place).
 fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let id_store = state.id_store.clone();
+    let identity_store = state.identity_store.clone();
     let wstore = state.wstore.clone();
     let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_BUNDLE_IMPORT,
         Box::new(move |data, _ctx| {
             let id_store = id_store.clone();
+            let identity_store = identity_store.clone();
             let wstore = wstore.clone();
             let broker = broker.clone();
             Box::pin(async move {
@@ -1927,7 +1945,7 @@ fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // not have fully succeeded.
                 let rollback_skills = |ids: &[String]| -> Vec<String> {
                     ids.iter()
-                        .filter_map(|id| wstore.skill_delete(id).err().map(|e| format!("{id}: {e}")))
+                        .filter_map(|id| wstore.skill_delete(&identity_store, id).err().map(|e| format!("{id}: {e}")))
                         .collect()
                 };
 
@@ -1946,7 +1964,7 @@ fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         created_at: now,
                         updated_at: now,
                     };
-                    match wstore.skill_upsert_unique_global(&row) {
+                    match identity_store.skill_upsert_unique_global(&row) {
                         Ok(()) => imported_skill_ids.push(row.id),
                         Err(crate::backend::storage::error::StoreError::Other(msg))
                             if msg.contains("already exists") =>
@@ -2043,6 +2061,7 @@ fn register_bundle_import(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 warnings.extend(bind_imported_components(
                     &wstore,
                     &id_store,
+                    &identity_store,
                     &memory.id,
                     &imported_skill_ids,
                     &parsed.mcp_servers.iter().map(|m| m.config.clone()).collect::<Vec<_>>(),
@@ -2250,6 +2269,7 @@ struct PreviewReq {
 /// only deserializes the request and forwards).
 async fn bundle_import_preview_impl(
     id_store: &crate::backend::storage::store::Store,
+    identity_store: &crate::backend::storage::store::Store,
     wstore: &crate::backend::storage::store::Store,
     req: PreviewReq,
 ) -> Result<serde_json::Value, String> {
@@ -2266,7 +2286,7 @@ async fn bundle_import_preview_impl(
 
     // Skill collision detection (§3.1, two-pass).
     let global_slugs: std::collections::HashSet<String> = wstore
-        .skill_list_global()
+        .skill_list_global(identity_store)
         .map_err(|e| format!("bundle.import.preview: {e}"))?
         .into_iter()
         .map(|item| item.skill.name)
@@ -2384,16 +2404,18 @@ async fn bundle_import_preview_impl(
 
 fn register_bundle_import_preview(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let id_store = state.id_store.clone();
+    let identity_store = state.identity_store.clone();
     let wstore = state.wstore.clone();
     engine.register_handler(
         COMMAND_BUNDLE_IMPORT_PREVIEW,
         Box::new(move |data, _ctx| {
             let id_store = id_store.clone();
+            let identity_store = identity_store.clone();
             let wstore = wstore.clone();
             Box::pin(async move {
                 let req: PreviewReq = serde_json::from_value(data)
                     .map_err(|e| format!("bundle.import.preview: {e}"))?;
-                Ok(Some(bundle_import_preview_impl(&id_store, &wstore, req).await?))
+                Ok(Some(bundle_import_preview_impl(&id_store, &identity_store, &wstore, req).await?))
             })
         }),
     );
@@ -2438,6 +2460,7 @@ struct CommitReq {
 /// forwards).
 async fn bundle_import_commit_impl(
     id_store: &crate::backend::storage::store::Store,
+    identity_store: &crate::backend::storage::store::Store,
     wstore: &crate::backend::storage::store::Store,
     broker: &crate::backend::wps::Broker,
     req: CommitReq,
@@ -2535,7 +2558,7 @@ async fn bundle_import_commit_impl(
                 // an empty rename, since skill_upsert_unique_global alone
                 // wouldn't reject it until the second attempt.
                 let global_slugs: std::collections::HashSet<String> = wstore
-                    .skill_list_global()
+                    .skill_list_global(identity_store)
                     .map_err(|e| format!("bundle.import.commit: {e}"))?
                     .into_iter()
                     .map(|item| item.skill.name)
@@ -2544,7 +2567,7 @@ async fn bundle_import_commit_impl(
 
                 let rollback_skills = |ids: &[String]| -> Vec<String> {
                     ids.iter()
-                        .filter_map(|id| wstore.skill_delete(id).err().map(|e| format!("{id}: {e}")))
+                        .filter_map(|id| wstore.skill_delete(identity_store, id).err().map(|e| format!("{id}: {e}")))
                         .collect()
                 };
 
@@ -2596,7 +2619,7 @@ async fn bundle_import_commit_impl(
                         created_at: now,
                         updated_at: now,
                     };
-                    match wstore.skill_upsert_unique_global(&row) {
+                    match identity_store.skill_upsert_unique_global(&row) {
                         Ok(()) => imported_skill_ids.push(row.id),
                         Err(crate::backend::storage::error::StoreError::Other(msg))
                             if msg.contains("already exists") =>
@@ -2680,6 +2703,7 @@ async fn bundle_import_commit_impl(
                 warnings.extend(bind_imported_components(
                     &wstore,
                     &id_store,
+                    &identity_store,
                     &memory.id,
                     &imported_skill_ids,
                     &selected_mcp_servers.iter().map(|c| (*c).clone()).collect::<Vec<_>>(),
@@ -2713,18 +2737,20 @@ async fn bundle_import_commit_impl(
 
 fn register_bundle_import_commit(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let id_store = state.id_store.clone();
+    let identity_store = state.identity_store.clone();
     let wstore = state.wstore.clone();
     let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_BUNDLE_IMPORT_COMMIT,
         Box::new(move |data, _ctx| {
             let id_store = id_store.clone();
+            let identity_store = identity_store.clone();
             let wstore = wstore.clone();
             let broker = broker.clone();
             Box::pin(async move {
                 let req: CommitReq = serde_json::from_value(data)
                     .map_err(|e| format!("bundle.import.commit: {e}"))?;
-                Ok(Some(bundle_import_commit_impl(&id_store, &wstore, &broker, req).await?))
+                Ok(Some(bundle_import_commit_impl(&id_store, &identity_store, &wstore, &broker, req).await?))
             })
         }),
     );
@@ -2769,7 +2795,7 @@ mod import_preview_commit_tests {
             entry("skills/deploy/SKILL.md", &skill_md("deploy", "Runs the checklist", "1. Test\n2. Deploy")),
         ];
         let req = PreviewReq { file_path: None, zip_base64: None, files: Some(files) };
-        let resp = bundle_import_preview_impl(&state.id_store, &state.wstore, req).await.unwrap();
+        let resp = bundle_import_preview_impl(&state.id_store, &state.identity_store, &state.wstore, req).await.unwrap();
 
         assert_eq!(resp["name"], "test-bundle");
         assert_eq!(resp["instructions_preview"], "Be concise.");
@@ -2787,7 +2813,7 @@ mod import_preview_commit_tests {
         let state = test_state();
         // Seed an existing global skill named "deploy".
         state
-            .wstore
+            .identity_store
             .skill_upsert_unique_global(&crate::backend::storage::Skill {
                 id: "existing-1".to_string(),
                 name: "deploy".to_string(),
@@ -2806,7 +2832,7 @@ mod import_preview_commit_tests {
             entry("skills/deploy/SKILL.md", &skill_md("deploy", "d", "body")),
         ];
         let req = PreviewReq { file_path: None, zip_base64: None, files: Some(files) };
-        let resp = bundle_import_preview_impl(&state.id_store, &state.wstore, req).await.unwrap();
+        let resp = bundle_import_preview_impl(&state.id_store, &state.identity_store, &state.wstore, req).await.unwrap();
         assert_eq!(resp["skills"][0]["collision"], "name_conflict");
     }
 
@@ -2824,7 +2850,7 @@ mod import_preview_commit_tests {
             entry("skills/code-review-old/SKILL.md", &skill_md("code-review", "old", "body-old")),
         ];
         let req = PreviewReq { file_path: None, zip_base64: None, files: Some(files) };
-        let resp = bundle_import_preview_impl(&state.id_store, &state.wstore, req).await.unwrap();
+        let resp = bundle_import_preview_impl(&state.id_store, &state.identity_store, &state.wstore, req).await.unwrap();
         let skills = resp["skills"].as_array().unwrap();
         assert_eq!(skills.len(), 2);
         assert!(skills.iter().all(|s| s["collision"] == "duplicate_in_bundle"));
@@ -2845,7 +2871,7 @@ mod import_preview_commit_tests {
             include_skills: vec![],
             include_mcp_servers: vec![],
         };
-        let err = bundle_import_commit_impl(&state.id_store, &state.wstore, &state.broker, req)
+        let err = bundle_import_commit_impl(&state.id_store, &state.identity_store, &state.wstore, &state.broker, req)
             .await
             .unwrap_err();
         assert!(err.contains("digest mismatch"));
@@ -2870,7 +2896,7 @@ mod import_preview_commit_tests {
             include_skills: vec![],
             include_mcp_servers: vec![],
         };
-        let resp = bundle_import_commit_impl(&state.id_store, &state.wstore, &state.broker, req).await.unwrap();
+        let resp = bundle_import_commit_impl(&state.id_store, &state.identity_store, &state.wstore, &state.broker, req).await.unwrap();
         let bundle_id = resp["bundle_id"].as_str().unwrap();
         let saved = state.id_store.bundle_get(bundle_id).unwrap().unwrap();
         assert_eq!(saved.name, "Renamed Bundle");
@@ -2896,7 +2922,7 @@ mod import_preview_commit_tests {
             include_skills: vec![],
             include_mcp_servers: vec![],
         };
-        let resp = bundle_import_commit_impl(&state.id_store, &state.wstore, &state.broker, req).await.unwrap();
+        let resp = bundle_import_commit_impl(&state.id_store, &state.identity_store, &state.wstore, &state.broker, req).await.unwrap();
         let bundle_id = resp["bundle_id"].as_str().unwrap();
         let saved = state.id_store.bundle_get(bundle_id).unwrap().unwrap();
         assert_eq!(saved.name.chars().count(), bi::MAX_BUNDLE_NAME_CHARS);
@@ -2929,10 +2955,10 @@ mod import_preview_commit_tests {
             include_skills,
             include_mcp_servers: vec![],
         };
-        let resp = bundle_import_commit_impl(&state.id_store, &state.wstore, &state.broker, req).await.unwrap();
+        let resp = bundle_import_commit_impl(&state.id_store, &state.identity_store, &state.wstore, &state.broker, req).await.unwrap();
         let imported = resp["imported_skill_ids"].as_array().unwrap();
         assert_eq!(imported.len(), 1, "expected only the first occurrence of the repeated source_dir to be written");
-        let saved_skill = state.wstore.skill_get(imported[0].as_str().unwrap()).unwrap().unwrap();
+        let saved_skill = state.identity_store.skill_get(imported[0].as_str().unwrap()).unwrap().unwrap();
         assert_eq!(saved_skill.name, "deploy-0");
     }
 
@@ -2978,7 +3004,7 @@ mod import_preview_commit_tests {
             include_skills,
             include_mcp_servers: vec![],
         };
-        let resp = bundle_import_commit_impl(&state.id_store, &state.wstore, &state.broker, req).await.unwrap();
+        let resp = bundle_import_commit_impl(&state.id_store, &state.identity_store, &state.wstore, &state.broker, req).await.unwrap();
         assert!(
             resp["imported_skill_ids"].as_array().unwrap().is_empty(),
             "the three real selections beyond the MAX_IMPORTED_SKILLS boundary must be dropped by the cap, not imported"
@@ -3010,7 +3036,7 @@ mod import_preview_commit_tests {
             include_skills: vec![],
             include_mcp_servers: vec![],
         };
-        let resp = bundle_import_commit_impl(&state.id_store, &state.wstore, &state.broker, req).await.unwrap();
+        let resp = bundle_import_commit_impl(&state.id_store, &state.identity_store, &state.wstore, &state.broker, req).await.unwrap();
         let bundle_id = resp["bundle_id"].as_str().unwrap();
         let saved = state.id_store.bundle_get(bundle_id).unwrap().unwrap();
         assert!(saved.context_files.contains("content B"));
@@ -3023,7 +3049,7 @@ mod import_preview_commit_tests {
         // known-conflicting slug.
         let state = test_state();
         state
-            .wstore
+            .identity_store
             .skill_upsert_unique_global(&crate::backend::storage::Skill {
                 id: "existing-1".to_string(),
                 name: "deploy".to_string(),
@@ -3055,7 +3081,7 @@ mod import_preview_commit_tests {
             include_skills: vec![SkillSelection { source_dir: "skills/deploy".to_string(), import_as: None }],
             include_mcp_servers: vec![],
         };
-        let resp = bundle_import_commit_impl(&state.id_store, &state.wstore, &state.broker, req).await.unwrap();
+        let resp = bundle_import_commit_impl(&state.id_store, &state.identity_store, &state.wstore, &state.broker, req).await.unwrap();
         assert!(resp["imported_skill_ids"].as_array().unwrap().is_empty());
         assert_eq!(resp["skipped_skills"][0], "deploy");
     }
@@ -3064,7 +3090,7 @@ mod import_preview_commit_tests {
     async fn commit_imports_colliding_skill_under_a_non_empty_rename() {
         let state = test_state();
         state
-            .wstore
+            .identity_store
             .skill_upsert_unique_global(&crate::backend::storage::Skill {
                 id: "existing-1".to_string(),
                 name: "deploy".to_string(),
@@ -3099,10 +3125,10 @@ mod import_preview_commit_tests {
             }],
             include_mcp_servers: vec![],
         };
-        let resp = bundle_import_commit_impl(&state.id_store, &state.wstore, &state.broker, req).await.unwrap();
+        let resp = bundle_import_commit_impl(&state.id_store, &state.identity_store, &state.wstore, &state.broker, req).await.unwrap();
         assert_eq!(resp["imported_skill_ids"].as_array().unwrap().len(), 1);
         let imported_id = resp["imported_skill_ids"][0].as_str().unwrap();
-        let saved_skill = state.wstore.skill_get(imported_id).unwrap().unwrap();
+        let saved_skill = state.identity_store.skill_get(imported_id).unwrap().unwrap();
         assert_eq!(saved_skill.name, "deploy-team-x");
     }
 
@@ -3117,7 +3143,7 @@ mod import_preview_commit_tests {
         let state = test_state();
         let oversized_name = "n".repeat(bi::MAX_DISPLAY_FIELD_CHARS + 500);
         state
-            .wstore
+            .identity_store
             .skill_upsert_unique_global(&crate::backend::storage::Skill {
                 id: "existing-1".to_string(),
                 name: "deploy".to_string(),
@@ -3131,7 +3157,7 @@ mod import_preview_commit_tests {
             })
             .unwrap();
         state
-            .wstore
+            .identity_store
             .skill_upsert_unique_global(&crate::backend::storage::Skill {
                 id: "existing-2".to_string(),
                 name: oversized_name.clone(),
@@ -3166,7 +3192,7 @@ mod import_preview_commit_tests {
             }],
             include_mcp_servers: vec![],
         };
-        let resp = bundle_import_commit_impl(&state.id_store, &state.wstore, &state.broker, req).await.unwrap();
+        let resp = bundle_import_commit_impl(&state.id_store, &state.identity_store, &state.wstore, &state.broker, req).await.unwrap();
         assert!(resp["imported_skill_ids"].as_array().unwrap().is_empty());
         let warnings = resp["warnings"].as_array().unwrap();
         assert!(!warnings.is_empty(), "expected an already-exists warning");
@@ -3205,7 +3231,7 @@ mod import_preview_commit_tests {
             include_skills: vec![],
             include_mcp_servers: vec!["mcp/github.server.json".to_string()],
         };
-        let resp = bundle_import_commit_impl(&state.id_store, &state.wstore, &state.broker, req).await.unwrap();
+        let resp = bundle_import_commit_impl(&state.id_store, &state.identity_store, &state.wstore, &state.broker, req).await.unwrap();
         let bundle_id = resp["bundle_id"].as_str().unwrap();
         let saved = state.id_store.bundle_get(bundle_id).unwrap().unwrap();
         let mcp_servers: serde_json::Value = serde_json::from_str(&saved.mcp_servers).unwrap();
@@ -3368,7 +3394,7 @@ mod export_import_for_agent_tests {
         };
         state
             .wstore
-            .bundle_mcp_upsert_unique(&state.id_store, bundle_id, &server, true)
+            .bundle_mcp_upsert_unique(&state.identity_store, &state.id_store, bundle_id, &server, true)
             .unwrap();
     }
 
@@ -3387,7 +3413,7 @@ mod export_import_for_agent_tests {
         };
         state
             .wstore
-            .bundle_skill_upsert_unique(&state.id_store, bundle_id, &skill, true)
+            .bundle_skill_upsert_unique(&state.identity_store, &state.id_store, bundle_id, &skill, true)
             .unwrap();
     }
 
@@ -3452,6 +3478,7 @@ mod export_import_for_agent_tests {
         let result = bundle_export_impl(
             &state.id_store,
             &state.wstore,
+            &state.identity_store,
             ExportReq { id: "bundle-1".to_string(), format: String::new() },
         )
         .unwrap();
@@ -3493,7 +3520,7 @@ mod export_import_for_agent_tests {
         bind_skill(&state, "bundle-1", "Deploy");
         bind_mcp(&state, "bundle-1", "github", r#"{"command":"gh-mcp"}"#);
 
-        let before = resolve_bundle_components(&state.wstore, "bundle-1").unwrap();
+        let before = resolve_bundle_components(&state.wstore, &state.identity_store, "bundle-1").unwrap();
         assert_eq!(before.skills.len(), 1);
         assert_eq!(before.mcp_entries.len(), 1);
 
@@ -3510,7 +3537,7 @@ mod export_import_for_agent_tests {
 
         // Re-create a bundle with the same id: it must start empty.
         make_bundle(&state, "bundle-1", "Reused id.");
-        let after = resolve_bundle_components(&state.wstore, "bundle-1").unwrap();
+        let after = resolve_bundle_components(&state.wstore, &state.identity_store, "bundle-1").unwrap();
         assert!(
             after.skills.is_empty() && after.mcp_entries.is_empty(),
             "a reused bundle id must not inherit the old bundle's components"
@@ -3530,6 +3557,7 @@ mod export_import_for_agent_tests {
 
         let report = crate::server::app_api::bundle_validate_impl(
             &state.wstore,
+            &state.identity_store,
             json!({ "id": "bundle-1", "name": "Bundle bundle-1" }),
         )
         .unwrap();
@@ -3561,6 +3589,7 @@ mod export_import_for_agent_tests {
         let result = bundle_export_for_agent_impl(
             &state.id_store,
             &state.wstore,
+            &state.identity_store,
             ExportForAgentReq {
                 bundle_id: "bundle-1".to_string(),
                 agent_id: "agent-1".to_string(),
@@ -3606,6 +3635,7 @@ mod export_import_for_agent_tests {
         let result = bundle_export_for_agent_impl(
             &state.id_store,
             &state.wstore,
+            &state.identity_store,
             ExportForAgentReq {
                 bundle_id: "bundle-1".to_string(),
                 agent_id: "agent-1".to_string(),
@@ -3839,7 +3869,7 @@ mod export_import_for_agent_tests {
         make_bundle(&state, "bundle-1", "Be helpful.");
         bind_mcp(&state, "bundle-1", "broken", "not json at all");
 
-        let components = resolve_bundle_components(&state.wstore, "bundle-1").unwrap();
+        let components = resolve_bundle_components(&state.wstore, &state.identity_store, "bundle-1").unwrap();
         assert!(components.mcp_entries.is_empty(), "unparseable config must not be exported");
         assert!(
             components.warnings.iter().any(|w| w.contains("broken") && w.contains("invalid config")),
@@ -3857,7 +3887,7 @@ mod export_import_for_agent_tests {
         make_bundle(&state, "bundle-2", "Other.");
         bind_mcp(&state, "bundle-2", "elsewhere", r#"{"command":"x"}"#);
 
-        let components = resolve_bundle_components(&state.wstore, "bundle-1").unwrap();
+        let components = resolve_bundle_components(&state.wstore, &state.identity_store, "bundle-1").unwrap();
         assert!(
             components.mcp_entries.is_empty(),
             "another bundle's server must not leak in: {:?}",
@@ -3880,7 +3910,7 @@ mod export_import_for_agent_tests {
         std::fs::create_dir_all(&memory_dir).unwrap();
         std::fs::write(memory_dir.join("MEMORY.md"), "Learned fact.").unwrap();
 
-        let result = bundle_export_for_agent_impl(&state.id_store, &state.wstore, ExportForAgentReq {
+        let result = bundle_export_for_agent_impl(&state.id_store, &state.wstore, &state.identity_store, ExportForAgentReq {
             bundle_id: "bundle-1".to_string(),
             agent_id: "agent-1".to_string(),
             format: String::new(),
@@ -3911,7 +3941,7 @@ mod export_import_for_agent_tests {
         make_agent(&state, "agent-1", "/work/proj", config_dir.path());
         make_bundle(&state, "bundle-1", "Be helpful.");
 
-        let result = bundle_export_for_agent_impl(&state.id_store, &state.wstore, ExportForAgentReq {
+        let result = bundle_export_for_agent_impl(&state.id_store, &state.wstore, &state.identity_store, ExportForAgentReq {
             bundle_id: "bundle-1".to_string(),
             agent_id: "agent-1".to_string(),
             format: String::new(),
@@ -3931,14 +3961,14 @@ mod export_import_for_agent_tests {
         make_agent(&state, "agent-1", "/work/proj", config_dir.path());
         make_bundle(&state, "bundle-1", "Be helpful.");
 
-        let err = bundle_export_for_agent_impl(&state.id_store, &state.wstore, ExportForAgentReq {
+        let err = bundle_export_for_agent_impl(&state.id_store, &state.wstore, &state.identity_store, ExportForAgentReq {
             bundle_id: "no-such-bundle".to_string(),
             agent_id: "agent-1".to_string(),
             format: String::new(),
         }).await.unwrap_err();
         assert!(err.contains("no bundle"));
 
-        let err = bundle_export_for_agent_impl(&state.id_store, &state.wstore, ExportForAgentReq {
+        let err = bundle_export_for_agent_impl(&state.id_store, &state.wstore, &state.identity_store, ExportForAgentReq {
             bundle_id: "bundle-1".to_string(),
             agent_id: "no-such-agent".to_string(),
             format: String::new(),
@@ -3985,6 +4015,7 @@ mod export_import_for_agent_tests {
         let result = bundle_export_impl(
             &state.id_store,
             &state.wstore,
+            &state.identity_store,
             ExportReq { id: "bundle-1".to_string(), format: String::new() },
         )
         .unwrap();
@@ -4027,6 +4058,7 @@ mod export_import_for_agent_tests {
         let result = bundle_export_impl(
             &state.id_store,
             &state.wstore,
+            &state.identity_store,
             ExportReq { id: "bundle-2".to_string(), format: String::new() },
         )
         .unwrap();
@@ -4132,6 +4164,7 @@ mod export_import_for_agent_tests {
 
         let result = bundle_import_for_agent_impl(
             &state.id_store,
+            &state.identity_store,
             &state.wstore,
             ImportForAgentReq {
                 agent_id: "agent-1".to_string(),
@@ -4149,7 +4182,7 @@ mod export_import_for_agent_tests {
             .expect("import must report the bundle it created")
             .to_string();
 
-        let components = resolve_bundle_components(&state.wstore, &bundle_id).unwrap();
+        let components = resolve_bundle_components(&state.wstore, &state.identity_store, &bundle_id).unwrap();
         assert_eq!(
             components.skills.len(),
             1,
@@ -4166,6 +4199,7 @@ mod export_import_for_agent_tests {
         let exported = bundle_export_impl(
             &state.id_store,
             &state.wstore,
+            &state.identity_store,
             ExportReq { id: bundle_id, format: String::new() },
         )
         .unwrap();
@@ -4187,7 +4221,7 @@ mod export_import_for_agent_tests {
         state.id_store.agent_native_memory_upsert("agent-1", "MEMORY.md", "already here", None, "/x", 5, 0).unwrap();
 
         let files = abf_files_with_memory("Be helpful.", "MEMORY.md", "Imported fact.");
-        let err = bundle_import_for_agent_impl(&state.id_store, &state.wstore, ImportForAgentReq {
+        let err = bundle_import_for_agent_impl(&state.id_store, &state.identity_store, &state.wstore, ImportForAgentReq {
             agent_id: "agent-1".to_string(),
             file_path: None,
             zip_base64: None,
@@ -4219,7 +4253,7 @@ mod export_import_for_agent_tests {
         assert!(state.id_store.agent_native_memory_list_meta("agent-1").unwrap().is_empty());
 
         let files = abf_files_with_memory("Be helpful.", "MEMORY.md", "Would-be overwrite.");
-        let err = bundle_import_for_agent_impl(&state.id_store, &state.wstore, ImportForAgentReq {
+        let err = bundle_import_for_agent_impl(&state.id_store, &state.identity_store, &state.wstore, ImportForAgentReq {
             agent_id: "agent-1".to_string(),
             file_path: None,
             zip_base64: None,
@@ -4263,7 +4297,7 @@ mod export_import_for_agent_tests {
         state.wstore.agent_def_insert(&mut def).unwrap();
 
         let files = abf_files_with_memory("Be helpful.", "MEMORY.md", "Some fact.");
-        let err = bundle_import_for_agent_impl(&state.id_store, &state.wstore, ImportForAgentReq {
+        let err = bundle_import_for_agent_impl(&state.id_store, &state.identity_store, &state.wstore, ImportForAgentReq {
             agent_id: "agent-no-workdir".to_string(),
             file_path: None,
             zip_base64: None,
@@ -4290,7 +4324,7 @@ mod export_import_for_agent_tests {
         let oversized = "x".repeat(10 * 1024 * 1024 + 1);
         std::fs::write(memory_dir.join("MEMORY.md"), &oversized).unwrap();
 
-        let result = bundle_export_for_agent_impl(&state.id_store, &state.wstore, ExportForAgentReq {
+        let result = bundle_export_for_agent_impl(&state.id_store, &state.wstore, &state.identity_store, ExportForAgentReq {
             bundle_id: "bundle-1".to_string(),
             agent_id: "agent-1".to_string(),
             format: String::new(),
@@ -4321,7 +4355,7 @@ mod export_import_for_agent_tests {
         std::fs::write(memory_dir.join("MEMORY.md"), &oversized).unwrap();
 
         // First export mirrors it (and warns).
-        let _ = bundle_export_for_agent_impl(&state.id_store, &state.wstore, ExportForAgentReq {
+        let _ = bundle_export_for_agent_impl(&state.id_store, &state.wstore, &state.identity_store, ExportForAgentReq {
             bundle_id: "bundle-1".to_string(),
             agent_id: "agent-1".to_string(),
             format: String::new(),
@@ -4330,7 +4364,7 @@ mod export_import_for_agent_tests {
         // Second export: file on disk is byte-for-byte unchanged (same
         // size+mtime), so the mirror-refresh's "unchanged" fast path
         // applies — the warning must still fire.
-        let result = bundle_export_for_agent_impl(&state.id_store, &state.wstore, ExportForAgentReq {
+        let result = bundle_export_for_agent_impl(&state.id_store, &state.wstore, &state.identity_store, ExportForAgentReq {
             bundle_id: "bundle-1".to_string(),
             agent_id: "agent-1".to_string(),
             format: String::new(),
@@ -4349,7 +4383,7 @@ mod export_import_for_agent_tests {
         make_agent(&state, "agent-1", "/work/proj", config_dir.path());
 
         let files = abf_files_with_memory("Be helpful.", "MEMORY.md", "Imported fact.");
-        let result = bundle_import_for_agent_impl(&state.id_store, &state.wstore, ImportForAgentReq {
+        let result = bundle_import_for_agent_impl(&state.id_store, &state.identity_store, &state.wstore, ImportForAgentReq {
             agent_id: "agent-1".to_string(),
             file_path: None,
             zip_base64: None,
@@ -4388,7 +4422,7 @@ mod export_import_for_agent_tests {
         make_agent(&state, "agent-1", "/work/proj", config_dir.path());
 
         let files = abf_files_with_memory("Be helpful.", "MEMORY.md", "Imported fact.");
-        let result = bundle_import_for_agent_impl(&state.id_store, &state.wstore, ImportForAgentReq {
+        let result = bundle_import_for_agent_impl(&state.id_store, &state.identity_store, &state.wstore, ImportForAgentReq {
             agent_id: "agent-1".to_string(),
             file_path: None,
             zip_base64: None,
@@ -4437,10 +4471,10 @@ mod export_import_for_agent_tests {
         let files_b = abf_files_with_memory("B.", "MEMORY.md", "From import B.");
 
         let (result_a, result_b) = tokio::join!(
-            bundle_import_for_agent_impl(&state.id_store, &state.wstore, ImportForAgentReq {
+            bundle_import_for_agent_impl(&state.id_store, &state.identity_store, &state.wstore, ImportForAgentReq {
                 agent_id: "agent-1".to_string(), file_path: None, zip_base64: None, files: Some(files_a),
             }),
-            bundle_import_for_agent_impl(&state.id_store, &state.wstore, ImportForAgentReq {
+            bundle_import_for_agent_impl(&state.id_store, &state.identity_store, &state.wstore, ImportForAgentReq {
                 agent_id: "agent-1".to_string(), file_path: None, zip_base64: None, files: Some(files_b),
             }),
         );
@@ -4476,7 +4510,7 @@ mod export_import_for_agent_tests {
             FileEntry { path: "armory.json".to_string(), content: manifest.to_string() },
             FileEntry { path: "memory/../escape.md".to_string(), content: "malicious".to_string() },
         ];
-        let result = bundle_import_for_agent_impl(&state.id_store, &state.wstore, ImportForAgentReq {
+        let result = bundle_import_for_agent_impl(&state.id_store, &state.identity_store, &state.wstore, ImportForAgentReq {
             agent_id: "agent-1".to_string(),
             file_path: None,
             zip_base64: None,
@@ -4513,7 +4547,7 @@ mod export_import_for_agent_tests {
         let files = vec![
             FileEntry { path: "armory.json".to_string(), content: manifest.to_string() },
         ];
-        let result = bundle_import_for_agent_impl(&state.id_store, &state.wstore, ImportForAgentReq {
+        let result = bundle_import_for_agent_impl(&state.id_store, &state.identity_store, &state.wstore, ImportForAgentReq {
             agent_id: "agent-1".to_string(),
             file_path: None,
             zip_base64: None,
@@ -4540,7 +4574,7 @@ mod export_import_for_agent_tests {
         std::fs::create_dir_all(&memory_dir_a).unwrap();
         std::fs::write(memory_dir_a.join("MEMORY.md"), "Agent A's learned fact.").unwrap();
 
-        let exported = bundle_export_for_agent_impl(&state.id_store, &state.wstore, ExportForAgentReq {
+        let exported = bundle_export_for_agent_impl(&state.id_store, &state.wstore, &state.identity_store, ExportForAgentReq {
             bundle_id: "bundle-src".to_string(),
             agent_id: "agent-a".to_string(),
             format: String::new(),
@@ -4553,7 +4587,7 @@ mod export_import_for_agent_tests {
             })
             .collect();
 
-        let imported = bundle_import_for_agent_impl(&state.id_store, &state.wstore, ImportForAgentReq {
+        let imported = bundle_import_for_agent_impl(&state.id_store, &state.identity_store, &state.wstore, ImportForAgentReq {
             agent_id: "agent-b".to_string(),
             file_path: None,
             zip_base64: None,
@@ -4587,7 +4621,7 @@ mod export_import_for_agent_tests {
         bundle.model = "anthropic".to_string();
         state.id_store.bundle_upsert(&bundle).unwrap();
 
-        let exported = bundle_export_for_agent_impl(&state.id_store, &state.wstore, ExportForAgentReq {
+        let exported = bundle_export_for_agent_impl(&state.id_store, &state.wstore, &state.identity_store, ExportForAgentReq {
             bundle_id: "bundle-src".to_string(),
             agent_id: "agent-a".to_string(),
             format: String::new(),
@@ -4606,7 +4640,7 @@ mod export_import_for_agent_tests {
                 content: f["content"].as_str().unwrap().to_string(),
             })
             .collect();
-        let imported = bundle_import_for_agent_impl(&state.id_store, &state.wstore, ImportForAgentReq {
+        let imported = bundle_import_for_agent_impl(&state.id_store, &state.identity_store, &state.wstore, ImportForAgentReq {
             agent_id: "agent-b".to_string(),
             file_path: None,
             zip_base64: None,
@@ -4625,7 +4659,7 @@ mod export_import_for_agent_tests {
         make_agent(&state, "agent-a", "/work/a", config_a.path());
         make_bundle(&state, "bundle-unbound", "Shared instructions."); // provider/model left empty
 
-        let exported = bundle_export_for_agent_impl(&state.id_store, &state.wstore, ExportForAgentReq {
+        let exported = bundle_export_for_agent_impl(&state.id_store, &state.wstore, &state.identity_store, ExportForAgentReq {
             bundle_id: "bundle-unbound".to_string(),
             agent_id: "agent-a".to_string(),
             format: String::new(),

--- a/agentmux-srv/src/server/app_api/mcp.rs
+++ b/agentmux-srv/src/server/app_api/mcp.rs
@@ -7,6 +7,11 @@
 //! Plus the Armory-level catalog (mcp.catalog.*): global servers only,
 //! window-scoped — no `agent_id`, no `check_s1` (mirrors bundle.* auth
 //! shape, since the Armory has no agent connection context to gate on).
+//!
+//! `db_mcp_servers` is authoritatively `identity_store` as of Phase 2 of
+//! SPEC_DURABLE_BINDINGS_2026_09_10.md (§5.1/§5.4) — see `skill.rs`'s
+//! module doc comment for the full `catalog`/`wstore` split; this file
+//! mirrors it exactly for MCP servers.
 
 use super::*;
 
@@ -33,17 +38,19 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_mcp_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     engine.register_handler(
         COMMAND_MCP_LIST,
         Box::new(move |data, ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("mcp.list: {e}"))?;
                 check_s1(&ctx, &req.agent_id)?;
-                let servers = wstore.mcp_server_list(&req.agent_id)
+                let servers = wstore.mcp_server_list(&identity_store, &req.agent_id)
                     .map_err(|e| format!("mcp.list: {e}"))?;
                 Ok(Some(serde_json::to_value(&servers).map_err(|e| e.to_string())?))
             })
@@ -53,22 +60,24 @@ fn register_mcp_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_mcp_get(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     engine.register_handler(
         COMMAND_MCP_GET,
         Box::new(move |data, ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String, id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("mcp.get: {e}"))?;
                 check_s1(&ctx, &req.agent_id)?;
-                if !wstore.mcp_server_is_accessible_to(&req.agent_id, &req.id)
+                if !wstore.mcp_server_is_accessible_to(&identity_store, &req.agent_id, &req.id)
                     .map_err(|e| format!("mcp.get: {e}"))?
                 {
                     return Err("FORBIDDEN: MCP server not accessible to this agent".to_string());
                 }
-                let server = wstore.mcp_server_get(&req.id)
+                let server = identity_store.mcp_server_get(&req.id)
                     .map_err(|e| format!("mcp.get: {e}"))?;
                 Ok(Some(serde_json::to_value(&server).map_err(|e| e.to_string())?))
             })
@@ -78,11 +87,13 @@ fn register_mcp_get(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_mcp_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_MCP_UPSERT,
         Box::new(move |data, ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
@@ -120,7 +131,7 @@ fn register_mcp_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     {
                         return Err("FORBIDDEN: MCP server not bound to this agent".to_string());
                     }
-                    let existing = wstore.mcp_server_get(&req.id)
+                    let existing = identity_store.mcp_server_get(&req.id)
                         .map_err(|e| format!("mcp.upsert: {e}"))?;
                     match existing {
                         Some(s) if s.is_global => {
@@ -140,9 +151,11 @@ fn register_mcp_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     created_at,
                     updated_at: now,
                 };
-                // Atomic: name-uniqueness check + upsert + (bind on create) in one
-                // transaction, so concurrent same-name upserts can't both pass.
-                wstore.mcp_server_upsert_unique(&req.agent_id, &server, req.id.is_empty())
+                // No longer a single transaction across the catalog insert and
+                // the ref-bind (Phase 2 of SPEC_DURABLE_BINDINGS_2026_09_10.md
+                // §5.4, accepted interim gap) — see
+                // `Store::managed_upsert_unique`'s doc comment.
+                wstore.mcp_server_upsert_unique(&identity_store, &req.agent_id, &server, req.id.is_empty())
                     .map_err(|e| format!("mcp.upsert: {e}"))?;
                 broker.publish(crate::backend::wps::WaveEvent {
                     event: "mcp:changed".to_string(),
@@ -156,11 +169,13 @@ fn register_mcp_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_mcp_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_MCP_DELETE,
         Box::new(move |data, ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
@@ -173,14 +188,14 @@ fn register_mcp_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 {
                     return Err("FORBIDDEN: MCP server not bound to this agent".to_string());
                 }
-                if let Some(existing) = wstore.mcp_server_get(&req.id)
+                if let Some(existing) = identity_store.mcp_server_get(&req.id)
                     .map_err(|e| format!("mcp.delete: {e}"))?
                 {
                     if existing.is_global {
                         return Err("FORBIDDEN: cannot delete a global MCP server".to_string());
                     }
                 }
-                let deleted = wstore.mcp_server_delete(&req.id)
+                let deleted = wstore.mcp_server_delete(&identity_store, &req.id)
                     .map_err(|e| format!("mcp.delete: {e}"))?;
                 if deleted {
                     broker.publish(crate::backend::wps::WaveEvent {
@@ -196,11 +211,13 @@ fn register_mcp_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_mcp_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_MCP_BIND,
         Box::new(move |data, ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
@@ -210,7 +227,7 @@ fn register_mcp_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 check_s1(&ctx, &req.agent_id)?;
                 // Only global servers (or ones already bound) may be bound, so an
                 // agent can't escalate to read another agent's server config.
-                match wstore.mcp_server_get(&req.mcp_id)
+                match identity_store.mcp_server_get(&req.mcp_id)
                     .map_err(|e| format!("mcp.bind: {e}"))?
                 {
                     None => return Err("mcp.bind: MCP server not found".to_string()),
@@ -223,7 +240,7 @@ fn register_mcp_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     }
                     Some(_) => {}
                 }
-                wstore.mcp_server_bind(&req.agent_id, &req.mcp_id)
+                wstore.mcp_server_bind(&identity_store, &req.agent_id, &req.mcp_id)
                     .map_err(|e| format!("mcp.bind: {e}"))?;
                 // An agent binding a server to itself over its own authenticated
                 // connection should reach an already-open Stash MCP Servers tab
@@ -274,22 +291,24 @@ fn register_mcp_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
 /// valid JSON" check, which tells you nothing about reachability.
 fn register_mcp_probe(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     engine.register_handler(
         COMMAND_MCP_PROBE,
         Box::new(move |data, ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String, id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("mcp.probe: {e}"))?;
                 check_s1(&ctx, &req.agent_id)?;
-                if !wstore.mcp_server_is_accessible_to(&req.agent_id, &req.id)
+                if !wstore.mcp_server_is_accessible_to(&identity_store, &req.agent_id, &req.id)
                     .map_err(|e| format!("mcp.probe: {e}"))?
                 {
                     return Err("FORBIDDEN: MCP server not accessible to this agent".to_string());
                 }
-                let server = wstore.mcp_server_get(&req.id)
+                let server = identity_store.mcp_server_get(&req.id)
                     .map_err(|e| format!("mcp.probe: {e}"))?
                     .ok_or_else(|| "mcp.probe: MCP server not found".to_string())?;
                 let result = crate::backend::mcp_probe::probe(&server.transport, &server.config).await;
@@ -301,12 +320,14 @@ fn register_mcp_probe(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_mcp_catalog_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     engine.register_handler(
         COMMAND_MCP_CATALOG_LIST,
         Box::new(move |_data, _ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             Box::pin(async move {
-                let servers = wstore.mcp_server_list_global()
+                let servers = wstore.mcp_server_list_global(&identity_store)
                     .map_err(|e| format!("mcp.catalog.list: {e}"))?;
                 Ok(Some(serde_json::to_value(&servers).map_err(|e| e.to_string())?))
             })
@@ -315,12 +336,12 @@ fn register_mcp_catalog_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
 }
 
 fn register_mcp_catalog_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
-    let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_MCP_CATALOG_UPSERT,
         Box::new(move |data, _ctx| {
-            let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
@@ -348,7 +369,7 @@ fn register_mcp_catalog_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let (id, created_at) = if req.id.is_empty() {
                     (uuid::Uuid::new_v4().to_string(), now)
                 } else {
-                    let existing = wstore.mcp_server_get(&req.id)
+                    let existing = identity_store.mcp_server_get(&req.id)
                         .map_err(|e| format!("mcp.catalog.upsert: {e}"))?;
                     match existing {
                         // No agent_id/check_s1 here to verify ownership of a private
@@ -377,7 +398,8 @@ fn register_mcp_catalog_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // JSON object keyed by name, so two same-named global
                 // servers would silently clobber each other's config for
                 // every agent that has either bound. Reagent P1 on #1948.
-                wstore.mcp_server_upsert_unique_global(&server)
+                // Pure single-table op — called directly on identity_store.
+                identity_store.mcp_server_upsert_unique_global(&server)
                     .map_err(|e| format!("mcp.catalog.upsert: {e}"))?;
                 broker.publish(crate::backend::wps::WaveEvent {
                     event: "mcp:changed".to_string(),
@@ -401,11 +423,13 @@ fn register_mcp_catalog_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
 // See docs/reports/REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md.
 fn register_mcp_catalog_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_MCP_CATALOG_BIND,
         Box::new(move |data, _ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
@@ -416,7 +440,7 @@ fn register_mcp_catalog_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // the catalog surface can't be used to bootstrap read access
                 // to another agent's private server config — same rule as
                 // mcp.bind.
-                match wstore.mcp_server_get(&req.mcp_id)
+                match identity_store.mcp_server_get(&req.mcp_id)
                     .map_err(|e| format!("mcp.catalog.bind: {e}"))?
                 {
                     None => return Err("mcp.catalog.bind: MCP server not found".to_string()),
@@ -429,7 +453,7 @@ fn register_mcp_catalog_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     }
                     Some(_) => {}
                 }
-                wstore.mcp_server_bind(&req.agent_id, &req.mcp_id)
+                wstore.mcp_server_bind(&identity_store, &req.agent_id, &req.mcp_id)
                     .map_err(|e| format!("mcp.catalog.bind: {e}"))?;
                 // Lets any other open Stash/Armory view for this agent pick up
                 // the new binding without a manual refresh — mcp.bind (the
@@ -458,16 +482,18 @@ fn register_mcp_catalog_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
 /// docs/reports/REPORT_ARMORY_ARCHITECTURE_AND_NAMING_REVIEW_2026_07_23.md §2.2.
 fn register_mcp_catalog_list_for_agent(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     engine.register_handler(
         COMMAND_MCP_CATALOG_LIST_FOR_AGENT,
         Box::new(move |data, _ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("mcp.catalog.list_for_agent: {e}"))?;
-                let servers = wstore.mcp_server_list_global_for_agent(&req.agent_id)
+                let servers = wstore.mcp_server_list_global_for_agent(&identity_store, &req.agent_id)
                     .map_err(|e| format!("mcp.catalog.list_for_agent: {e}"))?;
                 Ok(Some(serde_json::to_value(&servers).map_err(|e| e.to_string())?))
             })
@@ -487,18 +513,20 @@ fn register_mcp_catalog_list_for_agent(engine: &Arc<WshRpcEngine>, state: &AppSt
 /// reagentx P1 on PR #2329 (round 2).
 fn register_mcp_catalog_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_MCP_CATALOG_UNBIND,
         Box::new(move |data, _ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String, mcp_id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("mcp.catalog.unbind: {e}"))?;
-                match wstore.mcp_server_get(&req.mcp_id)
+                match identity_store.mcp_server_get(&req.mcp_id)
                     .map_err(|e| format!("mcp.catalog.unbind: {e}"))?
                 {
                     None => return Err("mcp.catalog.unbind: MCP server not found".to_string()),
@@ -523,25 +551,27 @@ fn register_mcp_catalog_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_mcp_catalog_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_MCP_CATALOG_DELETE,
         Box::new(move |data, _ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("mcp.catalog.delete: {e}"))?;
-                if let Some(existing) = wstore.mcp_server_get(&req.id)
+                if let Some(existing) = identity_store.mcp_server_get(&req.id)
                     .map_err(|e| format!("mcp.catalog.delete: {e}"))?
                 {
                     if !existing.is_global {
                         return Err("FORBIDDEN: cannot delete a private MCP server via the catalog".to_string());
                     }
                 }
-                let deleted = wstore.mcp_server_delete(&req.id)
+                let deleted = wstore.mcp_server_delete(&identity_store, &req.id)
                     .map_err(|e| format!("mcp.catalog.delete: {e}"))?;
                 if deleted {
                     broker.publish(crate::backend::wps::WaveEvent {
@@ -563,12 +593,14 @@ fn register_mcp_catalog_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
 fn register_mcp_catalog_bind_to_bundle(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
     let id_store = state.id_store.clone();
+    let identity_store = state.identity_store.clone();
     let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_MCP_CATALOG_BIND_TO_BUNDLE,
         Box::new(move |data, _ctx| {
             let wstore = wstore.clone();
             let id_store = id_store.clone();
+            let identity_store = identity_store.clone();
             let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
@@ -579,12 +611,12 @@ fn register_mcp_catalog_bind_to_bundle(engine: &Arc<WshRpcEngine>, state: &AppSt
                 // this surface can't be used to bootstrap read access to
                 // another entity's private server config — same rule as
                 // mcp.catalog.bind.
-                match wstore.mcp_server_get(&req.mcp_id)
+                match identity_store.mcp_server_get(&req.mcp_id)
                     .map_err(|e| format!("mcp.catalog.bind_to_bundle: {e}"))?
                 {
                     None => return Err("mcp.catalog.bind_to_bundle: MCP server not found".to_string()),
                     Some(s) if !s.is_global => {
-                        if !wstore.bundle_mcp_is_accessible_to(&req.bundle_id, &req.mcp_id)
+                        if !wstore.bundle_mcp_is_accessible_to(&identity_store, &req.bundle_id, &req.mcp_id)
                             .map_err(|e| format!("mcp.catalog.bind_to_bundle: {e}"))?
                         {
                             return Err("FORBIDDEN: can only bind global MCP servers to a bundle".to_string());
@@ -592,7 +624,7 @@ fn register_mcp_catalog_bind_to_bundle(engine: &Arc<WshRpcEngine>, state: &AppSt
                     }
                     Some(_) => {}
                 }
-                wstore.bundle_mcp_bind(&id_store, &req.bundle_id, &req.mcp_id)
+                wstore.bundle_mcp_bind(&identity_store, &id_store, &req.bundle_id, &req.mcp_id)
                     .map_err(|e| format!("mcp.catalog.bind_to_bundle: {e}"))?;
                 broker.publish(crate::backend::wps::WaveEvent {
                     event: "mcp:changed".to_string(),
@@ -613,16 +645,18 @@ fn register_mcp_catalog_bind_to_bundle(engine: &Arc<WshRpcEngine>, state: &AppSt
 /// `bundle_mcp_list`'s own implementation.
 fn register_mcp_catalog_list_for_bundle(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     engine.register_handler(
         COMMAND_MCP_CATALOG_LIST_FOR_BUNDLE,
         Box::new(move |data, _ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { bundle_id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("mcp.catalog.list_for_bundle: {e}"))?;
-                let servers = wstore.bundle_mcp_list(&req.bundle_id)
+                let servers = wstore.bundle_mcp_list(&identity_store, &req.bundle_id)
                     .map_err(|e| format!("mcp.catalog.list_for_bundle: {e}"))?;
                 Ok(Some(serde_json::to_value(&servers).map_err(|e| e.to_string())?))
             })
@@ -641,12 +675,14 @@ fn register_mcp_catalog_list_for_bundle(engine: &Arc<WshRpcEngine>, state: &AppS
 fn register_mcp_catalog_upsert_for_bundle(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
     let id_store = state.id_store.clone();
+    let identity_store = state.identity_store.clone();
     let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_MCP_CATALOG_UPSERT_FOR_BUNDLE,
         Box::new(move |data, _ctx| {
             let wstore = wstore.clone();
             let id_store = id_store.clone();
+            let identity_store = identity_store.clone();
             let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
@@ -680,7 +716,7 @@ fn register_mcp_catalog_upsert_for_bundle(engine: &Arc<WshRpcEngine>, state: &Ap
                     {
                         return Err("FORBIDDEN: MCP server not bound to this bundle".to_string());
                     }
-                    let existing = wstore.mcp_server_get(&req.id)
+                    let existing = identity_store.mcp_server_get(&req.id)
                         .map_err(|e| format!("mcp.catalog.upsert_for_bundle: {e}"))?;
                     match existing {
                         Some(s) if s.is_global => {
@@ -700,7 +736,7 @@ fn register_mcp_catalog_upsert_for_bundle(engine: &Arc<WshRpcEngine>, state: &Ap
                     created_at,
                     updated_at: now,
                 };
-                wstore.bundle_mcp_upsert_unique(&id_store, &req.bundle_id, &server, req.id.is_empty())
+                wstore.bundle_mcp_upsert_unique(&identity_store, &id_store, &req.bundle_id, &server, req.id.is_empty())
                     .map_err(|e| format!("mcp.catalog.upsert_for_bundle: {e}"))?;
                 broker.publish(crate::backend::wps::WaveEvent {
                     event: "mcp:changed".to_string(),
@@ -755,17 +791,17 @@ fn register_mcp_catalog_unbind_from_bundle(engine: &Arc<WshRpcEngine>, state: &A
 /// connected/error status per row before any agent has bound the server.
 /// See SPEC_MCP_INTEGRATION_PARITY_ABLETON_PILOT_2026_07_08.md §4.4.
 fn register_mcp_catalog_probe(engine: &Arc<WshRpcEngine>, state: &AppState) {
-    let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     engine.register_handler(
         COMMAND_MCP_CATALOG_PROBE,
         Box::new(move |data, _ctx| {
-            let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("mcp.catalog.probe: {e}"))?;
-                let server = wstore.mcp_server_get(&req.id)
+                let server = identity_store.mcp_server_get(&req.id)
                     .map_err(|e| format!("mcp.catalog.probe: {e}"))?
                     .ok_or_else(|| "mcp.catalog.probe: MCP server not found".to_string())?;
                 if !server.is_global {

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -801,6 +801,7 @@ pub(crate) async fn bundle_get_impl(
 /// draft has no bindings, so it is still checked without touching the store.
 pub(crate) fn bundle_validate_impl(
     wstore: &crate::backend::storage::store::Store,
+    identity_store: &crate::backend::storage::store::Store,
     data: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let memory: Bundle = serde_json::from_value(bundle::normalize_bundle_upsert_input(data))
@@ -812,7 +813,7 @@ pub(crate) fn bundle_validate_impl(
         // that would return a clean, apparently-successful report for a check
         // that never ran (Codex, PR #3153). The UI is built to show a failed
         // validate; give it one.
-        let resolved = bundle::resolve_bundle_components(wstore, &memory.id)
+        let resolved = bundle::resolve_bundle_components(wstore, identity_store, &memory.id)
             .map_err(|e| format!("bundle.validate: {e}"))?;
         (resolved.mcp_entries, resolved.warnings)
     };

--- a/agentmux-srv/src/server/app_api/skill.rs
+++ b/agentmux-srv/src/server/app_api/skill.rs
@@ -7,6 +7,15 @@
 //! Plus the Armory-level catalog (skill.catalog.*): global skills only,
 //! window-scoped — no `agent_id`, no `check_s1` (mirrors bundle.* auth
 //! shape, since the Armory has no agent connection context to gate on).
+//!
+//! `db_skills` is authoritatively `identity_store` as of Phase 2 of
+//! SPEC_DURABLE_BINDINGS_2026_09_10.md (§5.1/§5.4) — `wstore` stays the
+//! ref-table owner (`db_agent_skills_ref`/`db_bundle_skills_ref` are not
+//! promoted until Phase 3/6). Pure single-table reads/writes (`skill_get`,
+//! `skill_upsert_unique_global`) call directly on `identity_store`; methods
+//! that combine a ref table with the catalog now take `identity_store` as an
+//! explicit `catalog` parameter while still being called ON `wstore` (the
+//! ref-owning receiver).
 
 use super::*;
 
@@ -31,17 +40,19 @@ pub fn register(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_skill_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     engine.register_handler(
         COMMAND_SKILL_LIST,
         Box::new(move |data, ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("skill.list: {e}"))?;
                 check_s1(&ctx, &req.agent_id)?;
-                let skills = wstore.skill_list(&req.agent_id)
+                let skills = wstore.skill_list(&identity_store, &req.agent_id)
                     .map_err(|e| format!("skill.list: {e}"))?;
                 Ok(Some(serde_json::to_value(&skills).map_err(|e| e.to_string())?))
             })
@@ -51,22 +62,24 @@ fn register_skill_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_skill_get(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     engine.register_handler(
         COMMAND_SKILL_GET,
         Box::new(move |data, ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String, id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("skill.get: {e}"))?;
                 check_s1(&ctx, &req.agent_id)?;
-                if !wstore.skill_is_accessible_to(&req.agent_id, &req.id)
+                if !wstore.skill_is_accessible_to(&identity_store, &req.agent_id, &req.id)
                     .map_err(|e| format!("skill.get: {e}"))?
                 {
                     return Err("FORBIDDEN: skill not accessible to this agent".to_string());
                 }
-                let skill = wstore.skill_get(&req.id)
+                let skill = identity_store.skill_get(&req.id)
                     .map_err(|e| format!("skill.get: {e}"))?;
                 Ok(Some(serde_json::to_value(&skill).map_err(|e| e.to_string())?))
             })
@@ -76,11 +89,13 @@ fn register_skill_get(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_skill_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_SKILL_UPSERT,
         Box::new(move |data, ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
@@ -110,7 +125,7 @@ fn register_skill_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     {
                         return Err("FORBIDDEN: skill not bound to this agent".to_string());
                     }
-                    let existing = wstore.skill_get(&req.id)
+                    let existing = identity_store.skill_get(&req.id)
                         .map_err(|e| format!("skill.upsert: {e}"))?;
                     match existing {
                         Some(s) if s.is_global => {
@@ -132,9 +147,11 @@ fn register_skill_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     created_at,
                     updated_at: now,
                 };
-                // Atomic: name-uniqueness check + upsert + (bind on create) in one
-                // transaction, so concurrent same-name upserts can't both pass.
-                wstore.skill_upsert_unique(&req.agent_id, &skill, req.id.is_empty())
+                // No longer a single transaction across the catalog insert and
+                // the ref-bind (Phase 2 of SPEC_DURABLE_BINDINGS_2026_09_10.md
+                // §5.4, accepted interim gap) — see
+                // `Store::managed_upsert_unique`'s doc comment.
+                wstore.skill_upsert_unique(&identity_store, &req.agent_id, &skill, req.id.is_empty())
                     .map_err(|e| format!("skill.upsert: {e}"))?;
                 broker.publish(crate::backend::wps::WaveEvent {
                     event: "skills:changed".to_string(),
@@ -148,11 +165,13 @@ fn register_skill_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_skill_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_SKILL_DELETE,
         Box::new(move |data, ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
@@ -165,14 +184,14 @@ fn register_skill_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 {
                     return Err("FORBIDDEN: skill not bound to this agent".to_string());
                 }
-                if let Some(existing) = wstore.skill_get(&req.id)
+                if let Some(existing) = identity_store.skill_get(&req.id)
                     .map_err(|e| format!("skill.delete: {e}"))?
                 {
                     if existing.is_global {
                         return Err("FORBIDDEN: cannot delete a global skill".to_string());
                     }
                 }
-                let deleted = wstore.skill_delete(&req.id)
+                let deleted = wstore.skill_delete(&identity_store, &req.id)
                     .map_err(|e| format!("skill.delete: {e}"))?;
                 if deleted {
                     broker.publish(crate::backend::wps::WaveEvent {
@@ -188,11 +207,13 @@ fn register_skill_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_skill_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_SKILL_BIND,
         Box::new(move |data, ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
@@ -202,7 +223,7 @@ fn register_skill_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 check_s1(&ctx, &req.agent_id)?;
                 // Only global skills (or ones already bound) may be bound, so an
                 // agent can't bootstrap read access to another agent's private skill.
-                match wstore.skill_get(&req.skill_id)
+                match identity_store.skill_get(&req.skill_id)
                     .map_err(|e| format!("skill.bind: {e}"))?
                 {
                     None => return Err("skill.bind: skill not found".to_string()),
@@ -215,7 +236,7 @@ fn register_skill_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     }
                     Some(_) => {}
                 }
-                wstore.skill_bind(&req.agent_id, &req.skill_id)
+                wstore.skill_bind(&identity_store, &req.agent_id, &req.skill_id)
                     .map_err(|e| format!("skill.bind: {e}"))?;
                 // An agent binding a skill to itself over its own authenticated
                 // connection should reach an already-open Stash Skills tab for
@@ -261,12 +282,14 @@ fn register_skill_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_skill_catalog_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     engine.register_handler(
         COMMAND_SKILL_CATALOG_LIST,
         Box::new(move |_data, _ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             Box::pin(async move {
-                let skills = wstore.skill_list_global()
+                let skills = wstore.skill_list_global(&identity_store)
                     .map_err(|e| format!("skill.catalog.list: {e}"))?;
                 Ok(Some(serde_json::to_value(&skills).map_err(|e| e.to_string())?))
             })
@@ -275,12 +298,12 @@ fn register_skill_catalog_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
 }
 
 fn register_skill_catalog_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
-    let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_SKILL_CATALOG_UPSERT,
         Box::new(move |data, _ctx| {
-            let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
@@ -300,7 +323,7 @@ fn register_skill_catalog_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let (id, created_at) = if req.id.is_empty() {
                     (uuid::Uuid::new_v4().to_string(), now)
                 } else {
-                    let existing = wstore.skill_get(&req.id)
+                    let existing = identity_store.skill_get(&req.id)
                         .map_err(|e| format!("skill.catalog.upsert: {e}"))?;
                     match existing {
                         // No agent_id/check_s1 here to verify ownership of a private
@@ -328,8 +351,9 @@ fn register_skill_catalog_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 };
                 // Global-scoped uniqueness (not skill_upsert_unique's
                 // per-agent check) — same defense-in-depth as the mcp.catalog
-                // fix, reagent P1 on #1948.
-                wstore.skill_upsert_unique_global(&skill)
+                // fix, reagent P1 on #1948. Pure single-table op — called
+                // directly on identity_store.
+                identity_store.skill_upsert_unique_global(&skill)
                     .map_err(|e| format!("skill.catalog.upsert: {e}"))?;
                 broker.publish(crate::backend::wps::WaveEvent {
                     event: "skills:changed".to_string(),
@@ -353,11 +377,13 @@ fn register_skill_catalog_upsert(engine: &Arc<WshRpcEngine>, state: &AppState) {
 // See docs/reports/REPORT_ARMORY_SKILLS_MARKDOWN_AND_BIND_BUG_2026_07_27.md §2.4.
 fn register_skill_catalog_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_SKILL_CATALOG_BIND,
         Box::new(move |data, _ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
@@ -367,7 +393,7 @@ fn register_skill_catalog_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // Only global skills (or ones already bound) may be bound, so the
                 // catalog surface can't be used to bootstrap read access to
                 // another agent's private skill — same rule as skill.bind.
-                match wstore.skill_get(&req.skill_id)
+                match identity_store.skill_get(&req.skill_id)
                     .map_err(|e| format!("skill.catalog.bind: {e}"))?
                 {
                     None => return Err("skill.catalog.bind: skill not found".to_string()),
@@ -380,7 +406,7 @@ fn register_skill_catalog_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     }
                     Some(_) => {}
                 }
-                wstore.skill_bind(&req.agent_id, &req.skill_id)
+                wstore.skill_bind(&identity_store, &req.agent_id, &req.skill_id)
                     .map_err(|e| format!("skill.catalog.bind: {e}"))?;
                 // Lets any other open Stash/Armory view for this agent pick up
                 // the new binding without a manual refresh — skill.bind (the
@@ -410,16 +436,18 @@ fn register_skill_catalog_bind(engine: &Arc<WshRpcEngine>, state: &AppState) {
 /// docs/reports/REPORT_ARMORY_ARCHITECTURE_AND_NAMING_REVIEW_2026_07_23.md §2.2.
 fn register_skill_catalog_list_for_agent(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     engine.register_handler(
         COMMAND_SKILL_CATALOG_LIST_FOR_AGENT,
         Box::new(move |data, _ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("skill.catalog.list_for_agent: {e}"))?;
-                let skills = wstore.skill_list_global_for_agent(&req.agent_id)
+                let skills = wstore.skill_list_global_for_agent(&identity_store, &req.agent_id)
                     .map_err(|e| format!("skill.catalog.list_for_agent: {e}"))?;
                 Ok(Some(serde_json::to_value(&skills).map_err(|e| e.to_string())?))
             })
@@ -439,18 +467,20 @@ fn register_skill_catalog_list_for_agent(engine: &Arc<WshRpcEngine>, state: &App
 /// reagentx P1 on PR #2329 (round 2).
 fn register_skill_catalog_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_SKILL_CATALOG_UNBIND,
         Box::new(move |data, _ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { agent_id: String, skill_id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("skill.catalog.unbind: {e}"))?;
-                match wstore.skill_get(&req.skill_id)
+                match identity_store.skill_get(&req.skill_id)
                     .map_err(|e| format!("skill.catalog.unbind: {e}"))?
                 {
                     None => return Err("skill.catalog.unbind: skill not found".to_string()),
@@ -481,12 +511,14 @@ fn register_skill_catalog_unbind(engine: &Arc<WshRpcEngine>, state: &AppState) {
 fn register_skill_catalog_bind_to_bundle(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
     let id_store = state.id_store.clone();
+    let identity_store = state.identity_store.clone();
     let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_SKILL_CATALOG_BIND_TO_BUNDLE,
         Box::new(move |data, _ctx| {
             let wstore = wstore.clone();
             let id_store = id_store.clone();
+            let identity_store = identity_store.clone();
             let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
@@ -497,12 +529,12 @@ fn register_skill_catalog_bind_to_bundle(engine: &Arc<WshRpcEngine>, state: &App
                 // this surface can't be used to bootstrap read access to
                 // another entity's private skill — same rule as
                 // skill.catalog.bind.
-                match wstore.skill_get(&req.skill_id)
+                match identity_store.skill_get(&req.skill_id)
                     .map_err(|e| format!("skill.catalog.bind_to_bundle: {e}"))?
                 {
                     None => return Err("skill.catalog.bind_to_bundle: skill not found".to_string()),
                     Some(s) if !s.is_global => {
-                        if !wstore.bundle_skill_is_accessible_to(&req.bundle_id, &req.skill_id)
+                        if !wstore.bundle_skill_is_accessible_to(&identity_store, &req.bundle_id, &req.skill_id)
                             .map_err(|e| format!("skill.catalog.bind_to_bundle: {e}"))?
                         {
                             return Err("FORBIDDEN: can only bind global skills to a bundle".to_string());
@@ -510,7 +542,7 @@ fn register_skill_catalog_bind_to_bundle(engine: &Arc<WshRpcEngine>, state: &App
                     }
                     Some(_) => {}
                 }
-                wstore.bundle_skill_bind(&id_store, &req.bundle_id, &req.skill_id)
+                wstore.bundle_skill_bind(&identity_store, &id_store, &req.bundle_id, &req.skill_id)
                     .map_err(|e| format!("skill.catalog.bind_to_bundle: {e}"))?;
                 broker.publish(crate::backend::wps::WaveEvent {
                     event: "skills:changed".to_string(),
@@ -530,16 +562,18 @@ fn register_skill_catalog_bind_to_bundle(engine: &Arc<WshRpcEngine>, state: &App
 /// own implementation.
 fn register_skill_catalog_list_for_bundle(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     engine.register_handler(
         COMMAND_SKILL_CATALOG_LIST_FOR_BUNDLE,
         Box::new(move |data, _ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { bundle_id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("skill.catalog.list_for_bundle: {e}"))?;
-                let skills = wstore.bundle_skill_list(&req.bundle_id)
+                let skills = wstore.bundle_skill_list(&identity_store, &req.bundle_id)
                     .map_err(|e| format!("skill.catalog.list_for_bundle: {e}"))?;
                 Ok(Some(serde_json::to_value(&skills).map_err(|e| e.to_string())?))
             })
@@ -554,12 +588,14 @@ fn register_skill_catalog_list_for_bundle(engine: &Arc<WshRpcEngine>, state: &Ap
 fn register_skill_catalog_upsert_for_bundle(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
     let id_store = state.id_store.clone();
+    let identity_store = state.identity_store.clone();
     let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_SKILL_CATALOG_UPSERT_FOR_BUNDLE,
         Box::new(move |data, _ctx| {
             let wstore = wstore.clone();
             let id_store = id_store.clone();
+            let identity_store = identity_store.clone();
             let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
@@ -585,7 +621,7 @@ fn register_skill_catalog_upsert_for_bundle(engine: &Arc<WshRpcEngine>, state: &
                     {
                         return Err("FORBIDDEN: skill not bound to this bundle".to_string());
                     }
-                    let existing = wstore.skill_get(&req.id)
+                    let existing = identity_store.skill_get(&req.id)
                         .map_err(|e| format!("skill.catalog.upsert_for_bundle: {e}"))?;
                     match existing {
                         Some(s) if s.is_global => {
@@ -607,7 +643,7 @@ fn register_skill_catalog_upsert_for_bundle(engine: &Arc<WshRpcEngine>, state: &
                     created_at,
                     updated_at: now,
                 };
-                wstore.bundle_skill_upsert_unique(&id_store, &req.bundle_id, &skill, req.id.is_empty())
+                wstore.bundle_skill_upsert_unique(&identity_store, &id_store, &req.bundle_id, &skill, req.id.is_empty())
                     .map_err(|e| format!("skill.catalog.upsert_for_bundle: {e}"))?;
                 broker.publish(crate::backend::wps::WaveEvent {
                     event: "skills:changed".to_string(),
@@ -651,25 +687,27 @@ fn register_skill_catalog_unbind_from_bundle(engine: &Arc<WshRpcEngine>, state: 
 
 fn register_skill_catalog_delete(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
+    let identity_store = state.identity_store.clone();
     let broker = state.broker.clone();
     engine.register_handler(
         COMMAND_SKILL_CATALOG_DELETE,
         Box::new(move |data, _ctx| {
             let wstore = wstore.clone();
+            let identity_store = identity_store.clone();
             let broker = broker.clone();
             Box::pin(async move {
                 #[derive(serde::Deserialize)]
                 struct Req { id: String }
                 let req: Req = serde_json::from_value(data)
                     .map_err(|e| format!("skill.catalog.delete: {e}"))?;
-                if let Some(existing) = wstore.skill_get(&req.id)
+                if let Some(existing) = identity_store.skill_get(&req.id)
                     .map_err(|e| format!("skill.catalog.delete: {e}"))?
                 {
                     if !existing.is_global {
                         return Err("FORBIDDEN: cannot delete a private skill via the catalog".to_string());
                     }
                 }
-                let deleted = wstore.skill_delete(&req.id)
+                let deleted = wstore.skill_delete(&identity_store, &req.id)
                     .map_err(|e| format!("skill.catalog.delete: {e}"))?;
                 if deleted {
                     broker.publish(crate::backend::wps::WaveEvent {


### PR DESCRIPTION
Follow-up to #3182 (design) — implements Phase 2's application-layer read/write redirect per `SPEC_DURABLE_BINDINGS_2026_09_10.md` §5.4, including the two additional migrations Codex's review of #3182 surfaced as hard prerequisites (both re-verified against the code independently before implementing):

- **`m0032_drop_catalog_fk_from_ref_tables`** — the four skill/MCP ref tables' `skill_id`/`mcp_id` FK targeted `wstore`'s own local catalog copy. Once that copy stops gaining new rows (writes redirect to `identity_store`), binding any post-redirect catalog row would hard-fail with `FOREIGN KEY constraint failed` under `PRAGMA foreign_keys=ON`. Rebuilds all four tables without that FK (`agent_id → db_agents` kept), mirroring `db_bundle_skills_ref`'s existing no-FK-to-`db_bundles` precedent. Existence is now checked explicitly in `managed_bind_agent`/`managed_bind_bundle`.
- **`m0033_narrow_skill_global_uniqueness_index`** — the Phase 2a unique index was `(name, skill_type)`, narrower than `skill_upsert_unique_global`'s own application-level invariant (`name` alone). Once the catalog is shared cross-process, a same-name-different-type race could slip past both layers. Narrows the index to `name`-only, with a defensive collapse-duplicates pass for any store where `m0031`'s own `(name, skill_type)`-keyed dedup already produced a colliding pair.

`storage/managed.rs`: every method that used to join the catalog table with a ref table in one SQL statement now takes an explicit `catalog: &Store` parameter and composes two queries in Rust instead (`managed_list`, `managed_list_global`, `managed_list_global_for_agent`, `managed_delete`, `managed_is_accessible_to`, `managed_upsert_unique`, `managed_union_bundle_refs`). `managed_upsert_unique` performs a best-effort compensating delete of the catalog row if the subsequent ref-bind fails, so a failed RPC and durable state agree instead of leaving a permanent orphan. Careful attention to `Mutex<Connection>` non-reentrancy where `self`/`catalog` may alias (test fixtures, degraded-mode fallback) — each cross-store helper acquires and releases its own lock rather than holding one while calling into the other.

`skills.rs`/`mcp_servers.rs` thread the new parameter through their public wrappers; `skill.rs`/`mcp.rs`/`bundle.rs`/`agent_open.rs`/`agent_handlers/skills.rs` redirect call sites to `state.identity_store`. `m0015`/`m0016`/`m0030`/`m0031` needed small compile-only fixes (passing `wstore` as its own `catalog` — they predate this redirect or specifically operate on `wstore`'s own local mirror, verified individually, not a semantic change).

3328 tests pass (up from 3304 baseline), including new cross-store composition tests in `managed.rs` that use two genuinely separate `Store` instances rather than the shared `test_state()` fixture, which would hide a wrong-store bug behind "querying the same store twice trivially works."

Known, documented nit (not fixed here, low risk): `bundle_export_impl`/`bundle_export_for_agent_impl`'s parameter order is `(id_store, wstore, identity_store)` while every other multi-store function in `bundle.rs` uses `(id_store, identity_store, wstore)` — cosmetic only, both are internally consistent with their own call sites and fully tested.

<!-- agentmux:agent_id=agenta -->