### PR TITLE
Clare@starpower: fix(mcp): SendMessage reports whether a message was delivered or only queued

### DIFF
--- a/.changesets/1789087893-fix-mcp-sendmessage-reports-whether-a-message-was-delivered--mzmm.md
+++ b/.changesets/1789087893-fix-mcp-sendmessage-reports-whether-a-message-was-delivered--mzmm.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(mcp): SendMessage reports whether a message was delivered or only queued

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -1153,7 +1153,34 @@ async fn call_tool(
                 .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
 
             if result.get("success").and_then(|v| v.as_bool()) == Some(true) {
-                Ok(format!("Message sent to {to}"))
+                // `success: true` spans two very different outcomes and the old
+                // message conflated them, which made agent-to-agent delivery
+                // unfalsifiable from the sender side: a name that exists on no
+                // machine anywhere reported exactly the same string as a
+                // message injected into a live conversation. Verified against a
+                // running srv — `SendMessage(to="definitely-not-a-real-agent-xyz123")`
+                // returned "Message sent to ...", and the server log showed
+                // "cloud relay: queued for WAN delivery" for it, identical to a
+                // real remote agent.
+                //
+                // The response already carries the distinction: the handler sets
+                // `block_id` to the receiving block on local/host delivery
+                // (backend/reactive/handler.rs), while the cloud-relay path
+                // leaves it `None` because no receiver has seen the message yet
+                // (server/reactive.rs, `try_cloud_relay` — "Queued is not
+                // delivered"). Report which one happened.
+                if result.get("block_id").and_then(|v| v.as_str()).is_some() {
+                    Ok(format!("Delivered to {to} — injected into their conversation."))
+                } else {
+                    Ok(format!(
+                        "QUEUED for {to} via the cloud relay — NOT yet delivered. \
+                         The relay accepted it; their AgentMux picks it up on its next \
+                         sync, which never happens if that instance is offline. You get \
+                         this same result for an agent name that does not exist anywhere, \
+                         so check the spelling against DiscoverAgents if you expected \
+                         local delivery."
+                    ))
+                }
             } else {
                 let err = result
                     .get("error")

--- a/agentmux-mcp/src/tool_schemas.rs
+++ b/agentmux-mcp/src/tool_schemas.rs
@@ -146,7 +146,7 @@ pub(crate) const PTY_SHELL_STOP_TOOL: &str = r#"{
 
 pub(crate) const SEND_MESSAGE_TOOL: &str = r#"{
   "name": "SendMessage",
-  "description": "Send a message to another agent by name. The message is injected as input into the target agent's active conversation. Use for agent-to-agent coordination — handoff, task delegation, status notifications. Delivery is best-effort and tries local → same-host → LAN → cloud in order. The first three tiers return only once the message has actually been injected; the cloud tier is store-and-forward, so success there means the relay accepted it and the recipient's AgentMux will pick it up when it next syncs (which never happens if that instance stays offline). Returns once one tier has taken the message or all have failed.",
+  "description": "Send a message to another agent by name. The message is injected as input into the target agent's active conversation. Use for agent-to-agent coordination — handoff, task delegation, status notifications. Delivery is best-effort and tries local → same-host → LAN → cloud in order. The first three tiers return only once the message has actually been injected; the cloud tier is store-and-forward, so success there means the relay accepted it and the recipient's AgentMux will pick it up when it next syncs (which never happens if that instance stays offline). The return value names which happened: \"Delivered to X\" means it was injected into a live conversation; \"QUEUED for X\" means only the relay has it. An agent name that exists nowhere also returns QUEUED, so treat that as 'unconfirmed', not 'sent' — check DiscoverAgents if you expected local delivery.",
   "inputSchema": {
     "type": "object",
     "properties": {


### PR DESCRIPTION
## The bug

`success: true` spans two very different outcomes, and the old return string conflated them — making agent-to-agent delivery **unfalsifiable from the sender's side**.

Verified against a running srv, not inferred. Sending to a name that exists on no machine anywhere:

```
SendMessage(to="definitely-not-a-real-agent-xyz123")
  -> "Message sent to definitely-not-a-real-agent-xyz123"
```

Server log for that same call:

```
"cloud relay: queued for WAN delivery"  target=definitely-not-a-real-agent-xyz123
```

**Byte-identical treatment to a real remote agent.** Meanwhile a same-host target logs:

```
"inject: structured delivery to non-PTY controller (mid-turn steer)"  target_agent=AgentO
```

…and AgentO confirmed receipt by replying (`DELIVERY=host TRUST=host-verified`).

So all three outcomes returned the same string:

| Outcome | Old return |
|---|---|
| injected into a live conversation | `Message sent to X` |
| queued for a real but unreachable agent | `Message sent to X` |
| queued for a name nobody has ever claimed | `Message sent to X` |

This is very likely why *"jekt messages not coming through"* has been so hard to pin down — the sender gets a confirmation, reasonably assumes delivery, and nothing contradicts it.

## The fix needs no srv change

The response **already carries the distinction**; the MCP layer was discarding it.

| Path | `block_id` |
|---|---|
| local delivery (`backend/reactive/handler.rs:947`) | `Some(block_id)` — the receiving block |
| cloud relay (`server/reactive.rs:1357`) | `None` — no receiver has seen it |

`try_cloud_relay`'s own doc comment already says **"Queued is not delivered."** The information was there and unused.

Now:

- `Delivered to X — injected into their conversation.`
- `QUEUED for X via the cloud relay — NOT yet delivered. …You get this same result for an agent name that does not exist anywhere, so check the spelling against DiscoverAgents if you expected local delivery.`

The nonexistent-name case is called out explicitly so it's actionable rather than mysterious. Tool description updated to match, since agents read that to decide whether to trust the result.

## Why this matters beyond cosmetics

`DiscoverAgents` cannot tell you whether a remote agent exists — the WAN entry lists only *this* host's subscribers, and the relay exposes no remote directory (documented behaviour). Combined with unconditional success reporting, there was no way for a sender to establish delivery at all. This restores that.

## Related but separate

agentmuxai/agentmux-cloud#71 (merged today) fixed `merge.ts` / `ci-failure.ts` silently dropping notifications for agents on shared GitHub accounts. That's the GitHub→jekt path; this is agent→agent.

<!-- agentmux:agent_id=clare -->