### PR TITLE
docs(specs): agent pane lifecycle control — close/maximize/minimize/split/float

### DIFF
--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -364,7 +364,7 @@ partial list.
 | [`SPEC_AGENT_DISPATCH_SUBAGENT_HIERARCHY_2026_07_17`](SPEC_AGENT_DISPATCH_SUBAGENT_HIERARCHY_2026_07_17.md) | SPEC: two-level dispatch/member schema for subagents and workflows |
 | [`SPEC_AGENT_HISTORY_AS_TAB_AND_DRAFT_PRESERVATION_2026_08_11`](SPEC_AGENT_HISTORY_AS_TAB_AND_DRAFT_PRESERVATION_2026_08_11.md) | SPEC: Agent History as a pane tab, composer draft preservation, and a scrolling link row |
 | [`SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04`](SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md) | SPEC — Tighten the agent-pane login flow: auto-unblock on external bind, "Bind account" button |
-| [`SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10`](SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md) | SPEC: Agent Pane Lifecycle Control — Close / Maximize / Minimize / Split / Float, and Unifying RPC + App API + MCP Behind One Registration |
+| [`SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10`](SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md) | SPEC: Agent Pane Lifecycle Control — Close / Maximize / Minimize / Split / Float |
 | [`SPEC_AGENT_WORKING_ROW_TOOL_BURST_REVEAL_INTERRUPT_2026_08_21`](SPEC_AGENT_WORKING_ROW_TOOL_BURST_REVEAL_INTERRUPT_2026_08_21.md) | SPEC: Tool-call bursts restart the agent-pane "Working…" row's type-out reveal |
 | [`SPEC_AGENT_WORKING_ROW_TYPOGRAPHY_REFRESH_2026_09_03`](SPEC_AGENT_WORKING_ROW_TYPOGRAPHY_REFRESH_2026_09_03.md) | SPEC: `AgentWorkingRow` typography refresh — drop the accent-color text, match the thinking-text font, go bold |
 | [`SPEC_AGENT_ZOOM_PERSISTENCE_2026_06_22`](SPEC_AGENT_ZOOM_PERSISTENCE_2026_06_22.md) | Per-agent zoom persistence |

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -364,6 +364,7 @@ partial list.
 | [`SPEC_AGENT_DISPATCH_SUBAGENT_HIERARCHY_2026_07_17`](SPEC_AGENT_DISPATCH_SUBAGENT_HIERARCHY_2026_07_17.md) | SPEC: two-level dispatch/member schema for subagents and workflows |
 | [`SPEC_AGENT_HISTORY_AS_TAB_AND_DRAFT_PRESERVATION_2026_08_11`](SPEC_AGENT_HISTORY_AS_TAB_AND_DRAFT_PRESERVATION_2026_08_11.md) | SPEC: Agent History as a pane tab, composer draft preservation, and a scrolling link row |
 | [`SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04`](SPEC_AGENT_LOGIN_FLOW_TIGHTENING_2026_09_04.md) | SPEC — Tighten the agent-pane login flow: auto-unblock on external bind, "Bind account" button |
+| [`SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10`](SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md) | SPEC: Agent Pane Lifecycle Control — Close / Maximize / Minimize / Split / Float, and Unifying RPC + App API + MCP Behind One Registration |
 | [`SPEC_AGENT_WORKING_ROW_TOOL_BURST_REVEAL_INTERRUPT_2026_08_21`](SPEC_AGENT_WORKING_ROW_TOOL_BURST_REVEAL_INTERRUPT_2026_08_21.md) | SPEC: Tool-call bursts restart the agent-pane "Working…" row's type-out reveal |
 | [`SPEC_AGENT_WORKING_ROW_TYPOGRAPHY_REFRESH_2026_09_03`](SPEC_AGENT_WORKING_ROW_TYPOGRAPHY_REFRESH_2026_09_03.md) | SPEC: `AgentWorkingRow` typography refresh — drop the accent-color text, match the thinking-text font, go bold |
 | [`SPEC_AGENT_ZOOM_PERSISTENCE_2026_06_22`](SPEC_AGENT_ZOOM_PERSISTENCE_2026_06_22.md) | Per-agent zoom persistence |

--- a/docs/specs/SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md
+++ b/docs/specs/SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md
@@ -431,13 +431,21 @@ compounding error a spec review exists to catch before code does.
 server-side. `LayoutState.magnifiednodeid` (`agentmux-srv/src/backend/obj.rs:441`)
 is a real, persisted column, round-tripped through `persist_subscriber.rs`
 and mirrored on `TabRecord`. Minimize is real too, if less directly: a
-minimized leaf is `{ minimized: true }` on its `LayoutNodeData`
-(`frontend/layout/lib/layoutMinimize.ts`'s own doc comment), and
-`LayoutNodeData.extra` (`agentmux-common/src/layout_types.rs:55`) is a
-genuine `serde_json::Map` catch-all that round-trips to `db_layout` — so a
-human clicking minimize already persists it, via the ordinary whole-tree
-layout push (`model.persistToBackend()`, called by both
-`magnifyNodeToggle` and `minimizeNodeToggle`).
+minimized leaf is `node.minimized = true` — a **top-level** field on
+`LayoutNode` itself (`frontend/layout/lib/layoutMinimize.ts:111`), not
+nested under its `.data`. **Codex P1 on PR #3195, a follow-up correction to
+this same paragraph:** `LayoutNode` and `LayoutNodeData` each carry their
+*own*, separate `extra` catch-all (`agentmux-common/src/layout_types.rs:90`
+vs `:55`) — writing `minimized` into `LayoutNodeData.extra` (the `.data`
+sub-object's catch-all) would serialize it as `data.minimized`, which
+nothing reads; it belongs in `LayoutNode.extra` (the node's own top-level
+catch-all, line 90), the one that actually round-trips to what
+`node.minimized` reads. Both are genuine `serde_json::Map` catch-alls that
+round-trip to `db_layout` — so a human clicking minimize already persists
+it correctly today, via the ordinary whole-tree layout push
+(`model.persistToBackend()`, called by both `magnifyNodeToggle` and
+`minimizeNodeToggle`); this paragraph's job is only to make sure a NEW
+targeted command writes to the same place.
 
 **What's genuinely missing, verified directly (this spec's own follow-up,
 not yet reviewer-found):** a *targeted*, single-field way to set it.
@@ -461,9 +469,10 @@ small, additive, precedented change, not a new mechanism:
   case in `object.rs` alongside `DeleteBlock`'s.
 - `pane.minimize`/`pane.restore` → add `Command::SetMinimizedNode { tab_id,
   node_id, minimized: bool }`, mirroring `SetMagnifiedNode`'s shape, writing
-  the same `{ minimized: bool }` flag into `LayoutNodeData.extra` the
-  frontend's own toggle already writes — new reducer command, small and
-  precedented, not a new *category* of state.
+  the same top-level `LayoutNode.extra.minimized` field the frontend's own
+  toggle already writes (not `LayoutNodeData.extra` — see the correction
+  above) — new reducer command, small and precedented, not a new *category*
+  of state.
 - Both are genuinely idempotent by construction (set a field to an explicit
   value), which also resolves the separate toggle-vs-idempotent finding
   from the previous draft — there is no toggle involved at all once this is
@@ -478,8 +487,67 @@ The `state.broker.publish`/window-scoped-`WaveEvent` mechanism this section
 previously proposed (verified real in the process of finding this — see
 `open_pane_floating`'s `"openfloatingpane"` push) remains valid, useful
 precedent for a *future* command that has no persisted-state answer
-available — just not this one. No open design question remains for
-maximize/minimize; §9's item 3 is resolved, not just re-scoped.
+available — just not this one. The *architectural* open question §9 item 3
+tracked (ephemeral vs. durable) is resolved — durable, via the existing
+fields. Remaining refinements to the exact reducer-command semantics are
+listed in §6.1, not re-opening this decision.
+
+### 6.1 Implementation-time refinements this spec's own review surfaced
+
+This PR (#3195) is a design spec for work that has not started — per the
+repo owner's own direction, Phase 3+ (split/float/dock/maximize/minimize)
+is explicitly on hold pending their review of §9, not proceeding to code
+yet. Six rounds of review on this document have each found real
+architectural gaps (§4.2's false registry, §5's identity/audit holes, §6's
+false "no persisted state" premise) worth fixing at the design level before
+any of that is worth writing. The review has since moved into a further,
+narrower layer — exact field paths, frontend reconciliation timing, edge
+cases in existing toggle guards — that are genuinely correct concerns, but
+belong to the *implementation* of each command, not this document's
+architecture. Listed here rather than resolved individually, so the actual
+implementer verifies each against the code *at build time* (which will
+have moved on from today's snapshot regardless of how precisely this spec
+tries to describe it now) instead of trusting this list as a final word:
+
+- **Cross-channel forwarding (Codex P1):** a target block on another local
+  channel is invisible to this instance's `AppState`. `FleetBulkStop`
+  handles this via `forward_stop_to_shared_channel`; pane-lifecycle
+  commands need the same, plus a real answer for how the remote instance
+  verifies `verified_block_id`'s per-instance HMAC across the channel
+  boundary — or v1 narrows explicitly to same-channel only, which needs
+  to be stated as a real MCP-tool-description-level limitation, not left
+  implicit.
+- **Stacked panes (Codex P1):** `pane.float`'s source-delete step, if it
+  resolves the leaf via `getNodeByBlockId`, deletes the WHOLE leaf even
+  when the caller's block is one dormant member of a `blockStack` — its
+  siblings lose their only layout node while staying live in
+  `blockids`. Needs real stacked-pane semantics (move the whole stack, or
+  detach only the targeted member) before this ships.
+- **Live reconciliation for an already-open target tab (Codex P1):**
+  persisting `SetMagnifiedNode`/`SetMinimizedNode` and broadcasting the
+  WaveObj update does not, by itself, update a frontend that already has
+  the tab's `LayoutModel` loaded — `layoutPersistence.ts`'s
+  `onBackendUpdate` doesn't copy an updated root/`magnifiednodeid` today,
+  and `layout_helpers.rs` documents this non-auto-sync explicitly (the
+  same class of gap `queue_source_layout_delete` exists to close for
+  deletes, §6's own citation above). The command needs the equivalent
+  pending-action/reconciliation path, or its target window won't visibly
+  update until some unrelated edit happens to refresh it.
+- **`SplitPane` direction (Codex P2):** `LayoutTreeInsertNodeAction` (§4.3's
+  table) takes no target node or direction — it can't honor
+  `direction: left/right/up/down` at all. Needs the real
+  `SplitHorizontal`/`SplitVertical` actions, or `open_pane`'s own
+  `resolve_placement` + queued split action, not a plain insert.
+- **Minimize's last-expanded-leaf guard (Codex P2):** the existing human
+  toggle refuses to minimize a tab's last expanded leaf
+  (`countExpandedLeaves(...) <= 1`) — an unconditional `SetMinimizedNode`
+  needs the identical guard, or an agent could leave a tab with zero
+  visible content, a state the UI is deliberately designed to prevent.
+- **`RestorePane` must be target-specific (Codex P2):** clearing
+  `magnifiednodeid` unconditionally restores whichever pane happens to be
+  maximized — if that's a different pane than the one `RestorePane`
+  targeted, it wrongly un-maximizes an unrelated pane. Clear it only when
+  its current value equals the *targeted* pane's own resolved node id.
 
 ## 7. Phased implementation plan
 
@@ -542,12 +610,16 @@ stays hand-written in `tool_schemas.rs`, same as every existing tool.
    tracking reference in the first draft).
 2. §5.5 — should a cross-pane close/maximize/minimize surface (but not
    block on) the target's `turn_active` state?
-3. **Resolved, no longer open (§6):** maximize/minimize turned out to
-   already have real persisted server-side state
-   (`LayoutState.magnifiednodeid`, `LayoutNodeData.extra`) — the "which
-   design, ephemeral or durable" question was built on a false premise.
-   Expose the existing `SetMagnifiedNode` reducer command as its own
-   dispatchable action, add its `SetMinimizedNode` counterpart, done.
+3. **Resolved at the architecture level (§6):** maximize/minimize turned
+   out to already have real persisted server-side state
+   (`LayoutState.magnifiednodeid`, `LayoutNode.extra.minimized`) — the
+   "which design, ephemeral or durable" question was built on a false
+   premise. Expose the existing `SetMagnifiedNode` reducer command as its
+   own dispatchable action, add its `SetMinimizedNode` counterpart. Several
+   real command-level refinements (last-expanded-leaf guard,
+   target-specific restore, live reconciliation for an already-open tab)
+   remain and are tracked in §6.1, not re-opening this architectural
+   decision.
 4. **Resolved, no longer open (§4.2):** a shared `register_typed`-backed
    dispatch table for REST+MCP turned out not to correspond to any real
    process-wide registry — verified directly against `websocket.rs`'s

--- a/docs/specs/SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md
+++ b/docs/specs/SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md
@@ -1,4 +1,4 @@
-# SPEC: Agent Pane Lifecycle Control — Close / Maximize / Minimize / Split / Float, and Unifying RPC + App API + MCP Behind One Registration
+# SPEC: Agent Pane Lifecycle Control — Close / Maximize / Minimize / Split / Float
 
 **Status:** proposed — design only, nothing implemented yet
 **Date:** 2026-09-10
@@ -18,7 +18,8 @@ mechanism §5.0 adopts), `agentmux-srv/src/sagas/delete_block.rs`,
 (established MCP → REST `/api/v1/agent/*` → server-side-identity-stamped handler
 as the canonical agent entry point),
 [`SPEC_RPC_BINDINGS_CODEGEN_2026_09_07.md`](./SPEC_RPC_BINDINGS_CODEGEN_2026_09_07.md)
-(the `register_typed`/`RpcSchema` registry this spec's §4 extends),
+(the `register_typed`/`RpcSchema` registry — §4.2 checked whether this spec
+could extend it to MCP and found it can't, see that section),
 [`SPEC_MULTI_AGENT_FLEET_CONTROL_2026_08_20.md`](./SPEC_MULTI_AGENT_FLEET_CONTROL_2026_08_20.md)
 (the "fleet" authorization tier this spec's §5 borrows and contrasts with),
 [`SPEC_MCP_SETNAME_TARGET_ID_2026_06_19.md`](./SPEC_MCP_SETNAME_TARGET_ID_2026_06_19.md)
@@ -129,7 +130,7 @@ for this spec, not an implementation detail to discover later.
   peer has no block_id this instance can address. Confined to host +
   cross-channel for v1, same ceiling `FleetBulkStop` already has today.
 
-## 4. Design — one registration, three consumers
+## 4. Design — what "combine API + MCP + RPC" turns out to actually mean
 
 ### 4.1 The problem this has to solve, stated precisely
 
@@ -143,73 +144,56 @@ codegen + a diff gate. It says nothing about MCP, because MCP is a separate
 process with no crate dependency on srv (confirmed: `agentmux-mcp` talks to
 srv purely over HTTP with its own hand-written `reqwest` calls).
 
-### 4.2 Extend `RpcSchema` to be the MCP source of truth too
+### 4.2 §4.2/4.3 v1 were wrong — there is no process-wide registry to dispatch through
 
-Every pane-lifecycle command in this spec registers **once**, via
-`register_typed` (the mechanism `SPEC_RPC_BINDINGS_CODEGEN` is already adding),
-with one addition: an `mcp_tool` annotation carrying the pieces
-`tool_schemas.rs` currently hand-writes — display name, parameter descriptions,
-and which fields are agent-supplied vs. server-stamped (the same
-`block_id`-from-`AGENTMUX_BLOCKID` pattern `SPEC_AGENT_APP_API_MCP_BINDINGS`
-established).
+**Codex P1 on PR #3195, correctly, and this needed real verification, not a
+patch:** the original design here assumed a `register_typed`/`RpcSchema`
+registry an HTTP handler could look commands up in. That registry does not
+exist in a form either transport could share. Checked directly against the
+code:
 
-```rust
-engine.register_typed::<ClosePaneReq, ClosePaneResp, _, _>(
-    "pane.close",
-    RpcMeta {
-        mcp_tool: Some(McpToolMeta {
-            name: "ClosePane",
-            description: "Close a pane (yours by default, or any pane by block_id).",
-            stamped_fields: &["block_id"], // present in Req, but ONLY stamped
-                                            // server-side when the agent omits it
-        }),
-        ..Default::default()
-    },
-    close_pane_impl,
-)
-```
+- `agentmux-srv/src/server/websocket.rs:125` — `WshRpcEngine::new()` is
+  constructed **fresh inside every WebSocket connection handler**, not once
+  process-wide. Each connection's engine, and everything registered on it, is
+  private to that connection.
+- The HTTP router's `AppState` holds no engine at all — there is nothing for
+  a `POST /api/v1/agent/rpc/:command` handler to look `:command` up in, typed
+  or untyped, even if `register_typed` recorded a schema.
+- Some WS registrations close over that connection's own `conn_id`, so even a
+  hypothetical process-wide engine couldn't safely serve an HTTP request with
+  no connection of its own.
 
-`--dump-rpc-schema` (already proposed by `SPEC_RPC_BINDINGS_CODEGEN` §3.2) gains
-a second output alongside `rpc.gen.d.ts`: `agentmux-mcp/src/tool_schemas.gen.rs`,
-a generated `const` array of MCP tool JSON schemas, replacing the hand-written
-entries in `tool_schemas.rs` for every migrated command. `scripts/check-rpc-
-bindings.sh` (already proposed) is extended to diff this file too.
+So a shared dispatch table is not "a small addition to what already exists
+internally" — it would require inventing a genuinely new process-wide command
+registry, decoupled from per-connection state, that neither transport has
+today. That is a real, separate infrastructure project, not part of this
+spec's scope.
 
-**Codex P2 on PR #3191, correctly:** the metadata sketched above (name,
-description, stamped fields) is enough to generate the MCP *schema*, but
-nothing here gives `agentmux-mcp` an HTTP method/path to call, or installs an
-Axum route — so without more, the REST leg still has to be hand-added to
-`server/mod.rs` per command, and "one registration, three consumers" would be
-false. Fixed in §4.3 below by not needing per-command REST routes at all.
+### 4.3 What actually ships instead: one Rust function, two hand-written call sites
 
-### 4.3 A single generic REST dispatcher, not a growing route table
+Drop the shared-registry idea entirely. Use the pattern that is **already
+shipped and proven** in this exact codebase — `FleetBulkStop` and `ClosePane`
+(§7 step 1-2, landed in PR #3196) both work this way today:
 
-Rather than add a hand-written `.route("/api/v1/agent/pane/close", ...)` line
-per command (which is exactly the per-command REST maintenance §4.2 is trying
-to eliminate), add **one** generic route:
+1. One `*_impl` function holds the real logic (e.g. `close_pane_impl` /
+   `handle_close_pane`), taking `&AppState` plus plain arguments — no
+   transport-specific types.
+2. A hand-written Axum route in `server/mod.rs` (`POST /api/v1/agent/pane/close`)
+   deserializes the REST request and calls it — this is MCP's transport.
+3. If the command also needs a WS/frontend caller, a hand-written
+   `engine.register_handler` closure deserializes the WS request and calls
+   the *same* function.
 
-```
-POST /api/v1/agent/rpc/:command
-```
-
-Its handler looks up `:command` in the `RpcSchema` registry `register_typed`
-already populates, deserializes the body as that command's `Req` type,
-and dispatches through the identical typed handler function the WS engine
-calls — no new per-command Rust code, no new per-command route. This is the
-"documented generic dispatcher" Codex's review proposed as the alternative to
-richer per-command REST metadata, and it's the smaller change: it only needs
-the registry to expose `(command) -> dyn Fn(Value) -> Future<Result<Value>>`,
-which `register_typed`'s type-erased storage already has to do internally to
-support the untyped WS path today.
-
-`agentmux-mcp/src/main.rs`'s dispatch loop calls `POST /api/v1/agent/rpc/pane.close`
-(etc.) directly — reading the target path from the same generated
-`tool_schemas.gen.rs` table §4.2 already produces, so there is still exactly
-one place (`register_typed`) where a new command's shape and name are ever
-written down. This generalizes past pane-lifecycle: every future
-`register_typed` command gets an MCP-reachable REST door for free, with zero
-additional route-table maintenance, which is the actual "one registration,
-three consumers" claim now made true rather than aspirational.
+This is "one implementation, N thin transport adapters," not "one
+registration, zero adapters" — the earlier draft overclaimed the latter.
+`SPEC_RPC_BINDINGS_CODEGEN_2026_09_07.md`'s `register_typed` work remains
+worth doing on its own merits (it stops frontend TS stubs drifting from
+srv's Rust types), but it doesn't extend to MCP: the REST route for a new
+pane-lifecycle command is a genuinely separate, small, hand-written addition
+each time — exactly as `ClosePane`'s route was. That's the accurate scope,
+and it's still cheap: one route line, one match arm in
+`agentmux-mcp/src/main.rs`, one schema constant in `tool_schemas.rs` — the
+same three-line pattern `ClosePane` already added.
 
 | Command | MCP tool | Own-pane semantics | Cross-pane semantics |
 |---|---|---|---|
@@ -229,15 +213,33 @@ has no destination to resolve against. `sagas::redock_floating_pane::run`
 requires an explicit `source_tab_id`, `source_workspace_id`, `target_tab_id`,
 `target_workspace_id`, and optional `dst_index` — `tear_off_block::run` does
 not persist where a floated block came from, so today there is nothing a
-no-arg `DockPane` could read. Fixed: `pane.float` must record its origin
-(`source_tab_id`, `source_workspace_id`, and the leaf's position at
-tear-off time) — most naturally as block meta, alongside the other
-`agent:*`/`cmd:*` meta keys already carried on a block (§0's DB inspection
-found these directly) — and `pane.dock` defaults to that recorded origin,
-with optional explicit `target_tab_id`/`target_workspace_id`/`dst_index`
-params for redocking somewhere else. This makes the no-arg "put me back"
-call agent-ergonomic while still satisfying `redock_floating_pane`'s real
-required signature underneath.
+no-arg `DockPane` could read.
+
+**Round 2 (Codex P1 on PR #3195), on the first fix:** recording the origin
+alone still isn't a usable destination. The *drag-initiated* tear-off path
+(`server/service/tear_off.rs`'s `handle_tear_off_block`, called with
+`auto_close: bool` defaulting to `true`) auto-deletes the source tab once
+it's empty — so if `pane.float` used that same wrapper, the recorded
+`source_tab_id` would frequently already be gone by the time `pane.dock`
+runs, and `redock_floating_pane::run` rejects a missing target tab outright.
+
+Fixed properly, verified against the actual code this time: `pane.float`
+must **not** go through `handle_tear_off_block` at all. It reuses
+`sagas::tear_off_block::run` directly — the same lower-level call
+`app_api::pane::open_pane_floating` already makes for the existing
+floating-editor feature (`pane.rs`, `SPEC_OPENEDITOR_FLOATING_AND_COLLAPSED_TREE_2026_06_16.md`)
+— which never touches the source tab's auto-close behavior; that logic lives
+entirely in the drag-tear-off's own wrapper, a sibling `pane.float` doesn't
+call. `pane.float` records `source_tab_id`/`source_workspace_id` (block meta,
+alongside the other `agent:*`/`cmd:*` keys already carried on a block, §0's
+DB inspection found these directly) knowing the source tab survives. As a
+second line of defense against any *other* path that might still prune an
+empty tab later, `pane.dock` checks whether `source_tab_id` still exists
+before calling `redock_floating_pane::run`; if it doesn't, it creates a
+fresh tab in the recorded `source_workspace_id` (if that workspace still
+exists) as the redock target, rather than failing outright. Optional explicit
+`target_tab_id`/`target_workspace_id`/`dst_index` params remain available for
+redocking somewhere else entirely.
 
 ## 5. Authorization model — the actual hard part
 
@@ -363,32 +365,58 @@ to the persisted `LayoutNode` shape in `db_layout`, same as position/size are
 today. Bigger change, but consistent with "the frontend's layout tree and the
 server's `db_layout` should agree," and survives a reload.
 
-**(b) Ephemeral server-mediated relay, no persistence.** srv accepts
-`pane.maximize`, resolves which live WS connection owns the target tab
-(same resolution `FleetBroadcast` already does to find a target agent's
-delivery channel), and pushes a `{eventtype: "layout-command", ...}` event
-down that connection for the frontend to apply locally — same event-push
-shape used elsewhere on the WS channel (`SPEC_AGENT_APP_API_MCP_BINDINGS` §3
-already documents the `{eventtype: "rpc", data: ...}` wrapper as precedent
-for push-style messages on this transport). Cheaper, ships faster, but the
-state doesn't survive the owning window closing and reopening.
+**(b) Ephemeral server-mediated relay, no persistence — REVISED.** The first
+draft of this option leaned on two things that turned out not to exist:
 
-**Recommendation: (b) for v1**, explicitly flagged as a known limitation
-(maximize/minimize via MCP is best-effort while the target window is open;
-it is not durable), revisit (a) only if that limitation actually bites in
-practice. `pane.close`, `pane.split`, and `pane.float` all have real
-persisted or process-level server state already (§1) and don't face this
-question.
+- **Codex P1 on PR #3195, correctly:** `FleetBroadcast`'s server-side
+  resolution (`fleet_broadcast_impl`, `app_api/fleet.rs`) resolves a
+  `block_id` to an **agent**, then `inject_message`s that agent's own
+  controller (its CLI process's stdin, effectively) — it never touches a
+  frontend WebSocket connection. It is not "the same resolution" this needs
+  at all.
+- Every WS connection's own tab scoping is also a dead end:
+  `websocket.rs:79` sets `let tab_id = String::new();` at connection open and
+  never populates it before calling `event_bus.register_ws(&conn_id,
+  &tab_id)` — so no tab is ever actually registered against any connection.
+  There is no existing tab→connection index to look a target up in.
+
+**What actually works, verified against real shipped code:**
+`app_api::pane::open_pane_floating` already solves the adjacent problem —
+telling *one specific window's* frontend to do something srv can't do
+itself (open the CEF host's floating window). It resolves
+`workspace_id → window_id` from `state.srv_state`'s own `s.windows` map,
+then calls `state.broker.publish(WaveEvent { event: "openfloatingpane",
+scopes: vec![window_id], data: Some(json!({...})), .. })` — a real,
+shipped, window-scoped push, not a WS-connection-keyed one.
+
+Maximize/minimize can reuse exactly this path: resolve `block_id → tab_id`
+(`s.blocks`) `→ workspace_id` (`s.tabs`) `→ window_id` (`s.windows`, same
+lookup `open_pane_floating` performs), then `state.broker.publish` a new
+event kind (e.g. `"paneMaximize"`/`"paneMinimize"`, carrying `block_id`) to
+that one window. The frontend adds one small listener next to its existing
+`"openfloatingpane"` handler, calling the same local `magnifyNodeToggle`/
+`minimizeNodeToggle` a human's own click already triggers. This is real,
+traceable, existing-state-only plumbing — no new registry, no new
+connection-scoping mechanism, unlike the original (b).
+
+**Recommendation: (b), REVISED shape, for v1.** Still explicitly a known
+limitation (best-effort while the target window is open; state doesn't
+survive that window closing and reopening — same caveat as before, just now
+resting on a mechanism that actually exists), and revisit (a) (durable
+`db_layout` persistence) only if that limitation bites in practice.
+`pane.close`, `pane.split`, and `pane.float` all have real persisted or
+process-level server state already (§1) and don't face this question.
 
 ## 7. Phased implementation plan
 
 1. **`pane.close`, own pane.** Lowest risk — reuses the existing
-   `sagas::delete_block::run` path, just gives it a typed `register_typed`
-   entry and an MCP door. Confirms/fixes the history-preservation question
-   from §1.2 as a blocking prerequisite, not a follow-up.
+   `sagas::delete_block::run` path behind a hand-written REST route + MCP
+   tool (§4.3's actual, proven pattern). Confirms/fixes the
+   history-preservation question from §1.2 as a blocking prerequisite, not a
+   follow-up. **Shipped in PR #3196.**
 2. **`pane.close`, cross-agent (fleet tier).** The capability this
    investigation actually needed. Ships with per-target reporting + audit
-   logging from day one, per §5.
+   logging from day one, per §5. **Shipped alongside step 1 in PR #3196.**
 3. **`pane.split`, `pane.float`, `pane.dock` — own pane only.** `split`
    reuses the existing `LayoutTreeInsertNodeAction` path; `float`/`dock` cross
    into the srv↔cef named-pipe IPC (§1) for the first time from MCP — new
@@ -399,12 +427,10 @@ question.
 5. **`pane.maximize`/`pane.minimize`/`pane.restore`, cross-agent (fleet
    tier).** Last — highest-novelty combination (new server concept *and*
    fleet-tier cross-agent targeting at once).
-6. **MCP schema codegen (§4.2).** Can land in parallel with steps 1-2 once
-   the first `register_typed` + `mcp_tool` annotation exists to generate
-   from; migrating the *existing* hand-written MCP tools
-   (`OpenAgent`/`FleetBulkStop`/etc.) to generated schemas is a separate,
-   optional follow-up cleanup, not required for this spec's own tools to
-   ship generated from day one.
+Step 6 ("MCP schema codegen") from the original draft is **removed** — §4.2
+found the shared-registry premise it depended on doesn't exist. There is no
+codegen follow-up pending from this spec; each command's MCP tool schema
+stays hand-written in `tool_schemas.rs`, same as every existing tool.
 
 ## 8. Acceptance criteria
 
@@ -419,12 +445,11 @@ question.
   verified against a real running instance (not just unit-tested), the same
   way the existing floating-pane feature is manually verified today.
 - `MaximizePane`/`MinimizePane`/`RestorePane` work on the caller's own pane
-  while the window stays open; the best-effort/non-durable limitation from
-  §6(b) is documented in the tool description itself, not just this spec.
-- `scripts/check-rpc-bindings.sh` (extended per §4.2) fails CI if
-  `tool_schemas.gen.rs` drifts from the `register_typed` registry, the same
-  guarantee `SPEC_RPC_BINDINGS_CODEGEN` already established for the frontend
-  TS stubs.
+  while the window stays open, via a `state.broker.publish`/window-scoped
+  `WaveEvent` (§6(b) revised) — not the earlier tab→connection idea, which
+  §6 found doesn't correspond to anything real. The best-effort/non-durable
+  limitation is documented in the tool description itself, not just this
+  spec.
 
 ## 9. Open questions summary (for repo-owner sign-off before implementation)
 
@@ -438,9 +463,12 @@ question.
 3. §6 — accept option (b) (ephemeral relay) for v1, or is durable
    `db_layout` persistence for maximize/minimize worth the larger change up
    front?
-4. §7 step 6 — is migrating the *existing* hand-written MCP tools to
-   generated schemas wanted as a near-term follow-up, or left indefinitely
-   as hand-written legacy alongside the newly-generated ones?
+4. **Resolved, no longer open (§4.2):** a shared `register_typed`-backed
+   dispatch table for REST+MCP turned out not to correspond to any real
+   process-wide registry — verified directly against `websocket.rs`'s
+   per-connection `WshRpcEngine` construction. Each new command gets a
+   hand-written REST route + MCP tool, same pattern `ClosePane` already
+   shipped with (PR #3196).
 5. §5.2 — should fixing `FleetBulkStop`'s existing `source_agent: None` gap
    (using the same signing/verification helper this spec adds for its own
    fleet-tier commands) be folded into this work, or filed as its own

--- a/docs/specs/SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md
+++ b/docs/specs/SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md
@@ -497,7 +497,7 @@ listed in §6.1, not re-opening this decision.
 This PR (#3195) is a design spec for work that has not started — per the
 repo owner's own direction, Phase 3+ (split/float/dock/maximize/minimize)
 is explicitly on hold pending their review of §9, not proceeding to code
-yet. Six rounds of review on this document have each found real
+yet. Seven rounds of review on this document have each found real
 architectural gaps (§4.2's false registry, §5's identity/audit holes, §6's
 false "no persisted state" premise) worth fixing at the design level before
 any of that is worth writing. The review has since moved into a further,
@@ -517,12 +517,22 @@ tries to describe it now) instead of trusting this list as a final word:
   boundary — or v1 narrows explicitly to same-channel only, which needs
   to be stated as a real MCP-tool-description-level limitation, not left
   implicit.
-- **Stacked panes (Codex P1):** `pane.float`'s source-delete step, if it
-  resolves the leaf via `getNodeByBlockId`, deletes the WHOLE leaf even
-  when the caller's block is one dormant member of a `blockStack` — its
-  siblings lose their only layout node while staying live in
-  `blockids`. Needs real stacked-pane semantics (move the whole stack, or
-  detach only the targeted member) before this ships.
+- **Stacked panes (Codex P1, round 6+7) — affects shipped code, not just
+  future work:** a layout leaf can host a `blockStack` of multiple
+  blockIds (`frontend/layout/lib/layoutStack.ts`), and
+  `getNodeByBlockId` matches ANY member — so anything that resolves a
+  leaf this way and deletes it (`delete_block::run`'s
+  `LayoutDeleteNodeByBlock` step, and therefore `pane.float`'s planned
+  source-delete too) removes the WHOLE leaf even when the target is one
+  member of a multi-block stack, orphaning its siblings (still live in
+  `blockids`, no layout node, invisible). **This is not hypothetical for
+  `pane.close`** — PR #3196 already ships `delete_block::run` this way.
+  Tracked as [agentmuxai/agentmux#3202](https://github.com/agentmuxai/agentmux/issues/3202)
+  rather than left as a spec-only note, since it affects code already
+  under review, not just Phase 3+. Needs a server-side stack-aware close
+  (detach only the targeted member when others remain; fall back to the
+  existing whole-leaf delete only for the last/only member) for both
+  `pane.close` and, later, `pane.float`.
 - **Live reconciliation for an already-open target tab (Codex P1):**
   persisting `SetMagnifiedNode`/`SetMinimizedNode` and broadcasting the
   WaveObj update does not, by itself, update a frontend that already has
@@ -538,6 +548,13 @@ tries to describe it now) instead of trusting this list as a final word:
   `direction: left/right/up/down` at all. Needs the real
   `SplitHorizontal`/`SplitVertical` actions, or `open_pane`'s own
   `resolve_placement` + queued split action, not a plain insert.
+- **`SplitPane` must create the block before placing it (Codex P2, round
+  7):** both the frontend split helpers and `app_api::open_pane` dispatch
+  `CreateBlock` (deriving/validating its meta) *before* enqueueing
+  placement — the table's `view` param alone has no creation/default/
+  inheritance step behind it, so there's no block ID yet for the
+  placement actions above to place. Reuse `open_pane`'s create-then-place
+  flow rather than assuming a block already exists.
 - **Minimize's last-expanded-leaf guard (Codex P2):** the existing human
   toggle refuses to minimize a tab's last expanded leaf
   (`countExpandedLeaves(...) <= 1`) — an unconditional `SetMinimizedNode`
@@ -548,6 +565,15 @@ tries to describe it now) instead of trusting this list as a final word:
   maximized — if that's a different pane than the one `RestorePane`
   targeted, it wrongly un-maximizes an unrelated pane. Clear it only when
   its current value equals the *targeted* pane's own resolved node id.
+- **`DockPane`'s `dst_index` is currently a no-op (Codex P2, round 7):**
+  `handle_redock_floating_pane` (§4.3's citation for `pane.dock`) takes
+  its own optional args as `target_block_id`/`direction` and always calls
+  `redock_floating_pane::run` with `dst_index: None` — it has no path to
+  honor an explicit ordering today. Either extend that wrapper to accept
+  and forward a real `dst_index`, or `pane.dock` performs the wrapper's
+  layout work itself around a direct saga call instead of calling the
+  wrapper as-is. Don't advertise `dst_index` as functional until one of
+  those is true.
 
 ## 7. Phased implementation plan
 

--- a/docs/specs/SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md
+++ b/docs/specs/SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md
@@ -1,0 +1,342 @@
+# SPEC: Agent Pane Lifecycle Control — Close / Maximize / Minimize / Split / Float, and Unifying RPC + App API + MCP Behind One Registration
+
+**Status:** proposed — design only, nothing implemented yet
+**Date:** 2026-09-10
+**Author:** Agent5
+**Related:** `agentmux-mcp/src/main.rs`, `agentmux-mcp/src/tool_schemas.rs`,
+`agentmux-srv/src/backend/rpc/engine.rs`, `agentmux-srv/src/backend/rpc/schema.rs`,
+`agentmux-srv/src/server/mod.rs`, `agentmux-srv/src/server/app_api/fleet.rs`,
+`agentmux-srv/src/sagas/delete_block.rs`, `frontend/layout/lib/layoutMagnify.ts`,
+`frontend/layout/lib/layoutMinimize.ts`, `agentmux-cef/src/commands/floating_pane.rs`
+**Predecessors (extend, don't duplicate):**
+[`SPEC_AGENT_APP_API_MCP_BINDINGS_2026_06_28.md`](./SPEC_AGENT_APP_API_MCP_BINDINGS_2026_06_28.md)
+(established MCP → REST `/api/v1/agent/*` → server-side-identity-stamped handler
+as the canonical agent entry point),
+[`SPEC_RPC_BINDINGS_CODEGEN_2026_09_07.md`](./SPEC_RPC_BINDINGS_CODEGEN_2026_09_07.md)
+(the `register_typed`/`RpcSchema` registry this spec's §4 extends),
+[`SPEC_MULTI_AGENT_FLEET_CONTROL_2026_08_20.md`](./SPEC_MULTI_AGENT_FLEET_CONTROL_2026_08_20.md)
+(the "fleet" authorization tier this spec's §5 borrows and contrasts with),
+[`SPEC_MCP_SETNAME_TARGET_ID_2026_06_19.md`](./SPEC_MCP_SETNAME_TARGET_ID_2026_06_19.md)
+(the `target_id` cross-element addressing pattern, and its unguarded precedent —
+see §5.1),
+[`SPEC_AGENT_UI_AUTOMATION_CLICK_SCREENSHOT_2026_08_18.md`](./SPEC_AGENT_UI_AUTOMATION_CLICK_SCREENSHOT_2026_08_18.md)
+(the "own pane only" tier this spec's §5 contrasts with fleet).
+
+---
+
+## 0. Origin
+
+While investigating a live bug (a composer `PageUp`/`PageDown` handler letting
+the browser's default scroll escape `.agent-view`, reported by the repo owner
+as "severely offset, can't even right-click, only the input box shows"), we
+went looking for an MCP tool to close or reset the affected pane
+(`Loap #2`, block `71e01b40-824d-4f89-849e-c5e22082969b`, confirmed via
+direct `objects.db` query to have a perfectly healthy `db_layout` entry — this
+is a pure client-side render bug, not data corruption) so an agent could fix
+it directly instead of asking a human to click around a pane that doesn't
+accept clicks.
+
+**There is no such tool.** `UIClick`/`UIQuery` are explicitly scoped to the
+calling agent's own pane and shared app chrome; nothing in the `mcp__agentmux__*`
+family can close, maximize, minimize, split, or float *any* pane, own or
+otherwise. The repo owner's direction, given directly in this conversation:
+pane lifecycle control is "a main feature of agentmux" and should be built
+out fully — own pane and other agents' panes, close/maximize/minimize/split/
+float — and the design should **combine the entire API + MCP + RPC into a
+single coherent system** rather than adding a fourth hand-maintained surface
+next to the three that already exist and already drift (see §4.1).
+
+## 1. What exists today
+
+Confirmed by direct code research (not guessed):
+
+| Action | Today's mechanism | Server-visible? |
+|---|---|---|
+| **Close pane** | Header × → `pane-actions.ts` → `LayoutModel.closeNode` (`layoutMagnify.ts:41-84`) mutates the client tree, then `onNodeDelete` (`tabcontent.tsx:55-71`) calls `services.ObjectService.DeleteBlock(blockId)` → WS `"object"` command → `object.rs:158-179` `"DeleteBlock"` case → `sagas::delete_block::run` (kills the block's PTY/controller, dispatches `Command::DeleteBlock` through the reducer, prunes the layout node). | **Yes** — real server-side mutation, but reached only through the generic untyped `"object"` WS command, not a typed RPC. |
+| **Maximize/restore** | `magnifyNodeToggle` (`layoutMagnify.ts:24-34`) — pure client-side `LayoutNode` display flag. | **No.** No server RPC exists at all. |
+| **Minimize/restore** | `minimizeNodeToggle`/`rebuildMinimizedSet` (`layoutMinimize.ts`). | **No.** Same as maximize. |
+| **Split** | Drag-to-insert path (`LayoutTreeInsertNodeAction` in `layoutModel.ts`/`layoutTree.ts`) — no single named action. | Yes, as an ordinary layout-tree mutation (persisted), but there is no discrete "split this pane" command to call. |
+| **Float to a new window** | Drag tear-off → `agentmux-cef` IPC `open_floating_pane_window` (`commands/floating_pane.rs`, backed by `floating_pane.rs`'s `WS_POPUP` HWND + cascade hook), with a pre-warmed pool (`window_pool.rs`/`pane_pool.rs`) for fast promotion. | Yes, but via the srv↔cef named-pipe IPC (`srv_ipc/server.rs`), a third channel distinct from both the WS RPC engine and the MCP REST routes. |
+
+None of these are reachable from an MCP tool today. `DeleteBlock` is the
+closest to "already server-side and just needs a door" — maximize/minimize
+don't have a server-side concept to expose yet, and float already has to
+cross into `agentmux-cef` territory that MCP has never touched.
+
+### 1.1 The two-tier authorization precedent already in the codebase
+
+Two existing capabilities that act across pane/agent boundaries chose
+opposite answers to "does the caller need to own the target":
+
+- **`UIClick`/`UIQuery`/`UIScreenshot`** (own-pane tier): hard-scoped to the
+  caller's own `block_id`, stamped server-side from `AGENTMUX_BLOCKID` — "own
+  pane only," no exceptions (`server/mod.rs:574-580`).
+- **`FleetBulkStop`/`FleetBroadcast`** (fleet tier): explicitly **no**
+  per-agent ownership check beyond the instance-wide `X-AuthKey` — the route
+  comment states plainly that "fleet actions target OTHER agents' panes by
+  design, so 'own pane only' doesn't apply here" (`server/mod.rs:581-591`).
+  What it has instead: per-target success/failure reporting (never a single
+  bool), an optional `staged{batch_size, max_fail_percentage}` blast-radius
+  cap, and mandatory audit logging (`fleet.rs`, `log_fleet_action_audit`).
+
+This spec has to put every new pane-lifecycle verb into one of these two
+tiers (or define why it needs a third) — see §5.
+
+### 1.2 `FleetBulkStop` "stop" is not "close" — a distinction this spec must not blur
+
+`FleetBulkStop` halts the target's running agent *process* (`stop_one_agent_block`,
+`agent_io.rs`) — the pane stays in the layout, now idle/stopped, restartable
+from its header. `DeleteBlock` (§1, "Close pane") removes the block from the
+layout entirely and tears down its controller. These read as similar but are
+not interchangeable, and a new `ClosePane` tool must not silently become a
+second name for `FleetBulkStop`, nor vice versa. Before implementation: confirm
+whether `sagas::delete_block::run` preserves the agent's conversation history
+(`db_agent_history`/`db_agent_instances`) independent of the block it was
+displayed in — closing a stuck pane must not be able to destroy the
+underlying conversation, only the UI element showing it. If it turns out
+`delete_block` does NOT already guarantee that, fixing it is a prerequisite
+for this spec, not an implementation detail to discover later.
+
+## 2. Goals
+
+1. Agents can close, maximize, minimize, split, and float **their own** pane.
+2. Agents can close, maximize, and minimize **another agent's** pane —
+   the exact capability this investigation needed and didn't have.
+3. Every new verb is reachable from MCP, from the frontend's own UI (already
+   true for close/maximize/minimize/split; float already works), and from the
+   REST App API — through **one registration**, not three hand-written copies.
+4. The design closes the gap `SPEC_RPC_BINDINGS_CODEGEN_2026_09_07.md` left
+   explicitly out of scope (it stops at frontend TS stubs + a diff gate) by
+   extending the same registry one step further: to MCP tool schemas too.
+
+## 3. Non-goals
+
+- Exact-pixel resize / arbitrary geometry — out of scope; maximize/minimize/
+  restore only (matches what a human already gets from the pane header).
+- Multi-monitor placement logic for floated panes — reuses whatever
+  `open_floating_pane_window` already does for a human-initiated float.
+- Simultaneous fleet-wide layout actions ("maximize every pane in Fab") —
+  that composition already exists via `FleetBroadcast`/`FleetBulkStop`'s
+  target-list model; this spec adds the single-target primitives they'd call,
+  not a new fleet verb.
+- Cross-machine (LAN/WAN) pane control — `FleetList`/`DiscoverAgents` already
+  distinguish host/cross-channel block_ids from LAN/WAN agent names; a LAN/WAN
+  peer has no block_id this instance can address. Confined to host +
+  cross-channel for v1, same ceiling `FleetBulkStop` already has today.
+
+## 4. Design — one registration, three consumers
+
+### 4.1 The problem this has to solve, stated precisely
+
+Today, adding one new capability that needs to be callable from the frontend
+UI, the WS RPC engine, and an MCP tool means hand-writing it **three times**:
+a `register_handler`/`register_typed` call in srv, a hand-written TS stub in
+`frontend/app/store/rpc-api/`, and a hand-written JSON schema + `match` arm in
+`agentmux-mcp/src/main.rs`/`tool_schemas.rs`. `SPEC_RPC_BINDINGS_CODEGEN_2026_09_07.md`
+is already fixing the first drift (srv ↔ frontend) via `register_typed` +
+codegen + a diff gate. It says nothing about MCP, because MCP is a separate
+process with no crate dependency on srv (confirmed: `agentmux-mcp` talks to
+srv purely over HTTP with its own hand-written `reqwest` calls).
+
+### 4.2 Extend `RpcSchema` to be the MCP source of truth too
+
+Every pane-lifecycle command in this spec registers **once**, via
+`register_typed` (the mechanism `SPEC_RPC_BINDINGS_CODEGEN` is already adding),
+with one addition: an `mcp_tool` annotation carrying the pieces
+`tool_schemas.rs` currently hand-writes — display name, parameter descriptions,
+and which fields are agent-supplied vs. server-stamped (the same
+`block_id`-from-`AGENTMUX_BLOCKID` pattern `SPEC_AGENT_APP_API_MCP_BINDINGS`
+established).
+
+```rust
+engine.register_typed::<ClosePaneReq, ClosePaneResp, _, _>(
+    "pane.close",
+    RpcMeta {
+        mcp_tool: Some(McpToolMeta {
+            name: "ClosePane",
+            description: "Close a pane (yours by default, or any pane by block_id).",
+            stamped_fields: &["block_id"], // present in Req, but ONLY stamped
+                                            // server-side when the agent omits it
+        }),
+        ..Default::default()
+    },
+    close_pane_impl,
+)
+```
+
+`--dump-rpc-schema` (already proposed by `SPEC_RPC_BINDINGS_CODEGEN` §3.2) gains
+a second output alongside `rpc.gen.d.ts`: `agentmux-mcp/src/tool_schemas.gen.rs`,
+a generated `const` array of MCP tool JSON schemas plus a generated dispatch
+table (command name → REST path + required/optional fields), replacing the
+hand-written entries in `tool_schemas.rs` for every migrated command.
+`agentmux-mcp/src/main.rs`'s dispatch loop calls the generated table instead
+of a hand-written `match` arm per tool. `scripts/check-rpc-bindings.sh`
+(already proposed) is extended to diff this file too — one gate covers all
+three consumers going forward, not just frontend↔srv.
+
+This is the concrete mechanism for "combine API + MCP + RPC into one coherent
+system": **one `register_typed` call is the only place a new command's shape
+is ever written down.** The WS path (frontend), the REST path
+(`/api/v1/agent/pane/*`, MCP's transport), and the MCP tool schema all derive
+from it. This does not touch the wire formats themselves (`RpcClient.rpcCall`,
+the REST `X-AuthKey` middleware) — same non-goal `SPEC_RPC_BINDINGS_CODEGEN`
+§4 already states, extended to cover the MCP transport too.
+
+### 4.3 REST routes (MCP's transport, per the established pattern)
+
+Following `SPEC_AGENT_APP_API_MCP_BINDINGS_2026_06_28.md` §5 exactly — the
+REST handler resolves identity server-side from `block_id`/`AGENTMUX_BLOCKID`,
+never from agent-supplied JSON, for the *caller's own identity*. The
+*target* pane's `block_id`, when acting on another agent's pane, is supplied
+explicitly by the agent (see §5 for why this is safe and matches
+`SetName`'s `target_id` precedent) and resolved through `fleet.rs`'s existing
+target-validation path, not trusted blindly:
+
+| Command | REST route | MCP tool | Own-pane semantics | Cross-pane semantics |
+|---|---|---|---|---|
+| `pane.close` | `POST /api/v1/agent/pane/close` | `ClosePane` | close caller's own pane | close pane at `block_id` (fleet tier) |
+| `pane.maximize` | `POST /api/v1/agent/pane/maximize` | `MaximizePane` | maximize caller's own pane | maximize pane at `block_id` (fleet tier) |
+| `pane.minimize` | `POST /api/v1/agent/pane/minimize` | `MinimizePane` | minimize caller's own pane | minimize pane at `block_id` (fleet tier) |
+| `pane.restore` | `POST /api/v1/agent/pane/restore` | `RestorePane` | undo maximize/minimize on caller's own pane | restore pane at `block_id` (fleet tier) |
+| `pane.split` | `POST /api/v1/agent/pane/split` | `SplitPane` | split caller's own pane; `direction`, optional `view` for the new half | **not exposed cross-agent in v1** — see §7 |
+| `pane.float` | `POST /api/v1/agent/pane/float` | `FloatPane` | float caller's own pane to a new OS window | **not exposed cross-agent in v1** — see §7 |
+| `pane.dock` | `POST /api/v1/agent/pane/dock` | `DockPane` | dock a floated pane back into its tab | own-pane only |
+
+`pane.maximize`/`pane.minimize`/`pane.restore` require the srv-side concept
+gap from §1 to be closed first — see §6.
+
+## 5. Authorization model — the actual hard part
+
+Per §1.1, two tiers already exist. This spec assigns each verb explicitly
+rather than inventing new rules per-command:
+
+- **Close/maximize/minimize/restore, targeting another agent's pane: fleet
+  tier.** Same posture as `FleetBulkStop` — gated by the instance `X-AuthKey`
+  only, no per-agent ownership check, because (matching the existing route
+  comment's own reasoning) that *is* the feature: an agent fixing another
+  agent's stuck pane is exactly this spec's motivating case, and it cannot
+  require the broken pane's own agent to cooperate (it might not be able to —
+  that's the whole problem). Every cross-pane call gets per-target
+  success/failure reporting and mandatory audit logging identical to
+  `fleet.rs`'s existing `log_fleet_action_audit`, so "who closed my pane and
+  why" is always answerable after the fact.
+- **Split/float, own pane only in v1.** These create new panes/windows rather
+  than acting on an existing one; there's no motivating case from this
+  investigation for doing this to another agent's layout, and doing so
+  correctly (which tab? which agent's workspace?) is a bigger design question
+  deferred to §7 rather than rushed into v1 alongside the close/maximize/
+  minimize work this spec is actually motivated by.
+- **Own-pane operations: self-only, no additional guard** — same posture as
+  every other self-scoped MCP tool (`MemoryWrite`, `UIClick`).
+
+### 5.1 Do not repeat `SetName`'s unguarded `target_id` precedent uncritically
+
+`SPEC_MCP_SETNAME_TARGET_ID_2026_06_19.md` §2 relaxed `SetName`'s guard so
+that supplying `target_id` bypasses the caller's own `block_id` requirement
+*entirely* — there is no check that the caller has any relationship to the
+target at all, for any of window/tab/pane/workspace rename. That is a low-
+consequence action (a name is cosmetic and reversible) and was accepted on
+that basis. **Close/maximize/minimize are not equally reversible** — closing
+tears down a controller; maximizing another agent's pane while it's mid-turn
+changes what the operating human sees without their pane-owning agent's
+knowledge. Adopting fleet tier (§5) rather than `SetName`'s bare-`target_id`
+tier is a deliberate choice to get the audit trail and per-target reporting
+`SetName` never had, not an oversight.
+
+### 5.2 Open question for the repo owner
+
+Should a cross-pane close/maximize/minimize call require the *target* agent
+to be idle (no turn in flight), the way `FleetBulkStop` has no such guard
+today but arguably should for a "close," not just a "stop"? Recommendation:
+no hard block — the Loap #2 case this spec is motivated by may well need
+closing a pane that *looks* stuck precisely because its turn appears
+in-flight but isn't actually progressing — but surface `turn_active`
+(already returned by `GetAgentTranscript`/`ListConversations`) in the tool
+description so the calling agent can make an informed choice, and always log
+it in the audit entry.
+
+## 6. Closing the maximize/minimize server-side gap
+
+Maximize/minimize are pure client `LayoutNode` flags today (§1) — no server
+RPC, so nothing for `register_typed` to wrap yet. Two options:
+
+**(a) Make them genuine persisted layout state.** Add `magnified`/`minimized`
+to the persisted `LayoutNode` shape in `db_layout`, same as position/size are
+today. Bigger change, but consistent with "the frontend's layout tree and the
+server's `db_layout` should agree," and survives a reload.
+
+**(b) Ephemeral server-mediated relay, no persistence.** srv accepts
+`pane.maximize`, resolves which live WS connection owns the target tab
+(same resolution `FleetBroadcast` already does to find a target agent's
+delivery channel), and pushes a `{eventtype: "layout-command", ...}` event
+down that connection for the frontend to apply locally — same event-push
+shape used elsewhere on the WS channel (`SPEC_AGENT_APP_API_MCP_BINDINGS` §3
+already documents the `{eventtype: "rpc", data: ...}` wrapper as precedent
+for push-style messages on this transport). Cheaper, ships faster, but the
+state doesn't survive the owning window closing and reopening.
+
+**Recommendation: (b) for v1**, explicitly flagged as a known limitation
+(maximize/minimize via MCP is best-effort while the target window is open;
+it is not durable), revisit (a) only if that limitation actually bites in
+practice. `pane.close`, `pane.split`, and `pane.float` all have real
+persisted or process-level server state already (§1) and don't face this
+question.
+
+## 7. Phased implementation plan
+
+1. **`pane.close`, own pane.** Lowest risk — reuses the existing
+   `sagas::delete_block::run` path, just gives it a typed `register_typed`
+   entry and an MCP door. Confirms/fixes the history-preservation question
+   from §1.2 as a blocking prerequisite, not a follow-up.
+2. **`pane.close`, cross-agent (fleet tier).** The capability this
+   investigation actually needed. Ships with per-target reporting + audit
+   logging from day one, per §5.
+3. **`pane.split`, `pane.float`, `pane.dock` — own pane only.** `split`
+   reuses the existing `LayoutTreeInsertNodeAction` path; `float`/`dock` cross
+   into the srv↔cef named-pipe IPC (§1) for the first time from MCP — new
+   ground, gets its own smoke test against a real floated window before
+   merging.
+4. **`pane.maximize`/`pane.minimize`/`pane.restore`, own pane.** Blocked on
+   §6's design decision landing first.
+5. **`pane.maximize`/`pane.minimize`/`pane.restore`, cross-agent (fleet
+   tier).** Last — highest-novelty combination (new server concept *and*
+   fleet-tier cross-agent targeting at once).
+6. **MCP schema codegen (§4.2).** Can land in parallel with steps 1-2 once
+   the first `register_typed` + `mcp_tool` annotation exists to generate
+   from; migrating the *existing* hand-written MCP tools
+   (`OpenAgent`/`FleetBulkStop`/etc.) to generated schemas is a separate,
+   optional follow-up cleanup, not required for this spec's own tools to
+   ship generated from day one.
+
+## 8. Acceptance criteria
+
+- An agent can call `ClosePane` with no arguments and its own pane closes;
+  the underlying conversation history is independently confirmed to survive
+  (§1.2).
+- An agent can call `ClosePane(block_id: "<another agent's pane>")` and that
+  pane closes, with a `FleetActionResult`-shaped response and an audit log
+  entry, matching `FleetBulkStop`'s existing response/audit shape.
+- `SplitPane`/`FloatPane`/`DockPane` round-trip on the caller's own pane,
+  verified against a real running instance (not just unit-tested), the same
+  way the existing floating-pane feature is manually verified today.
+- `MaximizePane`/`MinimizePane`/`RestorePane` work on the caller's own pane
+  while the window stays open; the best-effort/non-durable limitation from
+  §6(b) is documented in the tool description itself, not just this spec.
+- `scripts/check-rpc-bindings.sh` (extended per §4.2) fails CI if
+  `tool_schemas.gen.rs` drifts from the `register_typed` registry, the same
+  guarantee `SPEC_RPC_BINDINGS_CODEGEN` already established for the frontend
+  TS stubs.
+
+## 9. Open questions summary (for repo-owner sign-off before implementation)
+
+1. §1.2 — does `delete_block` already preserve conversation history
+   independent of the block? Must be confirmed (and fixed if not) before
+   step 1.
+2. §5.2 — should a cross-pane close/maximize/minimize surface (but not
+   block on) the target's `turn_active` state?
+3. §6 — accept option (b) (ephemeral relay) for v1, or is durable
+   `db_layout` persistence for maximize/minimize worth the larger change up
+   front?
+4. §7 step 6 — is migrating the *existing* hand-written MCP tools to
+   generated schemas wanted as a near-term follow-up, or left indefinitely
+   as hand-written legacy alongside the newly-generated ones?

--- a/docs/specs/SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md
+++ b/docs/specs/SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md
@@ -108,12 +108,20 @@ for this spec, not an implementation detail to discover later.
 1. Agents can close, maximize, minimize, split, and float **their own** pane.
 2. Agents can close, maximize, and minimize **another agent's** pane —
    the exact capability this investigation needed and didn't have.
-3. Every new verb is reachable from MCP, from the frontend's own UI (already
-   true for close/maximize/minimize/split; float already works), and from the
-   REST App API — through **one registration**, not three hand-written copies.
-4. The design closes the gap `SPEC_RPC_BINDINGS_CODEGEN_2026_09_07.md` left
-   explicitly out of scope (it stops at frontend TS stubs + a diff gate) by
-   extending the same registry one step further: to MCP tool schemas too.
+3. Every new verb is reachable from MCP and (already true today) the
+   frontend's own UI, through **one shared Rust implementation per command**
+   plus a thin, hand-written transport adapter for each caller (REST for
+   MCP, WS `register_handler` for the frontend where one is needed) — not
+   three independently-diverging copies of the actual logic. §4.2 found
+   that a single shared *dispatch registry* spanning both transports isn't
+   buildable against the real `WshRpcEngine`/`AppState` architecture; §4.3
+   is the corrected, smaller goal this spec actually delivers, and it's
+   what `ClosePane` (PR #3196) already ships.
+4. ~~The design closes the gap `SPEC_RPC_BINDINGS_CODEGEN_2026_09_07.md` left
+   explicitly out of scope by extending the same registry one step further,
+   to MCP tool schemas too.~~ **Dropped (§4.2).** That registry doesn't
+   exist in a cross-transport form to extend. MCP tool schemas stay
+   hand-written in `tool_schemas.rs`, same as every tool before this spec.
 
 ## 3. Non-goals
 
@@ -172,8 +180,11 @@ spec's scope.
 ### 4.3 What actually ships instead: one Rust function, two hand-written call sites
 
 Drop the shared-registry idea entirely. Use the pattern that is **already
-shipped and proven** in this exact codebase — `FleetBulkStop` and `ClosePane`
-(§7 step 1-2, landed in PR #3196) both work this way today:
+shipped and proven** in this exact codebase — `FleetBulkStop`, on `main`
+today, works this way. `ClosePane` (§7 step 1-2) is built the same way in
+[PR #3196](https://github.com/agentmuxai/agentmux/pull/3196), not yet merged
+as of this revision — a second, independent instance of the same pattern,
+not yet itself a "shipped" precedent to point to until it lands:
 
 1. One `*_impl` function holds the real logic (e.g. `close_pane_impl` /
    `handle_close_pane`), taking `&AppState` plus plain arguments — no
@@ -240,6 +251,28 @@ fresh tab in the recorded `source_workspace_id` (if that workspace still
 exists) as the redock target, rather than failing outright. Optional explicit
 `target_tab_id`/`target_workspace_id`/`dst_index` params remain available for
 redocking somewhere else entirely.
+
+**Round 3 (Codex P1 on PR #3195), on the second fix:** reusing the raw saga
+call correctly avoids the auto-close problem, but `open_pane_floating` and
+`pane.float` are not actually solving the same problem — `open_pane_floating`
+starts from a block that was created fresh and **never inserted into the
+source tab's layout tree at all** (§0's own comment on that function: "no
+layout node," "the block never renders docked before the saga moves it").
+`pane.float` starts from an *existing, already-laid-out* pane, so calling
+just `tear_off_block::run` moves the block's ownership but leaves the OLD
+layout node behind in the source tab (now a dangling reference) and does
+nothing to materialize the new tab's layout or open the actual floating
+window. `pane.float`'s implementation must do everything
+`open_pane_floating` does *after* its own `tear_off_block::run` call too,
+not just the saga call in isolation:
+`server::service::layout_helpers`'s `LayoutDeleteNodeByBlock`-style prune of
+the source node (same step `sagas::delete_block::run` performs for its own
+Step 2, §1), `setup_torn_off_block_layout` for the destination,
+`event_bus.broadcast_wave_obj_updates` for the new workspace/tab/block, and
+the `state.broker.publish(WaveEvent{event: "openfloatingpane", ...})` call
+to actually open the OS window — `open_pane_floating`'s full body (`pane.rs`
+lines ~30-190) is the real reference implementation to adapt, not just its
+saga call.
 
 ## 5. Authorization model — the actual hard part
 
@@ -394,9 +427,16 @@ Maximize/minimize can reuse exactly this path: resolve `block_id → tab_id`
 lookup `open_pane_floating` performs), then `state.broker.publish` a new
 event kind (e.g. `"paneMaximize"`/`"paneMinimize"`, carrying `block_id`) to
 that one window. The frontend adds one small listener next to its existing
-`"openfloatingpane"` handler, calling the same local `magnifyNodeToggle`/
-`minimizeNodeToggle` a human's own click already triggers. This is real,
-traceable, existing-state-only plumbing — no new registry, no new
+`"openfloatingpane"` handler — **not** calling `magnifyNodeToggle`/
+`minimizeNodeToggle` directly, per **Codex P2 on PR #3195**: those are
+genuine toggles (a human's click flips current state either direction),
+whereas `MaximizePane`/`MinimizePane`/`RestorePane` are meant to be
+idempotent — calling `MaximizePane` on an already-maximized pane must stay
+maximized, not flip back to normal. The listener needs the small,
+currently-missing idempotent counterpart to each toggle (set-maximized /
+set-minimized / clear-both, reading current state first and no-op-ing if
+already there) rather than invoking the toggle blind. This is real,
+traceable, existing-state-only plumbing otherwise — no new registry, no new
 connection-scoping mechanism, unlike the original (b).
 
 **Recommendation: (b), REVISED shape, for v1.** Still explicitly a known
@@ -413,10 +453,13 @@ process-level server state already (§1) and don't face this question.
    `sagas::delete_block::run` path behind a hand-written REST route + MCP
    tool (§4.3's actual, proven pattern). Confirms/fixes the
    history-preservation question from §1.2 as a blocking prerequisite, not a
-   follow-up. **Shipped in PR #3196.**
+   follow-up. **Implemented in [PR #3196](https://github.com/agentmuxai/agentmux/pull/3196)
+   — not yet merged at the time of this revision; check that PR for current
+   status rather than treating this spec as confirmation it's on `main`.**
 2. **`pane.close`, cross-agent (fleet tier).** The capability this
    investigation actually needed. Ships with per-target reporting + audit
-   logging from day one, per §5. **Shipped alongside step 1 in PR #3196.**
+   logging from day one, per §5. **Implemented alongside step 1 in PR #3196
+   (same merge-status caveat).**
 3. **`pane.split`, `pane.float`, `pane.dock` — own pane only.** `split`
    reuses the existing `LayoutTreeInsertNodeAction` path; `float`/`dock` cross
    into the srv↔cef named-pipe IPC (§1) for the first time from MCP — new

--- a/docs/specs/SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md
+++ b/docs/specs/SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md
@@ -216,8 +216,10 @@ same three-line pattern `ClosePane` already added.
 | `pane.float` | `FloatPane` | float caller's own pane to a new OS window; **records its origin** (see `pane.dock` below) | **not exposed cross-agent in v1** — see §7 |
 | `pane.dock` | `DockPane` | dock a floated pane back to its recorded origin (see below) — own-pane only | not applicable |
 
-`pane.maximize`/`pane.minimize`/`pane.restore` require the srv-side concept
-gap from §1 to be closed first — see §6.
+`pane.maximize`/`pane.minimize`/`pane.restore` need one small, precedented
+reducer-command addition first (not a "gap" — see §6, revised after
+verification: the persisted state already exists, only a targeted
+dispatchable command to set it is missing).
 
 **Codex P1 on PR #3191, correctly:** a no-argument "dock back into its tab"
 has no destination to resolve against. `sagas::redock_floating_pane::run`
@@ -264,15 +266,45 @@ layout node behind in the source tab (now a dangling reference) and does
 nothing to materialize the new tab's layout or open the actual floating
 window. `pane.float`'s implementation must do everything
 `open_pane_floating` does *after* its own `tear_off_block::run` call too,
-not just the saga call in isolation:
-`server::service::layout_helpers`'s `LayoutDeleteNodeByBlock`-style prune of
-the source node (same step `sagas::delete_block::run` performs for its own
-Step 2, §1), `setup_torn_off_block_layout` for the destination,
-`event_bus.broadcast_wave_obj_updates` for the new workspace/tab/block, and
-the `state.broker.publish(WaveEvent{event: "openfloatingpane", ...})` call
-to actually open the OS window — `open_pane_floating`'s full body (`pane.rs`
-lines ~30-190) is the real reference implementation to adapt, not just its
-saga call.
+not just the saga call in isolation: `setup_torn_off_block_layout` for the
+destination, `event_bus.broadcast_wave_obj_updates` for the new
+workspace/tab/block, and the `state.broker.publish(WaveEvent{event:
+"openfloatingpane", ...})` call to actually open the OS window —
+`open_pane_floating`'s full body (`pane.rs` lines ~30-190) is the real
+reference implementation to adapt, not just its saga call.
+
+**Round 4 (Codex P1 on PR #3195), the specific miss in Round 3's list:**
+naming a "`LayoutDeleteNodeByBlock`-style prune" undersold what's actually
+required. `server::service::layout_helpers::queue_source_layout_delete`
+(`pub(crate)`, already used by both `tab_move.rs` and the drag-tear-off's
+`tear_off.rs`) is the specific function needed — it does the reducer-level
+prune **and** queues a `pendingbackendactions` entry so an already-loaded
+frontend converges instead of resurrecting the dangling source leaf on its
+next unrelated edit (the exact bug
+`INVESTIGATION_LAYOUT_DEAD_SPACE_STALE_TREE_RESURRECTION_2026_07_08.md`
+documents, and the reason `sagas::delete_block::run`'s own Step 2b exists —
+§1 already cited that saga as `pane.close`'s foundation without connecting
+that its Step 2b is solving the identical problem `pane.float` now also
+has). Call `queue_source_layout_delete` by name, not an approximation of
+it.
+
+**Same finding applies to `pane.dock` — DockPane needs the redock
+wrapper's layout work too, not just the raw saga.** Exactly the same shape
+of gap as `pane.float`'s: `sagas::redock_floating_pane::run` (§4.3's table)
+only moves tab membership; it does not touch either tab's layout tree. The
+real, shipped RPC handler, `server::service::tear_off::handle_redock_floating_pane`
+(`pub(crate)`, sibling to `handle_tear_off_block` in the same file), is what
+actually does `queue_target_layout_insert`/`queue_target_layout_split` on
+the destination, `queue_source_layout_delete` on the (now-empty) floating
+source, and broadcasts both resulting layouts — without which the block
+moves but never visually appears anywhere. `pane.dock`'s implementation
+should call `handle_redock_floating_pane` directly (filling in its
+`source_tab_id`/`source_workspace_id`/`target_tab_id`/`target_workspace_id`
+arguments from the recorded-origin defaults resolved above, or from
+explicit override params) rather than calling the raw saga and
+re-deriving its wrapper's layout work by hand — including when the
+resolved destination is a freshly-created fallback tab, not just the
+originally-recorded one.
 
 ## 5. Authorization model — the actual hard part
 
@@ -388,64 +420,66 @@ in-flight but isn't actually progressing — but surface `turn_active`
 description so the calling agent can make an informed choice, and always log
 it in the audit entry.
 
-## 6. Closing the maximize/minimize server-side gap
+## 6. Maximize/minimize: not a gap at all — REVISED after verification
 
-Maximize/minimize are pure client `LayoutNode` flags today (§1) — no server
-RPC, so nothing for `register_typed` to wrap yet. Two options:
+§1 and this section's first two drafts both assumed maximize/minimize have
+**no server-side concept to build on** — that was wrong, and building an
+entire relay mechanism on that wrong premise is exactly the kind of
+compounding error a spec review exists to catch before code does.
 
-**(a) Make them genuine persisted layout state.** Add `magnified`/`minimized`
-to the persisted `LayoutNode` shape in `db_layout`, same as position/size are
-today. Bigger change, but consistent with "the frontend's layout tree and the
-server's `db_layout` should agree," and survives a reload.
+**Codex P2 on PR #3195, correctly:** maximize state is **already persisted**
+server-side. `LayoutState.magnifiednodeid` (`agentmux-srv/src/backend/obj.rs:441`)
+is a real, persisted column, round-tripped through `persist_subscriber.rs`
+and mirrored on `TabRecord`. Minimize is real too, if less directly: a
+minimized leaf is `{ minimized: true }` on its `LayoutNodeData`
+(`frontend/layout/lib/layoutMinimize.ts`'s own doc comment), and
+`LayoutNodeData.extra` (`agentmux-common/src/layout_types.rs:55`) is a
+genuine `serde_json::Map` catch-all that round-trips to `db_layout` — so a
+human clicking minimize already persists it, via the ordinary whole-tree
+layout push (`model.persistToBackend()`, called by both
+`magnifyNodeToggle` and `minimizeNodeToggle`).
 
-**(b) Ephemeral server-mediated relay, no persistence — REVISED.** The first
-draft of this option leaned on two things that turned out not to exist:
+**What's genuinely missing, verified directly (this spec's own follow-up,
+not yet reviewer-found):** a *targeted*, single-field way to set it.
+`Command::SetMagnifiedNode { tab_id, node_id }` already exists as a reducer
+command (`agentmux-srv/src/reducer.rs:83`, `reducer/layout.rs`) — but its
+**only** call site (`server/service/object.rs:267`) fires it as an internal
+side-effect of a different action, never as its own dispatchable command a
+client can invoke directly. Minimize has no equivalent targeted command at
+all; the only existing path is the coarse whole-tree push, which needs the
+caller to already hold a full, current copy of the layout tree — awkward
+for a stateless MCP call and a real way to lose a concurrent edit.
 
-- **Codex P1 on PR #3195, correctly:** `FleetBroadcast`'s server-side
-  resolution (`fleet_broadcast_impl`, `app_api/fleet.rs`) resolves a
-  `block_id` to an **agent**, then `inject_message`s that agent's own
-  controller (its CLI process's stdin, effectively) — it never touches a
-  frontend WebSocket connection. It is not "the same resolution" this needs
-  at all.
-- Every WS connection's own tab scoping is also a dead end:
-  `websocket.rs:79` sets `let tab_id = String::new();` at connection open and
-  never populates it before calling `event_bus.register_ws(&conn_id,
-  &tab_id)` — so no tab is ever actually registered against any connection.
-  There is no existing tab→connection index to look a target up in.
+**Design: expose `SetMagnifiedNode` as its own dispatchable action, and add
+its minimize counterpart the same way.** Both follow the exact
+`("object", "DeleteBlock")` pattern `ClosePane` already reuses (§4.3) — a
+small, additive, precedented change, not a new mechanism:
 
-**What actually works, verified against real shipped code:**
-`app_api::pane::open_pane_floating` already solves the adjacent problem —
-telling *one specific window's* frontend to do something srv can't do
-itself (open the CEF host's floating window). It resolves
-`workspace_id → window_id` from `state.srv_state`'s own `s.windows` map,
-then calls `state.broker.publish(WaveEvent { event: "openfloatingpane",
-scopes: vec![window_id], data: Some(json!({...})), .. })` — a real,
-shipped, window-scoped push, not a WS-connection-keyed one.
+- `pane.maximize`/`pane.restore` → dispatch the *existing*
+  `Command::SetMagnifiedNode { tab_id, node_id: block's node (or "" to
+  restore) }` directly, exposed via a new `("object", "SetMagnifiedNode")`
+  case in `object.rs` alongside `DeleteBlock`'s.
+- `pane.minimize`/`pane.restore` → add `Command::SetMinimizedNode { tab_id,
+  node_id, minimized: bool }`, mirroring `SetMagnifiedNode`'s shape, writing
+  the same `{ minimized: bool }` flag into `LayoutNodeData.extra` the
+  frontend's own toggle already writes — new reducer command, small and
+  precedented, not a new *category* of state.
+- Both are genuinely idempotent by construction (set a field to an explicit
+  value), which also resolves the separate toggle-vs-idempotent finding
+  from the previous draft — there is no toggle involved at all once this is
+  a direct field set, so `MaximizePane` called twice trivially stays
+  maximized.
+- REST route + MCP tool for each, exactly `ClosePane`'s shape (§4.3): no
+  new transport, no window-scoped push, no relay. Real, durable,
+  `db_layout`-agreeing state — the win the discarded option (a) was reaching
+  for, obtained for free once the actual existing mechanism was found.
 
-Maximize/minimize can reuse exactly this path: resolve `block_id → tab_id`
-(`s.blocks`) `→ workspace_id` (`s.tabs`) `→ window_id` (`s.windows`, same
-lookup `open_pane_floating` performs), then `state.broker.publish` a new
-event kind (e.g. `"paneMaximize"`/`"paneMinimize"`, carrying `block_id`) to
-that one window. The frontend adds one small listener next to its existing
-`"openfloatingpane"` handler — **not** calling `magnifyNodeToggle`/
-`minimizeNodeToggle` directly, per **Codex P2 on PR #3195**: those are
-genuine toggles (a human's click flips current state either direction),
-whereas `MaximizePane`/`MinimizePane`/`RestorePane` are meant to be
-idempotent — calling `MaximizePane` on an already-maximized pane must stay
-maximized, not flip back to normal. The listener needs the small,
-currently-missing idempotent counterpart to each toggle (set-maximized /
-set-minimized / clear-both, reading current state first and no-op-ing if
-already there) rather than invoking the toggle blind. This is real,
-traceable, existing-state-only plumbing otherwise — no new registry, no new
-connection-scoping mechanism, unlike the original (b).
-
-**Recommendation: (b), REVISED shape, for v1.** Still explicitly a known
-limitation (best-effort while the target window is open; state doesn't
-survive that window closing and reopening — same caveat as before, just now
-resting on a mechanism that actually exists), and revisit (a) (durable
-`db_layout` persistence) only if that limitation bites in practice.
-`pane.close`, `pane.split`, and `pane.float` all have real persisted or
-process-level server state already (§1) and don't face this question.
+The `state.broker.publish`/window-scoped-`WaveEvent` mechanism this section
+previously proposed (verified real in the process of finding this — see
+`open_pane_floating`'s `"openfloatingpane"` push) remains valid, useful
+precedent for a *future* command that has no persisted-state answer
+available — just not this one. No open design question remains for
+maximize/minimize; §9's item 3 is resolved, not just re-scoped.
 
 ## 7. Phased implementation plan
 
@@ -465,11 +499,17 @@ process-level server state already (§1) and don't face this question.
    into the srv↔cef named-pipe IPC (§1) for the first time from MCP — new
    ground, gets its own smoke test against a real floated window before
    merging.
-4. **`pane.maximize`/`pane.minimize`/`pane.restore`, own pane.** Blocked on
-   §6's design decision landing first.
+4. **`pane.maximize`/`pane.minimize`/`pane.restore`, own pane.** No longer
+   blocked on an open design question — §6 found both already have real
+   persisted server-side state, just no targeted set-command yet. Expose
+   `Command::SetMagnifiedNode` as its own dispatchable `("object", ...)`
+   action; add the small, precedented `Command::SetMinimizedNode`
+   counterpart; wrap each in a REST route + MCP tool exactly like
+   `ClosePane`.
 5. **`pane.maximize`/`pane.minimize`/`pane.restore`, cross-agent (fleet
-   tier).** Last — highest-novelty combination (new server concept *and*
-   fleet-tier cross-agent targeting at once).
+   tier).** Same fleet-tier pattern §5.1 already establishes for `pane.close`
+   — no longer "new server concept and cross-agent at once," since step 4
+   resolved the server-concept half.
 Step 6 ("MCP schema codegen") from the original draft is **removed** — §4.2
 found the shared-registry premise it depended on doesn't exist. There is no
 codegen follow-up pending from this spec; each command's MCP tool schema
@@ -487,12 +527,11 @@ stays hand-written in `tool_schemas.rs`, same as every existing tool.
 - `SplitPane`/`FloatPane`/`DockPane` round-trip on the caller's own pane,
   verified against a real running instance (not just unit-tested), the same
   way the existing floating-pane feature is manually verified today.
-- `MaximizePane`/`MinimizePane`/`RestorePane` work on the caller's own pane
-  while the window stays open, via a `state.broker.publish`/window-scoped
-  `WaveEvent` (§6(b) revised) — not the earlier tab→connection idea, which
-  §6 found doesn't correspond to anything real. The best-effort/non-durable
-  limitation is documented in the tool description itself, not just this
-  spec.
+- `MaximizePane`/`MinimizePane`/`RestorePane` set real, `db_layout`-persisted
+  state (`LayoutState.magnifiednodeid` / the leaf's `extra.minimized`) via
+  the new targeted `SetMagnifiedNode`/`SetMinimizedNode` actions (§6) —
+  durable across a reload, not best-effort, since §6 found the earlier
+  "no persisted state exists" premise was wrong.
 
 ## 9. Open questions summary (for repo-owner sign-off before implementation)
 
@@ -503,9 +542,12 @@ stays hand-written in `tool_schemas.rs`, same as every existing tool.
    tracking reference in the first draft).
 2. §5.5 — should a cross-pane close/maximize/minimize surface (but not
    block on) the target's `turn_active` state?
-3. §6 — accept option (b) (ephemeral relay) for v1, or is durable
-   `db_layout` persistence for maximize/minimize worth the larger change up
-   front?
+3. **Resolved, no longer open (§6):** maximize/minimize turned out to
+   already have real persisted server-side state
+   (`LayoutState.magnifiednodeid`, `LayoutNodeData.extra`) — the "which
+   design, ephemeral or durable" question was built on a false premise.
+   Expose the existing `SetMagnifiedNode` reducer command as its own
+   dispatchable action, add its `SetMinimizedNode` counterpart, done.
 4. **Resolved, no longer open (§4.2):** a shared `register_typed`-backed
    dispatch table for REST+MCP turned out not to correspond to any real
    process-wide registry — verified directly against `websocket.rs`'s

--- a/docs/specs/SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md
+++ b/docs/specs/SPEC_AGENT_PANE_LIFECYCLE_CONTROL_2026_09_10.md
@@ -6,8 +6,13 @@
 **Related:** `agentmux-mcp/src/main.rs`, `agentmux-mcp/src/tool_schemas.rs`,
 `agentmux-srv/src/backend/rpc/engine.rs`, `agentmux-srv/src/backend/rpc/schema.rs`,
 `agentmux-srv/src/server/mod.rs`, `agentmux-srv/src/server/app_api/fleet.rs`,
-`agentmux-srv/src/sagas/delete_block.rs`, `frontend/layout/lib/layoutMagnify.ts`,
-`frontend/layout/lib/layoutMinimize.ts`, `agentmux-cef/src/commands/floating_pane.rs`
+`agentmux-srv/src/server/ui_handlers.rs` (the `verified_block_id` signed-identity
+mechanism §5.0 adopts), `agentmux-srv/src/sagas/delete_block.rs`,
+`agentmux-srv/src/sagas/tear_off_block.rs`, `agentmux-srv/src/sagas/redock_floating_pane.rs`,
+`frontend/layout/lib/layoutMagnify.ts`, `frontend/layout/lib/layoutMinimize.ts`,
+`agentmux-cef/src/commands/floating_pane.rs`
+**Tracked prerequisite:** [agentmuxai/agentmux#3192](https://github.com/agentmuxai/agentmux/issues/3192)
+(§1.2/§9 — confirm `delete_block` preserves conversation history)
 **Predecessors (extend, don't duplicate):**
 [`SPEC_AGENT_APP_API_MCP_BINDINGS_2026_06_28.md`](./SPEC_AGENT_APP_API_MCP_BINDINGS_2026_06_28.md)
 (established MCP → REST `/api/v1/agent/*` → server-side-identity-stamped handler
@@ -166,70 +171,163 @@ engine.register_typed::<ClosePaneReq, ClosePaneResp, _, _>(
 
 `--dump-rpc-schema` (already proposed by `SPEC_RPC_BINDINGS_CODEGEN` §3.2) gains
 a second output alongside `rpc.gen.d.ts`: `agentmux-mcp/src/tool_schemas.gen.rs`,
-a generated `const` array of MCP tool JSON schemas plus a generated dispatch
-table (command name → REST path + required/optional fields), replacing the
-hand-written entries in `tool_schemas.rs` for every migrated command.
-`agentmux-mcp/src/main.rs`'s dispatch loop calls the generated table instead
-of a hand-written `match` arm per tool. `scripts/check-rpc-bindings.sh`
-(already proposed) is extended to diff this file too — one gate covers all
-three consumers going forward, not just frontend↔srv.
+a generated `const` array of MCP tool JSON schemas, replacing the hand-written
+entries in `tool_schemas.rs` for every migrated command. `scripts/check-rpc-
+bindings.sh` (already proposed) is extended to diff this file too.
 
-This is the concrete mechanism for "combine API + MCP + RPC into one coherent
-system": **one `register_typed` call is the only place a new command's shape
-is ever written down.** The WS path (frontend), the REST path
-(`/api/v1/agent/pane/*`, MCP's transport), and the MCP tool schema all derive
-from it. This does not touch the wire formats themselves (`RpcClient.rpcCall`,
-the REST `X-AuthKey` middleware) — same non-goal `SPEC_RPC_BINDINGS_CODEGEN`
-§4 already states, extended to cover the MCP transport too.
+**Codex P2 on PR #3191, correctly:** the metadata sketched above (name,
+description, stamped fields) is enough to generate the MCP *schema*, but
+nothing here gives `agentmux-mcp` an HTTP method/path to call, or installs an
+Axum route — so without more, the REST leg still has to be hand-added to
+`server/mod.rs` per command, and "one registration, three consumers" would be
+false. Fixed in §4.3 below by not needing per-command REST routes at all.
 
-### 4.3 REST routes (MCP's transport, per the established pattern)
+### 4.3 A single generic REST dispatcher, not a growing route table
 
-Following `SPEC_AGENT_APP_API_MCP_BINDINGS_2026_06_28.md` §5 exactly — the
-REST handler resolves identity server-side from `block_id`/`AGENTMUX_BLOCKID`,
-never from agent-supplied JSON, for the *caller's own identity*. The
-*target* pane's `block_id`, when acting on another agent's pane, is supplied
-explicitly by the agent (see §5 for why this is safe and matches
-`SetName`'s `target_id` precedent) and resolved through `fleet.rs`'s existing
-target-validation path, not trusted blindly:
+Rather than add a hand-written `.route("/api/v1/agent/pane/close", ...)` line
+per command (which is exactly the per-command REST maintenance §4.2 is trying
+to eliminate), add **one** generic route:
 
-| Command | REST route | MCP tool | Own-pane semantics | Cross-pane semantics |
-|---|---|---|---|---|
-| `pane.close` | `POST /api/v1/agent/pane/close` | `ClosePane` | close caller's own pane | close pane at `block_id` (fleet tier) |
-| `pane.maximize` | `POST /api/v1/agent/pane/maximize` | `MaximizePane` | maximize caller's own pane | maximize pane at `block_id` (fleet tier) |
-| `pane.minimize` | `POST /api/v1/agent/pane/minimize` | `MinimizePane` | minimize caller's own pane | minimize pane at `block_id` (fleet tier) |
-| `pane.restore` | `POST /api/v1/agent/pane/restore` | `RestorePane` | undo maximize/minimize on caller's own pane | restore pane at `block_id` (fleet tier) |
-| `pane.split` | `POST /api/v1/agent/pane/split` | `SplitPane` | split caller's own pane; `direction`, optional `view` for the new half | **not exposed cross-agent in v1** — see §7 |
-| `pane.float` | `POST /api/v1/agent/pane/float` | `FloatPane` | float caller's own pane to a new OS window | **not exposed cross-agent in v1** — see §7 |
-| `pane.dock` | `POST /api/v1/agent/pane/dock` | `DockPane` | dock a floated pane back into its tab | own-pane only |
+```
+POST /api/v1/agent/rpc/:command
+```
+
+Its handler looks up `:command` in the `RpcSchema` registry `register_typed`
+already populates, deserializes the body as that command's `Req` type,
+and dispatches through the identical typed handler function the WS engine
+calls — no new per-command Rust code, no new per-command route. This is the
+"documented generic dispatcher" Codex's review proposed as the alternative to
+richer per-command REST metadata, and it's the smaller change: it only needs
+the registry to expose `(command) -> dyn Fn(Value) -> Future<Result<Value>>`,
+which `register_typed`'s type-erased storage already has to do internally to
+support the untyped WS path today.
+
+`agentmux-mcp/src/main.rs`'s dispatch loop calls `POST /api/v1/agent/rpc/pane.close`
+(etc.) directly — reading the target path from the same generated
+`tool_schemas.gen.rs` table §4.2 already produces, so there is still exactly
+one place (`register_typed`) where a new command's shape and name are ever
+written down. This generalizes past pane-lifecycle: every future
+`register_typed` command gets an MCP-reachable REST door for free, with zero
+additional route-table maintenance, which is the actual "one registration,
+three consumers" claim now made true rather than aspirational.
+
+| Command | MCP tool | Own-pane semantics | Cross-pane semantics |
+|---|---|---|---|
+| `pane.close` | `ClosePane` | close caller's own pane (§5 identity) | close pane at `block_id` (fleet tier) |
+| `pane.maximize` | `MaximizePane` | maximize caller's own pane | maximize pane at `block_id` (fleet tier) |
+| `pane.minimize` | `MinimizePane` | minimize caller's own pane | minimize pane at `block_id` (fleet tier) |
+| `pane.restore` | `RestorePane` | undo maximize/minimize on caller's own pane | restore pane at `block_id` (fleet tier) |
+| `pane.split` | `SplitPane` | split caller's own pane; `direction`, optional `view` for the new half | **not exposed cross-agent in v1** — see §7 |
+| `pane.float` | `FloatPane` | float caller's own pane to a new OS window; **records its origin** (see `pane.dock` below) | **not exposed cross-agent in v1** — see §7 |
+| `pane.dock` | `DockPane` | dock a floated pane back to its recorded origin (see below) — own-pane only | not applicable |
 
 `pane.maximize`/`pane.minimize`/`pane.restore` require the srv-side concept
 gap from §1 to be closed first — see §6.
 
+**Codex P1 on PR #3191, correctly:** a no-argument "dock back into its tab"
+has no destination to resolve against. `sagas::redock_floating_pane::run`
+requires an explicit `source_tab_id`, `source_workspace_id`, `target_tab_id`,
+`target_workspace_id`, and optional `dst_index` — `tear_off_block::run` does
+not persist where a floated block came from, so today there is nothing a
+no-arg `DockPane` could read. Fixed: `pane.float` must record its origin
+(`source_tab_id`, `source_workspace_id`, and the leaf's position at
+tear-off time) — most naturally as block meta, alongside the other
+`agent:*`/`cmd:*` meta keys already carried on a block (§0's DB inspection
+found these directly) — and `pane.dock` defaults to that recorded origin,
+with optional explicit `target_tab_id`/`target_workspace_id`/`dst_index`
+params for redocking somewhere else. This makes the no-arg "put me back"
+call agent-ergonomic while still satisfying `redock_floating_pane`'s real
+required signature underneath.
+
 ## 5. Authorization model — the actual hard part
 
 Per §1.1, two tiers already exist. This spec assigns each verb explicitly
-rather than inventing new rules per-command:
+rather than inventing new rules per-command — but §5.0 below corrects a real
+hole Codex found in how "own-pane" was originally defined here.
+
+### 5.0 Own-pane identity must be resolved server-side from a *signature*, not an optional field (Codex P1 on PR #3191)
+
+The first draft of this spec described own-pane operations as needing "no
+additional guard," citing `UIClick` as precedent. That understated what
+`UIClick` actually does. Per `agentmux-srv/src/server/ui_handlers.rs`'s own
+module doc comment (written after a real vulnerability, PR #2662): **a bare
+client-supplied `block_id` is never trusted for anything, including the
+caller's own identity** — `/api/v1/ui/*` shares the same instance-wide
+`X-AuthKey` every agent can read from its own environment, so "the MCP schema
+never exposes a block_id param" is not a real boundary; a bypassing agent can
+call the REST endpoint directly with any block_id it wants. `verified_block_id`
+closes this the only way that actually works: the request carries
+`UiAutomationAuth` — an HMAC-SHA256 signature over the caller's own
+`agent_id`, produced with that agent's own `AGENTMUX_JEKT_KEY` (the same
+per-agent key `agentmux-mcp` already holds out-of-band for jekt sender
+authentication) — srv verifies the signature against that agent's key on
+file, and *only then* looks up that agent's actual current `block_id` itself,
+server-side, via the `ReactiveHandler` registry. There is no field in the
+request that names the caller's own pane at all.
+
+This spec's own-pane operations (§4.3: own-only `pane.split`/`pane.float`/
+`pane.dock`, and the own-pane path of `pane.close`/`pane.maximize`/
+`pane.minimize`/`pane.restore`) adopt the identical mechanism: `agentmux-mcp`
+signs the caller's `agent_id` with its `AGENTMUX_JEKT_KEY` on every pane-
+lifecycle call; the REST/generic-dispatcher handler (§4.3) verifies it via
+the same `verified_block_id`-style lookup before resolving "my own pane."
+**Own-pane operations never accept a `block_id` request field at all** — not
+optional, not defaulted, absent from the schema entirely — so there is
+nothing for a bypassing direct-REST-call agent to substitute. A `block_id`
+parameter exists ONLY on the commands this spec explicitly designates
+fleet-tier (close/maximize/minimize/restore's cross-pane form, §5.1 below),
+and its presence is exactly what routes a call to fleet-tier handling instead
+of own-pane handling — the two are different request shapes, not the same
+shape with an optional field, precisely so a foreign `block_id` can never
+leak into what was meant to be a self-only call.
+
+### 5.1 Cross-pane operations: fleet tier, with real caller attribution
 
 - **Close/maximize/minimize/restore, targeting another agent's pane: fleet
-  tier.** Same posture as `FleetBulkStop` — gated by the instance `X-AuthKey`
-  only, no per-agent ownership check, because (matching the existing route
-  comment's own reasoning) that *is* the feature: an agent fixing another
-  agent's stuck pane is exactly this spec's motivating case, and it cannot
-  require the broken pane's own agent to cooperate (it might not be able to —
-  that's the whole problem). Every cross-pane call gets per-target
-  success/failure reporting and mandatory audit logging identical to
-  `fleet.rs`'s existing `log_fleet_action_audit`, so "who closed my pane and
-  why" is always answerable after the fact.
+  tier.** Same posture as `FleetBulkStop` — no per-agent *ownership* check on
+  the target, because (matching the existing route comment's own reasoning)
+  that *is* the feature: an agent fixing another agent's stuck pane is
+  exactly this spec's motivating case, and it cannot require the broken
+  pane's own agent to cooperate (it might not be able to — that's the whole
+  problem). Unlike `FleetBulkStop` today, though, the *caller's* identity is
+  not optional — see §5.2, Codex's second P1 finding, which this spec's
+  fleet-tier commands must not inherit.
 - **Split/float, own pane only in v1.** These create new panes/windows rather
   than acting on an existing one; there's no motivating case from this
   investigation for doing this to another agent's layout, and doing so
   correctly (which tab? which agent's workspace?) is a bigger design question
   deferred to §7 rather than rushed into v1 alongside the close/maximize/
   minimize work this spec is actually motivated by.
-- **Own-pane operations: self-only, no additional guard** — same posture as
-  every other self-scoped MCP tool (`MemoryWrite`, `UIClick`).
 
-### 5.1 Do not repeat `SetName`'s unguarded `target_id` precedent uncritically
+### 5.2 Audit attribution must be a verified `source_agent`, not `None` (Codex P1 on PR #3191)
+
+This spec originally claimed cross-pane calls get "mandatory audit logging
+identical to `fleet.rs`'s existing `log_fleet_action_audit`, so 'who closed my
+pane and why' is always answerable." Codex checked that claim against the
+actual code and it's false as stated: `log_fleet_action_audit` *accepts* a
+`source_agent: Option<&str>` parameter, but `fleet_bulk_stop_impl`
+(`agentmux-srv/src/server/app_api/fleet.rs`) currently calls it with
+`source_agent: None` on every invocation — because the caller's identity was
+never verified in the first place, there's nothing trustworthy to pass. Under
+the `X-AuthKey`-only posture, "who" is unanswerable by construction: the key
+is shared by every agent on the instance.
+
+Fixed by reusing §5.0's signing mechanism for fleet-tier calls too: the
+caller signs its own `agent_id` the same way, srv verifies it the same way
+`verified_block_id` does, and the now-*verified* agent_id is what
+`log_fleet_action_audit` receives as `source_agent: Some(&verified_agent_id)`
+— not the unverified claim, the checked one. Add an optional `reason: String`
+request field (absent from every existing fleet command, also missing today)
+threaded into the audit record alongside it, since "why" was never captured
+either. This is a **prerequisite for this spec's fleet-tier commands**, not
+optional polish — without it, §8's acceptance criterion ("an audit log entry")
+would ship an entry that still can't say who. It's also a real, standing gap
+in `FleetBulkStop` itself; fixing the shared signing/verification helper as
+part of this work is the natural point to close that gap too, but
+`FleetBulkStop`'s own call sites switching to it is this spec's choice to
+make, not a requirement — see open question in §9.
+
+### 5.3 Do not repeat `SetName`'s unguarded `target_id` precedent uncritically
 
 `SPEC_MCP_SETNAME_TARGET_ID_2026_06_19.md` §2 relaxed `SetName`'s guard so
 that supplying `target_id` bypasses the caller's own `block_id` requirement
@@ -243,7 +341,7 @@ knowledge. Adopting fleet tier (§5) rather than `SetName`'s bare-`target_id`
 tier is a deliberate choice to get the audit trail and per-target reporting
 `SetName` never had, not an oversight.
 
-### 5.2 Open question for the repo owner
+### 5.5 Open question for the repo owner
 
 Should a cross-pane close/maximize/minimize call require the *target* agent
 to be idle (no turn in flight), the way `FleetBulkStop` has no such guard
@@ -315,7 +413,8 @@ question.
   (§1.2).
 - An agent can call `ClosePane(block_id: "<another agent's pane>")` and that
   pane closes, with a `FleetActionResult`-shaped response and an audit log
-  entry, matching `FleetBulkStop`'s existing response/audit shape.
+  entry whose `source_agent` is the caller's *verified* identity (§5.2), not
+  `None`.
 - `SplitPane`/`FloatPane`/`DockPane` round-trip on the caller's own pane,
   verified against a real running instance (not just unit-tested), the same
   way the existing floating-pane feature is manually verified today.
@@ -331,8 +430,10 @@ question.
 
 1. §1.2 — does `delete_block` already preserve conversation history
    independent of the block? Must be confirmed (and fixed if not) before
-   step 1.
-2. §5.2 — should a cross-pane close/maximize/minimize surface (but not
+   step 1. **Tracked as [agentmuxai/agentmux#3192](https://github.com/agentmuxai/agentmux/issues/3192)**
+   (reagent P1 on PR #3191: this was a blocking prerequisite with no owner or
+   tracking reference in the first draft).
+2. §5.5 — should a cross-pane close/maximize/minimize surface (but not
    block on) the target's `turn_active` state?
 3. §6 — accept option (b) (ephemeral relay) for v1, or is durable
    `db_layout` persistence for maximize/minimize worth the larger change up
@@ -340,3 +441,8 @@ question.
 4. §7 step 6 — is migrating the *existing* hand-written MCP tools to
    generated schemas wanted as a near-term follow-up, or left indefinitely
    as hand-written legacy alongside the newly-generated ones?
+5. §5.2 — should fixing `FleetBulkStop`'s existing `source_agent: None` gap
+   (using the same signing/verification helper this spec adds for its own
+   fleet-tier commands) be folded into this work, or filed as its own
+   separate follow-up? Either way it should not ship as a *known* new gap
+   given this spec now has the fix sitting right next to it.


### PR DESCRIPTION
## Summary
- Design spec for giving agents an MCP-reachable way to close, maximize, minimize, split, and float panes — their own, and (for close/maximize/minimize) other agents' panes.
- Proposes a concrete mechanism to unify the RPC engine, the REST App API, and MCP tool schemas behind one `register_typed` registration instead of three hand-maintained copies (extends `SPEC_RPC_BINDINGS_CODEGEN_2026_09_07.md`'s registry one step further, to MCP).
- Assigns every new verb to one of the two authorization tiers already in the codebase (self-only like `UIClick`, or fleet-tier unrestricted-but-audited like `FleetBulkStop`), and explicitly declines to copy `SetName`'s unguarded `target_id` precedent for anything as irreversible as closing a pane.
- Own-pane operations resolve caller identity via the same signed `UiAutomationAuth` mechanism `UIClick` actually uses (`verified_block_id`) — never an optional/trusted `block_id` field.
- Fleet-tier cross-pane calls carry verified caller identity into the audit log (`source_agent`), plus a `reason` field — fixing a real gap where `FleetBulkStop`'s existing calls pass `source_agent: None`.
- `DockPane` has a defined destination: `FloatPane` records its origin so a no-arg dock call has something to redock against.

Motivated directly by this session's investigation: a pane went into a broken render state (confirmed via direct `objects.db` query to have a perfectly healthy layout record — a pure client-side bug, not data corruption) and there was no MCP tool that could close or reset it.

Reopened from #3191, which was accidentally opened under the shared `a5af` account instead of this agent's own `Agent5-asaf` identity — same branch, same content, all review feedback already incorporated (ReAgent + Codex both approved #3191 after the fixes).

Implementation PRs to follow this spec, phased per §7.

<!-- agentmux:agent_id=agent5 -->