### PR TITLE
chore: release v0.55.42

### DIFF
--- a/.changesets/1789033558-feat-install-ui-auto-scroll-install-log-details-provider-ins-dczu.md
+++ b/.changesets/1789033558-feat-install-ui-auto-scroll-install-log-details-provider-ins-dczu.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(install-ui): auto-scroll install-log Details, provider-installer progress bar, and system-tool brand icons

--- a/.changesets/1789054860-fix-srv-seed-starter-skills-mcp-servers-with-deterministic-i-rzpn.md
+++ b/.changesets/1789054860-fix-srv-seed-starter-skills-mcp-servers-with-deterministic-i-rzpn.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(srv): seed starter skills/MCP servers with deterministic ids on fresh channels

--- a/.changesets/1789057954-chore-deps-bump-vitest-vitest-mocker-and-vitest-coverage-ist-yv0j.md
+++ b/.changesets/1789057954-chore-deps-bump-vitest-vitest-mocker-and-vitest-coverage-ist-yv0j.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-chore(deps): bump vitest, @vitest/mocker and @vitest/coverage-istanbul (major)

--- a/.changesets/1789057969-feat-mcp-add-ptyshell-a-real-pty-backed-interactive-shell-ag-77no.md
+++ b/.changesets/1789057969-feat-mcp-add-ptyshell-a-real-pty-backed-interactive-shell-ag-77no.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(mcp): add PtyShell — a real PTY-backed interactive shell agents can drive without any UI

--- a/.changesets/1789058016-fix-cef-build-verify-angle-libs-sh-no-longer-false-positives-ebri.md
+++ b/.changesets/1789058016-fix-cef-build-verify-angle-libs-sh-no-longer-false-positives-ebri.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(cef-build): verify-angle-libs.sh no longer false-positives on a small-but-real libEGL.dll

--- a/.changesets/1789064782-feat-srv-identity-store-gains-authoritative-db-skills-db-mcp-fwmp.md
+++ b/.changesets/1789064782-feat-srv-identity-store-gains-authoritative-db-skills-db-mcp-fwmp.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(srv): identity store gains authoritative db_skills/db_mcp_servers tables (Phase 2a, no readers/writers yet)

--- a/.changesets/1789066675-feat-srv-carry-each-channel-s-skills-mcp-servers-into-the-id-3oag.md
+++ b/.changesets/1789066675-feat-srv-carry-each-channel-s-skills-mcp-servers-into-the-id-3oag.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(srv): carry each channel's skills/MCP servers into the identity store (Phase 2b)

--- a/.changesets/1789075390-feat-srv-redirect-skill-mcp-server-catalog-reads-and-writes--haz0.md
+++ b/.changesets/1789075390-feat-srv-redirect-skill-mcp-server-catalog-reads-and-writes--haz0.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-feat(srv): redirect skill/MCP-server catalog reads and writes to the identity store

--- a/.changesets/1789085480-docs-tone-down-the-early-alpha-warning-jl32.md
+++ b/.changesets/1789085480-docs-tone-down-the-early-alpha-warning-jl32.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: tone down the early-alpha warning

--- a/.changesets/1789086653-docs-say-alpha-software-not-early-alpha-6val.md
+++ b/.changesets/1789086653-docs-say-alpha-software-not-early-alpha-6val.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-docs: say 'alpha software', not 'early alpha'

--- a/.changesets/1789087612-fix-term-keep-alive-terminal-tabs-no-longer-leak-input-zoom--uev6.md
+++ b/.changesets/1789087612-fix-term-keep-alive-terminal-tabs-no-longer-leak-input-zoom--uev6.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(term): keep-alive terminal tabs no longer leak input/zoom into hidden dormant tabs

--- a/.changesets/1789087893-fix-mcp-sendmessage-reports-whether-a-message-was-delivered--mzmm.md
+++ b/.changesets/1789087893-fix-mcp-sendmessage-reports-whether-a-message-was-delivered--mzmm.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(mcp): SendMessage reports whether a message was delivered or only queued

--- a/.changesets/1789091270-fix-agent-pane-pageup-pagedown-in-composer-no-longer-scrolls-zn34.md
+++ b/.changesets/1789091270-fix-agent-pane-pageup-pagedown-in-composer-no-longer-scrolls-zn34.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(agent-pane): PageUp/PageDown in composer no longer scrolls the pane off screen

--- a/.changesets/1789092935-feat-mcp-ptyshell-attaches-to-the-pane-s-real-visible-shell--lxk0.md
+++ b/.changesets/1789092935-feat-mcp-ptyshell-attaches-to-the-pane-s-real-visible-shell--lxk0.md
@@ -1,5 +1,0 @@
----
-type: minor
----
-
-feat(mcp): PtyShell attaches to the pane's real visible shell, with a lease-based lock instead of destroying it on stop

--- a/.changesets/1789094219-fix-mcp-ptyshell-enforce-the-agent-lock-server-side-fix-stal-vda3.md
+++ b/.changesets/1789094219-fix-mcp-ptyshell-enforce-the-agent-lock-server-side-fix-stal-vda3.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(mcp): PtyShell — enforce the agent lock server-side, fix stale-handshake injection on reused shells, atomic first-create claim

--- a/.changesets/1789094899-fix-mcp-ptyshell-lock-the-shell-before-writing-not-after-per-4nqm.md
+++ b/.changesets/1789094899-fix-mcp-ptyshell-lock-the-shell-before-writing-not-after-per-4nqm.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(mcp): PtyShell — lock the shell before writing not after, persist the fallback block when the atomic claim's winner has vanished

--- a/.changesets/1789110842-fix-srv-correct-three-review-findings-in-the-catalog-redirec-oolw.md
+++ b/.changesets/1789110842-fix-srv-correct-three-review-findings-in-the-catalog-redirec-oolw.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(srv): correct three review findings in the catalog redirect (#3183)

--- a/.changesets/1789111084-fix-ci-add-concurrency-groups-to-ci-pr-yml-and-nightly-workf-ct4w.md
+++ b/.changesets/1789111084-fix-ci-add-concurrency-groups-to-ci-pr-yml-and-nightly-workf-ct4w.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ci): add concurrency groups to ci-pr.yml and nightly workflows — stop stale runs piling up on the shared runner pool

--- a/.changesets/1789113727-fix-armory-render-global-memory-s-provider-config-and-combin-15x6.md
+++ b/.changesets/1789113727-fix-armory-render-global-memory-s-provider-config-and-combin-15x6.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(armory): render Global Memory's provider-config and combined preview as markdown, make both resizable

--- a/.changesets/1789115609-fix-ci-cap-ci-pr-yml-s-required-job-at-20-minutes-9080.md
+++ b/.changesets/1789115609-fix-ci-cap-ci-pr-yml-s-required-job-at-20-minutes-9080.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(ci): cap ci-pr.yml's required job at 20 minutes

--- a/.changesets/1789119727-fix-mcp-ptyshell-create-s-spawn-failure-rollback-now-also-cl-mwng.md
+++ b/.changesets/1789119727-fix-mcp-ptyshell-create-s-spawn-failure-rollback-now-also-cl-mwng.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(mcp): PtyShell create's spawn-failure rollback now also clears the parent's stale shellsubblockid pointer

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.55.41"
+version = "0.55.42"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.55.41"
+version = "0.55.42"
 dependencies = [
  "agentmux-common",
  "ash",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.55.41"
+version = "0.55.42"
 dependencies = [
  "base64",
  "dirs 5.0.1",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.55.41"
+version = "0.55.42"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-mcp"
-version = "0.55.41"
+version = "0.55.42"
 dependencies = [
  "agentmux-common",
  "anyhow",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.55.41"
+version = "0.55.42"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # RFC #857 Phase 1.
 [workspace.package]
 
-version = "0.55.41"
+version = "0.55.42"
 
 [profile.release]
 strip = true

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -1,5 +1,29 @@
 # AgentMux Version History
 
+## 0.55.42 — 2026-09-11
+
+- feat(install-ui): auto-scroll install-log Details, provider-installer progress bar, and system-tool brand icons
+- fix(srv): seed starter skills/MCP servers with deterministic ids on fresh channels
+- chore(deps): bump vitest, @vitest/mocker and @vitest/coverage-istanbul (major)
+- feat(mcp): add PtyShell — a real PTY-backed interactive shell agents can drive without any UI
+- fix(cef-build): verify-angle-libs.sh no longer false-positives on a small-but-real libEGL.dll
+- feat(srv): identity store gains authoritative db_skills/db_mcp_servers tables (Phase 2a, no readers/writers yet)
+- feat(srv): carry each channel's skills/MCP servers into the identity store (Phase 2b)
+- feat(srv): redirect skill/MCP-server catalog reads and writes to the identity store
+- docs: tone down the early-alpha warning
+- docs: say 'alpha software', not 'early alpha'
+- fix(term): keep-alive terminal tabs no longer leak input/zoom into hidden dormant tabs
+- fix(mcp): SendMessage reports whether a message was delivered or only queued
+- fix(agent-pane): PageUp/PageDown in composer no longer scrolls the pane off screen
+- feat(mcp): PtyShell attaches to the pane's real visible shell, with a lease-based lock instead of destroying it on stop
+- fix(mcp): PtyShell — enforce the agent lock server-side, fix stale-handshake injection on reused shells, atomic first-create claim
+- fix(mcp): PtyShell — lock the shell before writing not after, persist the fallback block when the atomic claim's winner has vanished
+- fix(srv): correct three review findings in the catalog redirect (#3183)
+- fix(ci): add concurrency groups to ci-pr.yml and nightly workflows — stop stale runs piling up on the shared runner pool
+- fix(armory): render Global Memory's provider-config and combined preview as markdown, make both resizable
+- fix(ci): cap ci-pr.yml's required job at 20 minutes
+- fix(mcp): PtyShell create's spawn-failure rollback now also clears the parent's stale shellsubblockid pointer
+
 ## 0.55.41 — 2026-09-10
 
 - feat(zoom): Ctrl+Shift+Scroll zooms every pane in the window at once

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.55.41",
+  "version": "0.55.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.55.41",
+      "version": "0.55.42",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.55.41",
+  "version": "0.55.42",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Patch release, forced via \`--as patch\` per request (some queued changesets requested a minor bump — those ship under this patch version instead, per the override).

Consumes 21 pending changesets. All 5 version locations (VERSION_HISTORY.md, package.json, Cargo.toml, Cargo.lock, package-lock.json) agree at 0.55.42, verified by \`scripts/release.sh\`'s own post-bump check.

## Changelog

- feat(install-ui): auto-scroll install-log Details, provider-installer progress bar, and system-tool brand icons
- fix(srv): seed starter skills/MCP servers with deterministic ids on fresh channels
- chore(deps): bump vitest, @vitest/mocker and @vitest/coverage-istanbul (major)
- feat(mcp): add PtyShell — a real PTY-backed interactive shell agents can drive without any UI
- fix(cef-build): verify-angle-libs.sh no longer false-positives on a small-but-real libEGL.dll
- feat(srv): identity store gains authoritative db_skills/db_mcp_servers tables (Phase 2a, no readers/writers yet)
- feat(srv): carry each channel's skills/MCP servers into the identity store (Phase 2b)
- feat(srv): redirect skill/MCP-server catalog reads and writes to the identity store
- docs: tone down the early-alpha warning
- docs: say 'alpha software', not 'early alpha'
- fix(term): keep-alive terminal tabs no longer leak input/zoom into hidden dormant tabs
- fix(mcp): SendMessage reports whether a message was delivered or only queued
- fix(agent-pane): PageUp/PageDown in composer no longer scrolls the pane off screen
- feat(mcp): PtyShell attaches to the pane's real visible shell, with a lease-based lock instead of destroying it on stop
- fix(mcp): PtyShell — enforce the agent lock server-side, fix stale-handshake injection on reused shells, atomic first-create claim
- fix(mcp): PtyShell — lock the shell before writing not after, persist the fallback block when the atomic claim's winner has vanished
- fix(srv): correct three review findings in the catalog redirect (#3183)
- fix(ci): add concurrency groups to ci-pr.yml and nightly workflows — stop stale runs piling up on the shared runner pool
- fix(armory): render Global Memory's provider-config and combined preview as markdown, make both resizable
- fix(ci): cap ci-pr.yml's required job at 20 minutes
- fix(mcp): PtyShell create's spawn-failure rollback now also clears the parent's stale shellsubblockid pointer

<!-- agentmux:agent_id=agenta -->