### PR TITLE
docs: say 'alpha software', not 'early alpha'

### DIFF
--- a/.changesets/1789086653-docs-say-alpha-software-not-early-alpha-6val.md
+++ b/.changesets/1789086653-docs-say-alpha-software-not-early-alpha-6val.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs: say 'alpha software', not 'early alpha'

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-<!-- The early-alpha warning is the first content block by design — see
+<!-- The alpha warning is the first content block by design — see
 docs/specs/SPEC_EARLY_ALPHA_WARNING_2026_06_05.md. Decorative logo/title
 follow below so the warning is never pushed below the fold. -->
 
-> ## Early Alpha
+> ## Alpha
 >
-> **AgentMux is in early alpha.** Some features are incomplete or still
+> **AgentMux is alpha software.** Some features are incomplete or still
 > settling, and behavior can change between releases. A few things to keep
 > in mind:
 >

--- a/docs/specs/SPEC_EARLY_ALPHA_WARNING_2026_06_05.md
+++ b/docs/specs/SPEC_EARLY_ALPHA_WARNING_2026_06_05.md
@@ -14,14 +14,14 @@
 ## Motivation
 
 AgentMux is publicly available (GitHub README, Microsoft Store listing) but the
-product is still in **early alpha**: significant feature surfaces are partially
+product is still **alpha software**: significant feature surfaces are partially
 implemented, regress between releases, or are known-broken on specific
 platforms. Users arriving from the Microsoft Store in particular have no signal
 that they are installing pre-production software — the Store listing reads as a
 finished product, which produces unfair 1-star reviews and wastes the user's
 time.
 
-This spec defines a single, consistent **early-alpha warning** that lands in
+This spec defines a single, consistent **alpha warning** that lands in
 two places:
 
 1. **Top of `README.md`** in the `agentmuxai/agentmux` repo (the first thing a
@@ -73,14 +73,14 @@ it).
 
 ### Short form (one line, used in Store "Short description" and any tight slot)
 
-> **AgentMux is in early alpha — expect some bugs and breaking changes
+> **AgentMux is alpha software — expect some bugs and breaking changes
 > between releases. Please report issues at https://github.com/agentmuxai/agentmux/issues.**
 
 ### Long form (used at top of README and in Store "Description")
 
-> ## Early Alpha
+> ## Alpha
 >
-> **AgentMux is in early alpha.** Some features are incomplete or still
+> **AgentMux is alpha software.** Some features are incomplete or still
 > settling, and behavior can change between releases. A few things to keep
 > in mind:
 >
@@ -116,9 +116,9 @@ information. Decorative content should not push the warning below the fold.
 Prepend to `README.md` (at the repo root):
 
 ```markdown
-> ## Early Alpha
+> ## Alpha
 >
-> **AgentMux is in early alpha.** Some features are incomplete or still
+> **AgentMux is alpha software.** Some features are incomplete or still
 > settling, and behavior can change between releases. A few things to keep
 > in mind:
 >
@@ -174,7 +174,7 @@ any other locales we publish):
 4. For every additional locale, replicate the same English text (we are not
    translating during alpha).
 5. In the **Notes for certification** field, add: *"This submission adds an
-   early-alpha disclaimer to the Store listing. No package binary changes
+   alpha disclaimer to the Store listing. No package binary changes
    versus the previous submission unless otherwise noted."*
 6. Submit for certification.
 
@@ -212,7 +212,7 @@ that fallback to still carry the warning.
 
 ## Out-of-band: keeping the surfaces in sync
 
-When the warning text changes (e.g., when we drop "early alpha" for "beta"):
+When the warning text changes (e.g., when we drop "alpha" for "beta"):
 
 1. Edit this spec's **Canonical Warning Text** section.
 2. Update `README.md` to match.

--- a/frontend/app/element/quicktips.tsx
+++ b/frontend/app/element/quicktips.tsx
@@ -331,7 +331,7 @@ const QuickTips = (): JSX.Element => {
                 </div>
                 <div class="flex flex-col gap-2 text-secondary text-sm">
                     <p>
-                        AgentMux is in <b class="text-amber-300">early alpha</b>. Features may be incomplete, unstable, or change between releases.
+                        AgentMux is <b class="text-amber-300">alpha software</b>. Features may be incomplete, unstable, or change between releases.
                         AI agents generate code, text, and other outputs that may be <b>inaccurate, incomplete, or inappropriate</b>.
                         Always review agent outputs before using them.
                     </p>

--- a/packaging/msix/AppxManifest.xml.template
+++ b/packaging/msix/AppxManifest.xml.template
@@ -42,7 +42,7 @@
     <Application Id="AgentMux" Executable="agentmux.exe" EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements
         DisplayName="AgentMux"
-        Description="AgentMux is in early alpha — expect some bugs and breaking changes between releases. Please report issues at https://github.com/agentmuxai/agentmux/issues. Integrated agentic workflow environment — run multiple AI agents side by side."
+        Description="AgentMux is alpha software — expect some bugs and breaking changes between releases. Please report issues at https://github.com/agentmuxai/agentmux/issues. Integrated agentic workflow environment — run multiple AI agents side by side."
         BackgroundColor="transparent"
         Square150x150Logo="Assets\Square150x150Logo.png"
         Square44x44Logo="Assets\Square44x44Logo.png">


### PR DESCRIPTION
## Summary

Drops "Early" from the maturity-stage terminology across every live, current-facing surface — "Alpha" not "Early Alpha", "AgentMux is alpha software" not "AgentMux is in early alpha". Follow-up to #3184 (toned down the intensity; this is the wording itself).

## Updated

- `README.md` (long form)
- `docs/specs/SPEC_EARLY_ALPHA_WARNING_2026_06_05.md` — the canonical short/long form text, plus the spec's own motivation prose wherever it describes the product's *current* maturity stage. The spec's own title/filename stays as-is: it's a stable historical identifier cited elsewhere (`docs/specs/INDEX.md`), and renaming it is a separate, higher-blast-radius change nobody asked for here.
- `packaging/msix/AppxManifest.xml.template`'s `<Description>`
- `frontend/app/element/quicktips.tsx`'s in-app Quick Tips panel — its own heading already said "Alpha Software & AI Content"; the body text hadn't caught up.

## Deliberately left alone

- `VERSION_HISTORY.md` and the pending changeset from #3184 both describe past/in-flight work using the terminology that was actually live at the time — rewriting them now would misrepresent what that PR did.
- `docs/specs/SPEC_README_AUDIT_2026_06_25.md` and `docs/specs/INDEX.md`'s entry are dated historical records referencing the spec by its stable name, not live copy.

## Scope note

This covers the `agentmuxai/agentmux` repo only. The same terminology also appears in `agentmux-docs` (30 content pages, copy-pasted boilerplate rather than a shared component) and `agentmux-landing` (a shared `AlphaWarning` component plus two other files) — separate PRs follow in those repos.

<!-- agentmux:agent_id=agentx -->
