### PR TITLE
feat(mcp): add ClosePane — close your own pane, or any pane by block_id (fleet tier)

### DIFF
--- a/.changesets/1789093074-feat-mcp-closepane-close-your-own-pane-or-any-pane-by-block--r6b8.md
+++ b/.changesets/1789093074-feat-mcp-closepane-close-your-own-pane-or-any-pane-by-block--r6b8.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(mcp): ClosePane — close your own pane, or any pane by block_id (fleet tier)

--- a/agentmux-common/src/api_types.rs
+++ b/agentmux-common/src/api_types.rs
@@ -477,3 +477,28 @@ pub struct UiQueryRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub limit: Option<u32>,
 }
+
+/// `POST /api/v1/agent/pane/close` — backs the `ClosePane` MCP tool.
+/// See docs/specs/SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md.
+///
+/// `auth` is reused unchanged from `UiAutomationAuth` (the same signed
+/// per-agent identity `verified_block_id` already checks for UI automation)
+/// — it is what resolves the caller's OWN pane when `block_id` is omitted,
+/// and what supplies a verified `source_agent` for the audit log when
+/// `block_id` targets another agent's pane (§5.2 of that spec).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClosePaneRequest {
+    #[serde(flatten)]
+    pub auth: UiAutomationAuth,
+    /// Target pane to close. Omitted = the caller's own pane (self-only,
+    /// no ownership check needed — it's already the caller's). Present =
+    /// fleet tier: close ANY pane by block_id, no ownership check on the
+    /// TARGET either, by design (§5.1) — this is the capability that
+    /// motivated the whole spec.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_id: Option<String>,
+    /// Optional human-readable reason, threaded into the audit log entry
+    /// when closing another agent's pane.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -36,7 +36,7 @@ use agentmux_common::api_types::{
     ShellInputResponse, ShellStatusRequest, ShellStatusResponse, ShellStopRequest,
     ShellStopResponse, TabActivateRequest, TabNameRequest, TabNewRequest, UiClickRequest,
     UiQueryRequest, UiScreenshotRequest, UiScreenshotResponse, WindowFocusRequest,
-    WindowNameRequest, WorkspaceNameRequest, PaneTitleRequest,
+    WindowNameRequest, WorkspaceNameRequest, PaneTitleRequest, ClosePaneRequest,
 };
 use anyhow::Result;
 use serde_json::{json, Value};
@@ -181,6 +181,8 @@ async fn main() {
                     serde_json::from_str(UI_SCREENSHOT_TOOL).expect("static json");
                 let ui_click: Value = serde_json::from_str(UI_CLICK_TOOL).expect("static json");
                 let ui_query: Value = serde_json::from_str(UI_QUERY_TOOL).expect("static json");
+                let close_pane: Value =
+                    serde_json::from_str(CLOSE_PANE_TOOL).expect("static json");
                 let capture_window: Value =
                     serde_json::from_str(CAPTURE_WINDOW_TOOL).expect("static json");
                 let discover_windows: Value =
@@ -221,7 +223,7 @@ async fn main() {
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,
-                    "result": { "tools": [shell, shell_stop, shell_input, shell_status, pty_shell, pty_shell_input, pty_shell_resize, pty_shell_read, pty_shell_status, pty_shell_stop, open_editor, open_media, send_message, discover_agents, get_agent_transcript, list_conversations, supervisor_nudge, whoami, layout, set_name, set_active_tab, new_tab, focus_window, ui_screenshot, ui_click, ui_query, capture_window, discover_windows, fleet_list, fleet_broadcast, fleet_bulk_stop, open_agent, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, work_enqueue, work_claim, work_heartbeat, work_complete, work_release, work_list, memory_list, memory_read, memory_write, memory_history, memory_diff, memory_revert, preset_list, preset_get, identity_accounts, identity_validate] }
+                    "result": { "tools": [shell, shell_stop, shell_input, shell_status, pty_shell, pty_shell_input, pty_shell_resize, pty_shell_read, pty_shell_status, pty_shell_stop, open_editor, open_media, send_message, discover_agents, get_agent_transcript, list_conversations, supervisor_nudge, whoami, layout, set_name, set_active_tab, new_tab, focus_window, ui_screenshot, ui_click, ui_query, close_pane, capture_window, discover_windows, fleet_list, fleet_broadcast, fleet_bulk_stop, open_agent, loop_tool, loop_stop, loop_list, cron_create, cron_delete, cron_list, cron_pause, cron_resume, work_enqueue, work_claim, work_heartbeat, work_complete, work_release, work_list, memory_list, memory_read, memory_write, memory_history, memory_diff, memory_revert, preset_list, preset_get, identity_accounts, identity_validate] }
                 })
             }
             "tools/call" => {
@@ -2023,6 +2025,29 @@ async fn call_tool(
                 .unwrap_or_else(|| json!([]));
             Ok(serde_json::to_string_pretty(&matches).unwrap_or_else(|_| matches.to_string()))
         }
+        "ClosePane" => {
+            require_agent_env(local_url, auth_key, block_id)?;
+            let auth = sign_ui_automation_auth()?;
+            let target_block_id = arguments.get("block_id").and_then(|v| v.as_str()).map(str::to_string);
+            let reason = arguments.get("reason").and_then(|v| v.as_str()).map(str::to_string);
+            let url = format!("{}/api/v1/agent/pane/close", local_url.trim_end_matches('/'));
+            let resp = client
+                .post(&url)
+                .header("X-AuthKey", auth_key)
+                .json(&ClosePaneRequest { auth, block_id: target_block_id.clone(), reason })
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                anyhow::bail!("close failed: HTTP {status} — {text}");
+            }
+            match target_block_id {
+                Some(b) => Ok(format!("Closed pane {b:?}")),
+                None => Ok("Closed your own pane".to_string()),
+            }
+        }
         "Loop" => {
             let prompt = arguments
                 .get("prompt")
@@ -3351,6 +3376,7 @@ mod tests {
             CAPTURE_WINDOW_TOOL,
             DISCOVER_WINDOWS_TOOL,
             LIST_CONVERSATIONS_TOOL,
+            CLOSE_PANE_TOOL,
         ];
         // This array (and its count) has drifted from the real `tools/list`
         // response before this change too — SHELL_INPUT/STATUS, the three
@@ -3375,7 +3401,9 @@ mod tests {
         // OPEN_AGENT_TOOL added (REPORT_AGENT_OPEN_API_GAP_2026_09_06.md) —
         // same reasoning as the entries above, not fixing the pre-existing
         // drift between this running total and the prose breakdown.
-        assert_eq!(defs.len(), 43, "tools/list advertises 27 tools (11 original + 1 OpenMedia + 3 Loop + 5 Cron + 7 agent-API) + 3 memory-version-history + 3 fleet-control tools + 1 OpenAgent + 1 CaptureWindow + 1 ListConversations + 1 DiscoverWindows + 6 Muxqueue");
+        // CLOSE_PANE_TOOL added (SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md
+        // Phase 1) — same reasoning, not fixing the pre-existing drift.
+        assert_eq!(defs.len(), 44, "tools/list advertises 27 tools (11 original + 1 OpenMedia + 3 Loop + 5 Cron + 7 agent-API) + 3 memory-version-history + 3 fleet-control tools + 1 OpenAgent + 1 CaptureWindow + 1 ListConversations + 1 DiscoverWindows + 6 Muxqueue + 1 ClosePane");
         for d in defs {
             let v: Value = serde_json::from_str(d).expect("tool def must be valid JSON");
             assert!(

--- a/agentmux-mcp/src/tool_schemas.rs
+++ b/agentmux-mcp/src/tool_schemas.rs
@@ -275,6 +275,18 @@ pub(crate) const UI_QUERY_TOOL: &str = r#"{
   }
 }"#;
 
+pub(crate) const CLOSE_PANE_TOOL: &str = r#"{
+  "name": "ClosePane",
+  "description": "Close a pane. With no arguments, closes YOUR OWN pane (identity verified server-side, same mechanism as UIClick — there is no way to spoof this as a different pane). Pass block_id to close ANY pane instead — including one that is unresponsive/unclickable (e.g. a pane stuck in a broken render state) — with no ownership check on the target: this is a fleet-level action, logged to the audit trail with your own verified identity as the source, same posture as FleetBulkStop. Get a target block_id from Layout. Closing a pane only removes it from the layout; the underlying agent's conversation history is not deleted.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "block_id": { "type": "string", "description": "Target pane to close (from Layout). Omit to close your own pane." },
+      "reason": { "type": "string", "description": "Optional note recorded in the audit log — most useful when closing another agent's pane." }
+    }
+  }
+}"#;
+
 // Deliberately NOT part of the ui_handlers.rs signed-identity/pane-ownership
 // scheme UIScreenshot/UIClick/UIQuery use. Authorization here is by
 // `CaptureTier` (what is being captured), not by pane ownership.

--- a/agentmux-srv/src/backend/reactive/handler.rs
+++ b/agentmux-srv/src/backend/reactive/handler.rs
@@ -1484,15 +1484,21 @@ impl ReactiveHandler {
         self.inner.lock().unwrap().get_audit_log(limit)
     }
 
-    /// Records an action that isn't a jekt injection (currently: fleet
-    /// bulk-stop — `agentmux-srv/src/server/app_api/fleet.rs`) into the SAME
-    /// audit ring buffer, so it shows up in Warden's Audit tab exactly like
-    /// an ordinary injection (`SPEC_MULTI_AGENT_FLEET_CONTROL_2026_08_20.md`
-    /// §6 — fleet actions get visibility there without Warden owning any
-    /// new code). `action` fills the slot `log_audit` normally uses for the
-    /// injected message text (e.g. `"fleet.bulk-stop"`); `target_agent` is
-    /// the resolved agent name for `block_id` when known, else `block_id`
-    /// itself (an unregistered/already-stopped block has no agent to name).
+    /// Records an action that isn't a jekt injection (fleet bulk-stop,
+    /// pane-lifecycle close/etc. — `agentmux-srv/src/server/app_api/{fleet,
+    /// pane}.rs`) into the SAME audit ring buffer, so it shows up in
+    /// Warden's Audit tab exactly like an ordinary injection
+    /// (`SPEC_MULTI_AGENT_FLEET_CONTROL_2026_08_20.md` §6 — fleet actions get
+    /// visibility there without Warden owning any new code). `action` fills
+    /// the slot `log_audit` normally uses for the injected message text
+    /// (e.g. `"fleet.bulk-stop"`, `"pane.close"`); `target_agent` is the
+    /// resolved agent name for `block_id` when known, else `block_id` itself
+    /// (an unregistered/already-stopped block has no agent to name).
+    ///
+    /// `reason`: an optional caller-supplied free-text note (e.g.
+    /// `ClosePane`'s `reason` field, SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md
+    /// §5.2). `None` for every pre-existing caller (`FleetBulkStop` has no
+    /// such field today) — purely additive, no behavior change for them.
     #[allow(clippy::too_many_arguments)]
     pub fn log_fleet_action_audit(
         &self,
@@ -1503,6 +1509,7 @@ impl ReactiveHandler {
         success: bool,
         error_message: Option<&str>,
         request_id: &str,
+        reason: Option<&str>,
     ) {
         self.inner.lock().unwrap().log_audit(
             source_agent,
@@ -1513,7 +1520,7 @@ impl ReactiveHandler {
             error_message,
             request_id,
             None,
-            None,
+            reason,
         );
     }
 

--- a/agentmux-srv/src/server/app_api/fleet.rs
+++ b/agentmux-srv/src/server/app_api/fleet.rs
@@ -258,14 +258,14 @@ pub(crate) async fn fleet_bulk_stop_impl(
                 Ok(()) => {
                     state.reactive_handler.log_fleet_action_audit(
                         None, &target_agent, &block_id, FLEET_BULK_STOP_AUDIT_ACTION,
-                        true, None, &request_id,
+                        true, None, &request_id, None,
                     );
                     result.succeeded.push(block_id);
                 }
                 Err(e) => {
                     state.reactive_handler.log_fleet_action_audit(
                         None, &target_agent, &block_id, FLEET_BULK_STOP_AUDIT_ACTION,
-                        false, Some(&e), &request_id,
+                        false, Some(&e), &request_id, None,
                     );
                     batch_failures += 1;
                     result.failed.push(FleetActionFailure { id: block_id, error: e });

--- a/agentmux-srv/src/server/app_api/mod.rs
+++ b/agentmux-srv/src/server/app_api/mod.rs
@@ -44,7 +44,10 @@ mod agent_define;
 /// vendor-base-url validation `agent.define` already uses, instead of
 /// duplicating it.
 pub(crate) use agent_define::validate_vendor_base_url;
-mod pane;
+// pub(crate): `server/mod.rs`'s `POST /api/v1/agent/pane/close` handler (the
+// `ClosePane` MCP tool's backing route) calls `pane::handle_close_pane`
+// directly, same as `fleet`'s exposure just below.
+pub(crate) mod pane;
 mod blockfile;
 pub(crate) mod session;
 mod identity;

--- a/agentmux-srv/src/server/app_api/pane.rs
+++ b/agentmux-srv/src/server/app_api/pane.rs
@@ -412,3 +412,242 @@ pub(super) fn resolve_placement(
 
     (actiontype.to_string(), reference.to_string(), position.to_string())
 }
+
+/// `POST /api/v1/agent/pane/close` — backs the `ClosePane` MCP tool.
+/// See docs/specs/SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md.
+///
+/// Identity is always verified first via the same `verified_block_id`
+/// mechanism `UIClick`/`UIQuery`/`UIScreenshot` use (§5.0 of that spec) —
+/// this both resolves the caller's OWN pane when `req.block_id` is absent,
+/// and supplies a real, checked `source_agent` for the audit log when
+/// `req.block_id` targets another agent's pane (fleet tier, §5.1/§5.2): no
+/// ownership check on the TARGET (closing another agent's stuck pane without
+/// needing its cooperation is this spec's whole motivation), but the CALLER
+/// is never anonymous the way `FleetBulkStop`'s existing calls are today.
+pub(crate) async fn handle_close_pane(
+    axum::extract::State(state): axum::extract::State<AppState>,
+    axum::Json(req): axum::Json<agentmux_common::api_types::ClosePaneRequest>,
+) -> impl axum::response::IntoResponse {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use axum::Json;
+
+    let caller_agent_id = req.auth.agent_id.clone();
+    let verified_own_block_id = match crate::server::ui_handlers::verified_block_id(&state, &req.auth) {
+        Ok(b) => b,
+        Err(e) => return (StatusCode::UNAUTHORIZED, Json(json!({ "error": e }))).into_response(),
+    };
+
+    let target_block_id = req.block_id.clone().unwrap_or(verified_own_block_id);
+    let is_cross_pane = req.block_id.is_some();
+
+    let tab_id = {
+        let s = state.srv_state.lock().await;
+        match s.blocks.get(&target_block_id) {
+            Some(b) => b.tab_id.clone(),
+            None => {
+                let err = format!("block not found: {target_block_id}");
+                if is_cross_pane {
+                    let request_id = uuid::Uuid::new_v4().to_string();
+                    state.reactive_handler.log_fleet_action_audit(
+                        Some(&caller_agent_id), &target_block_id, &target_block_id,
+                        "pane.close", false, Some(&err), &request_id, req.reason.as_deref(),
+                    );
+                }
+                return (StatusCode::NOT_FOUND, Json(json!({ "error": err }))).into_response();
+            }
+        }
+    };
+
+    let result = crate::sagas::delete_block::run(&state, tab_id, target_block_id.clone()).await;
+
+    if is_cross_pane {
+        let request_id = uuid::Uuid::new_v4().to_string();
+        let target_agent = state
+            .reactive_handler
+            .get_agent_by_block(&target_block_id)
+            .map(|a| a.agent_id)
+            .unwrap_or_else(|| target_block_id.clone());
+        match &result {
+            Ok(_) => state.reactive_handler.log_fleet_action_audit(
+                Some(&caller_agent_id), &target_agent, &target_block_id,
+                "pane.close", true, None, &request_id, req.reason.as_deref(),
+            ),
+            Err(e) => state.reactive_handler.log_fleet_action_audit(
+                Some(&caller_agent_id), &target_agent, &target_block_id,
+                "pane.close", false, Some(e), &request_id, req.reason.as_deref(),
+            ),
+        }
+    }
+
+    match result {
+        Ok(v) => (StatusCode::OK, Json(v)).into_response(),
+        Err(e) => (StatusCode::BAD_REQUEST, Json(json!({ "error": e }))).into_response(),
+    }
+}
+
+#[cfg(test)]
+mod close_pane_tests {
+    use super::*;
+    use axum::response::IntoResponse;
+    use crate::server::tests::test_state;
+    use agentmux_common::api_types::{ClosePaneRequest, UiAutomationAuth};
+    use agentmux_common::ipc::{Command, Event};
+
+    async fn dispatch_apply(state: &AppState, cmd: Command) -> Vec<Event> {
+        let evs = crate::server::service::dispatch_to_reducer(state, cmd).await;
+        for ev in &evs {
+            crate::persist_subscriber::apply_event_to_wstore(ev, &state.wstore).unwrap();
+        }
+        evs
+    }
+
+    /// Seed a workspace + tab + block, same shape as
+    /// `sagas::delete_block::tests::seed` — duplicated rather than shared
+    /// across modules (both are small, private `#[cfg(test)]` helpers).
+    async fn seed(state: &AppState) -> (String, String) {
+        let ws_evs = dispatch_apply(state, Command::CreateWorkspace { name: "w".into() }).await;
+        let ws_id = ws_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let tab_evs = dispatch_apply(
+            state,
+            Command::CreateTab { workspace_id: ws_id, name: "t".into() },
+        )
+        .await;
+        let tab_id = tab_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let blk_evs = dispatch_apply(
+            state,
+            Command::CreateBlock { tab_id: tab_id.clone(), meta: serde_json::Value::Null },
+        )
+        .await;
+        let block_id = blk_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::BlockCreated { block_id, .. } => Some(block_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        (tab_id, block_id)
+    }
+
+    /// Mint a real signing key for `agent_id` (same store call
+    /// `agent_open`/spawn use) and sign a fresh `UiAutomationAuth` for it —
+    /// the exact mechanism `agentmux-mcp`'s `sign_ui_automation_auth` uses,
+    /// reproduced here since this is a different crate.
+    fn sign_auth(state: &AppState, agent_id: &str) -> UiAutomationAuth {
+        let key = state.wstore.agent_jekt_key_ensure(agent_id).unwrap();
+        let ts_secs = agentmux_common::time::now_secs();
+        let sig = agentmux_common::jekt_sign::sign_jekt(
+            &key, "ui-automation-identity", agent_id, "__srv__", ts_secs, "",
+        );
+        UiAutomationAuth { agent_id: agent_id.to_string(), ts_secs, sig }
+    }
+
+    #[tokio::test]
+    async fn own_pane_close_removes_the_caller_s_own_block() {
+        let state = test_state();
+        let (tab_id, block_id) = seed(&state).await;
+        let agent_id = format!("close-own-{}", uuid::Uuid::new_v4());
+        state.reactive_handler.register_agent(&agent_id, &block_id, Some(&tab_id)).unwrap();
+        let auth = sign_auth(&state, &agent_id);
+
+        let resp = handle_close_pane(
+            axum::extract::State(state.clone()),
+            axum::Json(ClosePaneRequest { auth, block_id: None, reason: None }),
+        )
+        .await
+        .into_response();
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+
+        let s = state.srv_state.lock().await;
+        assert!(!s.blocks.contains_key(&block_id), "own pane must be gone after close");
+    }
+
+    #[tokio::test]
+    async fn cross_pane_close_removes_the_target_and_logs_the_verified_caller() {
+        let state = test_state();
+        // Caller: registered with its OWN pane, but acts on someone else's.
+        let (caller_tab, caller_block) = seed(&state).await;
+        let caller_id = format!("close-caller-{}", uuid::Uuid::new_v4());
+        state.reactive_handler.register_agent(&caller_id, &caller_block, Some(&caller_tab)).unwrap();
+        let auth = sign_auth(&state, &caller_id);
+
+        // Target: a different agent's pane, entirely unrelated to the caller.
+        let (target_tab, target_block) = seed(&state).await;
+        let target_id = format!("close-target-{}", uuid::Uuid::new_v4());
+        state.reactive_handler.register_agent(&target_id, &target_block, Some(&target_tab)).unwrap();
+
+        let resp = handle_close_pane(
+            axum::extract::State(state.clone()),
+            axum::Json(ClosePaneRequest {
+                auth,
+                block_id: Some(target_block.clone()),
+                reason: Some("verifying the fix".to_string()),
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+
+        // Target pane gone; caller's own pane untouched.
+        {
+            let s = state.srv_state.lock().await;
+            assert!(!s.blocks.contains_key(&target_block), "target pane must be closed");
+            assert!(s.blocks.contains_key(&caller_block), "caller's own pane must be untouched");
+        }
+
+        // Audit entry carries the CALLER's verified identity as source_agent —
+        // not None, the gap this spec's §5.2 fixed (FleetBulkStop still has
+        // it; this new call site must not repeat it).
+        // get_audit_log returns most-recent-first (its own doc comment) — no
+        // extra .rev() needed; the closed-block entry is naturally first.
+        let entries = state.reactive_handler.get_audit_log(50);
+        let entry = entries
+            .iter()
+            .find(|e| e.block_id == target_block)
+            .expect("expected an audit entry for the closed target block");
+        assert_eq!(entry.source_agent.as_deref(), Some(caller_id.as_str()));
+        assert_eq!(entry.target_agent, target_id);
+        assert!(entry.success);
+        assert_eq!(entry.reason.as_deref(), Some("verifying the fix"));
+    }
+
+    #[tokio::test]
+    async fn rejects_an_invalid_signature() {
+        let state = test_state();
+        let (tab_id, block_id) = seed(&state).await;
+        let agent_id = format!("close-bad-sig-{}", uuid::Uuid::new_v4());
+        state.reactive_handler.register_agent(&agent_id, &block_id, Some(&tab_id)).unwrap();
+        // A signature signed with the WRONG key — this agent's real key was
+        // never used, simulating a forged/corrupted signature.
+        let bogus_key = vec![0u8; 32];
+        let ts_secs = agentmux_common::time::now_secs();
+        let sig = agentmux_common::jekt_sign::sign_jekt(
+            &bogus_key, "ui-automation-identity", &agent_id, "__srv__", ts_secs, "",
+        );
+        let auth = UiAutomationAuth { agent_id, ts_secs, sig };
+
+        let resp = handle_close_pane(
+            axum::extract::State(state.clone()),
+            axum::Json(ClosePaneRequest { auth, block_id: None, reason: None }),
+        )
+        .await
+        .into_response();
+        assert_eq!(resp.status(), axum::http::StatusCode::UNAUTHORIZED);
+
+        // Nothing was touched.
+        let s = state.srv_state.lock().await;
+        assert!(s.blocks.contains_key(&block_id));
+    }
+}

--- a/agentmux-srv/src/server/app_api/pane.rs
+++ b/agentmux-srv/src/server/app_api/pane.rs
@@ -441,6 +441,18 @@ pub(crate) async fn handle_close_pane(
     let target_block_id = req.block_id.clone().unwrap_or(verified_own_block_id);
     let is_cross_pane = req.block_id.is_some();
 
+    // codex P2 on PR #3193: resolve the target's agent name BEFORE deleting
+    // the block, not after. `delete_block::run` stops the block's
+    // controller, and a running agent's own exit-triggered
+    // `unregister_block` can race ahead of this lookup once it does — a
+    // post-delete lookup would then fall back to the bare block UUID
+    // instead of the real agent name, making attribution timing-dependent.
+    let target_agent = state
+        .reactive_handler
+        .get_agent_by_block(&target_block_id)
+        .map(|a| a.agent_id)
+        .unwrap_or_else(|| target_block_id.clone());
+
     let tab_id = {
         let s = state.srv_state.lock().await;
         match s.blocks.get(&target_block_id) {
@@ -450,7 +462,7 @@ pub(crate) async fn handle_close_pane(
                 if is_cross_pane {
                     let request_id = uuid::Uuid::new_v4().to_string();
                     state.reactive_handler.log_fleet_action_audit(
-                        Some(&caller_agent_id), &target_block_id, &target_block_id,
+                        Some(&caller_agent_id), &target_agent, &target_block_id,
                         "pane.close", false, Some(&err), &request_id, req.reason.as_deref(),
                     );
                 }
@@ -463,11 +475,6 @@ pub(crate) async fn handle_close_pane(
 
     if is_cross_pane {
         let request_id = uuid::Uuid::new_v4().to_string();
-        let target_agent = state
-            .reactive_handler
-            .get_agent_by_block(&target_block_id)
-            .map(|a| a.agent_id)
-            .unwrap_or_else(|| target_block_id.clone());
         match &result {
             Ok(_) => state.reactive_handler.log_fleet_action_audit(
                 Some(&caller_agent_id), &target_agent, &target_block_id,

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -578,6 +578,14 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/ui/screenshot", post(ui_handlers::handle_ui_screenshot))
         .route("/api/v1/ui/click", post(ui_handlers::handle_ui_click))
         .route("/api/v1/ui/query", post(ui_handlers::handle_ui_query))
+        // Pane lifecycle (SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md) —
+        // `ClosePane`. Own-pane identity is verified the same way as the
+        // ui/* routes above (`verified_block_id`); the target pane, when
+        // acting on another agent's pane, is fleet-tier (see the
+        // fleet/bulk-stop comment below) — no ownership check on the
+        // target, but the caller is never anonymous in the audit log the
+        // way `FleetBulkStop`'s calls are today.
+        .route("/api/v1/agent/pane/close", post(app_api::pane::handle_close_pane))
         // Fleet control (SPEC_MULTI_AGENT_FLEET_CONTROL_2026_08_20.md) —
         // bulk-stop is the one fleet action exposed to agentmux-mcp (see
         // `FleetBulkStop`): stopping a controller involves no jekt signing,

--- a/agentmux-srv/src/server/ui_handlers.rs
+++ b/agentmux-srv/src/server/ui_handlers.rs
@@ -59,7 +59,11 @@ fn now_unix_secs() -> i64 {
 /// agent's ACTUAL current block_id server-side. Never trusts a block_id
 /// from the client — there isn't one to trust. See this module's own doc
 /// comment for the full rationale.
-fn verified_block_id(state: &AppState, auth: &UiAutomationAuth) -> Result<String, String> {
+/// `pub(crate)`: also reused by `app_api::pane::handle_close_pane` (and any
+/// future own-pane-resolving handler) — the identity-verification mechanism
+/// isn't UI-automation-specific, just first built for it. See
+/// docs/specs/SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md §5.0.
+pub(crate) fn verified_block_id(state: &AppState, auth: &UiAutomationAuth) -> Result<String, String> {
     if auth.ts_secs <= 0 || (now_unix_secs() - auth.ts_secs).abs() > UI_AUTOMATION_SIG_MAX_AGE_SECS
     {
         return Err("signature timestamp missing or outside the freshness window".to_string());


### PR DESCRIPTION
## Summary

Phase 1+2 of `docs/specs/SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md` — the capability this session's stuck-pane investigation needed and didn't have: there was no MCP tool that could close or reset a pane stuck in a broken render state, own or another agent's.

- **Own-pane** (`ClosePane` with no args): identity resolved via the same signed mechanism `UIClick`/`UIQuery`/`UIScreenshot` already use (`verified_block_id`, made `pub(crate)` for reuse) — never a client-supplied `block_id`, per the real vulnerability that mechanism exists to close (PR #2662).
- **Cross-pane** (`ClosePane(block_id: "...")`): fleet tier, same posture as `FleetBulkStop` — no ownership check on the target (that's the point: this needs to work on a pane whose own agent might not be able to cooperate). But unlike `FleetBulkStop` today, the caller is never anonymous: `log_fleet_action_audit` gains an optional `reason` param, and both new call sites pass the caller's *verified* agent_id as `source_agent` instead of `None` — closing a real gap Codex found in `FleetBulkStop`'s existing audit trail while adding this.
- New: `POST /api/v1/agent/pane/close`, `ClosePaneRequest`/`ClosePaneResponse` (`agentmux-common`), `handle_close_pane` (`agentmux-srv/server/app_api/pane.rs`, reuses `sagas::delete_block::run` — no saga changes), `ClosePane` MCP tool.

## Test plan
- [x] `cargo test -p agentmux-srv --bin agentmux-srv close_pane_tests` — 3/3 pass (own-pane close, cross-pane close with verified audit attribution, rejects an invalid signature)
- [x] `cargo test -p agentmux-srv --bin agentmux-srv fleet` / `delete_block` — no regressions (21 + 11 pass)
- [x] `cargo test -p agentmux-mcp` — 26/26 pass (tool count assertion bumped 43→44)
- [x] `cargo check -p agentmux-common -p agentmux-srv -p agentmux-mcp` — clean
- [ ] Manual verification against a real running instance (closing another agent's stuck pane) — not yet done in this PR; recommend before merge given the destructive nature of the cross-pane path

One unrelated pre-existing failure, confirmed via `git stash`: `backend::sysinfo::handle_anomaly_tests::refresh_processes_specifics_does_not_leak_a_handle_per_call` fails identically with these changes fully stashed out — an environment-sensitive OS-handle-count test on this shared machine, not caused by this change.

<!-- agentmux:agent_id=agent5 -->