### PR TITLE
fix(ci): cap ci-pr.yml's required job at 20 minutes

### DIFF
--- a/.changesets/1789115609-fix-ci-cap-ci-pr-yml-s-required-job-at-20-minutes-9080.md
+++ b/.changesets/1789115609-fix-ci-cap-ci-pr-yml-s-required-job-at-20-minutes-9080.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(ci): cap ci-pr.yml's required job at 20 minutes

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -40,6 +40,13 @@ jobs:
         os: [windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.os != 'windows-latest' }}
+    # Normal baseline is ~13 min (see docs/incident/
+    # INCIDENT_2026_09_10_CI_PR_WINDOWS_RUNNER_HANG_BACKLOG.md). Without this,
+    # a hung GitHub-hosted runner occupies the REQUIRED check for GitHub's
+    # default of 360 minutes before being reaped -- that incident hit this
+    # exact ceiling twice. 20 min gives headroom over the baseline while
+    # bounding a hang to tens of minutes instead of hours.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
Follow-up to the retro in #3200. `ci-pr.yml`'s `rust` job (the required `windows-latest`/`ubuntu-latest` leg) sets no `timeout-minutes`, so it defaults to GitHub's own 360-minute ceiling. Two runs in the 2026-09-10 incident hit that exact ceiling before being reaped.

## Change
`timeout-minutes: 20` on the `rust` job — normal baseline is ~13 min, so this gives headroom for a slow-but-healthy run while bounding the next hang to tens of minutes instead of hours.

**Explicitly does not fix the hang's own cause** (external GitHub-hosted-runner-pool flakiness, per `docs/incident/INCIDENT_2026_09_10_CI_PR_WINDOWS_RUNNER_HANG_BACKLOG.md`) — this only bounds the blast radius, same distinction the incident doc's own recommendations section draws.

## Test plan
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] CI green on this PR

<!-- agentmux:agent_id=agenty -->