### PR TITLE
Camper@narko: fix(pane-tab-strip): stop terminal/agent tab pills flashing, keep terminal tabs mounted across a switch

### DIFF
--- a/.changesets/1789087612-fix-term-keep-alive-terminal-tabs-no-longer-leak-input-zoom--uev6.md
+++ b/.changesets/1789087612-fix-term-keep-alive-terminal-tabs-no-longer-leak-input-zoom--uev6.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(term): keep-alive terminal tabs no longer leak input/zoom into hidden dormant tabs

--- a/frontend/app/store/block-component-registry.test.ts
+++ b/frontend/app/store/block-component-registry.test.ts
@@ -2,71 +2,85 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Regression coverage for Codex P1/P2 on PR #3187: once a pane can keep
- * multiple stack members' `<Block>`s mounted simultaneously (terminal
- * keep-alive, `pane-leaf-chrome.tsx`), every registered blockId is no
- * longer automatically "the one currently-visible pane" — a dormant,
+ * Regression coverage for Codex P1/P2 + ReAgent P1 on PR #3187: once a pane
+ * can keep multiple stack members' `<Block>`s mounted simultaneously
+ * (terminal keep-alive, `pane-leaf-chrome.tsx`), every registered blockId
+ * is no longer automatically "the one currently-visible pane" — a dormant,
  * hidden stack member registers here too. `getAllBlockComponentModels`/
- * `getAllBlockComponentModelEntries` must still expose only the ACTIVE
- * member of each leaf, since every consumer (multi-input broadcast,
- * all-panes zoom, the multi-input-eligible terminal count) assumes that.
+ * `getAllBlockComponentModelEntries` must still expose only ACTIVE panes,
+ * since every consumer (multi-input broadcast, all-panes zoom, the
+ * multi-input-eligible terminal count) assumes that — and must do so
+ * WITHOUT depending on which tab a block lives in (ReAgent P1: an earlier
+ * version resolved this via the active tab's own layout tree, which
+ * silently excluded every pane in every background tab too).
  */
 
-import { afterEach, describe, expect, it, vi } from "vitest";
-
-const fakeNodesByBlockId = new Map<string, { data: { blockId: string } }>();
-
-vi.mock("@/layout/index", () => ({
-    getLayoutModelForStaticTab: () => ({
-        getNodeByBlockId: (blockId: string) => fakeNodesByBlockId.get(blockId) ?? null,
-    }),
-}));
-
-async function loadRegistry() {
-    return import("./block-component-registry");
-}
+import { afterEach, describe, expect, it } from "vitest";
+import {
+    getAllBlockComponentModelEntries,
+    getAllBlockComponentModels,
+    registerBlockComponentModel,
+    setKeepAliveBlockDormant,
+    unregisterBlockComponentModel,
+} from "./block-component-registry";
 
 afterEach(() => {
-    vi.resetModules();
-    fakeNodesByBlockId.clear();
+    // No exposed "clear" — unregister everything this suite may have
+    // registered so state doesn't leak between tests.
+    for (const id of ["b1", "b2", "b3"]) {
+        unregisterBlockComponentModel(id);
+        setKeepAliveBlockDormant(id, false);
+    }
 });
 
 describe("getAllBlockComponentModels / getAllBlockComponentModelEntries", () => {
-    it("excludes a dormant (non-active) stack member from the same leaf", async () => {
-        const { registerBlockComponentModel, getAllBlockComponentModels, getAllBlockComponentModelEntries } =
-            await loadRegistry();
-        // Both "b1" and "b2" resolve to the SAME leaf (a stacked terminal
-        // pane, keep-alive keeps both mounted+registered), but the leaf's
-        // own `data.blockId` — reassigned to whichever member is active on
-        // every switch (layoutStack.ts) — currently reads "b1".
-        fakeNodesByBlockId.set("b1", { data: { blockId: "b1" } });
-        fakeNodesByBlockId.set("b2", { data: { blockId: "b1" } });
+    it("excludes a blockId explicitly marked dormant", () => {
         registerBlockComponentModel("b1", { viewModel: { viewType: "term" } } as any);
         registerBlockComponentModel("b2", { viewModel: { viewType: "term" } } as any);
+        setKeepAliveBlockDormant("b2", true);
 
         expect(getAllBlockComponentModels()).toHaveLength(1);
         expect(getAllBlockComponentModelEntries().map(([id]) => id)).toEqual(["b1"]);
     });
 
-    it("includes a block once it becomes the active stack member", async () => {
-        const { registerBlockComponentModel, getAllBlockComponentModelEntries } = await loadRegistry();
-        fakeNodesByBlockId.set("b1", { data: { blockId: "b1" } });
-        fakeNodesByBlockId.set("b2", { data: { blockId: "b1" } });
+    it("includes a block again once it's un-marked (e.g. it becomes the active tab)", () => {
         registerBlockComponentModel("b1", { viewModel: { viewType: "term" } } as any);
         registerBlockComponentModel("b2", { viewModel: { viewType: "term" } } as any);
-
-        // Switch: the leaf's own blockId now points at "b2".
-        fakeNodesByBlockId.set("b1", { data: { blockId: "b2" } });
-        fakeNodesByBlockId.set("b2", { data: { blockId: "b2" } });
+        setKeepAliveBlockDormant("b1", true);
 
         expect(getAllBlockComponentModelEntries().map(([id]) => id)).toEqual(["b2"]);
+
+        // Switch: "b1" becomes active, "b2" becomes dormant.
+        setKeepAliveBlockDormant("b1", false);
+        setKeepAliveBlockDormant("b2", true);
+
+        expect(getAllBlockComponentModelEntries().map(([id]) => id)).toEqual(["b1"]);
     });
 
-    it("includes a registered block that isn't part of any stack at all (a plain, never-split pane)", async () => {
-        const { registerBlockComponentModel, getAllBlockComponentModels } = await loadRegistry();
-        fakeNodesByBlockId.set("b1", { data: { blockId: "b1" } });
+    it("includes every registered block when nothing is marked dormant (every non-keep-alive pane type)", () => {
         registerBlockComponentModel("b1", { viewModel: { viewType: "agent" } } as any);
+        registerBlockComponentModel("b2", { viewModel: { viewType: "editor" } } as any);
+        registerBlockComponentModel("b3", { viewModel: { viewType: "browser" } } as any);
 
+        expect(getAllBlockComponentModels()).toHaveLength(3);
+    });
+
+    // ReAgent P1's actual regression: a filter keyed on "does this blockId
+    // resolve in the ACTIVE tab's layout tree" would incorrectly treat
+    // every block belonging to a different, background tab as excluded.
+    // This suite never touches the layout model at all — proving the fix
+    // doesn't depend on it, so a block from any tab is included by default.
+    it("includes a registered block with no layout/tab resolution involved at all", () => {
+        registerBlockComponentModel("b1", { viewModel: { viewType: "browser" } } as any);
+        expect(getAllBlockComponentModels().map((bcm) => bcm.viewModel.viewType)).toEqual(["browser"]);
+    });
+
+    it("unregistering a block clears any stale dormancy marker instead of leaking it to a future blockId reuse", () => {
+        registerBlockComponentModel("b1", { viewModel: { viewType: "term" } } as any);
+        setKeepAliveBlockDormant("b1", true);
+        unregisterBlockComponentModel("b1");
+
+        registerBlockComponentModel("b1", { viewModel: { viewType: "term" } } as any);
         expect(getAllBlockComponentModels()).toHaveLength(1);
     });
 });

--- a/frontend/app/store/block-component-registry.test.ts
+++ b/frontend/app/store/block-component-registry.test.ts
@@ -1,0 +1,72 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regression coverage for Codex P1/P2 on PR #3187: once a pane can keep
+ * multiple stack members' `<Block>`s mounted simultaneously (terminal
+ * keep-alive, `pane-leaf-chrome.tsx`), every registered blockId is no
+ * longer automatically "the one currently-visible pane" — a dormant,
+ * hidden stack member registers here too. `getAllBlockComponentModels`/
+ * `getAllBlockComponentModelEntries` must still expose only the ACTIVE
+ * member of each leaf, since every consumer (multi-input broadcast,
+ * all-panes zoom, the multi-input-eligible terminal count) assumes that.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fakeNodesByBlockId = new Map<string, { data: { blockId: string } }>();
+
+vi.mock("@/layout/index", () => ({
+    getLayoutModelForStaticTab: () => ({
+        getNodeByBlockId: (blockId: string) => fakeNodesByBlockId.get(blockId) ?? null,
+    }),
+}));
+
+async function loadRegistry() {
+    return import("./block-component-registry");
+}
+
+afterEach(() => {
+    vi.resetModules();
+    fakeNodesByBlockId.clear();
+});
+
+describe("getAllBlockComponentModels / getAllBlockComponentModelEntries", () => {
+    it("excludes a dormant (non-active) stack member from the same leaf", async () => {
+        const { registerBlockComponentModel, getAllBlockComponentModels, getAllBlockComponentModelEntries } =
+            await loadRegistry();
+        // Both "b1" and "b2" resolve to the SAME leaf (a stacked terminal
+        // pane, keep-alive keeps both mounted+registered), but the leaf's
+        // own `data.blockId` — reassigned to whichever member is active on
+        // every switch (layoutStack.ts) — currently reads "b1".
+        fakeNodesByBlockId.set("b1", { data: { blockId: "b1" } });
+        fakeNodesByBlockId.set("b2", { data: { blockId: "b1" } });
+        registerBlockComponentModel("b1", { viewModel: { viewType: "term" } } as any);
+        registerBlockComponentModel("b2", { viewModel: { viewType: "term" } } as any);
+
+        expect(getAllBlockComponentModels()).toHaveLength(1);
+        expect(getAllBlockComponentModelEntries().map(([id]) => id)).toEqual(["b1"]);
+    });
+
+    it("includes a block once it becomes the active stack member", async () => {
+        const { registerBlockComponentModel, getAllBlockComponentModelEntries } = await loadRegistry();
+        fakeNodesByBlockId.set("b1", { data: { blockId: "b1" } });
+        fakeNodesByBlockId.set("b2", { data: { blockId: "b1" } });
+        registerBlockComponentModel("b1", { viewModel: { viewType: "term" } } as any);
+        registerBlockComponentModel("b2", { viewModel: { viewType: "term" } } as any);
+
+        // Switch: the leaf's own blockId now points at "b2".
+        fakeNodesByBlockId.set("b1", { data: { blockId: "b2" } });
+        fakeNodesByBlockId.set("b2", { data: { blockId: "b2" } });
+
+        expect(getAllBlockComponentModelEntries().map(([id]) => id)).toEqual(["b2"]);
+    });
+
+    it("includes a registered block that isn't part of any stack at all (a plain, never-split pane)", async () => {
+        const { registerBlockComponentModel, getAllBlockComponentModels } = await loadRegistry();
+        fakeNodesByBlockId.set("b1", { data: { blockId: "b1" } });
+        registerBlockComponentModel("b1", { viewModel: { viewType: "agent" } } as any);
+
+        expect(getAllBlockComponentModels()).toHaveLength(1);
+    });
+});

--- a/frontend/app/store/block-component-registry.ts
+++ b/frontend/app/store/block-component-registry.ts
@@ -12,6 +12,58 @@ import { createBlock } from "./block-layout-actions";
 
 const blockComponentModelMap = new Map<string, BlockComponentModel>();
 
+// Codex P1/P2 on PR #3187: `pane-leaf-chrome.tsx`'s keep-alive terminal tabs
+// (SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md's keep-alive
+// follow-up) mount EVERY stack member's `<Block>` simultaneously, not just
+// the active one — each still registers itself here under its own blockId,
+// same as always. Every existing consumer of the two "all panes" functions
+// below (`TermViewModel.multiInputHandler`'s keystroke broadcast,
+// `zoom.ts`'s all-panes stepper, `keymodel.ts`'s multi-input-eligible
+// terminal count) assumes one registry entry == one currently-visible pane
+// — true before keep-alive (a dormant stack member was simply unmounted and
+// therefore never registered at all), no longer true now that a hidden
+// terminal tab stays mounted AND registered.
+//
+// ReAgent P1 on this PR: a first version of this fix filtered via
+// `getLayoutModelForStaticTab().getNodeByBlockId(blockId)`, comparing the
+// found leaf's own (always-active) `data.blockId` — but
+// `getLayoutModelForStaticTab()` only resolves the CURRENTLY ACTIVE TAB's
+// own tree (`atoms.activeTabId()`). A block belonging to any OTHER (open
+// but not front-most) tab can never be found by that lookup at all, so
+// that version silently excluded every pane in every background TAB too —
+// far broader than the actual dormant-stack-member scope this exists to
+// cover, and a real regression for `stepAllPanes` (which its own spec,
+// SPEC_CTRL_SHIFT_SCROLL_ZOOM_ALL_PANES_2026_09_07.md, defines as
+// "every pane in the current window", not just the active tab).
+//
+// Fixed by tracking dormancy explicitly instead of re-deriving it from a
+// tab-scoped layout lookup: `pane-leaf-chrome.tsx`'s keep-alive rendering
+// is the ONE place that actually knows "this blockId is a currently-hidden
+// stack member," so it marks that directly via `setKeepAliveBlockDormant`
+// below — no layout/tab resolution involved at all, so cross-tab panes are
+// never touched by this filter. A no-op for every non-keep-alive pane
+// type and for a block in any other tab: nothing ever marks those,
+// so they're never excluded.
+const dormantKeepAliveBlockIds = new Set<string>();
+
+/**
+ * Marks `blockId` as a currently-HIDDEN, kept-alive stack member (a
+ * terminal tab that isn't the active one but stays mounted+registered
+ * anyway) — called only by `pane-leaf-chrome.tsx`'s keep-alive rendering,
+ * reactively, as a stack member's own visibility toggles. Clearing this
+ * (dormant=false, including on that member's own unmount/tab-close) is
+ * just as load-bearing as setting it: a stale `true` entry would silently
+ * exclude an ordinary, currently-visible pane from every "all panes"
+ * consumer forever.
+ */
+export function setKeepAliveBlockDormant(blockId: string, dormant: boolean) {
+    if (dormant) {
+        dormantKeepAliveBlockIds.add(blockId);
+    } else {
+        dormantKeepAliveBlockIds.delete(blockId);
+    }
+}
+
 export function registerBlockComponentModel(blockId: string, bcm: BlockComponentModel) {
     blockComponentModelMap.set(blockId, bcm);
 }
@@ -29,6 +81,10 @@ export function unregisterBlockComponentModel(blockId: string, owner?: BlockComp
         return;
     }
     blockComponentModelMap.delete(blockId);
+    // Safety net alongside pane-leaf-chrome.tsx's own onCleanup-driven
+    // clear: a real unregistration means the dormancy marker (if any) can
+    // never become meaningful again for this blockId.
+    dormantKeepAliveBlockIds.delete(blockId);
     cleanupBlockAtomCache(blockId);
 }
 
@@ -36,40 +92,10 @@ export function getBlockComponentModel(blockId: string): BlockComponentModel {
     return blockComponentModelMap.get(blockId);
 }
 
-// Codex P1/P2 on PR #3187: `pane-leaf-chrome.tsx`'s keep-alive terminal tabs
-// (SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md's keep-alive
-// follow-up) mount EVERY stack member's `<Block>` simultaneously, not just
-// the active one — each still registers itself here under its own blockId,
-// same as always. Every existing consumer of the two "all panes" functions
-// below (`TermViewModel.multiInputHandler`'s keystroke broadcast,
-// `zoom.ts`'s all-panes stepper, `keymodel.ts`'s multi-input-eligible
-// terminal count) assumes one registry entry == one currently-visible pane
-// — true before keep-alive (a dormant stack member was simply unmounted and
-// therefore never registered at all), no longer true now that a hidden
-// terminal tab stays mounted AND registered. Filtering here, once, fixes
-// every current (and future) "all panes" consumer instead of requiring each
-// call site to remember its own filter.
-//
-// `node.data.blockId` (`layoutStack.ts`'s mutators) is reassigned to
-// whichever stack member is ACTIVE on every switch — `getNodeByBlockId`
-// resolves the leaf for ANY member, dormant or active, of a stacked leaf
-// (`leaf.data.blockStack?.includes(blockId)`), so comparing its return
-// value's OWN `.blockId` against the id being tested is what actually
-// distinguishes "the currently active/visible member" from "some other
-// blockId that merely still exists somewhere in this leaf's stack." A
-// no-op for every non-keep-alive pane type: those only ever have their
-// current active member registered at all, so this always resolves true
-// for whatever's actually in the map.
-function isActiveStackMember(blockId: string): boolean {
-    const layoutModel = getLayoutModelForStaticTab();
-    const node = layoutModel.getNodeByBlockId(blockId);
-    return node?.data?.blockId === blockId;
-}
-
 export function getAllBlockComponentModels(): BlockComponentModel[] {
-    return Array.from(blockComponentModelMap.keys())
-        .filter(isActiveStackMember)
-        .map((blockId) => blockComponentModelMap.get(blockId));
+    return Array.from(blockComponentModelMap.entries())
+        .filter(([blockId]) => !dormantKeepAliveBlockIds.has(blockId))
+        .map(([, bcm]) => bcm);
 }
 
 // `ViewModel`'s base interface does not declare `blockId` (concrete view
@@ -79,7 +105,7 @@ export function getAllBlockComponentModels(): BlockComponentModel[] {
 // getAllBlockComponentModels() value. The map is already keyed on blockId;
 // this just exposes that key alongside its value instead of discarding it.
 export function getAllBlockComponentModelEntries(): [string, BlockComponentModel][] {
-    return Array.from(blockComponentModelMap.entries()).filter(([blockId]) => isActiveStackMember(blockId));
+    return Array.from(blockComponentModelMap.entries()).filter(([blockId]) => !dormantKeepAliveBlockIds.has(blockId));
 }
 
 export function getFocusedBlockId(): string {

--- a/frontend/app/store/block-component-registry.ts
+++ b/frontend/app/store/block-component-registry.ts
@@ -36,8 +36,40 @@ export function getBlockComponentModel(blockId: string): BlockComponentModel {
     return blockComponentModelMap.get(blockId);
 }
 
+// Codex P1/P2 on PR #3187: `pane-leaf-chrome.tsx`'s keep-alive terminal tabs
+// (SPEC_PANE_TAB_SWITCH_CHROME_STABILITY_2026_09_07.md's keep-alive
+// follow-up) mount EVERY stack member's `<Block>` simultaneously, not just
+// the active one — each still registers itself here under its own blockId,
+// same as always. Every existing consumer of the two "all panes" functions
+// below (`TermViewModel.multiInputHandler`'s keystroke broadcast,
+// `zoom.ts`'s all-panes stepper, `keymodel.ts`'s multi-input-eligible
+// terminal count) assumes one registry entry == one currently-visible pane
+// — true before keep-alive (a dormant stack member was simply unmounted and
+// therefore never registered at all), no longer true now that a hidden
+// terminal tab stays mounted AND registered. Filtering here, once, fixes
+// every current (and future) "all panes" consumer instead of requiring each
+// call site to remember its own filter.
+//
+// `node.data.blockId` (`layoutStack.ts`'s mutators) is reassigned to
+// whichever stack member is ACTIVE on every switch — `getNodeByBlockId`
+// resolves the leaf for ANY member, dormant or active, of a stacked leaf
+// (`leaf.data.blockStack?.includes(blockId)`), so comparing its return
+// value's OWN `.blockId` against the id being tested is what actually
+// distinguishes "the currently active/visible member" from "some other
+// blockId that merely still exists somewhere in this leaf's stack." A
+// no-op for every non-keep-alive pane type: those only ever have their
+// current active member registered at all, so this always resolves true
+// for whatever's actually in the map.
+function isActiveStackMember(blockId: string): boolean {
+    const layoutModel = getLayoutModelForStaticTab();
+    const node = layoutModel.getNodeByBlockId(blockId);
+    return node?.data?.blockId === blockId;
+}
+
 export function getAllBlockComponentModels(): BlockComponentModel[] {
-    return Array.from(blockComponentModelMap.values());
+    return Array.from(blockComponentModelMap.keys())
+        .filter(isActiveStackMember)
+        .map((blockId) => blockComponentModelMap.get(blockId));
 }
 
 // `ViewModel`'s base interface does not declare `blockId` (concrete view
@@ -47,7 +79,7 @@ export function getAllBlockComponentModels(): BlockComponentModel[] {
 // getAllBlockComponentModels() value. The map is already keyed on blockId;
 // this just exposes that key alongside its value instead of discarding it.
 export function getAllBlockComponentModelEntries(): [string, BlockComponentModel][] {
-    return Array.from(blockComponentModelMap.entries());
+    return Array.from(blockComponentModelMap.entries()).filter(([blockId]) => isActiveStackMember(blockId));
 }
 
 export function getFocusedBlockId(): string {

--- a/frontend/app/tab/pane-leaf-chrome.test.tsx
+++ b/frontend/app/tab/pane-leaf-chrome.test.tsx
@@ -92,6 +92,31 @@ vi.mock("@/app/store/global", () => ({
     },
 }));
 
+// Fake layout-tree lookup for `stackBlockIds` (pane-leaf-chrome.tsx) — the
+// keep-alive branch (term panes) reads a leaf's `data.blockStack` via
+// `getLayoutModelForStaticTab()` + `findNode()`. Reactive via a plain
+// signal so a test can push a new stack and see `stackBlockIds()`
+// re-derive, same as a real `localTreeStateAtom()` bump would.
+// Defaults to no configured node for a given nodeId — `stackBlockIds`
+// falls back to `[activeBlockId()]` in that case, so tests that never call
+// `setBlockStack` (every non-keep-alive one, and the single-member term
+// tests) see exactly the old single-entry list.
+const [fakeTreeVersion, bumpFakeTreeVersion] = createSignal(0);
+const fakeNodesByNodeId = new Map<string, { data?: { blockStack?: string[] } }>();
+function setBlockStack(nodeId: string, blockStack: string[] | undefined) {
+    fakeNodesByNodeId.set(nodeId, { data: { blockStack } });
+    bumpFakeTreeVersion((v) => v + 1);
+}
+vi.mock("@/layout/index", () => ({
+    getLayoutModelForStaticTab: () => ({
+        localTreeStateAtom: () => fakeTreeVersion(),
+        treeState: { rootNode: {} as any },
+    }),
+}));
+vi.mock("@/layout/lib/layoutNode", () => ({
+    findNode: (_root: unknown, nodeId: string) => fakeNodesByNodeId.get(nodeId),
+}));
+
 async function loadPaneLeafChrome() {
     const mod = await import("./pane-leaf-chrome");
     return mod.PaneLeafChrome;
@@ -155,6 +180,7 @@ function makeRealisticNodeModel(overrides?: { activeBlockId?: () => string }): N
 afterEach(() => {
     cleanup();
     blockMetaSignals.clear();
+    fakeNodesByNodeId.clear();
     renderPaneChromeCallCount = { count: 0 };
 });
 
@@ -289,5 +315,64 @@ describe("PaneLeafChrome — hoisted", () => {
 
         setActiveBlockId("b1");
         expect(renderPaneChromeCallCount.count).toBe(1); // switching back doesn't re-invoke either
+    });
+});
+
+describe("PaneLeafChrome — keep-alive (term)", () => {
+    // The content-side acceptance criterion, mirroring the chrome-side one
+    // above: under KEEP_ALIVE_TYPES (term), every stack member's own Block
+    // mounts ONCE and stays mounted — a switch must not unmount/remount
+    // either one, only change which is visible. Reported live: with
+    // chrome already stable, term still fully remounted its <Block> (new
+    // TermViewModel, new xterm.js instance) on every switch, showing a
+    // brief spinner flash editor's own (never-remounting) file tabs never
+    // have.
+    it("keeps every stack member's Block mounted across a switch instead of remounting", async () => {
+        setBlockView("b1", "term");
+        setBlockView("b2", "term");
+        setBlockStack("node-1", ["b1", "b2"]);
+        const [activeBlockId, setActiveBlockId] = createSignal("b1");
+        const nodeModel = makeRealisticNodeModel({ activeBlockId });
+        const PaneLeafChrome = await loadPaneLeafChrome();
+
+        render(() => <PaneLeafChrome nodeModel={nodeModel} />);
+
+        // Both members are mounted up front, not just the active one.
+        const blockB1Before = screen.getByTestId("block-b1");
+        const blockB2Before = screen.getByTestId("block-b2");
+        expect(renderPaneChromeCallCount.count).toBe(1);
+
+        setActiveBlockId("b2");
+
+        // Same DOM nodes for BOTH — neither one remounted, only which is
+        // visible changed. A naive re-render would have torn down and
+        // recreated at least the newly-active one.
+        expect(screen.getByTestId("block-b1")).toBe(blockB1Before);
+        expect(screen.getByTestId("block-b2")).toBe(blockB2Before);
+        expect(renderPaneChromeCallCount.count).toBe(1); // chrome still didn't re-invoke either
+
+        setActiveBlockId("b1");
+        expect(screen.getByTestId("block-b1")).toBe(blockB1Before);
+        expect(screen.getByTestId("block-b2")).toBe(blockB2Before);
+    });
+
+    // A brand-new tab (pushed onto the stack, not yet ever active) must
+    // still mount — keep-alive doesn't mean "only the members that have
+    // ever been active."
+    it("mounts a newly-pushed stack member immediately, before it's ever active", async () => {
+        setBlockView("b1", "term");
+        setBlockView("b2", "term");
+        setBlockStack("node-1", ["b1"]);
+        const [activeBlockId] = createSignal("b1");
+        const nodeModel = makeRealisticNodeModel({ activeBlockId });
+        const PaneLeafChrome = await loadPaneLeafChrome();
+
+        render(() => <PaneLeafChrome nodeModel={nodeModel} />);
+        expect(screen.queryByTestId("block-b2")).toBeNull();
+
+        setBlockStack("node-1", ["b1", "b2"]);
+
+        expect(screen.getByTestId("block-b1")).toBeInTheDocument();
+        expect(screen.getByTestId("block-b2")).toBeInTheDocument();
     });
 });

--- a/frontend/app/tab/pane-leaf-chrome.tsx
+++ b/frontend/app/tab/pane-leaf-chrome.tsx
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Block, resolveEffectiveViewType } from "@/app/block/block";
+import { setKeepAliveBlockDormant } from "@/app/store/block-component-registry";
 import { WOS } from "@/app/store/global";
 import { getLayoutModelForStaticTab, type NodeModel } from "@/layout/index";
 import { findNode } from "@/layout/lib/layoutNode";
 import { Key } from "@solid-primitives/keyed";
-import { createMemo, createSignal, For, Show, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
 
 /**
  * Router `tabcontent.tsx` renders instead of `<Block>` directly — the
@@ -269,19 +270,40 @@ export function PaneLeafChrome(props: { nodeModel: NodeModel }): JSX.Element {
                 fit logic (e.g. TermWrap's) stays correct in the background
                 and there is nothing to re-fit when it's revealed again. */}
             <For each={stackBlockIds()}>
-                {(id) => (
-                    <div
-                        class="pane-leaf-keepalive-slot"
-                        style={{
-                            position: "absolute",
-                            inset: "0",
-                            visibility: id === activeBlockId() ? "visible" : "hidden",
-                            "pointer-events": id === activeBlockId() ? "auto" : "none",
-                        }}
-                    >
-                        <Block nodeModel={keepAliveNodeModelFor(id)} preview={false} />
-                    </div>
-                )}
+                {(id) => {
+                    // Codex P1/P2 + ReAgent P1 on PR #3187: every "all
+                    // panes" consumer of the block-component registry
+                    // (multi-input broadcast, all-panes zoom, the
+                    // multi-input-eligible terminal count) assumes one
+                    // registry entry per currently-VISIBLE pane. Mark this
+                    // member dormant whenever it isn't the active one, so
+                    // those consumers keep seeing exactly what they did
+                    // before keep-alive existed — see
+                    // block-component-registry.ts's own comment for why
+                    // this is tracked explicitly here rather than
+                    // re-derived from a layout/tab lookup. Cleared on this
+                    // row's own unmount (the id left the stack — tab
+                    // closed), not just flipped to false, so a closed tab
+                    // can never linger as a phantom dormant entry.
+                    createEffect(() => {
+                        setKeepAliveBlockDormant(id, id !== activeBlockId());
+                    });
+                    onCleanup(() => setKeepAliveBlockDormant(id, false));
+
+                    return (
+                        <div
+                            class="pane-leaf-keepalive-slot"
+                            style={{
+                                position: "absolute",
+                                inset: "0",
+                                visibility: id === activeBlockId() ? "visible" : "hidden",
+                                "pointer-events": id === activeBlockId() ? "auto" : "none",
+                            }}
+                        >
+                            <Block nodeModel={keepAliveNodeModelFor(id)} preview={false} />
+                        </div>
+                    );
+                }}
             </For>
         </Show>
     );

--- a/frontend/app/tab/pane-leaf-chrome.tsx
+++ b/frontend/app/tab/pane-leaf-chrome.tsx
@@ -3,9 +3,10 @@
 
 import { Block, resolveEffectiveViewType } from "@/app/block/block";
 import { WOS } from "@/app/store/global";
-import type { NodeModel } from "@/layout/index";
+import { getLayoutModelForStaticTab, type NodeModel } from "@/layout/index";
+import { findNode } from "@/layout/lib/layoutNode";
 import { Key } from "@solid-primitives/keyed";
-import { createMemo, Show, type JSX } from "solid-js";
+import { createMemo, createSignal, For, Show, type JSX } from "solid-js";
 
 /**
  * Router `tabcontent.tsx` renders instead of `<Block>` directly — the
@@ -46,6 +47,25 @@ import { createMemo, Show, type JSX } from "solid-js";
  */
 const HOISTS_OWN_CHROME = new Set(["agent", "term"]);
 
+/**
+ * Subset of `HOISTS_OWN_CHROME` whose stack members stay mounted
+ * SIMULTANEOUSLY instead of being swapped one-at-a-time behind the inner
+ * `<Key>` — every member's own `<Block>` (xterm instance, PTY connection,
+ * ViewModel) is created once and never torn down again while it stays in
+ * the stack; switching tabs just toggles which one is visible. Reported
+ * live after the chrome-stability fix landed: with header/strip already
+ * stable, a terminal tab switch still showed a brief spinner/re-render
+ * flash from `block.tsx`'s ready()-gate cross-fade, since the inner `<Key>`
+ * was STILL fully remounting `<Block>` (new `TermViewModel`, new xterm.js
+ * instance) on every switch — editor's own file tabs never do this at all
+ * (one persistent block, no remount), which is why editor felt "flawless"
+ * by comparison. Scoped to `"term"` only for now: each terminal tab is a
+ * genuinely separate backend-backed block with its own live PTY, unlike
+ * agent's picker/history tabs, which have more entangled per-tab state
+ * (quick-fork, launch-in-place) not yet audited for keep-alive safety.
+ */
+const KEEP_ALIVE_TYPES = new Set(["term"]);
+
 export function PaneLeafChrome(props: { nodeModel: NodeModel }): JSX.Element {
     const nodeModel = props.nodeModel;
     const activeBlockId = () => nodeModel.activeBlockId?.() ?? nodeModel.blockId;
@@ -85,6 +105,16 @@ export function PaneLeafChrome(props: { nodeModel: NodeModel }): JSX.Element {
         return latchedHoisted;
     });
 
+    // Same latch shape as `hoisted` above, over the narrower KEEP_ALIVE_TYPES
+    // set — see that const's own doc comment for what this changes and why.
+    let latchedKeepAlive = false;
+    const keepAlive = createMemo(() => {
+        if (!latchedKeepAlive && KEEP_ALIVE_TYPES.has(effectiveViewType())) {
+            latchedKeepAlive = true;
+        }
+        return latchedKeepAlive;
+    });
+
     // Block-scoped NodeModel wrapper for the inner, per-activation <Block>
     // mount. The LEAF's own NodeModel.blockId is frozen — captured once,
     // never re-derived (see that field's own doc comment in types.ts) —
@@ -110,16 +140,150 @@ export function PaneLeafChrome(props: { nodeModel: NodeModel }): JSX.Element {
     // title entirely. A plain field, not a signal, deliberately: it's known
     // at wrapper-construction time, so there's no window where both headers
     // could render at once.
+    //
+    // Used only when !keepAlive() — the single-active-member path below,
+    // unchanged from before KEEP_ALIVE_TYPES existed.
     const scopedNodeModel = createMemo<NodeModel>(() => ({
         ...nodeModel,
         blockId: activeBlockId(),
         paneChromeHoisted: hoisted(),
     }));
 
+    // --- Keep-alive machinery (only ever touched when keepAlive() is true) ---
+    //
+    // Under keep-alive, EVERY stack member's <Block> mounts once and stays
+    // mounted — so `nodeModel.setActiveViewModel`/`activeViewModel` (a
+    // single shared slot, last-writer-wins) can no longer be trusted: every
+    // kept-alive Block calls `setActiveViewModel` once at its OWN mount, not
+    // on every switch, so the shared slot would end up holding whichever
+    // tab happened to mount MOST RECENTLY — not necessarily the one
+    // currently visible. `TermPaneChrome`'s own `runtimeLabel` and the
+    // header's `viewModel` prop both read `nodeModel.activeViewModel()`
+    // expecting it to track the ACTIVE tab on every switch (they don't
+    // latch), so this isn't just a chrome-identity concern the way
+    // `chromeVm` below is — it's a live-correctness one.
+    //
+    // Fixed by giving each kept-alive blockId its OWN private, owner-checked
+    // slot (mirrors layoutNodeModels.ts's real activeViewModel/
+    // setActiveViewModel pair), and deriving the LEAF-level accessor chrome
+    // actually reads from a lookup keyed by the CURRENT activeBlockId() —
+    // so switching tabs is just pointing the read at a different
+    // already-populated slot, no remount, no blip.
+    interface ViewModelSlot {
+        get: () => ViewModel | null;
+        set: (vm: ViewModel | null, owner: object) => void;
+    }
+    const viewModelSlots = new Map<string, ViewModelSlot>();
+    function viewModelSlotFor(id: string): ViewModelSlot {
+        let slot = viewModelSlots.get(id);
+        if (!slot) {
+            let owner: object | null = null;
+            const [get, setSig] = createSignal<ViewModel | null>(null);
+            const set = (vm: ViewModel | null, o: object) => {
+                if (vm === null) {
+                    if (owner !== o) return;
+                    owner = null;
+                    setSig(null);
+                    return;
+                }
+                owner = o;
+                setSig(() => vm);
+            };
+            slot = { get, set };
+            viewModelSlots.set(id, slot);
+        }
+        return slot;
+    }
+
+    const keepAliveNodeModelCache = new Map<string, NodeModel>();
+    function keepAliveNodeModelFor(id: string): NodeModel {
+        let scoped = keepAliveNodeModelCache.get(id);
+        if (!scoped) {
+            const slot = viewModelSlotFor(id);
+            scoped = {
+                ...nodeModel,
+                blockId: id,
+                paneChromeHoisted: true,
+                activeViewModel: slot.get,
+                setActiveViewModel: slot.set,
+            } as NodeModel;
+            keepAliveNodeModelCache.set(id, scoped);
+        }
+        return scoped;
+    }
+
+    // The full stack, reactive — same `localTreeStateAtom()` + live
+    // `findNode` lookup pattern term.tsx's own `termTabs` and agent-view.tsx's
+    // `stackTabs` already use, falling back to a single-entry list when this
+    // leaf hasn't split into a stack yet.
+    const layoutModel = getLayoutModelForStaticTab();
+    const stackBlockIds = createMemo<string[]>(() => {
+        layoutModel.localTreeStateAtom();
+        const node = findNode(layoutModel.treeState.rootNode, nodeModel.nodeId);
+        const stack = node?.data?.blockStack?.length ? node.data.blockStack : [activeBlockId()];
+        if (keepAlive()) {
+            // Drop cache/slot entries for blockIds no longer in the stack
+            // (tab closed) so a closed tab's ViewModel/NodeModel wrapper
+            // don't linger for the rest of the pane's lifetime.
+            const live = new Set(stack);
+            for (const id of keepAliveNodeModelCache.keys()) {
+                if (!live.has(id)) keepAliveNodeModelCache.delete(id);
+            }
+            for (const id of viewModelSlots.keys()) {
+                if (!live.has(id)) viewModelSlots.delete(id);
+            }
+        }
+        return stack;
+    });
+
+    // The NodeModel chrome itself renders with — plain passthrough when not
+    // keeping tabs alive (unchanged), otherwise `activeViewModel` is
+    // overridden to the per-id lookup above so a switch re-points the read
+    // at the newly-active tab's own slot instead of following whichever
+    // Block mounted last.
+    const chromeNodeModel = createMemo<NodeModel>(() => {
+        if (!keepAlive()) return nodeModel;
+        return {
+            ...nodeModel,
+            activeViewModel: () => viewModelSlots.get(activeBlockId())?.get() ?? null,
+        };
+    });
+
     const content = (
-        <Key each={[scopedNodeModel()]} by={(nm) => nm.blockId}>
-            {(nm) => <Block nodeModel={nm()} preview={false} />}
-        </Key>
+        <Show
+            when={keepAlive()}
+            fallback={
+                <Key each={[scopedNodeModel()]} by={(nm) => nm.blockId}>
+                    {(nm) => <Block nodeModel={nm()} preview={false} />}
+                </Key>
+            }
+        >
+            {/* Every stack member mounted simultaneously, absolutely
+                positioned over one another inside the (already
+                `position: relative`) content slot each keep-alive pane
+                type reserves (e.g. term.scss's `.term-pane-stack-content`)
+                — visibility, not existence, is what switches. A hidden
+                member keeps its real (non-zero) box size the whole time
+                (`visibility: hidden` does not collapse layout the way
+                `display: none` would), so its own ResizeObserver-driven
+                fit logic (e.g. TermWrap's) stays correct in the background
+                and there is nothing to re-fit when it's revealed again. */}
+            <For each={stackBlockIds()}>
+                {(id) => (
+                    <div
+                        class="pane-leaf-keepalive-slot"
+                        style={{
+                            position: "absolute",
+                            inset: "0",
+                            visibility: id === activeBlockId() ? "visible" : "hidden",
+                            "pointer-events": id === activeBlockId() ? "auto" : "none",
+                        }}
+                    >
+                        <Block nodeModel={keepAliveNodeModelFor(id)} preview={false} />
+                    </div>
+                )}
+            </For>
+        </Show>
     );
 
 
@@ -143,11 +307,15 @@ export function PaneLeafChrome(props: { nodeModel: NodeModel }): JSX.Element {
     // via whichever vm happened to be active at that FIRST hoist and never
     // re-derives afterward — the same "frozen after first hoist" identity
     // `anchorBlockId` (agent-model.ts's own `renderPaneChrome` closure)
-    // already assumes.
+    // already assumes. Reads through `chromeNodeModel()` (not the raw
+    // `nodeModel` prop) so the keep-alive path latches onto the per-id
+    // lookup's current value rather than the shared (and, under keep-alive,
+    // unreliable) leaf-level slot — doesn't change what gets latched for
+    // the non-keep-alive path, where `chromeNodeModel()` IS `nodeModel`.
     let latchedChromeVm: ViewModel | null = null;
     const chromeVm = createMemo(() => {
         if (!latchedChromeVm) {
-            latchedChromeVm = nodeModel.activeViewModel?.() ?? null;
+            latchedChromeVm = chromeNodeModel().activeViewModel?.() ?? null;
         }
         return latchedChromeVm;
     });
@@ -160,7 +328,7 @@ export function PaneLeafChrome(props: { nodeModel: NodeModel }): JSX.Element {
                 never returns to a falsy value after its first real
                 capture. */}
             <Show when={chromeVm()}>
-                {(vm) => vm().renderPaneChrome!(nodeModel, content)}
+                {(vm) => vm().renderPaneChrome!(chromeNodeModel(), content)}
             </Show>
         </Show>
     );

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -475,6 +475,30 @@ export const AgentPaneChrome = (props: {
     // here) reflects its new label immediately, without waiting on the
     // SetMetaCommand round-trip (term.tsx's titleOverrides precedent).
     const [titleOverrides, setTitleOverrides] = createSignal<Record<string, string>>({});
+    // Stable per-blockId object cache, shared across stackTabs/combinedTabs
+    // — mirrors term.tsx's tabObjectCache (same bug, same fix, reported live
+    // on the terminal pane first): `stackTabs` reruns on EVERY switch (it
+    // reads `layoutModel.localTreeStateAtom()`, bumped by every stack
+    // mutation, not just add/remove/rename), and a plain `.map(labelForBlock)`
+    // handed `<For>` (inside PaneTabStrip) a brand-new object per tab every
+    // time, indistinguishable from "the whole tab list changed" — so every
+    // pill's DOM node got torn down and recreated on every switch. Reusing
+    // the previous object when nothing about that tab actually changed lets
+    // `<For>` keep the DOM node in place and just update its `active` prop.
+    const paneTabObjectCache = new Map<string, PaneTab>();
+    function cachedTab(id: string, next: PaneTab): PaneTab {
+        const cached = paneTabObjectCache.get(id);
+        if (
+            cached &&
+            cached.label === next.label &&
+            cached.definitionId === next.definitionId &&
+            cached.isHistoryTab === next.isHistoryTab
+        ) {
+            return cached;
+        }
+        paneTabObjectCache.set(id, next);
+        return next;
+    }
     const labelForBlock = (id: string): PaneTab => {
         // The currently ACTIVE member reads its own reactive block meta
         // (activeBlockData, already memoized above); every other (dormant)
@@ -488,10 +512,10 @@ export const AgentPaneChrome = (props: {
             // tab is never user-renamed (see PaneTab.isHistoryTab) and
             // must read distinctly from its live sibling, which carries
             // the same copied agentName in its own meta.
-            return { blockId: id, label: "History", isHistoryTab: true };
+            return cachedTab(id, { blockId: id, label: "History", isHistoryTab: true });
         }
         const label = titleOverrides()[id] ?? (meta?.["agentName"] as string) ?? definitionId ?? "New Agent";
-        return { blockId: id, label, definitionId };
+        return cachedTab(id, { blockId: id, label, definitionId });
     };
     const stackTabs = createMemo<PaneTab[]>(() => {
         // Reactive dependency: re-derive whenever ANY layout mutation
@@ -506,7 +530,14 @@ export const AgentPaneChrome = (props: {
         const stackIds = new Set(stack.map((t) => t.blockId));
         const extras = switchableForks()
             .filter((f) => f.blockId && !stackIds.has(f.blockId))
-            .map((f): PaneTab => ({ blockId: f.blockId!, label: f.title, definitionId: f.definitionId }));
+            .map((f) => cachedTab(f.blockId!, { blockId: f.blockId!, label: f.title, definitionId: f.definitionId }));
+        // Drop cache entries for blockIds no longer present anywhere in this
+        // pane's tabs, so it doesn't grow unboundedly across a long
+        // session's worth of closed tabs/forks.
+        const liveIds = new Set([...stackIds, ...extras.map((t) => t.blockId)]);
+        for (const id of paneTabObjectCache.keys()) {
+            if (!liveIds.has(id)) paneTabObjectCache.delete(id);
+        }
         return [...stack, ...extras];
     });
     // Only render tab pills once there's something to switch BETWEEN — a

--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -466,6 +466,19 @@ const TermPaneChrome = (props: {
     // its new label immediately.
     // SPEC_PANE_TAB_STRIP_COMPACT_SIZING_AND_RENAME_2026_07_22.md §3.3.
     const [titleOverrides, setTitleOverrides] = createSignal<Record<string, string>>({});
+    // Stable per-blockId object cache — reused across recomputes so a tab
+    // whose blockId/label didn't change keeps the SAME object reference.
+    // `<For>` in PaneTabStrip keys rows by item identity, and this memo
+    // reruns on EVERY switch (it reads `layoutModel.localTreeStateAtom()`,
+    // which `setActiveBlockInStack` bumps on every switch, not just on
+    // add/remove/rename). Without this cache, a plain `.map()` below
+    // handed `<For>` a brand-new object for every tab on every switch —
+    // indistinguishable from "the whole tab list changed" — so `<For>`
+    // tore down and recreated every pill's DOM node each time. Invisible
+    // on the plain-text inactive tabs, but visible as a flicker on the
+    // active one, which actually has a background highlight to flash.
+    // Reported live after PR #3157 shipped the header/strip stability fix.
+    const tabObjectCache = new Map<string, TermTab>();
     const termTabs = createMemo<TermTab[]>(() => {
         layoutModel.localTreeStateAtom();
         const overrides = titleOverrides();
@@ -480,12 +493,25 @@ const TermPaneChrome = (props: {
         // via a non-reactive lookup since a dormant tab's block isn't
         // mounted; `overrides` is what makes a just-performed rename show up
         // immediately.
-        return stack.map((id, i) => {
+        const seen = new Set<string>();
+        const result = stack.map((id, i) => {
+            seen.add(id);
             const persistedTitle = WOS.getObjectValue<Block>(WOS.makeORef("block", id))?.meta?.["pane-title"] as
                 | string
                 | undefined;
-            return { blockId: id, label: overrides[id] ?? persistedTitle ?? `Terminal ${i + 1}` };
+            const label = overrides[id] ?? persistedTitle ?? `Terminal ${i + 1}`;
+            const cached = tabObjectCache.get(id);
+            if (cached && cached.label === label) return cached;
+            const tab: TermTab = { blockId: id, label };
+            tabObjectCache.set(id, tab);
+            return tab;
         });
+        // Drop entries for tabs no longer in the stack so the cache doesn't
+        // grow unboundedly across a long session's worth of closed tabs.
+        for (const id of tabObjectCache.keys()) {
+            if (!seen.has(id)) tabObjectCache.delete(id);
+        }
+        return result;
     });
     // Only render tab pills once there's something to switch BETWEEN — a lone
     // terminal shows just the "+".

--- a/frontend/app/view/term/term.tsx
+++ b/frontend/app/view/term/term.tsx
@@ -538,7 +538,22 @@ const TermPaneChrome = (props: {
         if (targetBlockId === activeBlockId()) return;
         const node = getOwnNode();
         if (!node) return;
+        const wasFocused = nodeModel.isFocused();
         setActiveBlockInStack(layoutModel, node.id, targetBlockId);
+        // Terminal panes keep every stack member's <Block> mounted
+        // (pane-leaf-chrome.tsx's KEEP_ALIVE_TYPES) instead of swapping
+        // which one exists — so the target tab's own onMount-driven
+        // `wasFocused && giveFocus()` (TerminalView, term.tsx) only ever
+        // fires on that tab's FIRST-ever activation, not on a repeat
+        // switch back to an already-mounted one. Replicate that hand-off
+        // explicitly here instead. `nodeModel` is `chromeNodeModel()` from
+        // pane-leaf-chrome.tsx — its `activeViewModel()` is a live lookup
+        // keyed by the CURRENT active blockId, so this already reads the
+        // TARGET tab's own ViewModel once `setActiveBlockInStack` above has
+        // taken effect.
+        if (wasFocused) {
+            (nodeModel.activeViewModel?.() as { giveFocus?: () => void } | null)?.giveFocus?.();
+        }
     };
     const handleTermTabClose = (targetBlockId: string) => {
         const node = getOwnNode();


### PR DESCRIPTION
## Summary

Follow-up to the pane-tab-switch chrome-stability work (#3136/#3151/#3157). With header/tab-strip already stable, two smaller flickers remained:

- **Tab pill flash on switch**: `termTabs`/`stackTabs` rebuilt a brand-new object per tab pill on every switch (they rerun on any layout-tree bump, not just add/remove/rename), so `<For>` saw an entirely new list each time and tore down + recreated every pill's DOM node — invisible on plain inactive tabs, but visible as a flash on the active one's highlighted background. Fixed by caching tab objects per blockId and reusing them when nothing about that tab actually changed.
- **Terminal content flash on switch**: `pane-leaf-chrome.tsx`'s inner `<Key>` fully remounted `<Block>` (new `TermViewModel`, new xterm.js instance) on every terminal tab switch, showing `block.tsx`'s ready-gate `BrainSpinner` cross-fade briefly. Editor's own file tabs never remount at all (one persistent block, no remount), which is why editor felt smooth by comparison. Terminal tabs now all mount once and stay mounted — a switch just toggles `visibility` on an absolutely-positioned wrapper instead of tearing down and rebuilding. Each tab gets its own private ViewModel slot (since multiple `<Block>`s are now live simultaneously and a shared slot would otherwise track whichever tab mounted most recently, not whichever is active), and the tab-switch handler explicitly hands off keyboard focus to the target tab since its own mount-time focus grab no longer fires on a repeat switch. Scoped to terminal only; agent tabs are unchanged.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Full frontend test suite passes (153 files / 2130 tests)
- [x] New tests: tab-pill identity caching regression coverage; `pane-leaf-chrome.test.tsx` keep-alive coverage (both stack members stay mounted across a switch, a newly-pushed member mounts immediately)
- [x] Manually verified in `task dev`: tab-pill flash gone, terminal switch flicker gone
- [ ] Reviewer: please double check the per-tab ViewModel slot isolation (`pane-leaf-chrome.tsx`'s `viewModelSlotFor`) and the explicit focus hand-off in `term.tsx`'s `handleTermTabSwitch`

<!-- agentmux:agent_id=camper -->