### PR TITLE
docs: tone down the early-alpha warning

### DIFF
--- a/.changesets/1789085480-docs-tone-down-the-early-alpha-warning-jl32.md
+++ b/.changesets/1789085480-docs-tone-down-the-early-alpha-warning-jl32.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs: tone down the early-alpha warning

--- a/README.md
+++ b/README.md
@@ -2,22 +2,25 @@
 docs/specs/SPEC_EARLY_ALPHA_WARNING_2026_06_05.md. Decorative logo/title
 follow below so the warning is never pushed below the fold. -->
 
-> ## ⚠️ EARLY ALPHA — Use At Your Own Risk
+> ## Early Alpha
 >
-> **AgentMux is in early alpha.** Many features are incomplete, partially
-> broken, or change between releases without notice. Expect:
+> **AgentMux is in early alpha.** Some features are incomplete or still
+> settling, and behavior can change between releases. A few things to keep
+> in mind:
 >
-> - **Broken features** — pieces of the UI may not function, or may regress
->   from one release to the next.
-> - **Data loss** — settings, pane layouts, and agent state may not migrate
->   cleanly across versions. Don't store anything you can't reproduce.
-> - **Breaking changes** — config files, identity bundles, memory bundles,
->   and the App API may change shape with no migration path during alpha.
-> - **Platform gaps** — Windows is the primary target; macOS and Linux
->   builds lag behind and have additional known issues.
+> - **Rough edges** — parts of the UI may not work as expected, and
+>   something that works today can regress in a later release.
+> - **Don't rely on persistence** — settings, pane layouts, and agent state
+>   may not carry over cleanly across versions, so avoid storing anything
+>   you can't easily recreate.
+> - **Interfaces are still moving** — config files, identity bundles,
+>   memory bundles, and the App API can change shape without a migration
+>   path during alpha.
+> - **Platform coverage varies** — Windows gets the most testing right now;
+>   macOS and Linux builds are a bit further behind.
 >
-> If you hit a problem, **please report it as a GitHub issue** at
-> https://github.com/agentmuxai/agentmux/issues — it's how alpha gets to beta.
+> Running into something? **Please open a GitHub issue** at
+> https://github.com/agentmuxai/agentmux/issues — that's how alpha gets to beta.
 
 ---
 

--- a/docs/specs/SPEC_EARLY_ALPHA_WARNING_2026_06_05.md
+++ b/docs/specs/SPEC_EARLY_ALPHA_WARNING_2026_06_05.md
@@ -73,27 +73,30 @@ it).
 
 ### Short form (one line, used in Store "Short description" and any tight slot)
 
-> **Early alpha — expect bugs, broken features, and breaking changes between
-> releases. Please report issues at https://github.com/agentmuxai/agentmux/issues.**
+> **AgentMux is in early alpha — expect some bugs and breaking changes
+> between releases. Please report issues at https://github.com/agentmuxai/agentmux/issues.**
 
 ### Long form (used at top of README and in Store "Description")
 
-> ## ⚠️ EARLY ALPHA — Use At Your Own Risk
+> ## Early Alpha
 >
-> **AgentMux is in early alpha.** Many features are incomplete, partially
-> broken, or change between releases without notice. Expect:
+> **AgentMux is in early alpha.** Some features are incomplete or still
+> settling, and behavior can change between releases. A few things to keep
+> in mind:
 >
-> - **Broken features** — pieces of the UI may not function, or may regress
->   from one release to the next.
-> - **Data loss** — settings, pane layouts, and agent state may not migrate
->   cleanly across versions. Don't store anything you can't reproduce.
-> - **Breaking changes** — config files, identity bundles, memory bundles,
->   and the App API may change shape with no migration path during alpha.
-> - **Platform gaps** — Windows is the primary target; macOS and Linux
->   builds lag behind and have additional known issues.
+> - **Rough edges** — parts of the UI may not work as expected, and
+>   something that works today can regress in a later release.
+> - **Don't rely on persistence** — settings, pane layouts, and agent state
+>   may not carry over cleanly across versions, so avoid storing anything
+>   you can't easily recreate.
+> - **Interfaces are still moving** — config files, identity bundles,
+>   memory bundles, and the App API can change shape without a migration
+>   path during alpha.
+> - **Platform coverage varies** — Windows gets the most testing right now;
+>   macOS and Linux builds are a bit further behind.
 >
-> If you hit a problem, **please report it as a GitHub issue** at
-> https://github.com/agentmuxai/agentmux/issues — it's how alpha gets to beta.
+> Running into something? **Please open a GitHub issue** at
+> https://github.com/agentmuxai/agentmux/issues — that's how alpha gets to beta.
 
 ---
 
@@ -113,22 +116,25 @@ information. Decorative content should not push the warning below the fold.
 Prepend to `README.md` (at the repo root):
 
 ```markdown
-> ## ⚠️ EARLY ALPHA — Use At Your Own Risk
+> ## Early Alpha
 >
-> **AgentMux is in early alpha.** Many features are incomplete, partially
-> broken, or change between releases without notice. Expect:
+> **AgentMux is in early alpha.** Some features are incomplete or still
+> settling, and behavior can change between releases. A few things to keep
+> in mind:
 >
-> - **Broken features** — pieces of the UI may not function, or may regress
->   from one release to the next.
-> - **Data loss** — settings, pane layouts, and agent state may not migrate
->   cleanly across versions. Don't store anything you can't reproduce.
-> - **Breaking changes** — config files, identity bundles, memory bundles,
->   and the App API may change shape with no migration path during alpha.
-> - **Platform gaps** — Windows is the primary target; macOS and Linux
->   builds lag behind and have additional known issues.
+> - **Rough edges** — parts of the UI may not work as expected, and
+>   something that works today can regress in a later release.
+> - **Don't rely on persistence** — settings, pane layouts, and agent state
+>   may not carry over cleanly across versions, so avoid storing anything
+>   you can't easily recreate.
+> - **Interfaces are still moving** — config files, identity bundles,
+>   memory bundles, and the App API can change shape without a migration
+>   path during alpha.
+> - **Platform coverage varies** — Windows gets the most testing right now;
+>   macOS and Linux builds are a bit further behind.
 >
-> If you hit a problem, **please report it as a GitHub issue** at
-> https://github.com/agentmuxai/agentmux/issues — it's how alpha gets to beta.
+> Running into something? **Please open a GitHub issue** at
+> https://github.com/agentmuxai/agentmux/issues — that's how alpha gets to beta.
 
 ---
 

--- a/packaging/msix/AppxManifest.xml.template
+++ b/packaging/msix/AppxManifest.xml.template
@@ -42,7 +42,7 @@
     <Application Id="AgentMux" Executable="agentmux.exe" EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements
         DisplayName="AgentMux"
-        Description="EARLY ALPHA — expect bugs, broken features, and breaking changes between releases. Please report issues at https://github.com/agentmuxai/agentmux/issues. Integrated agentic workflow environment — run multiple AI agents side by side."
+        Description="AgentMux is in early alpha — expect some bugs and breaking changes between releases. Please report issues at https://github.com/agentmuxai/agentmux/issues. Integrated agentic workflow environment — run multiple AI agents side by side."
         BackgroundColor="transparent"
         Square150x150Logo="Assets\Square150x150Logo.png"
         Square44x44Logo="Assets\Square44x44Logo.png">


### PR DESCRIPTION
## Summary

The README's early-alpha banner read as a liability waiver rather than a normal pre-1.0 disclaimer — "Use At Your Own Risk" as the header, a standalone bolded "Data loss" bullet, and clipped, alarm-cadence phrasing throughout. Every substantive claim survives (rough edges/regressions, unreliable persistence across versions, breaking config/API changes, uneven platform coverage, the GitHub-issue ask) — only the register changed, to something calmer and more conversational.

Before → after (README, long form):

> ⚠️ **EARLY ALPHA — Use At Your Own Risk** ... **Data loss** — settings, pane layouts, and agent state may not migrate cleanly across versions. Don't store anything you can't reproduce.

→

> **Early Alpha** ... **Don't rely on persistence** — settings, pane layouts, and agent state may not carry over cleanly across versions, so avoid storing anything you can't easily recreate.

## Scope — three linked surfaces, updated together

Per `docs/specs/SPEC_EARLY_ALPHA_WARNING_2026_06_05.md`, this warning is the canonical source of truth across three places, deliberately kept in sync by that spec. Updating only the README would immediately reintroduce the drift the spec exists to prevent:

- **`README.md`** — the long-form banner.
- **The spec's own Canonical Warning Text** — both the long form and the short form (used in Store copy).
- **`packaging/msix/AppxManifest.xml.template`**'s `<Description>` — the short form, which Microsoft Store falls back to if the Partner Center listing is empty.

## Not touched, and can't be from this repo

The Microsoft Store **Partner Center listing** itself (Description + "What's new" fields) is an external, non-versioned surface per the spec's own Surface 2 section. Whoever holds Partner Center access needs to re-submit that copy separately — same procedure the spec already documents for any future wording change. Flagging it here rather than leaving it silently out of sync.

## Constraint respected

The spec's own "Wording constraint — Store review policy" section requires the GitHub-issue ask stay a positive, freestanding request, never contrasted with leaving a Store review (a Store ratings-manipulation policy risk). Preserved verbatim in spirit in the new wording.

<!-- agentmux:agent_id=agentx -->
