### PR TITLE
Korp@claudius: fix(ci): add concurrency groups to ci-pr.yml and nightly workflows

### DIFF
--- a/.changesets/1789111084-fix-ci-add-concurrency-groups-to-ci-pr-yml-and-nightly-workf-ct4w.md
+++ b/.changesets/1789111084-fix-ci-add-concurrency-groups-to-ci-pr-yml-and-nightly-workf-ct4w.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(ci): add concurrency groups to ci-pr.yml and nightly workflows — stop stale runs piling up on the shared runner pool

--- a/.github/workflows/ci-nightly-artifacts.yml
+++ b/.github/workflows/ci-nightly-artifacts.yml
@@ -26,6 +26,14 @@ on:
     - cron: '0 6 * * *' # 06:00 UTC daily (ahead of Phase A at 07:00)
   workflow_dispatch: {}
 
+# Own group, distinct from both ci-pr.yml's and ci-nightly-build.yml's — see
+# the matching comment in ci-nightly-build.yml for the full reasoning
+# (queue rather than cancel a real nightly run; this does not give artifact
+# builds separate runner capacity from PR CI, only prevents self-collision).
+concurrency:
+  group: ci-nightly-artifacts
+  cancel-in-progress: false
+
 jobs:
   windows:
     name: Windows portable + installer + MSIX

--- a/.github/workflows/ci-nightly-build.yml
+++ b/.github/workflows/ci-nightly-build.yml
@@ -23,6 +23,25 @@ on:
     - cron: '0 7 * * *' # 07:00 UTC daily
   workflow_dispatch: {}
 
+# Own group, separate from ci-pr.yml's — a manual workflow_dispatch re-trigger
+# (or an unlucky overlap with the scheduled run) queues behind an
+# already-running nightly instead of racing it on the same windows-latest/
+# ubuntu-latest/macos-latest runners for no reason. cancel-in-progress:
+# false, not true — unlike a superseded PR run, a nightly run in progress is
+# still a real signal worth finishing; queue rather than throw it away.
+#
+# This does NOT give nightly its own runner capacity separate from
+# ci-pr.yml's — GitHub-hosted `windows-latest`/`ubuntu-latest`/`macos-latest`
+# are one shared pool per repo/org regardless of concurrency group; two
+# different groups still draw from the same queue. Actual capacity
+# separation would need self-hosted runners or GitHub Enterprise runner
+# groups, neither of which this repo has. What this achieves is narrower but
+# real: nightly stops competing with itself, which is one less source of
+# load on that shared pool.
+concurrency:
+  group: ci-nightly-build
+  cancel-in-progress: false
+
 jobs:
   build-and-test:
     name: cargo build + test (${{ matrix.os }})

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -31,6 +31,23 @@ on:
   push:
     branches: [main]
 
+# Cancel a superseded run for the same PR/branch instead of letting it run to
+# completion alongside the new one. Without this, every push to a PR spawns a
+# full new run that keeps burning windows-latest/ubuntu-latest runner minutes
+# even after it's obsolete — observed directly on 2026-09-11: several PRs had
+# 3-4 near-duplicate runs in flight within minutes of each other from quick
+# successive pushes, none cancelling the ones before it. That's wasted load
+# on a runner pool this repo's CI volume already puts real pressure on (88
+# ci-pr.yml runs in a 21-hour window from concurrent agents, sampled the same
+# day) — cutting the wasted volume doesn't fix GitHub-hosted-runner-side
+# flakiness on its own, but it reduces how often any one PR is exposed to it.
+# `github.head_ref` is empty for `push` (not a PR), so it falls through to
+# `github.ref` (the branch) — main pushes still get their own group, just
+# keyed differently than PR runs.
+concurrency:
+  group: ci-pr-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   rust:
     name: check --tests + test (${{ matrix.os }})

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -41,11 +41,19 @@ on:
 # ci-pr.yml runs in a 21-hour window from concurrent agents, sampled the same
 # day) — cutting the wasted volume doesn't fix GitHub-hosted-runner-side
 # flakiness on its own, but it reduces how often any one PR is exposed to it.
-# `github.head_ref` is empty for `push` (not a PR), so it falls through to
-# `github.ref` (the branch) — main pushes still get their own group, just
-# keyed differently than PR runs.
+# Codex P1 on #3198: keying on github.head_ref alone is wrong — for a
+# pull_request event it's just the source BRANCH NAME, with no owner/fork
+# qualifier. Two unrelated PRs (different forks, or even two agents in this
+# same repo) using a common branch name like "main" or "fix-typo" would
+# collide on the same group, and a push to one would cancel the OTHER PR's
+# required CI run — silent, cross-PR, and only noticed when someone's merge
+# is unexpectedly blocked. github.event.pull_request.number is unique per
+# PR regardless of branch naming; use that instead. It's only set for
+# pull_request events, so this still falls through to github.ref for `push`
+# (not a PR) — main pushes get their own group, keyed differently than PR
+# runs, same as before.
 concurrency:
-  group: ci-pr-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ci-pr-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

Investigated a 3+ hour hang on PR #3189's `windows-latest` CI leg (flagged directly by the repo owner). Root cause is **not** a code-level test hang — sampled job-level timing across recent `ci-pr.yml` runs and found two jobs that started **1.5 hours apart** both died at almost the exact same wall-clock moment (`04:08 UTC`), while a third job that started in between them succeeded normally in 15 minutes. That's the signature of GitHub-hosted-runner-side flakiness (a bad runner instance, eventually reaped), not a deterministic deadlock in this repo's own test suite — and it's not something a workflow YAML change can fix outright.

**What is fixable:** neither `ci-pr.yml` nor the nightly workflows had a `concurrency:` group at all. Every push to a PR spawned a full new run without cancelling the now-superseded previous one. Observed directly: several PRs had 3-4 near-duplicate runs in flight within minutes of each other from quick successive pushes. 88 `ci-pr.yml` runs fired in a sampled 21-hour window alone, across many concurrent agents — real, avoidable pressure on the same shared `windows-latest`/`ubuntu-latest` pool that makes exposure to the flaky-runner failure mode worse than it needs to be.

- **`ci-pr.yml`**: concurrency group keyed on workflow + branch/PR ref, `cancel-in-progress: true` — a new push cancels the stale run for the same PR instead of letting it run to completion pointlessly.
- **`ci-nightly-build.yml` / `ci-nightly-artifacts.yml`**: each gets its own group, `cancel-in-progress: false` (queue rather than cancel a real nightly run — unlike a superseded PR run, an in-progress nightly is still a signal worth finishing).

**Honest limitation, stated in the comments:** this does **not** give nightly separate runner capacity from PR CI. GitHub-hosted runners are one shared pool per repo/org regardless of concurrency group — true isolation would need self-hosted runners or GitHub Enterprise runner groups, neither of which this repo has. What this achieves is narrower but real: nightly stops competing with itself on re-trigger/schedule overlap, and PR CI stops piling up wasted, superseded runs — one less source of load on the shared pool, not a guarantee against GitHub's own runner flakiness.

## Test plan

- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`) on all three files
- [ ] CI green on this PR
- [ ] Manual: push a second commit to this PR and confirm the first run gets cancelled

<!-- agentmux:agent_id=korp -->