### PR TITLE
fix(srv): correct three review findings in the catalog redirect merged in #3183

### DIFF
--- a/.changesets/1789110842-fix-srv-correct-three-review-findings-in-the-catalog-redirec-oolw.md
+++ b/.changesets/1789110842-fix-srv-correct-three-review-findings-in-the-catalog-redirec-oolw.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(srv): correct three review findings in the catalog redirect (#3183)

--- a/agentmux-srv/src/backend/storage/managed.rs
+++ b/agentmux-srv/src/backend/storage/managed.rs
@@ -325,17 +325,39 @@ impl Store {
         }
     }
 
-    /// Purge `id`'s ref rows on `self`, then delete the catalog row on
-    /// `catalog`. True if a catalog row was deleted.
+    /// Delete the catalog row on `catalog` FIRST, then purge `id`'s ref rows
+    /// on `self`. True if a catalog row was deleted.
+    ///
+    /// Order matters (Codex P1, PR #3183): with the ref-purge running first,
+    /// a catalog-delete failure AFTER the ref purge already committed (disk
+    /// full, the identity store locked, any I/O error) stranded the row —
+    /// still present in `catalog`, but no ref points at it and it is not
+    /// necessarily global, so no access-check path can find it again, and
+    /// the ordinary delete RPC's own pre-check (`skill_is_bound_to`) now
+    /// rejects a retry too, since the ref that check depends on is already
+    /// gone. Catalog-first fixes the failure mode entirely: if the catalog
+    /// delete itself errors, `?` returns before the ref purge ever runs, so
+    /// the row keeps its ref(s) and stays exactly as accessible/retryable as
+    /// before the call. If the catalog delete SUCCEEDS (including "0 rows,
+    /// already gone") and the SUBSEQUENT ref purge then fails or a process
+    /// crashes between the two, the worst case is a dangling ref pointing at
+    /// an id the identity store no longer holds — the same already-accepted,
+    /// gracefully-degrading gap `SPEC_DURABLE_BINDINGS_2026_09_10.md` §5.4
+    /// documents for cross-channel dangling refs (`skill_get` on a missing
+    /// id returns `None`, which every read path already handles), not a new
+    /// failure mode.
     pub(super) fn managed_delete<R: ManagedResource>(&self, catalog: &Store, id: &str) -> Result<bool, StoreError> {
+        let deleted = {
+            let conn = catalog.conn.lock().unwrap();
+            let rows = conn.execute(&format!("DELETE FROM {} WHERE id = ?1", R::TABLE), params![id])?;
+            rows > 0
+        };
         {
             let conn = self.conn.lock().unwrap();
             conn.execute(&format!("DELETE FROM {} WHERE {} = ?1", R::AGENT_REF_TABLE, R::REF_COL), params![id])?;
             conn.execute(&format!("DELETE FROM {} WHERE {} = ?1", R::BUNDLE_REF_TABLE, R::REF_COL), params![id])?;
         }
-        let conn = catalog.conn.lock().unwrap();
-        let rows = conn.execute(&format!("DELETE FROM {} WHERE id = ?1", R::TABLE), params![id])?;
-        Ok(rows > 0)
+        Ok(deleted)
     }
 
     /// Purge every bundle-level ref for `bundle_id`, for one resource kind.

--- a/agentmux-srv/src/backend/storage/mcp_servers.rs
+++ b/agentmux-srv/src/backend/storage/mcp_servers.rs
@@ -520,22 +520,27 @@ impl Store {
         }
     }
 
-    /// Mirrors `Skill::skill_rewrite_ref_id` exactly, for the MCP ref tables.
-    /// Returns the number of ref rows actually repointed — see
+    /// Mirrors `Skill::skill_rewrite_ref_id` exactly, for the MCP ref tables
+    /// — including its insert-then-delete merge semantics (Codex P2, PR
+    /// #3183). Returns the number of ref rows actually repointed — see
     /// `Skill::skill_rewrite_ref_id`'s doc comment.
     pub(crate) fn mcp_server_rewrite_ref_id(&self, old_id: &str, new_id: &str) -> Result<usize, StoreError> {
         if old_id == new_id {
             return Ok(0);
         }
         let conn = self.conn.lock().unwrap();
-        let agent = conn.execute(
-            "UPDATE OR IGNORE db_agent_mcp_ref SET mcp_id = ?2 WHERE mcp_id = ?1",
+        conn.execute(
+            "INSERT OR IGNORE INTO db_agent_mcp_ref (agent_id, mcp_id)
+                SELECT agent_id, ?2 FROM db_agent_mcp_ref WHERE mcp_id = ?1",
             params![old_id, new_id],
         )?;
-        let bundle = conn.execute(
-            "UPDATE OR IGNORE db_bundle_mcp_ref SET mcp_id = ?2 WHERE mcp_id = ?1",
+        let agent = conn.execute("DELETE FROM db_agent_mcp_ref WHERE mcp_id = ?1", params![old_id])?;
+        conn.execute(
+            "INSERT OR IGNORE INTO db_bundle_mcp_ref (bundle_id, mcp_id)
+                SELECT bundle_id, ?2 FROM db_bundle_mcp_ref WHERE mcp_id = ?1",
             params![old_id, new_id],
         )?;
+        let bundle = conn.execute("DELETE FROM db_bundle_mcp_ref WHERE mcp_id = ?1", params![old_id])?;
         Ok(agent + bundle)
     }
 

--- a/agentmux-srv/src/backend/storage/skills.rs
+++ b/agentmux-srv/src/backend/storage/skills.rs
@@ -547,23 +547,31 @@ impl Store {
         Ok(rows)
     }
 
-    /// The first existing GLOBAL row matching `(name, skill_type)`, for the
+    /// The first existing GLOBAL row matching `name` alone, for the
     /// migration's first-wins dedup among global skills that aren't a
     /// recognized starter (those converge on `starter_skill_id` instead —
     /// see `skill_seed::starter_skill_trigger_for_name`).
-    pub(crate) fn skill_find_global_by_name_and_type(
-        &self,
-        name: &str,
-        skill_type: &str,
-    ) -> Result<Option<Skill>, StoreError> {
+    ///
+    /// Name-only, not `(name, skill_type)` — matching `idx_ids_skills_global_name`
+    /// (`IDENTITY_STORE_SCHEMA_VERSION` v8, `SPEC_DURABLE_BINDINGS_2026_09_10.md`
+    /// §5.4, Codex P1 on PR #3183): a `(name, skill_type)`-scoped re-query
+    /// would miss the actual winner whenever two channels' carries collide on
+    /// name but not type — the insert that failed did so because of the
+    /// name-only constraint, so the re-query must match the constraint that
+    /// actually fired, or it finds nothing, falls through to the
+    /// unrelated-PK-collision branch, and mints a fresh id whose insert
+    /// SILENTLY no-ops against the same name constraint (`INSERT OR IGNORE`),
+    /// leaving a local ref rewritten to an id the identity store never
+    /// actually holds — the skill vanishes the moment reads redirect there.
+    pub(crate) fn skill_find_global_by_name(&self, name: &str) -> Result<Option<Skill>, StoreError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT id, name, trigger, skill_type, description, content, is_global, created_at, updated_at
              FROM db_skills
-             WHERE is_global = 1 AND name = ?1 AND skill_type = ?2
+             WHERE is_global = 1 AND name = ?1
              LIMIT 1",
         )?;
-        let result = stmt.query_row(params![name, skill_type], |row| {
+        let result = stmt.query_row(params![name], |row| {
             Ok(Skill {
                 id: row.get(0)?,
                 name: row.get(1)?,
@@ -590,26 +598,44 @@ impl Store {
     /// row would name an id that no longer resolves anywhere once catalog
     /// reads redirect to the identity store (Phase 2's whole point).
     ///
-    /// `UPDATE ... WHERE skill_id = old_id`, not delete-then-insert: simpler,
-    /// and the PK `(agent_id, skill_id)`/`(bundle_id, skill_id)` only
-    /// collides if this exact owner already independently held a ref to
-    /// `new_id` too — vanishingly unlikely for real UUIDs, and `OR IGNORE`
-    /// makes that case a no-op (keep the existing ref) rather than an error.
-    /// Returns the number of ref rows actually repointed (0 if none named
-    /// `old_id`, distinct from "the call itself no-oped").
+    /// INSERT-survivor-then-DELETE-old, not a blind `UPDATE`: the PK
+    /// `(agent_id, skill_id)`/`(bundle_id, skill_id)` collides whenever this
+    /// exact owner already independently held a ref to `new_id` too — not
+    /// vanishingly unlikely once two DIFFERENT catalog rows (not just two
+    /// copies of the same one) can converge onto one survivor, which is
+    /// exactly what `m0033_narrow_skill_global_uniqueness_index`'s dedup
+    /// does (an owner can easily have bound BOTH of two same-name,
+    /// different-`skill_type` skills before the collision was discovered).
+    /// A plain `UPDATE OR IGNORE` left that case's old-id row untouched
+    /// (documented at the time as an acceptable no-op — ReAgent P1, PR
+    /// #3181, round 2) — but a caller that then deletes the OLD catalog row
+    /// (as `m0033` does, right after this rewrite) turns that "no-op" into a
+    /// permanently dangling ref pointing at an id nothing resolves anymore,
+    /// even within the current channel (Codex P2, PR #3183). Insert-then-
+    /// delete instead: `INSERT OR IGNORE` the survivor binding for every
+    /// owner who held `old_id` (already-bound owners no-op harmlessly, same
+    /// as before), then unconditionally `DELETE` every `old_id` row — so the
+    /// owner ends up bound to the survivor either way, never left pointing
+    /// at a name that's about to stop existing. Returns the number of
+    /// `old_id` ref rows resolved (0 if none named `old_id`, distinct from
+    /// "the call itself no-oped").
     pub(crate) fn skill_rewrite_ref_id(&self, old_id: &str, new_id: &str) -> Result<usize, StoreError> {
         if old_id == new_id {
             return Ok(0);
         }
         let conn = self.conn.lock().unwrap();
-        let agent = conn.execute(
-            "UPDATE OR IGNORE db_agent_skills_ref SET skill_id = ?2 WHERE skill_id = ?1",
+        conn.execute(
+            "INSERT OR IGNORE INTO db_agent_skills_ref (agent_id, skill_id)
+                SELECT agent_id, ?2 FROM db_agent_skills_ref WHERE skill_id = ?1",
             params![old_id, new_id],
         )?;
-        let bundle = conn.execute(
-            "UPDATE OR IGNORE db_bundle_skills_ref SET skill_id = ?2 WHERE skill_id = ?1",
+        let agent = conn.execute("DELETE FROM db_agent_skills_ref WHERE skill_id = ?1", params![old_id])?;
+        conn.execute(
+            "INSERT OR IGNORE INTO db_bundle_skills_ref (bundle_id, skill_id)
+                SELECT bundle_id, ?2 FROM db_bundle_skills_ref WHERE skill_id = ?1",
             params![old_id, new_id],
         )?;
+        let bundle = conn.execute("DELETE FROM db_bundle_skills_ref WHERE skill_id = ?1", params![old_id])?;
         Ok(agent + bundle)
     }
 
@@ -1230,5 +1256,185 @@ mod bundle_ref_tests {
         assert!(!store.bundle_skill_is_accessible_to(&store, "bundle-1", "skill-private").unwrap());
         store.bundle_skill_bind(&store, &store, "bundle-1", "skill-private").unwrap();
         assert!(store.bundle_skill_is_accessible_to(&store, "bundle-1", "skill-private").unwrap());
+    }
+}
+
+#[cfg(test)]
+mod rewrite_ref_id_and_delete_ordering_tests {
+    use super::*;
+    use crate::backend::storage::bundles::Bundle;
+
+    fn make_store() -> Store {
+        Store::open_in_memory().unwrap()
+    }
+
+    fn skill(id: &str, name: &str, is_global: bool) -> Skill {
+        Skill {
+            id: id.to_string(),
+            name: name.to_string(),
+            trigger: String::new(),
+            skill_type: "prompt".to_string(),
+            description: String::new(),
+            content: "content".to_string(),
+            is_global,
+            created_at: 1_700_000_000_000,
+            updated_at: 1_700_000_000_000,
+        }
+    }
+
+    fn insert_agent(store: &Store, id: &str) {
+        store
+            .conn()
+            .lock()
+            .unwrap()
+            .execute("INSERT INTO db_agents (id, name, provider) VALUES (?1, 'A', 'claude')", params![id])
+            .unwrap();
+    }
+
+    fn insert_bundle(store: &Store, id: &str) {
+        store
+            .bundle_upsert(&Bundle {
+                id: id.to_string(),
+                name: format!("Bundle {id}"),
+                description: String::new(),
+                is_blank: false,
+                is_global: false,
+                provider: "claude".to_string(),
+                model: "anthropic".to_string(),
+                instructions: String::new(),
+                instructions_by_provider: "{}".to_string(),
+                context_files: "[]".to_string(),
+                mcp_servers: "[]".to_string(),
+                skills: "[]".to_string(),
+                sort_order: 0,
+                created_at: 1_700_000_000_000,
+                updated_at: 1_700_000_000_000,
+                is_system: false,
+            })
+            .unwrap();
+    }
+
+    fn raw_bind_agent(store: &Store, agent_id: &str, skill_id: &str) {
+        store
+            .conn()
+            .lock()
+            .unwrap()
+            .execute(
+                "INSERT INTO db_agent_skills_ref (agent_id, skill_id) VALUES (?1, ?2)",
+                params![agent_id, skill_id],
+            )
+            .unwrap();
+    }
+
+    fn raw_bind_bundle(store: &Store, bundle_id: &str, skill_id: &str) {
+        store
+            .conn()
+            .lock()
+            .unwrap()
+            .execute(
+                "INSERT INTO db_bundle_skills_ref (bundle_id, skill_id) VALUES (?1, ?2)",
+                params![bundle_id, skill_id],
+            )
+            .unwrap();
+    }
+
+    /// Codex P2, PR #3183: when an owner already holds a ref to BOTH the
+    /// loser id and the survivor id (e.g. an agent independently bound two
+    /// same-name-different-type skills before `m0033` discovered the
+    /// collision), the old `UPDATE OR IGNORE` left the loser's ref row
+    /// untouched — a caller that then deletes the loser catalog row (as
+    /// `m0033` does) turns that into a permanently dangling ref. The fixed
+    /// insert-then-delete version must leave the owner bound to ONLY the
+    /// survivor.
+    #[test]
+    fn rewrite_resolves_a_ref_row_even_when_the_owner_already_holds_the_survivor_too() {
+        let store = make_store();
+        insert_agent(&store, "agent-1");
+        raw_bind_agent(&store, "agent-1", "loser-id");
+        raw_bind_agent(&store, "agent-1", "survivor-id");
+
+        let rewritten = store.skill_rewrite_ref_id("loser-id", "survivor-id").unwrap();
+        assert_eq!(rewritten, 1, "the loser ref row must be resolved (deleted, since the survivor was already bound)");
+
+        assert!(store.skill_is_bound_to("agent-1", "survivor-id").unwrap());
+        assert!(
+            !store.skill_is_bound_to("agent-1", "loser-id").unwrap(),
+            "no ref may still name the loser id after the rewrite — that id is about to be deleted from the catalog"
+        );
+    }
+
+    /// Same scenario, bundle-level ref table.
+    #[test]
+    fn rewrite_resolves_a_bundle_ref_row_even_when_the_bundle_already_holds_the_survivor_too() {
+        let store = make_store();
+        insert_bundle(&store, "bundle-1");
+        raw_bind_bundle(&store, "bundle-1", "loser-id");
+        raw_bind_bundle(&store, "bundle-1", "survivor-id");
+
+        let rewritten = store.skill_rewrite_ref_id("loser-id", "survivor-id").unwrap();
+        assert_eq!(rewritten, 1);
+
+        assert!(store.bundle_skill_is_bound_to("bundle-1", "survivor-id").unwrap());
+        assert!(!store.bundle_skill_is_bound_to("bundle-1", "loser-id").unwrap());
+    }
+
+    /// The ordinary case (no pre-existing survivor ref) must still behave
+    /// like a plain rename.
+    #[test]
+    fn rewrite_behaves_like_a_plain_rename_when_the_owner_has_no_prior_survivor_ref() {
+        let store = make_store();
+        insert_agent(&store, "agent-1");
+        raw_bind_agent(&store, "agent-1", "old-id");
+
+        let rewritten = store.skill_rewrite_ref_id("old-id", "new-id").unwrap();
+        assert_eq!(rewritten, 1);
+        assert!(store.skill_is_bound_to("agent-1", "new-id").unwrap());
+        assert!(!store.skill_is_bound_to("agent-1", "old-id").unwrap());
+    }
+
+    /// Codex P1, PR #3183: `managed_delete` (via `skill_delete`) must delete
+    /// the catalog row BEFORE purging refs, not after — so a catalog-delete
+    /// failure never leaves a private row's refs already gone (which would
+    /// make it permanently inaccessible and un-retryable, since the ordinary
+    /// delete RPC's own pre-check depends on the very ref this would have
+    /// already destroyed). Forces a real SQL error the same way
+    /// `managed_upsert_unique_compensates_by_deleting_the_catalog_row_when_the_bind_fails`
+    /// does (`managed.rs`'s own test) — dropping the catalog table, since
+    /// `DELETE ... WHERE id = ?` on a missing row is not itself an error.
+    #[test]
+    fn skill_delete_leaves_refs_intact_when_the_catalog_delete_itself_fails() {
+        let store = make_store();
+        insert_agent(&store, "agent-1");
+        store
+            .skill_upsert_unique(&store, "agent-1", &skill("private-1", "Deploy", false), true)
+            .unwrap();
+        assert!(store.skill_is_bound_to("agent-1", "private-1").unwrap());
+
+        store.conn().lock().unwrap().execute_batch("DROP TABLE db_skills;").unwrap();
+
+        let result = store.skill_delete(&store, "private-1");
+        assert!(result.is_err(), "the catalog delete must fail now that its table is gone");
+
+        // Re-create db_skills (empty) so the ref-table read below works —
+        // the point being verified is that the ref row was NEVER purged in
+        // the first place, i.e. the failure above happened before any ref
+        // mutation, not that the schema self-heals.
+        store
+            .conn()
+            .lock()
+            .unwrap()
+            .execute_batch(
+                "CREATE TABLE db_skills (
+                    id TEXT PRIMARY KEY, name TEXT NOT NULL, trigger TEXT NOT NULL DEFAULT '',
+                    skill_type TEXT NOT NULL DEFAULT 'prompt', description TEXT NOT NULL DEFAULT '',
+                    content TEXT NOT NULL DEFAULT '', is_global INTEGER NOT NULL DEFAULT 0,
+                    created_at INTEGER NOT NULL DEFAULT 0, updated_at INTEGER NOT NULL DEFAULT 0
+                );",
+            )
+            .unwrap();
+        assert!(
+            store.skill_is_bound_to("agent-1", "private-1").unwrap(),
+            "the ref row must still exist — a failed catalog delete must never strand a row with its bindings already purged"
+        );
     }
 }

--- a/agentmux-srv/src/migrations/m0031_carry_skills_and_mcp_servers_to_identity_store.rs
+++ b/agentmux-srv/src/migrations/m0031_carry_skills_and_mcp_servers_to_identity_store.rs
@@ -503,7 +503,30 @@ fn carry_mcp_servers(wstore: &Store, identity_store: &Store, channel_salt: &str)
                             let inserted = identity_store
                                 .mcp_server_insert_raw(&retry)
                                 .map_err(|e| format!("insert mcp server {} under fresh id: {e}", retry.name))?;
-                            (fresh_id, inserted)
+                            if inserted > 0 {
+                                (fresh_id, inserted)
+                            } else {
+                                // The fresh-id insert ALSO silently no-op'd —
+                                // mirrors carry_skills's identical defensive
+                                // re-check (ReAgent P1, PR #3197): only
+                                // reachable if a concurrent process won the
+                                // same name between our re-query above and
+                                // this insert. Never trust a silent
+                                // optimistic-insert failure without checking
+                                // what actually won.
+                                match identity_store
+                                    .mcp_server_find_global_by_name(&server.name)
+                                    .map_err(|e| format!("re-find global mcp server {} after fresh-id insert: {e}", server.name))?
+                                {
+                                    Some(existing) => (existing.id, 0),
+                                    None => {
+                                        return Err(format!(
+                                            "insert mcp server {} under fresh id {fresh_id} silently failed with no conflicting global row found — unreachable unless the identity store's schema changed underneath this migration",
+                                            retry.name
+                                        ));
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/agentmux-srv/src/migrations/m0031_carry_skills_and_mcp_servers_to_identity_store.rs
+++ b/agentmux-srv/src/migrations/m0031_carry_skills_and_mcp_servers_to_identity_store.rs
@@ -54,19 +54,24 @@
 //!   `INSERT OR IGNORE` under it is race-safe on PK equality alone; no
 //!   further arbitration needed.
 //! - **Any other global row** (a user-promoted global skill/server, not one
-//!   of the six starters) dedups by `(name, skill_type)` / `name` —
-//!   first-wins. Global rows are safe to collapse across channels because a
-//!   global row is owned by nobody (§5.3). Unlike a starter, this id is
-//!   NOT deterministic, so two channels' migrations running concurrently
-//!   (multiple AgentMux instances is an explicitly supported scenario) can
-//!   both observe "no match yet" before either inserts — Codex P1, PR
-//!   #3181. Arbitrated by a real database constraint
-//!   (`idx_ids_skills_global_name_type` / `idx_ids_mcp_servers_global_name`,
-//!   `IDENTITY_STORE_SCHEMA_VERSION` v7), not just an application-level
-//!   check: the insert is attempted optimistically under this row's own id,
-//!   and whichever channel's insert the constraint accepts is authoritative
-//!   — the loser re-queries for the winner rather than trusting its own
-//!   pre-insert guess.
+//!   of the six starters) dedups by `name` alone — first-wins. Global rows
+//!   are safe to collapse across channels because a global row is owned by
+//!   nobody (§5.3). Unlike a starter, this id is NOT deterministic, so two
+//!   channels' migrations running concurrently (multiple AgentMux instances
+//!   is an explicitly supported scenario) can both observe "no match yet"
+//!   before either inserts — Codex P1, PR #3181. Arbitrated by a real
+//!   database constraint (`idx_ids_skills_global_name` /
+//!   `idx_ids_mcp_servers_global_name`, `IDENTITY_STORE_SCHEMA_VERSION` v8),
+//!   not just an application-level check: the insert is attempted
+//!   optimistically under this row's own id, and whichever channel's insert
+//!   the constraint accepts is authoritative — the loser re-queries BY NAME
+//!   ALONE (never `(name, skill_type)` — Codex P1, PR #3183: the skill index
+//!   was `(name, skill_type)` until v8 narrowed it to match
+//!   `skill_upsert_unique_global`'s own name-only invariant, and a
+//!   `(name, skill_type)`-scoped re-query can miss a winner carried under a
+//!   different `skill_type`, silently stranding a local ref pointing at an
+//!   id the identity store never actually holds) for the winner rather than
+//!   trusting its own pre-insert guess.
 //! - **An owner-private row** (`is_global = 0`) is never deduplicated —
 //!   carried across under its own id unless that id collides with something
 //!   already in the identity store, in which case it gets a fresh one.
@@ -274,8 +279,10 @@ fn carry_skills(wstore: &Store, identity_store: &Store, channel_salt: &str) -> R
                 (id, inserted)
             } else {
                 // Non-starter global: optimistic insert under the row's own
-                // id, arbitrated by the (name, skill_type) unique index —
-                // see the module doc's race explanation.
+                // id, arbitrated by the name-only unique index (Codex P1, PR
+                // #3183 — was (name, skill_type) until IDENTITY_STORE_SCHEMA_VERSION
+                // v8 narrowed it to match skill_upsert_unique_global's own
+                // invariant; see the module doc's race explanation).
                 let mut to_insert = skill.clone();
                 let inserted = identity_store
                     .skill_insert_raw(&to_insert)
@@ -283,17 +290,29 @@ fn carry_skills(wstore: &Store, identity_store: &Store, channel_salt: &str) -> R
                 if inserted > 0 {
                     (to_insert.id.clone(), inserted)
                 } else {
+                    // Re-query by NAME ALONE, not (name, skill_type): the
+                    // insert failed because of the name-only constraint, so
+                    // that is what must be re-queried to find the actual
+                    // winner. A (name, skill_type)-scoped re-query would miss
+                    // a winner carried under a DIFFERENT skill_type, fall
+                    // through to the "unrelated collision" branch below, and
+                    // mint a fresh id whose insert then ALSO silently
+                    // no-ops against the same name constraint — leaving a
+                    // local ref rewritten to an id the identity store never
+                    // actually holds, so the skill vanishes the moment reads
+                    // redirect there (Codex P1, PR #3183 — caught exactly
+                    // this).
                     match identity_store
-                        .skill_find_global_by_name_and_type(&skill.name, &skill.skill_type)
+                        .skill_find_global_by_name(&skill.name)
                         .map_err(|e| format!("find global skill {}: {e}", skill.name))?
                     {
                         Some(existing) => (existing.id, 0),
                         None => {
                             // The insert failed for a reason unrelated to
-                            // (name, skill_type) — an astronomically
-                            // unlikely PK collision with an unrelated row.
-                            // Deterministic fallback id, same reasoning as
-                            // the private-row branch below.
+                            // name — an astronomically unlikely PK collision
+                            // with an unrelated row. Deterministic fallback
+                            // id, same reasoning as the private-row branch
+                            // below.
                             let fresh_id = deterministic_collision_id(
                                 SKILL_COLLISION_NAMESPACE_SEED,
                                 channel_salt,
@@ -304,7 +323,32 @@ fn carry_skills(wstore: &Store, identity_store: &Store, channel_salt: &str) -> R
                             let inserted = identity_store
                                 .skill_insert_raw(&to_insert)
                                 .map_err(|e| format!("insert skill {} under fresh id: {e}", to_insert.name))?;
-                            (fresh_id, inserted)
+                            if inserted > 0 {
+                                (fresh_id, inserted)
+                            } else {
+                                // The fresh-id insert ALSO silently no-op'd —
+                                // only reachable if a concurrent process won
+                                // the same name between our re-query above
+                                // and this insert (a narrow TOCTOU race, not
+                                // the deterministic bug this branch exists
+                                // for). Never trust a silent optimistic-
+                                // insert failure without checking what
+                                // actually won — same principle as the
+                                // private-row TOCTOU fix (ReAgent P1, PR
+                                // #3181, round 2).
+                                match identity_store
+                                    .skill_find_global_by_name(&skill.name)
+                                    .map_err(|e| format!("re-find global skill {} after fresh-id insert: {e}", skill.name))?
+                                {
+                                    Some(existing) => (existing.id, 0),
+                                    None => {
+                                        return Err(format!(
+                                            "insert skill {} under fresh id {fresh_id} silently failed with no conflicting global row found — unreachable unless the identity store's schema changed underneath this migration",
+                                            to_insert.name
+                                        ));
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -819,6 +863,57 @@ mod tests {
 
         assert!(identity_store.skill_get("id-from-a").unwrap().is_some());
         assert!(identity_store.skill_get("id-from-b").unwrap().is_none(), "must not create a second row for the same name+type");
+    }
+
+    /// Codex P1, PR #3183: the identity store's global-uniqueness index is
+    /// `name` alone as of `IDENTITY_STORE_SCHEMA_VERSION` v8 — narrower than
+    /// `(name, skill_type)`, which this dedup logic used to assume. Two
+    /// channels carrying the SAME NAME under DIFFERENT skill_types must
+    /// still converge onto one survivor: a re-query still scoped to
+    /// `(name, skill_type)` would find nothing (no row exists with the
+    /// LOSING channel's own exact type), fall through to the
+    /// unrelated-PK-collision branch, and mint a fresh id whose insert then
+    /// ALSO silently no-ops against the name constraint — stranding a local
+    /// ref pointing at an id the identity store never actually holds.
+    #[test]
+    fn two_channels_carrying_the_same_name_under_different_skill_types_still_converge() {
+        let identity_dir = tempfile::tempdir().unwrap();
+        let identity_store = Store::open_identity_store(&identity_dir.path().join("identity-store.db")).unwrap();
+
+        let dir_a = tempfile::tempdir().unwrap();
+        let wstore_a = Store::open(&dir_a.path().join("objects.db")).unwrap();
+        let mut skill_a = skill("id-from-a", "Deploy", "", true);
+        skill_a.skill_type = "prompt".to_string();
+        wstore_a.skill_insert_raw(&skill_a).unwrap();
+        carry_skills(&wstore_a, &identity_store, "channel-a").unwrap();
+
+        let dir_b = tempfile::tempdir().unwrap();
+        let wstore_b = Store::open(&dir_b.path().join("objects.db")).unwrap();
+        let mut skill_b = skill("id-from-b", "Deploy", "", true);
+        skill_b.skill_type = "agent-skill".to_string();
+        wstore_b.skill_insert_raw(&skill_b).unwrap();
+        rusqlite::Connection::open(dir_b.path().join("objects.db")).unwrap().execute(
+            "INSERT INTO db_agents (id, name, provider) VALUES ('agent-1', 'A', 'claude')",
+            [],
+        ).unwrap();
+        wstore_b.skill_bind(&wstore_b, "agent-1", "id-from-b").unwrap();
+
+        let (carried, rewritten) = carry_skills(&wstore_b, &identity_store, "channel-b").unwrap();
+        assert_eq!(carried, 0, "A's row already occupies the name — B adds nothing new to the identity store");
+        assert_eq!(rewritten, 1, "B's own agent-1 ref must be repointed at A's surviving id");
+
+        // Exactly one row in the identity store, under A's id, with A's
+        // content (first-wins) — NOT a phantom id B's fresh-id fallback
+        // would have minted.
+        assert!(identity_store.skill_get("id-from-a").unwrap().is_some());
+        assert!(identity_store.skill_get("id-from-b").unwrap().is_none());
+
+        // B's local mirror must resolve to A's id too — the whole point:
+        // nothing is left pointing at an id the identity store doesn't hold.
+        assert!(wstore_b.skill_get("id-from-a").unwrap().is_some());
+        assert!(wstore_b.skill_get("id-from-b").unwrap().is_none());
+        assert!(wstore_b.skill_is_bound_to("agent-1", "id-from-a").unwrap());
+        assert!(!wstore_b.skill_is_bound_to("agent-1", "id-from-b").unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Why this PR exists

PR #3183 (Phase 2's application-layer catalog read/write redirect) got 3 real P1/P2 findings from Codex during review. I pushed a fix commit, but a background merge-watcher raced ahead and merged #3183's PRE-fix commit before the fix registered as the new head — so `main` currently has the version of #3183 with these 3 bugs still present. Not shipped to end users (pre-release), but it's broken code on `main` and needs correcting properly through review rather than left as-is.

This PR is the same fix commit (verified, tested, already reviewed-in-spirit by Codex's own findings) cherry-picked onto current `main`.

## The three findings, all verified against the actual code before being fixed

- **P1:** `m0031`'s non-starter-global dedup fallback re-queried by `(name, skill_type)`, which the new name-only unique index (`m0033`, part of the same original PR) makes stale. Two channels carrying the same skill name under different `skill_type`s would both fail the re-query, fall through to the "unrelated collision" branch, and the fresh-id insert would ALSO silently no-op against the name constraint (`INSERT OR IGNORE`) — stranding a local ref pointing at an id the identity store never actually holds, which vanishes the moment reads redirect there. Fixed by re-querying by name alone (`skill_find_global_by_name`, mirroring the MCP-server equivalent, which never had this mismatch), plus a defensive re-check after the fresh-id insert for a residual TOCTOU race.

- **P1:** `managed_delete` purged ref rows BEFORE deleting the catalog row. If the catalog delete then failed (identity store locked, I/O error), the row's refs were already gone — for a private row, this made it permanently inaccessible (no ref, not global) and un-retryable (the delete RPC's own pre-check depends on the ref that was just destroyed). Reordered: catalog-delete first, so a failure there returns before any ref is touched and the row stays exactly as accessible as before the call.

- **P2:** `skill_rewrite_ref_id`/`mcp_server_rewrite_ref_id` used `UPDATE OR IGNORE`, which silently no-ops when the owner already holds a ref to both the loser and survivor ids (a real scenario once `m0033` can collapse two independently-bound skills into one). The untouched loser ref became a permanent dangling ref once `m0033` deletes the loser catalog row right after. Changed to insert-the-survivor-then-delete-the-loser, which resolves the ref correctly either way.

5 new regression tests, each exercising the exact failure shape described rather than a loosened version of it.

## Tests

`cargo test -p agentmux-srv --bins` — 3337 passed, 0 failed (excluding two known-flaky PTY-shell tests from #3177 that hang in this sandboxed environment regardless of these changes, and one `sysinfo` handle-count test confirmed flaky under heavy concurrent build load, not a real regression — both unrelated to this diff, verified by `git diff main --stat` showing neither touched file in this PR's changes).

<!-- agentmux:agent_id=agenta -->