### PR TITLE
fix(armory): render Global Memory's provider-config and combined preview as markdown, make both resizable

### DIFF
--- a/.changesets/1789113727-fix-armory-render-global-memory-s-provider-config-and-combin-15x6.md
+++ b/.changesets/1789113727-fix-armory-render-global-memory-s-provider-config-and-combin-15x6.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(armory): render Global Memory's provider-config and combined preview as markdown, make both resizable

--- a/frontend/app/view/global-bundle/global-bundle-manager.test.tsx
+++ b/frontend/app/view/global-bundle/global-bundle-manager.test.tsx
@@ -54,7 +54,13 @@ describe("GlobalBundleManager shared-provider-config block", () => {
 
         expect(await screen.findByText("Claude Code — shared provider config")).toBeInTheDocument();
         expect(screen.getByText("/home/user/.agentmux/shared/providers/claude/CLAUDE.md")).toBeInTheDocument();
-        expect(screen.getByText("# Global rules")).toBeInTheDocument();
+        // Rendered as markdown now, not a raw <pre> dump (this test's own
+        // history predates that change) — "# Global rules" becomes an <h1>
+        // reading "Global rules", the "#" consumed by markdown parsing
+        // rather than appearing as literal text. Asserting on the rendered
+        // heading proves markdown rendering actually happened, not just
+        // that the raw string made it into the DOM somewhere.
+        expect(screen.getByText("Global rules", { selector: ".heading" })).toBeInTheDocument();
         // Scoped to this block rather than the whole pane. Kept scoped even
         // though only one block renders now (the sibling host-config block it
         // originally disambiguated from is gone) — a pane-wide assertion

--- a/frontend/app/view/global-bundle/global-bundle-manager.tsx
+++ b/frontend/app/view/global-bundle/global-bundle-manager.tsx
@@ -194,7 +194,12 @@ export const GlobalBundleManager = (): JSX.Element => {
                                     (nativeScrollbar: a plain CSS scrollbar is
                                     plenty for a reference-only preview panel). */}
                                 <div class="global-bundle-machine-config-content">
-                                    <Markdown text={cfg().content} scrollable={true} nativeScrollbar={true} />
+                                    <Markdown
+                                        text={cfg().content}
+                                        scrollable={true}
+                                        nativeScrollbar={true}
+                                        contentClass="global-bundle-machine-config-markdown-content"
+                                    />
                                 </div>
                             </Show>
                         </div>
@@ -399,7 +404,12 @@ export const GlobalBundleManager = (): JSX.Element => {
                         block above — same reason this is a wrapper div, not a
                         class applied directly to <Markdown>. */}
                     <div class="global-bundle-preview-content">
-                        <Markdown text={model.previewAtom() || "(empty)"} scrollable={true} nativeScrollbar={true} />
+                        <Markdown
+                            text={model.previewAtom() || "(empty)"}
+                            scrollable={true}
+                            nativeScrollbar={true}
+                            contentClass="global-bundle-preview-markdown-content"
+                        />
                     </div>
                 </Show>
             </div>

--- a/frontend/app/view/global-bundle/global-bundle-manager.tsx
+++ b/frontend/app/view/global-bundle/global-bundle-manager.tsx
@@ -12,6 +12,7 @@
 // bundle_* RPCs. Spec: docs/specs/archive/SPEC_TRUST_CENTER_GLOBAL_BRAIN_2026_06_19.md.
 
 import { createSignal, For, onCleanup, Show, type JSX } from "solid-js";
+import { Markdown } from "@/app/element/markdown";
 import { showTextInputContextMenu } from "@/app/store/contextmenu";
 import { GlobalBundleViewModel, NEW_SECTION_ID } from "./global-bundle-model";
 import "./global-bundle.scss";
@@ -183,7 +184,18 @@ export const GlobalBundleManager = (): JSX.Element => {
                                 when={cfg().exists}
                                 fallback={<p class="global-bundle-machine-config-empty">No file at this path yet.</p>}
                             >
-                                <pre class="global-bundle-machine-config-content">{cfg().content}</pre>
+                                {/* The resize handle lives on this wrapper, not on
+                                    <Markdown> itself — Markdown's own root sets
+                                    `height: 100%; overflow: hidden`, which would
+                                    fight a resize/height override applied
+                                    directly to it. Markdown fills 100% of
+                                    whatever height this wrapper resizes to and
+                                    handles its own internal scrolling
+                                    (nativeScrollbar: a plain CSS scrollbar is
+                                    plenty for a reference-only preview panel). */}
+                                <div class="global-bundle-machine-config-content">
+                                    <Markdown text={cfg().content} scrollable={true} nativeScrollbar={true} />
+                                </div>
                             </Show>
                         </div>
                     </div>
@@ -383,9 +395,12 @@ export const GlobalBundleManager = (): JSX.Element => {
                     {model.showPreviewAtom() ? "▾" : "▸"} Combined preview
                 </button>
                 <Show when={model.showPreviewAtom()}>
-                    <pre class="global-bundle-preview-content">
-                        {model.previewAtom() || "(empty)"}
-                    </pre>
+                    {/* See the matching comment on the Claude Code provider-config
+                        block above — same reason this is a wrapper div, not a
+                        class applied directly to <Markdown>. */}
+                    <div class="global-bundle-preview-content">
+                        <Markdown text={model.previewAtom() || "(empty)"} scrollable={true} nativeScrollbar={true} />
+                    </div>
                 </Show>
             </div>
         </div>

--- a/frontend/app/view/global-bundle/global-bundle.scss
+++ b/frontend/app/view/global-bundle/global-bundle.scss
@@ -112,18 +112,24 @@
     color: var(--secondary-text-color);
 }
 
+// Wraps a <Markdown> (see the component for why: its root sets its own
+// `height: 100%; overflow: hidden`, so the resize handle + explicit height
+// have to live on this wrapper instead — Markdown fills 100% of whatever
+// height this resizes to and scrolls its own content internally).
+// `resize: vertical` needs an explicit starting `height`, not just
+// `max-height` — a resizable box needs a real starting value for the
+// browser's resize handle to grow/shrink from. `min-height`/`max-height`
+// bound the drag range.
 .global-bundle-machine-config-content {
-    margin: 0;
+    height: 240px;
+    min-height: 120px;
+    max-height: 600px;
+    overflow: hidden;
+    resize: vertical;
     padding: var(--space-2);
-    max-height: 240px;
-    overflow: auto;
     background: var(--main-bg-color);
     border: 1px solid var(--border-color);
-    font-family: var(--fixed-font, monospace);
-    font-size: 9px;
-    color: var(--main-text-color);
-    white-space: pre-wrap;
-    overflow-wrap: break-word;
+    font-size: 11px;
 }
 
 // ── Section list ─────────────────────────────────────────────────────────────
@@ -355,18 +361,18 @@
     }
 }
 
+// See .global-bundle-machine-config-content's comment — same wrapper-around-
+// <Markdown> pattern and the same reason `resize` needs an explicit `height`.
 .global-bundle-preview-content {
-    margin: 0;
+    height: 240px;
+    min-height: 120px;
+    max-height: 600px;
+    overflow: hidden;
+    resize: vertical;
     padding: var(--space-2);
-    max-height: 240px;
-    overflow: auto;
     background: var(--main-bg-color);
     border: 1px solid var(--border-color);
-    font-family: var(--fixed-font, monospace);
-    font-size: 9px;
-    color: var(--main-text-color);
-    white-space: pre-wrap;
-    overflow-wrap: break-word;
+    font-size: 11px;
 }
 
 // ── Buttons ──────────────────────────────────────────────────────────────────

--- a/frontend/app/view/global-bundle/global-bundle.scss
+++ b/frontend/app/view/global-bundle/global-bundle.scss
@@ -132,6 +132,18 @@
     font-size: 11px;
 }
 
+// Compound selector (needs the extra specificity to beat the base `.content
+// { overflow: scroll }` rule in markdown.scss). `nativeScrollbar` skips
+// OverlayScrollbars entirely, so `.content`'s own CSS `overflow` is what
+// actually renders the scrollbar — `auto` (not `scroll`) so a scrollbar
+// only appears when the content genuinely overflows this panel, matching
+// `.content.editor-preview-markdown-content`'s identical fix (codex P2 on
+// PR #2774, and again on PR #3199 for these two call sites). Shorthand,
+// not just overflow-y — the base rule sets BOTH axes.
+.content.global-bundle-machine-config-markdown-content {
+    overflow: auto;
+}
+
 // ── Section list ─────────────────────────────────────────────────────────────
 
 .global-bundle-sections {
@@ -373,6 +385,11 @@
     background: var(--main-bg-color);
     border: 1px solid var(--border-color);
     font-size: 11px;
+}
+
+// See .global-bundle-machine-config-markdown-content's comment — same fix.
+.content.global-bundle-preview-markdown-content {
+    overflow: auto;
 }
 
 // ── Buttons ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Part of the current push to get agent memory actually workable — this is the first, concrete UI fix flagged for the Armory → Memory → Global page.

## What changed

Two of the three content surfaces in `GlobalBundleManager` (Armory → Memory → Global) were plain `<pre>` dumps at a fixed `max-height: 240px`, no markdown rendering, no resize:

- The **"Claude Code provider config"** reference block (the one literally labeled "provider config" in the UI)
- The **"Combined preview"** toggle panel

The third surface (section content editors) was already a resizable `<textarea>` — untouched.

## How

Reuses two already-proven patterns already in this codebase rather than building anything new:
- `Markdown` (`frontend/app/element/markdown.tsx`) for rendering — the same component used in `AgentSkillsModal` and elsewhere.
- CSS `resize: vertical` for the drag handle, wrapped in a sized `<div>` rather than applied directly to `<Markdown>`'s own root — its root sets `height: 100%; overflow: hidden`, which would fight a resize/height override on the same element. `Markdown` fills 100% of whatever height the wrapper resizes to and handles its own scrolling internally (`nativeScrollbar={true}` — plain CSS scrollbar, appropriate for a read-only preview panel).

## Verification

- `npx tsc --noEmit` — clean, no type errors.
- **Automated test suite is broken repo-wide in this environment right now** (91 of 267 frontend test files fail identically with a `@solid-refresh`/vitest tooling error — confirmed on files I never touched, e.g. `global-bundle-model.test.ts`, so this is pre-existing and unrelated to this change, not something I introduced).
- Built and booted a full `task dev` instance with this change — compiles clean, app launches with no runtime errors.
- **Could not get a full click-through screenshot of the specific Armory → Memory → Global page**: the available UI-automation tools (`UIClick`/`UIQuery`) are scoped to my own pane and can't drive a separately-spawned dev instance's window, and I don't want to overstate what I verified. Saying so explicitly rather than claiming a visual check I didn't actually get. Worth a manual look before merge.

<!-- agentmux:agent_id=agenta -->