### PR TITLE
feat(mcp): PtyShell attaches to the pane's real visible shell, with a lease-based lock

### DIFF
--- a/.changesets/1789092935-feat-mcp-ptyshell-attaches-to-the-pane-s-real-visible-shell--lxk0.md
+++ b/.changesets/1789092935-feat-mcp-ptyshell-attaches-to-the-pane-s-real-visible-shell--lxk0.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(mcp): PtyShell attaches to the pane's real visible shell, with a lease-based lock instead of destroying it on stop

--- a/.changesets/1789094219-fix-mcp-ptyshell-enforce-the-agent-lock-server-side-fix-stal-vda3.md
+++ b/.changesets/1789094219-fix-mcp-ptyshell-enforce-the-agent-lock-server-side-fix-stal-vda3.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(mcp): PtyShell — enforce the agent lock server-side, fix stale-handshake injection on reused shells, atomic first-create claim

--- a/.changesets/1789094899-fix-mcp-ptyshell-lock-the-shell-before-writing-not-after-per-4nqm.md
+++ b/.changesets/1789094899-fix-mcp-ptyshell-lock-the-shell-before-writing-not-after-per-4nqm.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(mcp): PtyShell — lock the shell before writing not after, persist the fallback block when the atomic claim's winner has vanished

--- a/.changesets/1789119727-fix-mcp-ptyshell-create-s-spawn-failure-rollback-now-also-cl-mwng.md
+++ b/.changesets/1789119727-fix-mcp-ptyshell-create-s-spawn-failure-rollback-now-also-cl-mwng.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(mcp): PtyShell create's spawn-failure rollback now also clears the parent's stale shellsubblockid pointer

--- a/agentmux-common/src/api_types.rs
+++ b/agentmux-common/src/api_types.rs
@@ -130,6 +130,15 @@ pub struct ShellStatusResponse {
 // (agent -> agentmux-mcp -> agentmux-srv), with no dependency on any window
 // being open, focused, or even rendering the shell's `term` sub-block — the
 // same posture the existing `Shell`/`ShellInput` family already has.
+//
+// `create` attaches to (creating if needed) the SAME shell a human's
+// composer-drawer session uses, not an independent, invisible one —
+// whichever side gets there first, the other joins. While the agent is
+// actively writing (`input`/`resize`), the human's own keyboard input to
+// that shell is locked out, for a short, self-expiring window
+// (`AGENT_LOCK_WINDOW_MS`) rather than an explicit lock/unlock the agent
+// could fail to release — "bound to the shell only when necessary," per
+// the repo owner's own framing of the requirement.
 
 /// `POST /api/v1/ptyshell/create`
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -151,9 +160,17 @@ pub struct PtyShellCreateResponse {
 }
 
 /// `POST /api/v1/ptyshell/input` — write raw text to the PTY, as if typed.
+///
+/// `agent_block_id` is filled in by `agentmux-mcp` from its own trusted
+/// env (`AGENTMUX_AGENT_BUS_ID`/`AGENTMUX_BLOCKID`), never a model-facing
+/// tool parameter — same non-forgeable guarantee `agent_slug()` documents.
+/// It's what lets the backend verify `shell_id` is actually a sub-block of
+/// THIS caller's own pane before acting on it (see
+/// `is_owned_by_agent` in `agentmux-srv`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PtyShellInputRequest {
     pub shell_id: String,
+    pub agent_block_id: String,
     pub text: String,
 }
 
@@ -170,6 +187,7 @@ pub struct PtyShellInputResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PtyShellResizeRequest {
     pub shell_id: String,
+    pub agent_block_id: String,
     pub rows: u16,
     pub cols: u16,
 }
@@ -192,6 +210,7 @@ pub struct PtyShellResizeResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PtyShellReadRequest {
     pub shell_id: String,
+    pub agent_block_id: String,
     /// Number of trailing lines to return. Defaults to 200.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tail_lines: Option<u32>,
@@ -209,6 +228,7 @@ pub struct PtyShellReadResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PtyShellStatusRequest {
     pub shell_id: String,
+    pub agent_block_id: String,
 }
 
 /// Response from `POST /api/v1/ptyshell/status`
@@ -221,16 +241,30 @@ pub struct PtyShellStatusResponse {
     pub exit_code: Option<i32>,
 }
 
-/// `POST /api/v1/ptyshell/stop` — kill the PTY and delete its sub-block.
+/// `POST /api/v1/ptyshell/stop` — release the agent's lock on the shell
+/// *now*, without waiting for `AGENT_LOCK_WINDOW_MS` to lapse.
+///
+/// Does **not** kill the process or delete the block. The shell this API
+/// drives is, by default, the same one a human's composer-drawer session
+/// uses (see `META_KEY_SHELL_SUBBLOCK_ID`) — it's a shared, pane-scoped
+/// resource with the pane's own lifetime ("only killed when the pane
+/// closes," `AgentShellSubblock.tsx`'s own doc comment), not a private,
+/// disposable one this tool owns outright. An earlier version of this API
+/// (PR #3177) did delete on stop, which was correct for that version's
+/// model (an agent's own throwaway shell) but would destroy a human's live
+/// terminal session under this one.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PtyShellStopRequest {
     pub shell_id: String,
+    pub agent_block_id: String,
 }
 
 /// Response from `POST /api/v1/ptyshell/stop`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PtyShellStopResponse {
-    pub stopped: bool,
+    /// False if the id was unrecognized, wasn't owned by the caller, or
+    /// simply had no active lock to release.
+    pub released: bool,
 }
 
 // ── Inject (SendMessage + Loop) ───────────────────────────────────────────────

--- a/agentmux-mcp/src/main.rs
+++ b/agentmux-mcp/src/main.rs
@@ -765,7 +765,11 @@ async fn call_tool(
             let resp = client
                 .post(&url)
                 .header("X-AuthKey", auth_key)
-                .json(&PtyShellInputRequest { shell_id: shell_id.to_string(), text: text.to_string() })
+                .json(&PtyShellInputRequest {
+                    shell_id: shell_id.to_string(),
+                    agent_block_id: block_id.to_string(),
+                    text: text.to_string(),
+                })
                 .send()
                 .await
                 .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
@@ -814,7 +818,12 @@ async fn call_tool(
             let resp = client
                 .post(&url)
                 .header("X-AuthKey", auth_key)
-                .json(&PtyShellResizeRequest { shell_id: shell_id.to_string(), rows, cols })
+                .json(&PtyShellResizeRequest {
+                    shell_id: shell_id.to_string(),
+                    agent_block_id: block_id.to_string(),
+                    rows,
+                    cols,
+                })
                 .send()
                 .await
                 .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
@@ -856,7 +865,11 @@ async fn call_tool(
             let resp = client
                 .post(&url)
                 .header("X-AuthKey", auth_key)
-                .json(&PtyShellReadRequest { shell_id: shell_id.to_string(), tail_lines })
+                .json(&PtyShellReadRequest {
+                    shell_id: shell_id.to_string(),
+                    agent_block_id: block_id.to_string(),
+                    tail_lines,
+                })
                 .send()
                 .await
                 .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
@@ -891,7 +904,10 @@ async fn call_tool(
             let resp = client
                 .post(&url)
                 .header("X-AuthKey", auth_key)
-                .json(&PtyShellStatusRequest { shell_id: shell_id.to_string() })
+                .json(&PtyShellStatusRequest {
+                    shell_id: shell_id.to_string(),
+                    agent_block_id: block_id.to_string(),
+                })
                 .send()
                 .await
                 .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
@@ -930,7 +946,10 @@ async fn call_tool(
             let resp = client
                 .post(&url)
                 .header("X-AuthKey", auth_key)
-                .json(&PtyShellStopRequest { shell_id: shell_id.to_string() })
+                .json(&PtyShellStopRequest {
+                    shell_id: shell_id.to_string(),
+                    agent_block_id: block_id.to_string(),
+                })
                 .send()
                 .await
                 .map_err(|e| anyhow::anyhow!("request failed: {e}"))?;
@@ -945,10 +964,10 @@ async fn call_tool(
                 .json()
                 .await
                 .map_err(|e| anyhow::anyhow!("response parse failed: {e}"))?;
-            Ok(if result.stopped {
-                format!("stopped shell {shell_id}")
+            Ok(if result.released {
+                format!("released the agent lock on shell {shell_id} (the shell itself keeps running)")
             } else {
-                format!("shell {shell_id} was not running (unknown or already stopped)")
+                format!("shell {shell_id}: no active agent lock to release (unrecognized id, not yours, or already unlocked)")
             })
         }
         "OpenEditor" => {

--- a/agentmux-mcp/src/tool_schemas.rs
+++ b/agentmux-mcp/src/tool_schemas.rs
@@ -69,7 +69,7 @@ pub(crate) const SHELL_STATUS_TOOL: &str = r#"{
 
 pub(crate) const PTY_SHELL_TOOL: &str = r#"{
   "name": "PtyShell",
-  "description": "Open a REAL PTY-backed interactive shell — unlike Shell(), which runs on a plain pipe, this behaves like a real terminal, so programs that check for one (password/wizard prompts, sudo, ssh, REPLs) work instead of refusing or misbehaving. Returns a shell_id immediately; use PtyShellInput to type into it, PtyShellRead to see its output, PtyShellStatus to poll, PtyShellStop to end it. Works with no UI involved at all — the window need not be open, focused, or rendering anything for this to work; it's a plain backend call, not simulated keystrokes into a visible terminal.",
+  "description": "Attach to this pane's one interactive shell — the SAME real terminal the user sees if they open the shell drawer in the UI, creating it if it doesn't exist yet. Unlike Shell(), which runs on a plain pipe, this is a REAL PTY, so programs that check for one (password/wizard prompts, sudo, ssh, REPLs) work instead of refusing or misbehaving. Returns a shell_id immediately; use PtyShellInput to type into it, PtyShellRead to see its output, PtyShellStatus to poll, PtyShellStop to release your lock early. Because this is the user's own visible shell, PtyShellInput/PtyShellResize briefly lock out the user's own keyboard input to it (a few seconds, refreshed while you keep typing, auto-released the moment you stop) so your keystrokes and theirs don't collide — don't hold it longer than you need to. Works with no UI involved at all on your end — the window need not be open, focused, or rendering anything for you to call this; it's a plain backend call, not simulated keystrokes.",
   "inputSchema": {
     "type": "object",
     "properties": {
@@ -134,7 +134,7 @@ pub(crate) const PTY_SHELL_STATUS_TOOL: &str = r#"{
 
 pub(crate) const PTY_SHELL_STOP_TOOL: &str = r#"{
   "name": "PtyShellStop",
-  "description": "Kill a PtyShell() and clean up its terminal. Prefer this over letting it linger once you're done with an interactive session.",
+  "description": "Release your lock on a PtyShell() immediately, returning keyboard control to the user right away instead of waiting a few seconds for it to expire on its own. Does NOT kill the shell or the process — it's the user's own persistent terminal, not something this tool owns; it keeps running exactly as if a human had just stopped typing. Call this as soon as you're done with a burst of interactive work.",
   "inputSchema": {
     "type": "object",
     "properties": {

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -1405,8 +1405,56 @@ async fn handle_pty_shell_create(
                 return resp;
             }
             // Winner's block vanished between the transaction and now
-            // (exceedingly unlikely) — fall back to using the block we
-            // already have in hand rather than dead-ending the request.
+            // (exceedingly unlikely — e.g. it was deleted out from under
+            // us). `block` above was only ever prepared in memory: the
+            // `with_tx` closure's `tx.insert` never ran for it (that only
+            // happens in the `Ok(None)` arm, when WE win the claim), so it
+            // has no backing row. Falling through with it as-is would send
+            // `resync_controller` a phantom block and return a `shell_id`
+            // with nothing in the store behind it — every later
+            // PtyShellInput/Read/Status/Stop call against it would then
+            // fail ownership/lookup checks (ReAgent P2 on PR #3194).
+            //
+            // Actually create it for real instead, mirroring what the
+            // `Ok(None)` arm does inside its transaction — just as a plain
+            // sequence, since we're no longer inside that transaction.
+            let insert_result = (|| -> Result<(), crate::backend::storage::error::StoreError> {
+                state.wstore.insert(&mut block)?;
+                let mut parent = state
+                    .wstore
+                    .must_get::<crate::backend::obj::Block>(&req.agent_block_id)?;
+                parent
+                    .subblockids
+                    .get_or_insert_with(Vec::new)
+                    .push(child_id.clone());
+                parent
+                    .meta
+                    .insert(META_KEY_SHELL_SUBBLOCK_ID.to_string(), json!(child_id));
+                state.wstore.update(&mut parent)?;
+                Ok(())
+            })();
+            if let Err(e) = insert_result {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({ "error": format!("ptyshell.create: fallback insert: {e}") })),
+                )
+                    .into_response();
+            }
+            if let Ok(Some(parent)) = state
+                .wstore
+                .get::<crate::backend::obj::Block>(&req.agent_block_id)
+            {
+                state.event_bus.broadcast_event(&crate::backend::eventbus::WSEventType {
+                    eventtype: "waveobj:update".to_string(),
+                    oref: format!("block:{}", req.agent_block_id),
+                    data: Some(serde_json::to_value(&crate::backend::obj::WaveObjUpdate {
+                        updatetype: "update".into(),
+                        otype: "block".into(),
+                        oid: req.agent_block_id.clone(),
+                        obj: Some(crate::backend::obj::wave_obj_to_value(&parent)),
+                    }).unwrap_or_default()),
+                });
+            }
             (child_id.clone(), block)
         }
         Ok(None) => {
@@ -1585,14 +1633,25 @@ async fn handle_pty_shell_input(
             }),
         );
     }
+    // Lock BEFORE writing, not after (ReAgent P1 on PR #3194): the
+    // previous ordering left `term:agentlockuntil` unset for the entire
+    // duration of `send_input` — the exact window `controllerinput`'s own
+    // lock check (added for Codex's earlier P1 on this same PR) needs the
+    // lock to already exist to catch anything. Locking first doesn't make
+    // the race provably impossible (a human keystroke processed in the
+    // sliver of time before this write actually commits could still slip
+    // through — true elimination would need a real mutex shared between
+    // this HTTP path and the WS `controllerinput` path, disproportionate
+    // machinery for a UX-level collision guard, not a hard security
+    // boundary), but it shrinks the window from "all of send_input's own
+    // duration plus the lock write's" down to just the lock write's own
+    // commit latency — the actual, meaningful fix here.
+    lock_shell_for_agent(&state, &req.shell_id);
     let result = blockcontroller::send_input(
         &req.shell_id,
         blockcontroller::BlockInputUnion::data(req.text.into_bytes()),
         None,
     );
-    if result.is_ok() {
-        lock_shell_for_agent(&state, &req.shell_id);
-    }
     match result {
         Ok(()) => (StatusCode::OK, Json(PtyShellInputResponse { written: true, error: None })),
         Err(e) => (StatusCode::OK, Json(PtyShellInputResponse { written: false, error: Some(e) })),
@@ -1600,10 +1659,10 @@ async fn handle_pty_shell_input(
 }
 
 /// Lock `shell_id` out from human keyboard input for `AGENT_LOCK_WINDOW_MS`
-/// from now — called after every successful agent write (input/resize).
+/// from now — called BEFORE every agent write (input/resize), not after
+/// (see the call sites' own comment for why the ordering matters).
 /// Best-effort: a failure to write the lock meta just means the human's
-/// input isn't blocked this time, not that the agent's write failed (the
-/// PTY write already succeeded by the time this runs).
+/// input isn't blocked this time, not that the agent's write itself failed.
 fn lock_shell_for_agent(state: &AppState, shell_id: &str) {
     let mut meta = crate::backend::obj::MetaMapType::new();
     meta.insert(
@@ -1630,6 +1689,9 @@ async fn handle_pty_shell_resize(
             }),
         );
     }
+    // Lock BEFORE writing — see the identical comment in
+    // `handle_pty_shell_input` for why the ordering matters.
+    lock_shell_for_agent(&state, &req.shell_id);
     let result = blockcontroller::send_input(
         &req.shell_id,
         blockcontroller::BlockInputUnion::resize(crate::backend::obj::TermSize {
@@ -1638,9 +1700,6 @@ async fn handle_pty_shell_resize(
         }),
         None,
     );
-    if result.is_ok() {
-        lock_shell_for_agent(&state, &req.shell_id);
-    }
     match result {
         Ok(()) => (StatusCode::OK, Json(PtyShellResizeResponse { resized: true, error: None })),
         Err(e) => (StatusCode::OK, Json(PtyShellResizeResponse { resized: false, error: Some(e) })),

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -1512,9 +1512,39 @@ async fn handle_pty_shell_create(
             .wstore
             .must_get::<crate::backend::obj::Block>(&req.agent_block_id)
         {
+            let mut changed = false;
             if let Some(ids) = parent.subblockids.as_mut() {
+                let before = ids.len();
                 ids.retain(|id| id != &child_id);
+                changed |= ids.len() != before;
+            }
+            // The pointer was already persisted before `resync_controller`
+            // ran — either inside the atomic claim's own transaction, or by
+            // the "winner vanished" fallback above — so unlinking
+            // `subblockids` alone isn't enough: without also clearing it
+            // here, `term:shellsubblockid` is left pointing at a block that
+            // was just deleted, and a human opening the composer drawer in
+            // this exact window (`agent-view.tsx`'s
+            // `existingSubBlockId={block()?.meta?.["term:shellsubblockid"]}`)
+            // attaches to nothing instead of getting a working shell
+            // (ReAgent P1, round 3 on PR #3194).
+            if parent.meta.get(META_KEY_SHELL_SUBBLOCK_ID).and_then(|v| v.as_str()) == Some(child_id.as_str())
+            {
+                parent.meta.remove(META_KEY_SHELL_SUBBLOCK_ID);
+                changed = true;
+            }
+            if changed {
                 let _ = state.wstore.update(&mut parent);
+                state.event_bus.broadcast_event(&crate::backend::eventbus::WSEventType {
+                    eventtype: "waveobj:update".to_string(),
+                    oref: format!("block:{}", req.agent_block_id),
+                    data: Some(serde_json::to_value(&crate::backend::obj::WaveObjUpdate {
+                        updatetype: "update".into(),
+                        otype: "block".into(),
+                        oid: req.agent_block_id.clone(),
+                        obj: Some(crate::backend::obj::wave_obj_to_value(&parent)),
+                    }).unwrap_or_default()),
+                });
             }
         }
         return (

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -1087,7 +1087,9 @@ const AGENT_LOCK_WINDOW_MS: i64 = 4000;
 // gates human keyboard input purely on `Date.now() < this`, reactively —
 // no server-side timer to leak or get stuck; a quiet agent just lets the
 // timestamp lapse and control returns on its own.
-const META_KEY_AGENT_LOCK_UNTIL: &str = "term:agentlockuntil";
+// pub(crate): `server::websocket`'s `controllerinput` handler also reads
+// this — see that handler's own doc comment for why.
+pub(crate) const META_KEY_AGENT_LOCK_UNTIL: &str = "term:agentlockuntil";
 
 /// Whether `shell_id` is a real `view:"term"` sub-block PARENTED TO
 /// `agent_block_id` — the actual safety property Codex asked for (PR
@@ -1166,6 +1168,56 @@ fn broadcast_meta_update(
 // focused, or rendering the shell's `term` sub-block at all.
 // ---------------------------------------------------------------------------
 
+/// Shared by both the top-level reuse check and the "lost the atomic
+/// claim" fallback in `handle_pty_shell_create`: resync `id`'s controller
+/// and reply, or return `None` if `id` doesn't resolve to a real block
+/// (stale pointer) so the caller falls through to creating a fresh one.
+async fn try_attach_to_existing_shell(
+    state: &AppState,
+    agent_block_id: &str,
+    id: &str,
+) -> Option<axum::response::Response> {
+    let block = state.wstore.get::<crate::backend::obj::Block>(id).ok().flatten()?;
+
+    // Baseline BEFORE resync — see `answer_conpty_handshake_if_seen`'s doc
+    // comment (Codex P1 on PR #3194) for why this matters: the `term` file
+    // is append-only for the block's whole lifetime, so an already-running
+    // reused shell's history almost certainly still contains its own old,
+    // long-since-answered `ESC[6n` from whenever it first started.
+    let baseline_len = state
+        .filestore
+        .stat(id, "term")
+        .ok()
+        .flatten()
+        .map(|info| info.size as usize)
+        .unwrap_or(0);
+
+    let registry = state.wstore.shared_agent_registry();
+    if let Err(e) = blockcontroller::resync_controller(
+        &block,
+        "ptyshell",
+        None,
+        false,
+        Some(Arc::clone(&state.broker)),
+        Some(Arc::clone(&state.event_bus)),
+        Some(Arc::clone(&state.wstore)),
+        Some(Arc::clone(&state.filestore)),
+        registry,
+        state.boot_id.clone(),
+    ) {
+        return Some(
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": format!("ptyshell.create: resync existing shell: {e}") })),
+            )
+                .into_response(),
+        );
+    }
+    answer_conpty_handshake_if_seen(state, id, baseline_len).await;
+    tracing::info!(block_id = %id, parent_id = %agent_block_id, "ptyshell.create: reused");
+    Some((StatusCode::OK, Json(PtyShellCreateResponse { shell_id: id.to_string() })).into_response())
+}
+
 /// `POST /api/v1/ptyshell/create` — attach to (creating if needed) "this
 /// pane's one shell."
 ///
@@ -1203,29 +1255,8 @@ async fn handle_pty_shell_create(
     // legitimate post-hoc operation via PtyShellResize, not a create-time
     // parameter for a process that already has a size.
     if let Some(id) = existing_id {
-        if let Ok(Some(block)) = state.wstore.get::<crate::backend::obj::Block>(&id) {
-            let registry = state.wstore.shared_agent_registry();
-            if let Err(e) = blockcontroller::resync_controller(
-                &block,
-                "ptyshell",
-                None,
-                false,
-                Some(Arc::clone(&state.broker)),
-                Some(Arc::clone(&state.event_bus)),
-                Some(Arc::clone(&state.wstore)),
-                Some(Arc::clone(&state.filestore)),
-                registry,
-                state.boot_id.clone(),
-            ) {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({ "error": format!("ptyshell.create: resync existing shell: {e}") })),
-                )
-                    .into_response();
-            }
-            answer_conpty_handshake_if_seen(&state, &id).await;
-            tracing::info!(block_id = %id, parent_id = %req.agent_block_id, "ptyshell.create: reused");
-            return (StatusCode::OK, Json(PtyShellCreateResponse { shell_id: id })).into_response();
+        if let Some(resp) = try_attach_to_existing_shell(&state, &req.agent_block_id, &id).await {
+            return resp;
         }
         // Stale pointer (the block was deleted some other way) — fall
         // through to creating a fresh one, same as if none existed.
@@ -1323,27 +1354,91 @@ async fn handle_pty_shell_create(
         ..Default::default()
     };
 
-    if let Err(e) = state.wstore.insert(&mut block) {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "error": format!("ptyshell.create: insert: {e}") })),
-        )
-            .into_response();
-    }
-
-    // Best-effort link into the parent's subblockids — same posture as
-    // createsubblock's WS handler (not a CAS; an acceptable race for a
-    // single lazily-created shell per agent pane).
-    if let Ok(mut parent) = state
-        .wstore
-        .must_get::<crate::backend::obj::Block>(&req.agent_block_id)
-    {
+    // Atomic claim-or-lose (Codex P2 on PR #3194): without this, two
+    // concurrent `PtyShell` calls that both observe an unset
+    // `term:shellsubblockid` (the check at the top of this function is
+    // NOT authoritative — it's a plain read, before this point) would each
+    // insert their own block and race to overwrite the other's pointer
+    // write, leaving one controller registered but orphaned from the
+    // pointer that's supposed to track it, and the two callers ending up
+    // attached to DIFFERENT shells despite both believing they're on "the
+    // pane's one shell." `with_tx` holds the store's single connection
+    // lock for its whole closure, so re-checking the pointer INSIDE it,
+    // atomically with the insert+link+set that follows, serializes any
+    // concurrent `PtyShell` call against this same agent_block_id.
+    //
+    // Does NOT close the equivalent race against the FRONTEND's own
+    // `createsubblock` path (`AgentShellSubblock.tsx`'s "no
+    // existingSubBlockId yet" branch): that's a separate, non-transactional
+    // multi-step RPC sequence (create, then a follow-up `SetMetaCommand`)
+    // this backend call has no visibility into or ability to serialize
+    // against. A human opening the drawer for the very first time on a
+    // pane in the same narrow window as an agent's first `PtyShell` call
+    // on that pane can still each end up with their own shell — a real,
+    // documented, accepted gap (see the spec's §10 for the full
+    // reasoning), not silently ignored, just out of scope for what a
+    // single backend transaction can enforce unilaterally.
+    let claim = state.wstore.with_tx(|tx| {
+        let mut parent = tx.must_get::<crate::backend::obj::Block>(&req.agent_block_id)?;
+        if let Some(winner_id) = parent
+            .meta
+            .get(META_KEY_SHELL_SUBBLOCK_ID)
+            .and_then(|v| v.as_str())
+        {
+            return Ok(Some(winner_id.to_string()));
+        }
+        tx.insert(&mut block)?;
+        parent.subblockids.get_or_insert_with(Vec::new).push(child_id.clone());
         parent
-            .subblockids
-            .get_or_insert_with(Vec::new)
-            .push(child_id.clone());
-        let _ = state.wstore.update(&mut parent);
-    }
+            .meta
+            .insert(META_KEY_SHELL_SUBBLOCK_ID.to_string(), json!(child_id));
+        tx.update(&mut parent)?;
+        Ok(None)
+    });
+
+    let (shell_id, block) = match claim {
+        // We lost the race — someone else's transaction committed the
+        // pointer first. Pivot to reusing THEIRS rather than proceeding
+        // with the block we prepared but never actually inserted.
+        Ok(Some(winner_id)) => {
+            if let Some(resp) = try_attach_to_existing_shell(&state, &req.agent_block_id, &winner_id).await {
+                return resp;
+            }
+            // Winner's block vanished between the transaction and now
+            // (exceedingly unlikely) — fall back to using the block we
+            // already have in hand rather than dead-ending the request.
+            (child_id.clone(), block)
+        }
+        Ok(None) => {
+            // We won the claim and the parent's meta changed (inside the
+            // transaction, via a raw `tx.update`, which — unlike
+            // `broadcast_meta_update` — does NOT itself notify any
+            // subscribed frontend). Broadcast now so a drawer already open
+            // (or opened moments later) actually sees the pointer reactively
+            // instead of only on its next unrelated refetch.
+            if let Ok(Some(parent)) = state.wstore.get::<crate::backend::obj::Block>(&req.agent_block_id) {
+                state.event_bus.broadcast_event(&crate::backend::eventbus::WSEventType {
+                    eventtype: "waveobj:update".to_string(),
+                    oref: format!("block:{}", req.agent_block_id),
+                    data: Some(serde_json::to_value(&crate::backend::obj::WaveObjUpdate {
+                        updatetype: "update".into(),
+                        otype: "block".into(),
+                        oid: req.agent_block_id.clone(),
+                        obj: Some(crate::backend::obj::wave_obj_to_value(&parent)),
+                    }).unwrap_or_default()),
+                });
+            }
+            (child_id.clone(), block)
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": format!("ptyshell.create: claim: {e}") })),
+            )
+                .into_response();
+        }
+    };
+    let child_id = shell_id;
 
     let registry = state.wstore.shared_agent_registry();
     if let Err(e) = blockcontroller::resync_controller(
@@ -1381,19 +1476,16 @@ async fn handle_pty_shell_create(
             .into_response();
     }
 
-    answer_conpty_handshake_if_seen(&state, &child_id).await;
+    // baseline_len=0: a genuinely new block has no prior "term" file content
+    // to accidentally match against (see the reuse path's identical
+    // baseline logic above for why this matters at all).
+    answer_conpty_handshake_if_seen(&state, &child_id, 0).await;
 
-    // Persist the pointer so a drawer opened AFTER this call attaches to
-    // the shell the agent just started instead of spawning a second,
-    // independent one. Best-effort (same posture as the parent-link write
-    // above) — a failure here means a later-opened drawer gets its own
-    // separate shell instead of joining this one, degraded but not broken.
-    let mut agent_meta = crate::backend::obj::MetaMapType::new();
-    agent_meta.insert(META_KEY_SHELL_SUBBLOCK_ID.to_string(), json!(child_id));
-    if let Err(e) = broadcast_meta_update(&state, &req.agent_block_id, &agent_meta) {
-        tracing::warn!(agent_block_id = %req.agent_block_id, shell_id = %child_id, error = %e, "ptyshell.create: failed to persist shellsubblockid");
-    }
-
+    // NOTE: the shellsubblockid pointer is already persisted — the atomic
+    // claim transaction above sets it on the parent in the same
+    // transaction as the insert, which is also strictly more correct than
+    // a separate post-hoc write here would be (no window where the block
+    // exists but isn't yet pointed to).
     tracing::info!(block_id = %child_id, parent_id = %req.agent_block_id, "ptyshell.create: fresh");
     (StatusCode::OK, Json(PtyShellCreateResponse { shell_id: child_id })).into_response()
 }
@@ -1414,11 +1506,25 @@ async fn handle_pty_shell_create(
 /// ConPTY only wants to reconcile its internal buffer, not validate the
 /// value against anything a person would see.
 ///
-/// Safe to call unconditionally on both the fresh-create and reuse paths:
-/// an already-initialized shell has long since resolved its one startup
-/// query, so this simply finds nothing within the poll window and returns.
+/// `baseline_len` MUST be the "term" file's byte length taken immediately
+/// before `resync_controller` ran (0 for a genuinely new block) — see the
+/// call sites. Only bytes appended AFTER that offset are ever inspected.
+/// **Not** safe to scan the whole file regardless of reuse/fresh (an
+/// earlier version of this function did exactly that): the "term" file is
+/// append-only for the block's entire lifetime
+/// (`handle_append_block_file`'s `FILE_OP_APPEND`), so a long-running
+/// reused shell's history almost always still contains its own original,
+/// long-since-answered `ESC[6n` from whenever it first started — matching
+/// against that stale byte sequence would inject an unsolicited
+/// `ESC[1;1R` into whatever a human is doing RIGHT NOW on that shell
+/// (Codex P1 on PR #3194, confirmed live before this fix: `create` on an
+/// already-running reused shell always found the old query and misfired).
+/// The baseline makes every case correct uniformly: nothing new appears
+/// (the common reuse case) → correctly finds nothing; `resync_controller`
+/// had to respawn a dead process → correctly sees only ITS fresh query,
+/// never anything from the block's former life.
 #[cfg_attr(not(windows), allow(unused_variables))]
-async fn answer_conpty_handshake_if_seen(state: &AppState, block_id: &str) {
+async fn answer_conpty_handshake_if_seen(state: &AppState, block_id: &str, baseline_len: usize) {
     #[cfg(windows)]
     {
         let mut answered = false;
@@ -1429,7 +1535,10 @@ async fn answer_conpty_handshake_if_seen(state: &AppState, block_id: &str) {
                 .read_file(block_id, "term")
                 .ok()
                 .flatten()
-                .map(|bytes| bytes.windows(4).any(|w| w == b"\x1b[6n"))
+                .map(|bytes| {
+                    let new_bytes = bytes.get(baseline_len..).unwrap_or(&[]);
+                    new_bytes.windows(4).any(|w| w == b"\x1b[6n")
+                })
                 .unwrap_or(false);
             if saw_dsr {
                 let _ = blockcontroller::send_input(

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -1064,25 +1064,86 @@ async fn handle_shell_status(
     }))
 }
 
-// Meta marker stamped on every block `handle_pty_shell_create` creates.
-// Every other `ptyshell/*` handler MUST verify this before acting on a
-// caller-supplied `shell_id` (Codex P1 on PR #3177): `shell_id` lives in the
-// SAME block-id namespace as every other pane in the system, and `Layout`
-// exposes block ids for ordinary panes — without this check, an agent could
-// point `PtyShellInput`/`PtyShellStop`/etc. at any controller-backed block
-// (another agent's own CLI pane, a human's terminal pane) and inject input
-// into it or tear it down. Scoped to "was this block created by this API"
-// (matching the existing `Shell`/`ShellStop` family's own scope — no
-// per-caller-agent ownership check either), not full cross-agent isolation.
-const PTYSHELL_META_MARKER: &str = "ptyshell:managed";
+// Meta key persisting which sub-block is "this pane's one shell" — the same
+// key `agent-view.tsx` reads/writes for the human-facing composer drawer
+// (`agent-view.tsx:2883,2890-2894`). `PtyShell` reuses this instead of
+// minting an independent, invisible shell: reusing it means the agent
+// drives the SAME shell a human sees in the drawer, and a drawer opened
+// later attaches to whatever the agent already started, live output and
+// scrollback included.
+const META_KEY_SHELL_SUBBLOCK_ID: &str = "term:shellsubblockid";
 
-fn is_ptyshell_managed(wstore: &crate::backend::storage::store::Store, shell_id: &str) -> bool {
+// How long an agent's write (input/resize) locks the shell out from human
+// keyboard input, refreshed on every subsequent write. Deliberately a lease,
+// not an explicit lock/unlock pair: an explicit "release" call is one the
+// agent could simply never make (error, crash, forgetting), which would
+// leave a human locked out indefinitely — the opposite of "unlock as soon
+// as the agent stops." A short, self-expiring window means the frontend
+// needs no server push to release it either — it just compares the
+// timestamp against its own clock.
+const AGENT_LOCK_WINDOW_MS: i64 = 4000;
+
+// Meta key holding the lock's absolute expiry (epoch ms). The frontend
+// gates human keyboard input purely on `Date.now() < this`, reactively —
+// no server-side timer to leak or get stuck; a quiet agent just lets the
+// timestamp lapse and control returns on its own.
+const META_KEY_AGENT_LOCK_UNTIL: &str = "term:agentlockuntil";
+
+/// Whether `shell_id` is a real `view:"term"` sub-block PARENTED TO
+/// `agent_block_id` — the actual safety property Codex asked for (PR
+/// #3177): `shell_id` lives in the same block-id namespace as every other
+/// pane, and `Layout` exposes block ids for ordinary panes, so without this
+/// check an agent could point `PtyShellInput`/`PtyShellStop`/etc. at any
+/// controller-backed block (another agent's own CLI pane, a human's
+/// terminal pane) and inject input into it or tear it down. Framed as
+/// parentage rather than "did `PtyShell` create it" (the original,
+/// narrower check) specifically so it also covers the reuse case above: a
+/// shell the HUMAN created via the drawer is just as legitimate a target as
+/// one `PtyShell` created itself, as long as it's this agent's own pane.
+fn is_owned_by_agent(
+    wstore: &crate::backend::storage::store::Store,
+    shell_id: &str,
+    agent_block_id: &str,
+) -> bool {
     wstore
         .get::<crate::backend::obj::Block>(shell_id)
         .ok()
         .flatten()
-        .and_then(|b| b.meta.get(PTYSHELL_META_MARKER).and_then(|v| v.as_bool()))
+        .map(|b| {
+            b.parentoref == format!("block:{agent_block_id}")
+                && b.meta.get("view").and_then(|v| v.as_str()) == Some("term")
+        })
         .unwrap_or(false)
+}
+
+/// Merge `meta_update` into `block_id`'s meta and broadcast a
+/// `waveobj:update` WS event so every subscribed frontend (the drawer, if
+/// open) picks it up immediately — the same two steps the `setmeta` WS
+/// handler performs (`websocket.rs`'s `COMMAND_SET_META` handler), factored
+/// out since `ptyshell/*` needs the identical pattern from a plain HTTP
+/// handler with no `WshRpcEngine` in scope.
+fn broadcast_meta_update(
+    state: &AppState,
+    block_id: &str,
+    meta_update: &crate::backend::obj::MetaMapType,
+) -> Result<(), String> {
+    let oref_str = format!("block:{block_id}");
+    crate::server::service::object_helpers::update_object_meta(&state.wstore, &oref_str, meta_update)?;
+    let block = state
+        .wstore
+        .must_get::<crate::backend::obj::Block>(block_id)
+        .map_err(|e| e.to_string())?;
+    state.event_bus.broadcast_event(&crate::backend::eventbus::WSEventType {
+        eventtype: "waveobj:update".to_string(),
+        oref: oref_str,
+        data: Some(serde_json::to_value(&crate::backend::obj::WaveObjUpdate {
+            updatetype: "update".into(),
+            otype: "block".into(),
+            oid: block_id.to_string(),
+            obj: Some(crate::backend::obj::wave_obj_to_value(&block)),
+        }).unwrap_or_default()),
+    });
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -1105,20 +1166,71 @@ fn is_ptyshell_managed(wstore: &crate::backend::storage::store::Store, shell_id:
 // focused, or rendering the shell's `term` sub-block at all.
 // ---------------------------------------------------------------------------
 
-/// `POST /api/v1/ptyshell/create` — open a real PTY-backed shell.
+/// `POST /api/v1/ptyshell/create` — attach to (creating if needed) "this
+/// pane's one shell."
 ///
-/// Creates a headless sub-block (`view: "term", controller: "shell"`,
-/// no tab/layout entry) parented to the calling agent's own block — the
-/// same shape `createsubblock`'s WS handler builds for
-/// `AgentShellSubblock.tsx` — then immediately spawns its controller via
-/// `resync_controller`. Unlike the WS path (which waits for a frontend to
-/// mount a `term` view and call `ControllerResyncCommand`), the PTY is live
-/// the moment this call returns; a UI viewer for it is optional, not a
-/// prerequisite.
+/// Reuses the same sub-block a human's composer-drawer shell already uses
+/// or will use (`META_KEY_SHELL_SUBBLOCK_ID`), in either direction: if the
+/// human already opened the drawer, the agent joins that exact PTY — same
+/// scrollback, same live output. If nothing exists yet, this creates it
+/// (the same `view: "term", controller: "shell"` headless-sub-block shape
+/// `createsubblock`'s WS handler builds for `AgentShellSubblock.tsx`) and
+/// persists the pointer, so a drawer opened *afterward* attaches to what
+/// the agent already started instead of spawning a second, independent
+/// shell. Either way, `resync_controller` runs before returning — unlike
+/// the WS path (which waits for a frontend to mount a `term` view and call
+/// `ControllerResyncCommand`), the PTY is live the moment this call
+/// returns; a UI viewer for it is optional, not a prerequisite.
 async fn handle_pty_shell_create(
     State(state): State<AppState>,
     Json(req): Json<PtyShellCreateRequest>,
 ) -> impl IntoResponse {
+    let existing_id = state
+        .wstore
+        .get::<crate::backend::obj::Block>(&req.agent_block_id)
+        .ok()
+        .flatten()
+        .and_then(|b| {
+            b.meta
+                .get(META_KEY_SHELL_SUBBLOCK_ID)
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        });
+
+    // Reuse path: the pointer exists and still resolves to a real block.
+    // Deliberately ignores req.cwd/rows/cols here — an already-running
+    // shell's cwd can't change after spawn, and geometry is a separate,
+    // legitimate post-hoc operation via PtyShellResize, not a create-time
+    // parameter for a process that already has a size.
+    if let Some(id) = existing_id {
+        if let Ok(Some(block)) = state.wstore.get::<crate::backend::obj::Block>(&id) {
+            let registry = state.wstore.shared_agent_registry();
+            if let Err(e) = blockcontroller::resync_controller(
+                &block,
+                "ptyshell",
+                None,
+                false,
+                Some(Arc::clone(&state.broker)),
+                Some(Arc::clone(&state.event_bus)),
+                Some(Arc::clone(&state.wstore)),
+                Some(Arc::clone(&state.filestore)),
+                registry,
+                state.boot_id.clone(),
+            ) {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({ "error": format!("ptyshell.create: resync existing shell: {e}") })),
+                )
+                    .into_response();
+            }
+            answer_conpty_handshake_if_seen(&state, &id).await;
+            tracing::info!(block_id = %id, parent_id = %req.agent_block_id, "ptyshell.create: reused");
+            return (StatusCode::OK, Json(PtyShellCreateResponse { shell_id: id })).into_response();
+        }
+        // Stale pointer (the block was deleted some other way) — fall
+        // through to creating a fresh one, same as if none existed.
+    }
+
     let child_id = uuid::Uuid::new_v4().to_string();
 
     let mut meta = crate::backend::obj::MetaMapType::new();
@@ -1127,7 +1239,6 @@ async fn handle_pty_shell_create(
         blockcontroller::META_KEY_CONTROLLER.to_string(),
         json!(blockcontroller::BLOCK_CONTROLLER_SHELL),
     );
-    meta.insert(PTYSHELL_META_MARKER.to_string(), json!(true));
     // Force cmd.exe directly on Windows rather than the "shell" controller's
     // default pwsh/powershell auto-detection (`detect_local_shell_path_windows`,
     // which tries pwsh first). Discovered live, not assumed: PowerShell's
@@ -1270,21 +1381,44 @@ async fn handle_pty_shell_create(
             .into_response();
     }
 
-    // Answer ConPTY's own startup handshake before returning, on Windows.
-    // Discovered live (not assumed): the moment a Windows ConPTY is created,
-    // it queries the cursor position (`ESC[6n`, Device Status Report) and
-    // blocks its own internal state — and therefore every later write —
-    // until it sees a `ESC[<row>;<col>R` reply. A human-facing `term` pane
-    // gets this for free because xterm.js, running in the browser, answers
-    // real cursor queries as part of being an actual terminal emulator; this
-    // headless facility has nothing playing that role, so without this the
-    // PTY would sit permanently stuck before printing even its first
-    // prompt — confirmed by a live round trip that hung indefinitely until
-    // this was added. `ESC[1;1R` (cursor at row 1, col 1) is a plausible-
-    // enough fixed answer: nothing here has rendered anything yet, so
-    // "top-left" is as true as any other coordinate, and ConPTY only wants
-    // to reconcile its internal buffer, not validate the value against
-    // anything a person would see.
+    answer_conpty_handshake_if_seen(&state, &child_id).await;
+
+    // Persist the pointer so a drawer opened AFTER this call attaches to
+    // the shell the agent just started instead of spawning a second,
+    // independent one. Best-effort (same posture as the parent-link write
+    // above) — a failure here means a later-opened drawer gets its own
+    // separate shell instead of joining this one, degraded but not broken.
+    let mut agent_meta = crate::backend::obj::MetaMapType::new();
+    agent_meta.insert(META_KEY_SHELL_SUBBLOCK_ID.to_string(), json!(child_id));
+    if let Err(e) = broadcast_meta_update(&state, &req.agent_block_id, &agent_meta) {
+        tracing::warn!(agent_block_id = %req.agent_block_id, shell_id = %child_id, error = %e, "ptyshell.create: failed to persist shellsubblockid");
+    }
+
+    tracing::info!(block_id = %child_id, parent_id = %req.agent_block_id, "ptyshell.create: fresh");
+    (StatusCode::OK, Json(PtyShellCreateResponse { shell_id: child_id })).into_response()
+}
+
+/// Answer Windows ConPTY's own startup handshake, if seen, before the
+/// caller proceeds. Discovered live (not assumed): the moment a Windows
+/// ConPTY is created, it queries the cursor position (`ESC[6n`, Device
+/// Status Report) and blocks its own internal state — and therefore every
+/// later write — until it sees a `ESC[<row>;<col>R` reply. A human-facing
+/// `term` pane gets this for free because xterm.js, running in the
+/// browser, answers real cursor queries as part of being an actual
+/// terminal emulator; this headless facility has nothing playing that
+/// role, so without this the PTY would sit permanently stuck before
+/// printing even its first prompt — confirmed by a live round trip that
+/// hung indefinitely until this was added. `ESC[1;1R` (cursor at row 1,
+/// col 1) is a plausible-enough fixed answer: nothing here has rendered
+/// anything yet, so "top-left" is as true as any other coordinate, and
+/// ConPTY only wants to reconcile its internal buffer, not validate the
+/// value against anything a person would see.
+///
+/// Safe to call unconditionally on both the fresh-create and reuse paths:
+/// an already-initialized shell has long since resolved its one startup
+/// query, so this simply finds nothing within the poll window and returns.
+#[cfg_attr(not(windows), allow(unused_variables))]
+async fn answer_conpty_handshake_if_seen(state: &AppState, block_id: &str) {
     #[cfg(windows)]
     {
         let mut answered = false;
@@ -1292,14 +1426,14 @@ async fn handle_pty_shell_create(
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             let saw_dsr = state
                 .filestore
-                .read_file(&child_id, "term")
+                .read_file(block_id, "term")
                 .ok()
                 .flatten()
                 .map(|bytes| bytes.windows(4).any(|w| w == b"\x1b[6n"))
                 .unwrap_or(false);
             if saw_dsr {
                 let _ = blockcontroller::send_input(
-                    &child_id,
+                    block_id,
                     blockcontroller::BlockInputUnion::data(b"\x1b[1;1R".to_vec()),
                     None,
                 );
@@ -1307,11 +1441,8 @@ async fn handle_pty_shell_create(
                 break;
             }
         }
-        tracing::info!(block_id = %child_id, answered_dsr = answered, "ptyshell.create: ConPTY handshake");
+        tracing::info!(block_id = %block_id, answered_dsr = answered, "ptyshell: ConPTY handshake check");
     }
-
-    tracing::info!(block_id = %child_id, parent_id = %req.agent_block_id, "ptyshell.create");
-    (StatusCode::OK, Json(PtyShellCreateResponse { shell_id: child_id })).into_response()
 }
 
 /// `POST /api/v1/ptyshell/input` — write raw text to the PTY, as if typed.
@@ -1336,22 +1467,42 @@ async fn handle_pty_shell_input(
     State(state): State<AppState>,
     Json(req): Json<PtyShellInputRequest>,
 ) -> impl IntoResponse {
-    if !is_ptyshell_managed(&state.wstore, &req.shell_id) {
+    if !is_owned_by_agent(&state.wstore, &req.shell_id, &req.agent_block_id) {
         return (
             StatusCode::OK,
             Json(PtyShellInputResponse {
                 written: false,
-                error: Some("not a PtyShell-created shell".to_string()),
+                error: Some("not a shell belonging to this agent's own pane".to_string()),
             }),
         );
     }
-    match blockcontroller::send_input(
+    let result = blockcontroller::send_input(
         &req.shell_id,
         blockcontroller::BlockInputUnion::data(req.text.into_bytes()),
         None,
-    ) {
+    );
+    if result.is_ok() {
+        lock_shell_for_agent(&state, &req.shell_id);
+    }
+    match result {
         Ok(()) => (StatusCode::OK, Json(PtyShellInputResponse { written: true, error: None })),
         Err(e) => (StatusCode::OK, Json(PtyShellInputResponse { written: false, error: Some(e) })),
+    }
+}
+
+/// Lock `shell_id` out from human keyboard input for `AGENT_LOCK_WINDOW_MS`
+/// from now — called after every successful agent write (input/resize).
+/// Best-effort: a failure to write the lock meta just means the human's
+/// input isn't blocked this time, not that the agent's write failed (the
+/// PTY write already succeeded by the time this runs).
+fn lock_shell_for_agent(state: &AppState, shell_id: &str) {
+    let mut meta = crate::backend::obj::MetaMapType::new();
+    meta.insert(
+        META_KEY_AGENT_LOCK_UNTIL.to_string(),
+        json!(agentmux_common::time::now_ms() + AGENT_LOCK_WINDOW_MS),
+    );
+    if let Err(e) = broadcast_meta_update(state, shell_id, &meta) {
+        tracing::warn!(shell_id = %shell_id, error = %e, "ptyshell: failed to write agent lock");
     }
 }
 
@@ -1361,23 +1512,27 @@ async fn handle_pty_shell_resize(
     State(state): State<AppState>,
     Json(req): Json<PtyShellResizeRequest>,
 ) -> impl IntoResponse {
-    if !is_ptyshell_managed(&state.wstore, &req.shell_id) {
+    if !is_owned_by_agent(&state.wstore, &req.shell_id, &req.agent_block_id) {
         return (
             StatusCode::OK,
             Json(PtyShellResizeResponse {
                 resized: false,
-                error: Some("not a PtyShell-created shell".to_string()),
+                error: Some("not a shell belonging to this agent's own pane".to_string()),
             }),
         );
     }
-    match blockcontroller::send_input(
+    let result = blockcontroller::send_input(
         &req.shell_id,
         blockcontroller::BlockInputUnion::resize(crate::backend::obj::TermSize {
             rows: req.rows as i64,
             cols: req.cols as i64,
         }),
         None,
-    ) {
+    );
+    if result.is_ok() {
+        lock_shell_for_agent(&state, &req.shell_id);
+    }
+    match result {
         Ok(()) => (StatusCode::OK, Json(PtyShellResizeResponse { resized: true, error: None })),
         Err(e) => (StatusCode::OK, Json(PtyShellResizeResponse { resized: false, error: Some(e) })),
     }
@@ -1401,7 +1556,7 @@ async fn handle_pty_shell_read(
     State(state): State<AppState>,
     Json(req): Json<PtyShellReadRequest>,
 ) -> impl IntoResponse {
-    if !is_ptyshell_managed(&state.wstore, &req.shell_id) {
+    if !is_owned_by_agent(&state.wstore, &req.shell_id, &req.agent_block_id) {
         return (
             StatusCode::OK,
             Json(PtyShellReadResponse { content: String::new(), truncated: false }),
@@ -1432,7 +1587,7 @@ async fn handle_pty_shell_status(
     State(state): State<AppState>,
     Json(req): Json<PtyShellStatusRequest>,
 ) -> impl IntoResponse {
-    if !is_ptyshell_managed(&state.wstore, &req.shell_id) {
+    if !is_owned_by_agent(&state.wstore, &req.shell_id, &req.agent_block_id) {
         return (StatusCode::OK, Json(PtyShellStatusResponse { running: false, exit_code: None }));
     }
     match blockcontroller::get_block_controller_status(&req.shell_id) {
@@ -1449,48 +1604,35 @@ async fn handle_pty_shell_status(
     }
 }
 
-/// `POST /api/v1/ptyshell/stop` — kill the PTY and delete its sub-block.
-/// Mirrors `deletesubblock`'s WS handler: kill-first ordering (a lingering
-/// PTY tree is worse than a delayed row delete), best-effort unlink from the
-/// parent's subblockids.
+/// `POST /api/v1/ptyshell/stop` — release the agent's lock immediately,
+/// without waiting for `AGENT_LOCK_WINDOW_MS` to lapse on its own.
+///
+/// Does not touch the process or the block at all (see
+/// `PtyShellStopResponse`'s doc comment in `api_types.rs` for why: this
+/// shell is a shared, pane-scoped resource now, not a private one this API
+/// owns outright).
 async fn handle_pty_shell_stop(
     State(state): State<AppState>,
     Json(req): Json<PtyShellStopRequest>,
 ) -> impl IntoResponse {
-    // Codex P1 on PR #3177: without this, an arbitrary block_id (e.g. a
-    // human's terminal pane or another agent's own CLI pane, discoverable
-    // via `Layout`) could be torn down through this endpoint. Only ever act
-    // on blocks this API itself created.
-    if !is_ptyshell_managed(&state.wstore, &req.shell_id) {
-        return (StatusCode::OK, Json(PtyShellStopResponse { stopped: false }));
+    if !is_owned_by_agent(&state.wstore, &req.shell_id, &req.agent_block_id) {
+        return (StatusCode::OK, Json(PtyShellStopResponse { released: false }));
     }
-    // Whether a controller actually existed is the meaningful "did this
-    // stop anything" signal — unlike `Store::delete`, which succeeds
-    // (no-ops) even for a row that was never there, so `.is_ok()` alone
-    // can't distinguish "stopped a real shell" from "unknown id".
-    let stopped = blockcontroller::get_block_controller_status(&req.shell_id).is_some();
-    blockcontroller::delete_controller(&req.shell_id);
-
-    let parent_id = state
+    let was_locked = state
         .wstore
         .get::<crate::backend::obj::Block>(&req.shell_id)
         .ok()
         .flatten()
-        .and_then(|b| b.parentoref.strip_prefix("block:").map(str::to_string));
+        .and_then(|b| b.meta.get(META_KEY_AGENT_LOCK_UNTIL).and_then(|v| v.as_i64()))
+        .map(|until| until > agentmux_common::time::now_ms())
+        .unwrap_or(false);
 
-    let _ = state.wstore.delete::<crate::backend::obj::Block>(&req.shell_id);
+    let mut meta = crate::backend::obj::MetaMapType::new();
+    meta.insert(META_KEY_AGENT_LOCK_UNTIL.to_string(), serde_json::Value::Null);
+    let released = broadcast_meta_update(&state, &req.shell_id, &meta).is_ok() && was_locked;
 
-    if let Some(parent_id) = parent_id {
-        if let Ok(mut parent) = state.wstore.must_get::<crate::backend::obj::Block>(&parent_id) {
-            if let Some(ids) = parent.subblockids.as_mut() {
-                ids.retain(|id| id != &req.shell_id);
-                let _ = state.wstore.update(&mut parent);
-            }
-        }
-    }
-
-    tracing::info!(block_id = %req.shell_id, "ptyshell.stop");
-    (StatusCode::OK, Json(PtyShellStopResponse { stopped }))
+    tracing::info!(block_id = %req.shell_id, released, "ptyshell.stop: released lock");
+    (StatusCode::OK, Json(PtyShellStopResponse { released }))
 }
 
 /// `POST /api/v1/pane/open` — open a pane (editor/term/browser/…).

--- a/agentmux-srv/src/server/service/mod.rs
+++ b/agentmux-srv/src/server/service/mod.rs
@@ -22,7 +22,7 @@ mod introspect;
 pub(crate) mod layout_helpers;
 mod misc;
 mod object;
-mod object_helpers;
+pub(crate) mod object_helpers;
 mod reducer_helpers;
 pub(crate) mod session_restore;
 mod tab_lifecycle;

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -3695,9 +3695,13 @@ async fn ptyshell_stop_on_unknown_id_reports_not_released() {
 
 #[tokio::test]
 async fn ptyshell_input_locks_the_shell_and_stop_releases_it_early() {
-    // The locking feature: a successful write stamps an expiry timestamp
-    // the frontend reads to gate human keyboard input; PtyShellStop clears
-    // it immediately rather than waiting for AGENT_LOCK_WINDOW_MS to lapse.
+    // The locking feature: input/resize stamp an expiry timestamp the
+    // frontend reads to gate human keyboard input, BEFORE attempting the
+    // write itself (ReAgent P1 on PR #3194 — locking only on success left
+    // the lock unset for the write's entire duration, exactly the window
+    // controllerinput's own lock check needs it to already exist to catch
+    // anything). PtyShellStop clears it immediately rather than waiting
+    // for AGENT_LOCK_WINDOW_MS to lapse.
     let state = test_state();
     let app = build_router(state.clone());
 
@@ -3732,15 +3736,13 @@ async fn ptyshell_input_locks_the_shell_and_stop_releases_it_early() {
     .await;
     // No live controller for this synthetic block, so the PTY write itself
     // fails — but the ownership check passed (a different error, not the
-    // "not a shell belonging..." rejection), which is all this test needs;
-    // the lock is asserted directly against the store below regardless of
-    // whether the write "succeeded" in the no-controller sense.
+    // "not a shell belonging..." rejection), which is what proves the lock
+    // write below came from the REAL request path, not a bypassed check.
     assert!(!json["error"].as_str().unwrap_or("").contains("not a shell belonging"));
 
-    // Locking only happens on a SUCCESSFUL write (see `handle_pty_shell_input`),
-    // so simulate that success path directly for this assertion — the HTTP
-    // round trip above already proved the ownership gate passes.
-    lock_shell_for_agent(&state, &shell_id);
+    // The lock must be set by the real HTTP call itself — unconditionally,
+    // before the (here, failing) write is even attempted — not merely
+    // something this test simulates after the fact.
     let locked_block: crate::backend::obj::Block = state.wstore.must_get(&shell_id).unwrap();
     let until = locked_block.meta.get(META_KEY_AGENT_LOCK_UNTIL).and_then(|v| v.as_i64()).unwrap();
     assert!(until > before, "lock expiry must be in the future");

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -3785,6 +3785,18 @@ async fn ptyshell_create_input_read_stop_round_trips_through_a_real_pty() {
     let state = test_state();
     let app = build_router(state.clone());
 
+    // A real block, not just a fixture id: `create`'s atomic claim-or-lose
+    // step (Codex P2 on PR #3194) does a hard `must_get` on the agent
+    // block to check/set its shellsubblockid pointer inside one
+    // transaction — unlike the old best-effort parent-link, a genuinely
+    // missing agent block is now a real error, matching every actual
+    // caller in production (agent_block_id always names a real, live pane).
+    let mut agent_block = crate::backend::obj::Block {
+        oid: "test-agent-block".to_string(),
+        ..Default::default()
+    };
+    state.wstore.insert(&mut agent_block).expect("insert agent block");
+
     let (status, json) = post_json(
         &app,
         "/api/v1/ptyshell/create",

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -3395,10 +3395,26 @@ async fn ptyshell_create_returns_a_shell_id_and_inserts_a_real_term_block() {
     // afterward through the same store the request went through.
     let state = test_state();
     let app = build_router(state.clone());
+
+    // A real UUID, not a human-readable fixture id: `create`'s success path
+    // now persists `term:shellsubblockid` back onto the agent block via
+    // `update_object_meta`, which parses its oref through `ORef::parse` —
+    // strict about the oid being a real UUID (matching every genuine block
+    // in the app, always minted via `Uuid::new_v4()`). Also has to actually
+    // exist in the store, unlike the plain `wstore.get`-based checks
+    // elsewhere in this file that tolerate a fixture id referring to
+    // nothing at all.
+    let agent_block_id = uuid::Uuid::new_v4().to_string();
+    let mut agent_block = crate::backend::obj::Block {
+        oid: agent_block_id.clone(),
+        ..Default::default()
+    };
+    state.wstore.insert(&mut agent_block).expect("insert agent block");
+
     let (status, json) = post_json(
         &app,
         "/api/v1/ptyshell/create",
-        serde_json::json!({ "agent_block_id": "test-agent-block" }),
+        serde_json::json!({ "agent_block_id": agent_block_id }),
     )
     .await;
     assert_eq!(status, StatusCode::OK);
@@ -3415,7 +3431,17 @@ async fn ptyshell_create_returns_a_shell_id_and_inserts_a_real_term_block() {
         block.meta.get(blockcontroller::META_KEY_CONTROLLER).and_then(|v| v.as_str()),
         Some(blockcontroller::BLOCK_CONTROLLER_SHELL)
     );
-    assert_eq!(block.parentoref, "block:test-agent-block");
+    assert_eq!(block.parentoref, format!("block:{agent_block_id}"));
+
+    // The pointer is persisted on the AGENT's own block too — this is what
+    // lets a drawer opened afterward (or a human who already has one open)
+    // attach to the same shell instead of getting an independent one.
+    let agent_block: crate::backend::obj::Block =
+        state.wstore.must_get(&agent_block_id).expect("agent block exists");
+    assert_eq!(
+        agent_block.meta.get(META_KEY_SHELL_SUBBLOCK_ID).and_then(|v| v.as_str()),
+        Some(shell_id.as_str())
+    );
 
     // `create` spawns a REAL, persistent interactive shell process (unlike
     // every other non-`#[ignore]`d test in this file, which never spawns
@@ -3430,14 +3456,90 @@ async fn ptyshell_create_returns_a_shell_id_and_inserts_a_real_term_block() {
 }
 
 #[tokio::test]
-async fn ptyshell_rejects_operating_on_a_block_it_did_not_create() {
-    // Codex P1 on PR #3177: `shell_id` lives in the SAME namespace as every
-    // other pane block, and `Layout` exposes block ids for ordinary panes —
-    // without an ownership check, PtyShellInput/PtyShellStop etc. could be
-    // pointed at a completely unrelated pane (another agent's own CLI pane,
-    // a human's terminal). This inserts a real, ordinary "shell"-controller
-    // block through the front door (not one PtyShell created) and asserts
-    // every mutating/reading endpoint refuses to touch it.
+async fn ptyshell_create_reuses_the_pane_s_existing_shell_instead_of_spawning_a_second_one() {
+    // The core of the visible-shell feature: whichever side (agent or
+    // human-opened drawer) creates the shell first, the other attaches to
+    // the SAME one. This simulates the "human already has the drawer open"
+    // direction — a real `view:"term"` sub-block created the way
+    // `AgentShellSubblock.tsx` does it (through `createsubblock`, not
+    // `PtyShell`), with `term:shellsubblockid` already pointing at it on
+    // the agent's own block, exactly as `agent-view.tsx`'s
+    // `onSubBlockCreated` callback leaves it.
+    let state = test_state();
+    let app = build_router(state.clone());
+
+    // Real UUIDs, not human-readable fixture ids: the agent block gets
+    // written to via `update_object_meta` (parses its oref through
+    // `ORef::parse`, strict about a real-UUID oid, matching every genuine
+    // block in the app).
+    let agent_block_id = uuid::Uuid::new_v4().to_string();
+    let human_shell_id = uuid::Uuid::new_v4().to_string();
+
+    let mut agent_block = crate::backend::obj::Block {
+        oid: agent_block_id.clone(),
+        ..Default::default()
+    };
+    state.wstore.insert(&mut agent_block).expect("insert agent block");
+
+    let mut human_shell = crate::backend::obj::Block {
+        oid: human_shell_id.clone(),
+        parentoref: format!("block:{agent_block_id}"),
+        meta: {
+            let mut m = crate::backend::obj::MetaMapType::new();
+            m.insert("view".to_string(), serde_json::json!("term"));
+            m.insert(
+                blockcontroller::META_KEY_CONTROLLER.to_string(),
+                serde_json::json!(blockcontroller::BLOCK_CONTROLLER_SHELL),
+            );
+            m
+        },
+        ..Default::default()
+    };
+    state.wstore.insert(&mut human_shell).expect("insert human shell block");
+    let mut agent_meta = crate::backend::obj::MetaMapType::new();
+    agent_meta.insert(META_KEY_SHELL_SUBBLOCK_ID.to_string(), serde_json::json!(human_shell_id));
+    crate::server::service::object_helpers::update_object_meta(
+        &state.wstore,
+        &format!("block:{agent_block_id}"),
+        &agent_meta,
+    )
+    .expect("point agent block at the human's shell");
+
+    let (status, json) = post_json(
+        &app,
+        "/api/v1/ptyshell/create",
+        serde_json::json!({ "agent_block_id": agent_block_id }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        json["shell_id"].as_str(),
+        Some(human_shell_id.as_str()),
+        "PtyShell must attach to the pane's existing shell, not create a new one"
+    );
+
+    // The agent block's pointer is unchanged — `create` didn't mint a
+    // second, independent shell and repoint it there instead of reusing.
+    let agent_block: crate::backend::obj::Block = state.wstore.must_get(&agent_block_id).unwrap();
+    assert_eq!(
+        agent_block.meta.get(META_KEY_SHELL_SUBBLOCK_ID).and_then(|v| v.as_str()),
+        Some(human_shell_id.as_str())
+    );
+
+    blockcontroller::delete_controller(&human_shell_id);
+}
+
+#[tokio::test]
+async fn ptyshell_rejects_operating_on_a_block_outside_the_calling_agents_own_pane() {
+    // Codex P1 on PR #3177, reframed after the reuse feature (see
+    // `is_owned_by_agent`'s doc comment): `shell_id` lives in the SAME
+    // namespace as every other pane block, and `Layout` exposes block ids
+    // for ordinary panes — without this check, an agent could point
+    // PtyShellInput/PtyShellStop/etc. at a completely unrelated pane
+    // (another agent's own CLI pane, a human's terminal). This inserts a
+    // real "shell"-controller block parented to a DIFFERENT agent and
+    // asserts every mutating/reading endpoint refuses to touch it when the
+    // request claims a different `agent_block_id`.
     let state = test_state();
     let app = build_router(state.clone());
 
@@ -3460,16 +3562,16 @@ async fn ptyshell_rejects_operating_on_a_block_it_did_not_create() {
     let (_, json) = post_json(
         &app,
         "/api/v1/ptyshell/input",
-        serde_json::json!({ "shell_id": "someone-elses-real-pane", "text": "hi" }),
+        serde_json::json!({ "shell_id": "someone-elses-real-pane", "agent_block_id": "attacking-agent", "text": "hi" }),
     )
     .await;
     assert_eq!(json["written"], serde_json::json!(false));
-    assert!(json["error"].as_str().unwrap_or("").contains("not a PtyShell-created shell"));
+    assert!(json["error"].as_str().unwrap_or("").contains("not a shell belonging to this agent's own pane"));
 
     let (_, json) = post_json(
         &app,
         "/api/v1/ptyshell/resize",
-        serde_json::json!({ "shell_id": "someone-elses-real-pane", "rows": 30, "cols": 100 }),
+        serde_json::json!({ "shell_id": "someone-elses-real-pane", "agent_block_id": "attacking-agent", "rows": 30, "cols": 100 }),
     )
     .await;
     assert_eq!(json["resized"], serde_json::json!(false));
@@ -3477,7 +3579,7 @@ async fn ptyshell_rejects_operating_on_a_block_it_did_not_create() {
     let (_, json) = post_json(
         &app,
         "/api/v1/ptyshell/read",
-        serde_json::json!({ "shell_id": "someone-elses-real-pane" }),
+        serde_json::json!({ "shell_id": "someone-elses-real-pane", "agent_block_id": "attacking-agent" }),
     )
     .await;
     assert_eq!(json["content"], serde_json::json!(""));
@@ -3485,15 +3587,26 @@ async fn ptyshell_rejects_operating_on_a_block_it_did_not_create() {
     let (_, json) = post_json(
         &app,
         "/api/v1/ptyshell/stop",
-        serde_json::json!({ "shell_id": "someone-elses-real-pane" }),
+        serde_json::json!({ "shell_id": "someone-elses-real-pane", "agent_block_id": "attacking-agent" }),
     )
     .await;
-    assert_eq!(json["stopped"], serde_json::json!(false));
+    assert_eq!(json["released"], serde_json::json!(false));
 
-    // The foreign block must still exist — stop() must not have deleted it.
+    // The foreign block must still exist and be untouched.
     let still_there: Result<crate::backend::obj::Block, _> =
         state.wstore.must_get("someone-elses-real-pane");
-    assert!(still_there.is_ok(), "ptyshell/stop must not delete a block it didn't create");
+    assert!(still_there.is_ok(), "ptyshell/* must not delete a block outside the caller's own pane");
+
+    // The LEGITIMATE owner (matching agent_block_id) can still act on it —
+    // proves the rejection above is about ownership, not a broken check.
+    let (_, json) = post_json(
+        &app,
+        "/api/v1/ptyshell/resize",
+        serde_json::json!({ "shell_id": "someone-elses-real-pane", "agent_block_id": "someone-elses-agent", "rows": 30, "cols": 100 }),
+    )
+    .await;
+    assert_eq!(json["resized"], serde_json::json!(false), "no live controller yet, but ownership check must pass");
+    assert!(!json["error"].as_str().unwrap_or("").contains("not a shell belonging"));
 }
 
 #[tokio::test]
@@ -3542,7 +3655,7 @@ async fn ptyshell_status_on_unknown_id_is_a_plain_not_running_answer() {
     let (status, json) = post_json(
         &app,
         "/api/v1/ptyshell/status",
-        serde_json::json!({ "shell_id": "no-such-shell" }),
+        serde_json::json!({ "shell_id": "no-such-shell", "agent_block_id": "whoever" }),
     )
     .await;
     assert_eq!(status, StatusCode::OK);
@@ -3556,29 +3669,100 @@ async fn ptyshell_input_on_unknown_id_reports_written_false_with_a_reason() {
     let (status, json) = post_json(
         &app,
         "/api/v1/ptyshell/input",
-        serde_json::json!({ "shell_id": "no-such-shell", "text": "hello" }),
+        serde_json::json!({ "shell_id": "no-such-shell", "agent_block_id": "whoever", "text": "hello" }),
     )
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(json["written"], serde_json::json!(false));
-    // Caught by the ownership check (Codex P1 on PR #3177) before ever
-    // reaching `blockcontroller::send_input` — an unrecognized id is
-    // indistinguishable from "not a PtyShell-created shell" by design, so
-    // this asserts the same message a real cross-pane id would get too.
-    assert!(json["error"].as_str().unwrap_or("").contains("not a PtyShell-created shell"));
+    // Caught by the ownership check before ever reaching
+    // `blockcontroller::send_input` — an unrecognized id is
+    // indistinguishable from "not this agent's own pane" by design.
+    assert!(json["error"].as_str().unwrap_or("").contains("not a shell belonging to this agent's own pane"));
 }
 
 #[tokio::test]
-async fn ptyshell_stop_on_unknown_id_reports_not_stopped() {
+async fn ptyshell_stop_on_unknown_id_reports_not_released() {
     let app = test_router();
     let (status, json) = post_json(
         &app,
         "/api/v1/ptyshell/stop",
-        serde_json::json!({ "shell_id": "no-such-shell" }),
+        serde_json::json!({ "shell_id": "no-such-shell", "agent_block_id": "whoever" }),
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(json["stopped"], serde_json::json!(false));
+    assert_eq!(json["released"], serde_json::json!(false));
+}
+
+#[tokio::test]
+async fn ptyshell_input_locks_the_shell_and_stop_releases_it_early() {
+    // The locking feature: a successful write stamps an expiry timestamp
+    // the frontend reads to gate human keyboard input; PtyShellStop clears
+    // it immediately rather than waiting for AGENT_LOCK_WINDOW_MS to lapse.
+    let state = test_state();
+    let app = build_router(state.clone());
+
+    // Real UUIDs — the lock write goes through `update_object_meta`, strict
+    // about a real-UUID oid (see the identical note on the reuse test above).
+    let agent_block_id = uuid::Uuid::new_v4().to_string();
+    let shell_id = uuid::Uuid::new_v4().to_string();
+
+    let mut agent_block = crate::backend::obj::Block {
+        oid: agent_block_id.clone(),
+        ..Default::default()
+    };
+    state.wstore.insert(&mut agent_block).expect("insert agent block");
+    let mut shell = crate::backend::obj::Block {
+        oid: shell_id.clone(),
+        parentoref: format!("block:{agent_block_id}"),
+        meta: {
+            let mut m = crate::backend::obj::MetaMapType::new();
+            m.insert("view".to_string(), serde_json::json!("term"));
+            m
+        },
+        ..Default::default()
+    };
+    state.wstore.insert(&mut shell).expect("insert shell block");
+
+    let before = agentmux_common::time::now_ms();
+    let (_, json) = post_json(
+        &app,
+        "/api/v1/ptyshell/input",
+        serde_json::json!({ "shell_id": shell_id, "agent_block_id": agent_block_id, "text": "hi" }),
+    )
+    .await;
+    // No live controller for this synthetic block, so the PTY write itself
+    // fails — but the ownership check passed (a different error, not the
+    // "not a shell belonging..." rejection), which is all this test needs;
+    // the lock is asserted directly against the store below regardless of
+    // whether the write "succeeded" in the no-controller sense.
+    assert!(!json["error"].as_str().unwrap_or("").contains("not a shell belonging"));
+
+    // Locking only happens on a SUCCESSFUL write (see `handle_pty_shell_input`),
+    // so simulate that success path directly for this assertion — the HTTP
+    // round trip above already proved the ownership gate passes.
+    lock_shell_for_agent(&state, &shell_id);
+    let locked_block: crate::backend::obj::Block = state.wstore.must_get(&shell_id).unwrap();
+    let until = locked_block.meta.get(META_KEY_AGENT_LOCK_UNTIL).and_then(|v| v.as_i64()).unwrap();
+    assert!(until > before, "lock expiry must be in the future");
+    assert!(until <= before + AGENT_LOCK_WINDOW_MS + 1000, "lock window should be short, not indefinite");
+
+    let (_, json) = post_json(
+        &app,
+        "/api/v1/ptyshell/stop",
+        serde_json::json!({ "shell_id": shell_id, "agent_block_id": agent_block_id }),
+    )
+    .await;
+    assert_eq!(json["released"], serde_json::json!(true));
+
+    let unlocked_block: crate::backend::obj::Block = state.wstore.must_get(&shell_id).unwrap();
+    assert!(
+        unlocked_block.meta.get(META_KEY_AGENT_LOCK_UNTIL).is_none(),
+        "stop must clear the lock, not just let it expire"
+    );
+
+    // The block itself must still exist — stop() never deletes it (this
+    // shell is shared/pane-scoped now, not a private disposable one).
+    assert!(state.wstore.get::<crate::backend::obj::Block>(&shell_id).unwrap().is_some());
 }
 
 /// Real end-to-end PTY spawn: create a shell, type a command, read the
@@ -3596,7 +3780,10 @@ async fn ptyshell_stop_on_unknown_id_reports_not_stopped() {
 #[tokio::test]
 #[ignore]
 async fn ptyshell_create_input_read_stop_round_trips_through_a_real_pty() {
-    let app = test_router();
+    // Kept `AppState` handle (not `test_router()`) so the lock meta can be
+    // asserted directly against the store below.
+    let state = test_state();
+    let app = build_router(state.clone());
 
     let (status, json) = post_json(
         &app,
@@ -3614,11 +3801,21 @@ async fn ptyshell_create_input_read_stop_round_trips_through_a_real_pty() {
     let (status, json) = post_json(
         &app,
         "/api/v1/ptyshell/input",
-        serde_json::json!({ "shell_id": shell_id, "text": format!("echo {marker}\r\n") }),
+        serde_json::json!({ "shell_id": shell_id, "agent_block_id": "test-agent-block", "text": format!("echo {marker}\r\n") }),
     )
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(json["written"], serde_json::json!(true), "input write failed: {json:?}");
+
+    // A successful write must lock the shell out from human input — the
+    // whole point of the feature. Assert it directly against the store
+    // rather than adding a frontend round trip to this backend test.
+    let locked_block: crate::backend::obj::Block = state.wstore.must_get(&shell_id).unwrap();
+    let lock_until = locked_block.meta.get(META_KEY_AGENT_LOCK_UNTIL).and_then(|v| v.as_i64());
+    assert!(
+        lock_until.is_some_and(|until| until > agentmux_common::time::now_ms()),
+        "a successful PtyShellInput must set a future term:agentlockuntil"
+    );
 
     // Poll rather than a single fixed sleep — shell startup + echo latency
     // varies by machine/OS.
@@ -3628,14 +3825,14 @@ async fn ptyshell_create_input_read_stop_round_trips_through_a_real_pty() {
         let (_, json) = post_json(
             &app,
             "/api/v1/ptyshell/read",
-            serde_json::json!({ "shell_id": shell_id }),
+            serde_json::json!({ "shell_id": shell_id, "agent_block_id": "test-agent-block" }),
         )
         .await;
         content = json["content"].as_str().unwrap_or("").to_string();
         let (_, status_json) = post_json(
             &app,
             "/api/v1/ptyshell/status",
-            serde_json::json!({ "shell_id": shell_id }),
+            serde_json::json!({ "shell_id": shell_id, "agent_block_id": "test-agent-block" }),
         )
         .await;
         eprintln!("[poll {i}] status={status_json:?} content={content:?}");
@@ -3651,26 +3848,33 @@ async fn ptyshell_create_input_read_stop_round_trips_through_a_real_pty() {
     let (status, json) = post_json(
         &app,
         "/api/v1/ptyshell/status",
-        serde_json::json!({ "shell_id": shell_id }),
+        serde_json::json!({ "shell_id": shell_id, "agent_block_id": "test-agent-block" }),
     )
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(json["running"], serde_json::json!(true));
 
+    // stop() releases the lock but must NOT kill the shell — it's shared
+    // with whatever human drawer might attach to it later.
     let (status, json) = post_json(
         &app,
         "/api/v1/ptyshell/stop",
-        serde_json::json!({ "shell_id": shell_id }),
+        serde_json::json!({ "shell_id": shell_id, "agent_block_id": "test-agent-block" }),
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(json["stopped"], serde_json::json!(true));
+    assert_eq!(json["released"], serde_json::json!(true));
 
     let (_, json) = post_json(
         &app,
         "/api/v1/ptyshell/status",
-        serde_json::json!({ "shell_id": shell_id }),
+        serde_json::json!({ "shell_id": shell_id, "agent_block_id": "test-agent-block" }),
     )
     .await;
-    assert_eq!(json["running"], serde_json::json!(false));
+    assert_eq!(json["running"], serde_json::json!(true), "stop must not kill the shared shell");
+
+    // Actually kill it now, for real, so this test doesn't leave a live
+    // process running for the rest of the binary's life — see the
+    // identical cleanup note on the other real-spawn tests in this file.
+    blockcontroller::delete_controller(&shell_id);
 }

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1022,12 +1022,44 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState, conn_id: Strin
     );
 
     // controllerinput → route keyboard input / signals / resize to block controller
+    //
+    // Drops input for a block currently under an active PtyShell agent lock
+    // (`term:agentlockuntil`, docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md
+    // §10.3) rather than forwarding it — Codex P1 on PR #3194: the
+    // frontend's own gate (`AgentShellSubblock.tsx` dropping its
+    // `sendDataHandler` calls while locked) is necessarily eventually-
+    // consistent — it reacts to a WS-pushed meta value, not something
+    // synchronous with the backend's own state — so a human keystroke
+    // already in flight when the lock is set could otherwise still reach
+    // `send_input` and interleave with the agent's own write, exactly the
+    // collision the lease exists to prevent. This check, made at the
+    // moment this handler actually runs against the backend's own current
+    // state, is the real enforcement; the frontend gate is the UX layer
+    // that keeps it from happening in the first place, not the
+    // correctness boundary.
+    let wstore_ci = state.wstore.clone();
     engine.register_handler(
         COMMAND_CONTROLLER_INPUT,
-        Box::new(|data, _ctx| {
+        Box::new(move |data, _ctx| {
+            let wstore = wstore_ci.clone();
             Box::pin(async move {
                 let cmd: CommandBlockInputData = serde_json::from_value(data)
                     .map_err(|e| format!("controllerinput: {e}"))?;
+                let locked = wstore
+                    .get::<Block>(&cmd.blockid)
+                    .ok()
+                    .flatten()
+                    .and_then(|b| {
+                        b.meta
+                            .get(crate::server::META_KEY_AGENT_LOCK_UNTIL)
+                            .and_then(|v| v.as_i64())
+                    })
+                    .map(|until| until > agentmux_common::time::now_ms())
+                    .unwrap_or(false);
+                if locked {
+                    tracing::debug!(block_id = %cmd.blockid, "controllerinput: dropped — agent lock active");
+                    return Ok(None);
+                }
                 let input = parse_block_input(&cmd)?;
                 blockcontroller::send_input(&cmd.blockid, input, cmd.seq)?;
                 Ok(None)
@@ -1779,6 +1811,88 @@ fn parse_block_input(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Codex P1 on PR #3194: the frontend's own lock gate
+    /// (`AgentShellSubblock.tsx` dropping `sendDataHandler` while
+    /// `term:agentlockuntil` is in the future) is necessarily eventually-
+    /// consistent — it reacts to a WS-pushed meta value, not something
+    /// synchronous with the backend's own state — so a human keystroke
+    /// already in flight could otherwise still reach `send_input` and
+    /// interleave with an agent's own write. `controllerinput` must reject
+    /// it itself, checked against the backend's own current state at the
+    /// moment it actually runs.
+    ///
+    /// Distinguishes "silently dropped by the lock gate" from "attempted
+    /// and failed for lack of a live controller" by the response's `error`
+    /// field: a target block here has no real controller registered at
+    /// all, so an UNLOCKED call reaches `blockcontroller::send_input` and
+    /// gets a real `"no controller for block"` error back — proving the
+    /// call path is live. A LOCKED call must short-circuit before that
+    /// point, returning cleanly with no error.
+    #[tokio::test]
+    async fn controllerinput_is_dropped_while_an_agent_lock_is_active() {
+        use crate::backend::rpc::engine::WshRpcEngine;
+        use crate::backend::rpc_types::RpcMessage;
+        use crate::server::tests::test_state;
+
+        let state = test_state();
+        let (engine, mut output_rx) = WshRpcEngine::new();
+        register_handlers(&engine, state.clone(), "test-conn".to_string());
+
+        async fn send_input(
+            engine: &std::sync::Arc<WshRpcEngine>,
+            output_rx: &mut tokio::sync::mpsc::UnboundedReceiver<RpcMessage>,
+            block_id: &str,
+        ) -> RpcMessage {
+            engine.handle_message(RpcMessage {
+                command: COMMAND_CONTROLLER_INPUT.to_string(),
+                reqid: uuid::Uuid::new_v4().to_string(),
+                data: Some(serde_json::json!({ "blockid": block_id, "inputdata64": "eQ==" })), // "y"
+                ..Default::default()
+            });
+            tokio::time::timeout(std::time::Duration::from_secs(2), output_rx.recv())
+                .await
+                .expect("handler should respond within 2s")
+                .expect("response channel should not close")
+        }
+
+        // Locked target: no live controller registered, but the check must
+        // never reach that far.
+        let mut locked_block = crate::backend::obj::Block {
+            oid: "locked-shell".to_string(),
+            meta: {
+                let mut m = crate::backend::obj::MetaMapType::new();
+                m.insert(
+                    "term:agentlockuntil".to_string(),
+                    serde_json::json!(agentmux_common::time::now_ms() + 60_000),
+                );
+                m
+            },
+            ..Default::default()
+        };
+        state.wstore.insert(&mut locked_block).unwrap();
+        let resp = send_input(&engine, &mut output_rx, "locked-shell").await;
+        assert!(
+            resp.error.is_empty(),
+            "a locked target must be silently dropped, not reach send_input at all: {}",
+            resp.error
+        );
+
+        // Unlocked target (no lock meta at all) — proves the call path
+        // above is genuinely live: it must reach `send_input` and get a
+        // real "no controller" error, not silently succeed.
+        let mut unlocked_block = crate::backend::obj::Block {
+            oid: "unlocked-shell".to_string(),
+            ..Default::default()
+        };
+        state.wstore.insert(&mut unlocked_block).unwrap();
+        let resp = send_input(&engine, &mut output_rx, "unlocked-shell").await;
+        assert!(
+            resp.error.contains("no controller"),
+            "an unlocked target must reach send_input for real: {}",
+            resp.error
+        );
+    }
 
     fn rpc_event(block_id: &str) -> serde_json::Value {
         json!({

--- a/docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md
+++ b/docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md
@@ -550,6 +550,46 @@ All three reproduced the reasoning above by direct code inspection before
 being accepted as real (not just taking the review's word for it) — see
 §10.6's test list for what backs each one.
 
+### 10.6b Two more real bugs, caught by ReAgent's round-2 review of PR #3194
+
+**P1 — §10.6a #1's fix shrank the lock race but never actually closed the
+part it could have.** The lock was still only written on the SUCCESS path,
+after `blockcontroller::send_input` returned — meaning `send_input`'s own
+entire duration (from the caller's write until it returns) ran with no
+lock in place at all, so a human keystroke landing in that window could
+still interleave with the agent's write via `controllerinput`, which reads
+`term:agentlockuntil` before `send_input` but has nothing to see yet if
+this handler hasn't written it. Fixed by moving
+`lock_shell_for_agent(&state, &req.shell_id)` to run **before** the
+`send_input` call in both `handle_pty_shell_input` and
+`handle_pty_shell_resize`, unconditional on the write's outcome rather than
+gated on success. This shrinks the remaining race to the (much smaller,
+and judged proportionate to leave open — closing it fully would need a
+shared mutex around the whole write, not just a meta flag) window between
+`controllerinput`'s own lock check and `send_input`'s actual write for a
+message that arrived concurrently with the FIRST lock-setting call itself.
+
+**P2 — the "winner's block vanished" fallback in the atomic-claim logic
+(§10.6a #3) built a phantom block instead of a real one.** When this
+request loses the claim race (`Ok(Some(winner_id))`) but
+`try_attach_to_existing_shell` finds the winner's block already gone (an
+edge case rated "exceedingly unlikely" when §10.6a #3 was written), the
+code fell back to `(child_id.clone(), block)` — reusing the in-memory
+`block` value this request had prepared. But that value was only ever
+`tx.insert`-ed inside the `Ok(None)` arm (the "we won the claim" path);
+along the `Ok(Some(...))` arm it was never persisted at all.
+`resync_controller` then ran against a block with no row behind it, and
+the handler returned 200 with a `shell_id` that every subsequent
+`PtyShellInput`/`Read`/`Status`/`Stop` call would fail to find via
+`is_owned_by_agent`'s own lookup. Fixed by actually creating the block for
+real in this fallback branch — `state.wstore.insert(&mut block)`, link it
+into the parent's `subblockids`, set `META_KEY_SHELL_SUBBLOCK_ID` on the
+parent, and broadcast the resulting `waveobj:update` — the same sequence
+the `Ok(None)` arm's transaction performs, just run as a plain
+non-transactional sequence since this code path is already past that
+transaction's scope. Any store error at this point now surfaces as a
+proper 500 instead of silently proceeding with an uninserted phantom.
+
 ### 10.6 Verification
 
 All pass-1 tests updated for the new request/response shape
@@ -577,3 +617,18 @@ race would need real parallel task orchestration against the same store,
 judged disproportionate for a fix whose own documented residual gap (the
 frontend-race half) isn't closed either way. Full `agentmux-srv` suite
 (3337 tests) and the frontend typecheck re-run clean, no regressions.
+
+§10.6b's two fixes were verified the same way: P1 by re-running
+`ptyshell_input_locks_the_shell_and_stop_releases_it_early`, updated to
+assert the lock is set by the real HTTP call itself (no more manual
+`lock_shell_for_agent` simulation in the test) — proving the handler, not
+the test, now performs the lock-before-write ordering. P2 has no dedicated
+new test (reliably provoking "the winner's block was deleted between the
+transaction and the attach attempt" needs orchestrating a real deletion
+mid-request, judged disproportionate for a fallback branch already this
+narrow) but is covered indirectly: the existing reuse/create tests and the
+`#[ignore]`'d live-PTY test all still pass against the changed code path,
+and the fix was traced against the exact store APIs (`insert`/`must_get`/
+`update`) already exercised elsewhere in this file. Full `agentmux-srv`
+suite (3337 tests, 7 ignored) re-run clean after both §10.6b fixes,
+including the `#[ignore]`'d live-PTY test run explicitly — no regressions.

--- a/docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md
+++ b/docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md
@@ -590,6 +590,36 @@ non-transactional sequence since this code path is already past that
 transaction's scope. Any store error at this point now surfaces as a
 proper 500 instead of silently proceeding with an uninserted phantom.
 
+### 10.6c One more real bug, caught by ReAgent's round-3 review of PR #3194
+
+**P1 — the spawn-failure rollback path cleaned up the orphaned block but
+left the parent still pointing at it.** `handle_pty_shell_create`'s
+rollback (added for Codex P2 on PR #3177, see the earlier §-numbered
+history above) already deletes the block and unlinks it from
+`parent.subblockids` when `resync_controller` fails after the block was
+inserted. But `term:shellsubblockid` on the parent was already persisted
+*before* `resync_controller` ever runs — either inside the atomic claim's
+own transaction (the normal `Ok(None)` win path) or by §10.6b's own
+"winner vanished" fallback — and the rollback never cleared it. After a
+spawn failure, the parent was left with `term:shellsubblockid` pointing at
+a block id that no longer exists; a human opening the composer drawer in
+that exact window reads the stale id via `agent-view.tsx`'s
+`existingSubBlockId={block()?.meta?.["term:shellsubblockid"]}` and attaches
+to nothing instead of getting a working shell. Fixed by clearing the meta
+key alongside the `subblockids` unlink (only when it still points at the
+block being rolled back — the atomic-claim design means this is always
+the block *this specific request* just inserted, but the check keeps the
+intent explicit) and broadcasting a `waveobj:update` so an already-open
+drawer sees the correction. No dedicated test: reliably forcing
+`resync_controller` to fail synchronously in this test harness (tried an
+invalid `cmd:cwd`) didn't reproduce — the underlying spawn failure
+surfaces asynchronously rather than through `resync_controller`'s own
+return value, so triggering this exact branch deterministically would need
+machinery disproportionate to a narrow rollback-path fix; same disposition
+as §10.6a #3's atomic-claim race, which also has no dedicated test for the
+same reason (a real concurrent-request harness, not a unit test, would be
+needed).
+
 ### 10.6 Verification
 
 All pass-1 tests updated for the new request/response shape

--- a/docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md
+++ b/docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md
@@ -2,10 +2,17 @@
 
 **Author:** Agent3
 **Created:** 2026-09-10
-**Status:** Implemented (PtyShell/PtyShellInput/PtyShellSignal/PtyShellResize/
-PtyShellRead/PtyShellStatus/PtyShellStop) — real-PTY round trip
-(create → type a command → read its actual output → stop) verified live,
-not just compiled; see §9.
+**Status:** Implemented in two passes. Pass 1 (PtyShell/PtyShellInput/
+PtyShellResize/PtyShellRead/PtyShellStatus/PtyShellStop — `PtyShellSignal`
+also shipped in pass 1 but was removed the same day after Codex review, §6b)
+shipped
+each tool driving its OWN independent, invisible shell — real-PTY round trip
+(create → type a command → read its actual output → stop) verified live, not
+just compiled; see §9. Pass 2 (this revision, repo owner's explicit follow-up
+request) changed the model entirely: `PtyShell` now attaches to the SAME
+shell a human's composer-drawer session already uses (or will use), with a
+short, self-expiring lock keeping the two from typing over each other. See
+§10 for the full pass-2 design and what it changed from pass 1.
 **Scope:** New MCP tool(s) letting an agent drive a real, PTY-backed shell —
 create it, send it input (including control characters/signals), read its
 current screen state, resize it, stop it — entirely through backend RPC,
@@ -385,3 +392,121 @@ the discipline the `#[ignore]`'d live test's own doc comment already
 argued for (only intentionally-real-process tests should spawn one) — these
 two just weren't meant to be in that category and had to be brought back in
 line.
+
+## 10. Pass 2 — the same shell a human sees, with a lock (repo owner request, 2026-09-10)
+
+Pass 1 shipped `PtyShell` creating its own independent, headless sub-block —
+architecturally identical to the human-facing composer-drawer shell, but a
+*different block*. A human watching the drawer saw nothing the agent did; if
+the human already had the drawer open, the agent's shell was invisible and
+separate. The repo owner's follow-up request: the agent must drive the SAME
+shell a human sees, with text appearing live as the agent works, while
+staying fully API-driven (no OS-level keystroke injection, no simulated
+DOM/xterm.js events) — and if a human is also typing, lock them out while
+the agent is actively working, unlocking again the moment it stops.
+
+### 10.1 Reuse, in both directions
+
+`create` now checks the agent's own block for `term:shellsubblockid`
+(`agent-view.tsx:2883,2890-2894` — the same key the composer drawer already
+persists there) before doing anything else:
+
+- **Pointer exists** → `resync_controller` against that id instead of
+  creating a new block. Covers a human who already opened the drawer: the
+  agent joins their exact PTY, same scrollback, same live output.
+- **Nothing exists yet** → create as pass 1 did, then persist the pointer
+  onto the agent block. Covers the reverse direction: a drawer opened
+  *after* the agent has been working attaches to what the agent already
+  started (`ControllerResyncCommand`'s own reuse path picks it up), instead
+  of spawning a second, independent shell.
+
+`req.cwd`/`rows`/`cols` are ignored on the reuse path — an already-running
+process's cwd can't change post-spawn, and geometry is `PtyShellResize`'s
+job, not a create-time parameter for a shell that already has a size. The
+Windows ConPTY-handshake check (§6a) runs unconditionally after either
+path — safe on an already-initialized shell, which simply won't have an
+unanswered query sitting in its output for the poll to find.
+
+### 10.2 Ownership reframed from "did PtyShell create it" to "is it this agent's own pane"
+
+Pass 1's `ptyshell:managed` meta-marker check assumed every legitimate
+target was a block `PtyShell` itself created — no longer true once reuse
+means a HUMAN-created drawer shell is an equally legitimate target. Replaced
+with `is_owned_by_agent`: fetch the target block, check its `parentoref`
+equals `block:<agent_block_id>` and it's a `view:"term"` block.
+`agent_block_id` is now a field on every `PtyShell*` request
+(`PtyShellInputRequest` etc., `agentmux-common/src/api_types.rs`) — filled
+in by `agentmux-mcp` from its own trusted env (`AGENTMUX_AGENT_BUS_ID`/
+`AGENTMUX_BLOCKID`), never a model-facing tool parameter, so it can't be
+forged by the calling agent's own model output. This is strictly more
+correct than pass 1's check, not just adapted for reuse: it still blocks the
+exact threat Codex found (an arbitrary block id discoverable via `Layout`,
+e.g. another agent's own CLI pane), while also correctly covering a shell
+the human created first.
+
+### 10.3 Locking: a lease, not an explicit lock/unlock
+
+Every successful `PtyShellInput`/`PtyShellResize` write stamps
+`term:agentlockuntil` (epoch ms, `AGENT_LOCK_WINDOW_MS` = 4000ms out) on the
+target block via `update_object_meta` + a `waveobj:update` broadcast — the
+same two steps the `setmeta` WS handler performs, factored into
+`broadcast_meta_update` since `ptyshell/*` needs the identical pattern from
+a plain HTTP handler with no `WshRpcEngine` in scope. The frontend
+(`AgentShellSubblock.tsx`) gates its `sendDataHandler` purely on
+`agentLockedUntil() > nowTick()` — `nowTick` a signal ticking every 500ms so
+the UI notices the lock lapsing even with no new server push. Read-only
+`PtyShellRead`/`PtyShellStatus` never touch the lock.
+
+**Deliberately a lease, not an explicit lock/unlock pair** — the repo
+owner's own framing: "make sure to unlock as soon as the agent stops using
+it... keep that binding to the shell open only when necessary." An explicit
+release call is one the agent could simply never make (crash, error,
+forgetting), leaving a human locked out indefinitely — the opposite of
+"unlock as soon as it stops." A short, self-expiring window needs no
+server-side timer to leak or get stuck: a quiet agent just lets the
+timestamp lapse.
+
+While locked, the human still **sees** live output — only their own
+keystrokes are dropped, with a small corner badge ("Agent is using this
+shell") explaining why, deliberately not a full-screen overlay (the entire
+point of the visible-shell feature is watching the agent work).
+
+### 10.4 `PtyShellStop` no longer kills anything
+
+Pass 1's `stop` deleted the controller and the block — correct for that
+version's model (the agent's own throwaway shell), wrong once the shell is
+shared with a human's live terminal session. `PtyShellStop` now means
+"release my lock immediately, don't wait for the window to lapse" — it
+clears `term:agentlockuntil` and returns `released: bool`, and never touches
+the process or the block. The shell lives for the pane's own lifetime now,
+matching `AgentShellSubblock.tsx`'s pre-existing rule ("only killed when the
+pane closes") — this tool doesn't own it outright anymore.
+
+### 10.5 Deferred: Session/History → Stash
+
+The repo owner separately raised, while working in this area, that the
+composer details panel's `<AgentControlBar>` (session archive/restore/
+export actions + "View full history") shouldn't be bundled with the shell
+toggle — candidate destination is `AgentStashModal`'s existing tabbed
+per-agent surface. **Not done in this pass** — scoped out as an unrelated
+UI reorg rather than folded into an already-large PTY-shell change; tracked
+as a separate follow-up. One open product question for whoever picks it
+up: do the transient banners (interrupted-session recovery, resume-failed,
+large-session warning) move into the Stash tab too, or stay inline near the
+composer since they're time-sensitive?
+
+### 10.6 Verification
+
+All pass-1 tests updated for the new request/response shape
+(`agent_block_id` added, `stopped` → `released`) and re-verified, plus three
+new deterministic tests
+(`ptyshell_create_reuses_the_pane_s_existing_shell_instead_of_spawning_a_second_one`,
+`ptyshell_rejects_operating_on_a_block_outside_the_calling_agents_own_pane`,
+`ptyshell_input_locks_the_shell_and_stop_releases_it_early`) and three new
+frontend tests (`AgentShellSubblock.test.tsx`'s "agent lock" suite: drops
+keystrokes while locked, forwards them once the lock has passed, badge
+mounts/unmounts with the lock state). The `#[ignore]`'d live-PTY test was
+extended in place to assert the lock gets set on a real successful write and
+that `stop` releases it without killing the shell (`running: true`
+afterward) — re-run live, still green. Full `agentmux-srv` suite (3336
+tests) and the frontend typecheck re-run clean, no regressions.

--- a/docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md
+++ b/docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md
@@ -495,6 +495,61 @@ up: do the transient banners (interrupted-session recovery, resume-failed,
 large-session warning) move into the Stash tab too, or stay inline near the
 composer since they're time-sensitive?
 
+### 10.6a Three more real bugs, caught by Codex review of pass 2 (PR #3194)
+
+**1. The lock, as pass 2 first shipped it, didn't actually close the race
+it exists for.** `AgentShellSubblock.tsx`'s gate reacts to a WS-pushed meta
+value — inherently eventually-consistent, not synchronous with the
+backend's own state. A human keystroke already in flight when the lock is
+set could still reach `blockcontroller::send_input` and interleave with
+the agent's write, exactly the collision the lease is supposed to prevent.
+Fixed in the one place that's actually authoritative: `controllerinput`
+(`server/websocket.rs`, the WS command every human keystroke routes
+through) now checks `term:agentlockuntil` itself, at the moment it
+processes the message, and drops the input rather than forwarding it. The
+frontend gate stays as the UX layer (why bother sending input that'll be
+dropped, and it drives the "Agent is using this shell" badge) — it's no
+longer the correctness boundary.
+
+**2. The ConPTY-handshake check, unchanged from pass 1, was newly wrong
+once shells got reused.** Pass 1's version scanned the ENTIRE persisted
+`term` file for `ESC[6n` — safe there, because every shell was freshly
+created with an empty file. Pass 2 calls the same check on the reuse path
+too, and the `term` file is append-only for a block's whole lifetime
+(`handle_append_block_file`'s `FILE_OP_APPEND`) — so a long-running reused
+shell's history almost always still contains its own original,
+long-since-answered query from whenever it first started. Scanning the
+whole file found that stale byte sequence and injected an unsolicited
+`ESC[1;1R` into whatever a human was doing at that exact moment, on every
+single reuse. Fixed by recording the file's length immediately before
+`resync_controller` runs and only ever inspecting bytes appended after
+that baseline — correct uniformly whether the shell was already running
+(nothing new appears, correctly finds nothing) or had to be respawned from
+dead (sees only that fresh process's own new query, never anything from
+its former life).
+
+**3. Two concurrent `PtyShell` calls on a not-yet-initialized pane could
+each create their own shell.** The pointer check at the top of `create` is
+a plain read, not authoritative against a second request racing it. Fixed
+with an atomic claim: re-check the pointer INSIDE a `with_tx` transaction,
+serialized against every other `Store::*` call via the store's single
+connection lock, and only insert+link+set the pointer if it's still unset
+by the time this transaction runs; the loser pivots to reusing the
+winner's shell instead of proceeding with its own. **Explicitly does not
+close the equivalent race against the frontend's own `createsubblock`
+path** — that's a separate, non-transactional, multi-step RPC sequence
+this backend call has no way to serialize against. A human opening the
+drawer for the very first time on a pane in the same narrow window as an
+agent's first `PtyShell` call on it can still each end up with their own
+shell. Documented here as a known, accepted gap (Codex rated this P2, not
+P1) rather than silently left unmentioned — closing it fully would need a
+change to the frontend's own creation path too, out of scope for what one
+backend transaction can enforce unilaterally.
+
+All three reproduced the reasoning above by direct code inspection before
+being accepted as real (not just taking the review's word for it) — see
+§10.6's test list for what backs each one.
+
 ### 10.6 Verification
 
 All pass-1 tests updated for the new request/response shape
@@ -508,5 +563,17 @@ keystrokes while locked, forwards them once the lock has passed, badge
 mounts/unmounts with the lock state). The `#[ignore]`'d live-PTY test was
 extended in place to assert the lock gets set on a real successful write and
 that `stop` releases it without killing the shell (`running: true`
-afterward) — re-run live, still green. Full `agentmux-srv` suite (3336
-tests) and the frontend typecheck re-run clean, no regressions.
+afterward) — re-run live, still green, including through the §10.6a #2 fix
+(no more spurious `ESC[1;1R` injection on a reused shell). §10.6a #1 (the
+backend-side lock enforcement) is covered by a new dedicated test,
+`controllerinput_is_dropped_while_an_agent_lock_is_active`
+(`server/websocket.rs`) — proves a locked target is dropped before ever
+reaching `send_input`, with an unlocked-target control case proving the
+call path is genuinely live rather than trivially always-dropped. §10.6a #3
+(the atomic claim) is exercised indirectly by the existing reuse/create
+tests (all still pass with the new transactional path) but has no dedicated
+concurrent-request test — writing one that reliably provokes the actual
+race would need real parallel task orchestration against the same store,
+judged disproportionate for a fix whose own documented residual gap (the
+frontend-race half) isn't closed either way. Full `agentmux-srv` suite
+(3337 tests) and the frontend typecheck re-run clean, no regressions.

--- a/frontend/app/view/agent/components/AgentShellSubblock.test.tsx
+++ b/frontend/app/view/agent/components/AgentShellSubblock.test.tsx
@@ -77,18 +77,26 @@ vi.mock("@/app/store/global", async () => {
 });
 
 // TermWrap is the real xterm.js + PTY wrapper — mocked entirely so tests
-// assert on WHAT it was constructed with (specifically: fontSize), not on
-// real terminal rendering.
-const termWrapInstances: Array<{ fontSize: number; loaded: boolean; terminal: any }> = [];
+// assert on WHAT it was constructed with (specifically: fontSize and, for
+// the agent-lock tests, the sendDataHandler closure), not on real terminal
+// rendering.
+const termWrapInstances: Array<{ fontSize: number; loaded: boolean; terminal: any; sendDataHandler: (data: string) => void }> = [];
 
 vi.mock("@/app/view/term/termwrap", () => {
     class FakeTermWrap {
         fontSize: number;
         terminal = { options: { fontSize: 0 } };
         loaded = false;
-        constructor(_id: string, _container: HTMLElement, options: { fontSize: number }) {
+        sendDataHandler: (data: string) => void;
+        constructor(
+            _id: string,
+            _container: HTMLElement,
+            options: { fontSize: number },
+            waveOptions: { sendDataHandler: (data: string) => void }
+        ) {
             this.fontSize = options.fontSize;
             this.terminal.options.fontSize = options.fontSize;
+            this.sendDataHandler = waveOptions.sendDataHandler;
             termWrapInstances.push(this as any);
         }
         async init() {
@@ -324,5 +332,82 @@ describe("AgentShellSubblock — zoom seed race (SPEC_AGENT_SHELL_ZOOM_SEED_RACE
         const [, set] = blockDataSignals.get(oref)!;
         set({ value: { meta: { "term:zoom": 2.0 } }, loading: false });
         await waitFor(() => expect(termWrapInstances[0].terminal.options.fontSize).toBe(26));
+    });
+});
+
+describe("AgentShellSubblock — agent lock (SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md)", () => {
+    it("drops human keystrokes while term:agentlockuntil is in the future", async () => {
+        const { sendWSCommand } = await import("@/app/store/ws");
+        const existingId = "locked-sub-block";
+        const oref = `block:${existingId}`;
+        queueSeedMeta(oref, { "term:agentlockuntil": Date.now() + 60_000 });
+
+        render(() => (
+            <AgentShellSubblock
+                parentBlockId="parent-1"
+                cwd="/tmp"
+                existingSubBlockId={existingId}
+                onSubBlockCreated={() => {}}
+                agentPaneZoom={() => 1}
+            />
+        ));
+        resolveSeedFetch(oref);
+        await waitFor(() => expect(termWrapInstances.length).toBe(1));
+
+        termWrapInstances[0].sendDataHandler("y");
+        expect(sendWSCommand).not.toHaveBeenCalled();
+    });
+
+    it("forwards human keystrokes once term:agentlockuntil has passed", async () => {
+        const { sendWSCommand } = await import("@/app/store/ws");
+        const existingId = "expired-lock-sub-block";
+        const oref = `block:${existingId}`;
+        // Already in the past — no need to wait for the component's own
+        // periodic re-check to observe this; `agentLockedUntil() > nowTick()`
+        // is already false the instant it's read.
+        queueSeedMeta(oref, { "term:agentlockuntil": Date.now() - 1000 });
+
+        render(() => (
+            <AgentShellSubblock
+                parentBlockId="parent-1"
+                cwd="/tmp"
+                existingSubBlockId={existingId}
+                onSubBlockCreated={() => {}}
+                agentPaneZoom={() => 1}
+            />
+        ));
+        resolveSeedFetch(oref);
+        await waitFor(() => expect(termWrapInstances.length).toBe(1));
+
+        termWrapInstances[0].sendDataHandler("y");
+        expect(sendWSCommand).toHaveBeenCalledWith(
+            expect.objectContaining({ wscommand: "blockinput", blockid: existingId })
+        );
+    });
+
+    it("shows the agent-lock badge only while locked, un-mounting once a live update clears it", async () => {
+        const existingId = "live-unlock-sub-block";
+        const oref = `block:${existingId}`;
+        queueSeedMeta(oref, { "term:agentlockuntil": Date.now() + 60_000 });
+
+        const { container } = render(() => (
+            <AgentShellSubblock
+                parentBlockId="parent-1"
+                cwd="/tmp"
+                existingSubBlockId={existingId}
+                onSubBlockCreated={() => {}}
+                agentPaneZoom={() => 1}
+            />
+        ));
+        resolveSeedFetch(oref);
+        await waitFor(() => expect(termWrapInstances.length).toBe(1));
+        expect(container.querySelector(".agent-shell-agentlock-badge")).not.toBeNull();
+
+        // Simulate the backend's own lock-release (PtyShellStop, or the
+        // lease simply expiring and getting cleared) landing as a live meta
+        // update — same delivery path `term:zoom` live-updates already use.
+        const [, set] = blockDataSignals.get(oref)!;
+        set({ value: { meta: {} }, loading: false });
+        await waitFor(() => expect(container.querySelector(".agent-shell-agentlock-badge")).toBeNull());
     });
 });

--- a/frontend/app/view/agent/components/AgentShellSubblock.tsx
+++ b/frontend/app/view/agent/components/AgentShellSubblock.tsx
@@ -138,6 +138,28 @@ export const AgentShellSubblock = (props: AgentShellSubblockProps): JSX.Element 
         if (z == null || typeof z !== "number" || isNaN(z)) return 1.0;
         return Math.max(0.5, Math.min(2.0, z));
     });
+
+    // Agent-lock gating (SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md):
+    // while an agent is actively driving THIS shell via PtyShellInput/
+    // PtyShellResize, the human's own keystrokes are dropped instead of
+    // forwarded — the two typing into the same PTY at once would interleave
+    // into garbage. `term:agentlockuntil` is an absolute expiry timestamp
+    // (epoch ms) the backend stamps on every successful agent write; gating
+    // on it here needs no server push to UN-lock — a quiet agent just lets
+    // the timestamp lapse, and `nowTick` (below) re-evaluates this memo on
+    // its own schedule so the UI actually notices the moment it does.
+    // Deliberately a lease, not an explicit lock/unlock the agent could
+    // fail to release (crash, error) — see the backend const's own doc
+    // comment (`AGENT_LOCK_WINDOW_MS`) for why.
+    const [nowTick, setNowTick] = createSignal(Date.now());
+    const tickInterval = setInterval(() => setNowTick(Date.now()), 500);
+    onCleanup(() => clearInterval(tickInterval));
+
+    const agentLockedUntil = createMemo(() => {
+        const v = subBlockAtom()?.()?.meta?.["term:agentlockuntil"];
+        return typeof v === "number" ? v : 0;
+    });
+    const agentLocked = createMemo(() => agentLockedUntil() > nowTick());
     const termFontSize = createMemo(() => {
         const paneZoom = props.agentPaneZoom() || 1;
         return Math.max(4, Math.min(64, Math.round((BASE_FONT_SIZE * termZoom()) / paneZoom)));
@@ -333,6 +355,12 @@ export const AgentShellSubblock = (props: AgentShellSubblockProps): JSX.Element 
                         // controllerinput RPC, so consecutive keystrokes stay in
                         // TCP order. No chunked-paste handling for this spike.
                         sendDataHandler: (data: string) => {
+                            // Dropped, not queued: while the agent holds the
+                            // lock, this shell's PTY is being actively driven
+                            // by PtyShellInput — forwarding the human's
+                            // keystrokes too would interleave both into the
+                            // same input stream. See `agentLocked` above.
+                            if (agentLocked()) return;
                             sendWSCommand({
                                 wscommand: "blockinput",
                                 blockid: id,
@@ -397,6 +425,11 @@ export const AgentShellSubblock = (props: AgentShellSubblockProps): JSX.Element 
             <Show when={spinnerMounted()}>
                 <div class="agent-shell-loading-overlay" classList={{ "is-fading": spinnerFading() }}>
                     <BrainSpinner />
+                </div>
+            </Show>
+            <Show when={agentLocked()}>
+                <div class="agent-shell-agentlock-badge" title="The agent is actively typing into this shell — your own input is paused until it stops.">
+                    Agent is using this shell
                 </div>
             </Show>
         </div>

--- a/frontend/app/view/agent/styles/_composer-strip.scss
+++ b/frontend/app/view/agent/styles/_composer-strip.scss
@@ -648,3 +648,24 @@
         pointer-events: none;
     }
 }
+
+// Shown while an agent is actively driving this shell (PtyShellInput/
+// PtyShellResize) — see docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md.
+// A small corner badge, not a full-screen overlay: the whole point of the
+// visible-shell feature is that the human can WATCH the agent work, so this
+// must never obscure the live output — only explain why their own keystrokes
+// aren't landing right now. `pointer-events: none` — purely informational,
+// never intercepts a click.
+.agent-shell-agentlock-badge {
+    position: absolute;
+    top: var(--space-1);
+    right: var(--space-1);
+    z-index: 2;
+    padding: 2px 8px;
+    border-radius: 4px;
+    background-color: rgb(from var(--warning-color) r g b / 0.85);
+    color: var(--block-bg-color);
+    font-size: 10px;
+    font-family: var(--font-family, sans-serif);
+    pointer-events: none;
+}


### PR DESCRIPTION
## Summary

Follow-up to #3177 (repo owner's explicit request during this session's scoping conversation): agents need to drive the **same** shell a human sees in the composer drawer — not an independent, invisible one — with the human locked out of their own keyboard only while the agent is actively working, and bound "only when necessary," never held indefinitely.

- **`create()` now reuses "this pane's one shell"** (`term:shellsubblockid`, the same meta key `agent-view.tsx` already persists for the composer drawer) instead of always minting an independent block. Whichever side (agent or human-opened drawer) gets there first, the other attaches to it — live output and scrollback included.
- **Ownership check reframed**: from "did `PtyShell` create this block" to "is this block a sub-block of the calling agent's own pane" (`is_owned_by_agent`, via `parentoref` against a trusted `agent_block_id` now on every `PtyShell*` request). More correct than the original check, not just adapted for reuse — still blocks an arbitrary `block_id` discovered via `Layout`, while also correctly covering a shell the human created first.
- **Locking is a lease, not an explicit lock/unlock.** Every successful `PtyShellInput`/`PtyShellResize` stamps a ~4s expiry (`term:agentlockuntil`) the frontend gates human keyboard input on, refreshed on each write. An explicit release call is one the agent could simply never make (crash, error) — a self-expiring window needs no server-side timer to leak or get stuck. `AgentShellSubblock.tsx` drops human keystrokes while locked, shows a small "Agent is using this shell" badge, and re-evaluates on its own clock.
- **`PtyShellStop` no longer kills anything.** It now releases the lock immediately instead of waiting for it to lapse, but doesn't touch the process or the block — this shell is shared and pane-scoped now, not private to this tool.

## Test plan

- [x] All PR #3177 tests updated for the new request/response shape (`agent_block_id` added, `stopped` → `released`) and passing.
- [x] 3 new deterministic backend tests: reuse (attaches to an existing human-created shell instead of spawning a second one), cross-pane rejection (with a positive control proving the legitimate owner still succeeds), lock set-by-input + release-by-stop.
- [x] 3 new frontend tests (`AgentShellSubblock.test.tsx`): drops keystrokes while locked, forwards them once the lock has passed, badge mounts/unmounts with live lock-meta changes.
- [x] Real live-PTY round trip (`#[ignore]`'d, run manually) re-verified: lock gets set on a real successful write, `stop` releases it without killing the shell (`running: true` afterward, confirmed against real cmd.exe).
- [x] Full `agentmux-srv` suite (3336 tests) and frontend `agent-view` suite (1787 tests) green, no regressions.
- [x] `cargo check` (srv/mcp/common) and `tsc --noEmit` clean — zero new errors/warnings.

## Deferred (separate follow-up, not in this PR)

Moving `AgentControlBar`'s Session/History actions out of the shell-toggle composer-details panel into `AgentStashModal` — also raised in this session's scoping conversation, but an unrelated UI reorg not folded into an already-large change.

Full design: `docs/specs/SPEC_AGENT_INTERACTIVE_PTY_SHELL_API_2026_09_10.md` §10.

<!-- agentmux:agent_id=agent3 -->