### PR TITLE
fix(agent-pane): PageUp/PageDown in composer no longer scrolls the pane off screen

### DIFF
--- a/.changesets/1789091270-fix-agent-pane-pageup-pagedown-in-composer-no-longer-scrolls-zn34.md
+++ b/.changesets/1789091270-fix-agent-pane-pageup-pagedown-in-composer-no-longer-scrolls-zn34.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): PageUp/PageDown in composer no longer scrolls the pane off screen

--- a/frontend/app/view/agent/components/AgentFooter.test.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.test.tsx
@@ -93,6 +93,30 @@ describe("AgentFooter Esc-clear Undo", () => {
 });
 
 /**
+ * Regression test: the composer textarea is a flex sibling of the chat
+ * scroll region, not a descendant of it (see the PageUp/PageDown branch's
+ * own comment in handleKeyDown). Left unprevented, Page Up/Down's browser
+ * default escapes past the pane entirely to scroll an unrelated ancestor,
+ * which reads as the whole chat pane jumping off screen.
+ */
+describe("AgentFooter PageUp/PageDown", () => {
+    it("prevents the default scroll for PageUp and PageDown while the composer is focused", async () => {
+        render(() => <AgentFooter agentName="Test" />);
+        const user = userEvent.setup();
+        const ta = getComposer();
+        await user.click(ta);
+
+        const pageUp = new KeyboardEvent("keydown", { key: "PageUp", bubbles: true, cancelable: true });
+        ta.dispatchEvent(pageUp);
+        expect(pageUp.defaultPrevented).toBe(true);
+
+        const pageDown = new KeyboardEvent("keydown", { key: "PageDown", bubbles: true, cancelable: true });
+        ta.dispatchEvent(pageDown);
+        expect(pageDown.defaultPrevented).toBe(true);
+    });
+});
+
+/**
  * Regression tests for
  * docs/specs/SPEC_COMPOSER_SHIFT_UP_SELECTION_VS_HISTORY_RACE_2026-08-11.md.
  *

--- a/frontend/app/view/agent/components/AgentFooter.test.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.test.tsx
@@ -114,6 +114,24 @@ describe("AgentFooter PageUp/PageDown", () => {
         ta.dispatchEvent(pageDown);
         expect(pageDown.defaultPrevented).toBe(true);
     });
+
+    it("does not prevent default when the composer itself is overflowing and has its own paging to do (codex P2 on PR #3190)", async () => {
+        render(() => <AgentFooter agentName="Test" />);
+        const user = userEvent.setup();
+        const ta = getComposer();
+        await user.click(ta);
+
+        // jsdom never computes real layout, so scrollHeight/clientHeight are
+        // both 0 by default — simulate the "draft grew past the 200px cap"
+        // state (_pending-footer.scss's `max-height: 200px; overflow-y: auto`)
+        // the same way a long pasted prompt would trigger it for real.
+        Object.defineProperty(ta, "scrollHeight", { value: 400, configurable: true });
+        Object.defineProperty(ta, "clientHeight", { value: 200, configurable: true });
+
+        const pageUp = new KeyboardEvent("keydown", { key: "PageUp", bubbles: true, cancelable: true });
+        ta.dispatchEvent(pageUp);
+        expect(pageUp.defaultPrevented).toBe(false);
+    });
 });
 
 /**

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -886,7 +886,14 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         // nothing of its own left to scroll.
         if (e.key === "PageUp" || e.key === "PageDown") {
             const el = textareaRef;
-            if (el && el.scrollHeight > el.clientHeight) {
+            // This read isn't preceded by a style write in this handler
+            // (unlike the typing/auto-grow path SPEC_INPUT_RESPONSIVENESS_
+            // TERMINAL_AND_AGENT_2026_05_29.md §4 guards against), and
+            // PageUp/PageDown fire far less often than every keystroke, so
+            // it isn't the layout-thrashing pattern that rule targets. The
+            // decision has to be synchronous — deferring to a rAF read
+            // would make preventDefault() too late.
+            if (el && el.scrollHeight > el.clientHeight) { // perf:allow-layout-read — see comment above, not the typing hot path
                 return;
             }
             e.preventDefault();

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -865,6 +865,21 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         // events without setting `isComposing`. Both checks are
         // load-bearing. See SPEC_INPUT_RESPONSIVENESS §6.2.
         if (e.isComposing || e.keyCode === 229) return;
+        // PageUp/PageDown: this textarea is a flex sibling of
+        // .agent-document-scroll-region, not a descendant of it (see
+        // .agent-composer-region in styles/_control-bar.scss) — and
+        // .agent-view itself is overflow:hidden (agent-view.scss). So the
+        // scrollable chat history (.agent-document) is never an ancestor of
+        // this element. Left unhandled, the browser's default Page Up/Down
+        // walks PAST the pane looking for the nearest scrollable ancestor
+        // and scrolls whatever it finds outside .agent-view instead —
+        // which reads as the whole chat pane flying off screen. Nothing in
+        // this textarea needs paging (it's a composer box, not a scrollback
+        // buffer), so simply swallow the key here.
+        if (e.key === "PageUp" || e.key === "PageDown") {
+            e.preventDefault();
+            return;
+        }
         // Ghost-text next-prompt suggestion: Tab accepts it into the real
         // input, matching Claude Code CLI's own terminal UX (see
         // docs/specs/SPEC_AMBIENT_GHOST_TEXT_NEXT_PROMPT_2026_07_03.md).

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -873,10 +873,22 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         // this element. Left unhandled, the browser's default Page Up/Down
         // walks PAST the pane looking for the nearest scrollable ancestor
         // and scrolls whatever it finds outside .agent-view instead —
-        // which reads as the whole chat pane flying off screen. Nothing in
-        // this textarea needs paging (it's a composer box, not a scrollback
-        // buffer), so simply swallow the key here.
+        // which reads as the whole chat pane flying off screen.
+        //
+        // EXCEPTION (codex P2 on PR #3190): a long draft grows the textarea
+        // up to its own 200px cap, past which `.agent-input` becomes its own
+        // scroll container (`max-height: 200px; overflow-y: auto` in
+        // _pending-footer.scss). In that state the textarea itself IS the
+        // nearest scrollable ancestor of the caret, and PageUp/PageDown
+        // should page/scroll within it exactly like any other overflowing
+        // textarea — swallowing the key here would silently break paging
+        // through a long pasted prompt. Only intercept when the textarea has
+        // nothing of its own left to scroll.
         if (e.key === "PageUp" || e.key === "PageDown") {
+            const el = textareaRef;
+            if (el && el.scrollHeight > el.clientHeight) {
+                return;
+            }
             e.preventDefault();
             return;
         }


### PR DESCRIPTION
## Summary
- Root cause: the composer `<textarea>` in `AgentFooter.tsx` never handled `PageUp`/`PageDown`. It isn't nested inside the scrollable chat history (`.agent-document`, `overflow-y: auto`) — it's a flex sibling of it, and the whole pane wrapper (`.agent-view`) is `overflow: hidden`. The browser's default Page Up/Down behavior walked past the pane looking for a scrollable ancestor and found one outside `.agent-view` instead, displacing the entire pane.
- Fix: swallow `PageUp`/`PageDown` in the composer's `handleKeyDown` with `preventDefault()`.
- Added a regression test asserting `defaultPrevented` for both keys.

## Test plan
- [x] `npx vitest run app/view/agent/components/AgentFooter.test.tsx` — 25/25 pass (including the new PageUp/PageDown test)

<!-- agentmux:agent_id=agent5 -->