### PR TITLE
perf(srv): coalesce PTY output before broadcasting — cuts renderer/GPU CPU during active agent output

### DIFF
--- a/.changesets/1789141357-perf-srv-coalesce-pty-output-before-broadcasting-cuts-render-oiuk.md
+++ b/.changesets/1789141357-perf-srv-coalesce-pty-output-before-broadcasting-cuts-render-oiuk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+perf(srv): coalesce PTY output before broadcasting — cuts renderer/GPU CPU during active agent output

--- a/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
@@ -26,7 +26,8 @@ use super::controller::KILL_GRACE_SECS;
 use super::controller::{ShellController, SHELL_INPUT_CH_SIZE};
 use super::file_ops::handle_append_block_file;
 use super::pty::{
-    detect_local_shell_path_windows, PTY_COALESCE_MAX_BYTES, PTY_COALESCE_WINDOW, PTY_READ_BUF_SIZE,
+    detect_local_shell_path_windows, PTY_CHANNEL_CAPACITY, PTY_COALESCE_MAX_BYTES,
+    PTY_COALESCE_WINDOW, PTY_READ_BUF_SIZE,
 };
 use super::translation::accumulate_and_translate;
 use crate::backend::obj::{self, MetaMapType};
@@ -94,7 +95,7 @@ fn flush_pty_batch(
 /// it can be driven directly in a test with a synthetic channel and no real
 /// PTY — see `pty_output_flusher_tests` below.
 async fn run_pty_output_flusher(
-    mut rx: mpsc::UnboundedReceiver<PtyReadChunk>,
+    mut rx: mpsc::Receiver<PtyReadChunk>,
     broker: Option<Arc<wps::Broker>>,
     block_id: String,
     filestore: Option<Arc<crate::backend::storage::filestore::FileStore>>,
@@ -154,15 +155,33 @@ async fn run_pty_output_flusher(
             }
         };
 
-        flush_pty_batch(
-            &broker,
-            &block_id,
-            &batch,
-            &batch_osc,
-            filestore.as_ref(),
-            &mut line_buf,
-            translator.as_mut(),
-        );
+        // block_in_place, not a bare call (reagentx P1 on PR #3206):
+        // flush_pty_batch does blocking SQLite I/O (FileStore::stat /
+        // append_data_at) and takes std::sync::Mutex locks. Calling it
+        // directly here would run that on a Tokio async worker thread —
+        // this closure is inside a plain `tokio::spawn`, not
+        // `spawn_blocking` — and with several panes streaming output at
+        // once (exactly the scenario this whole fix targets), slow disk or
+        // lock contention could occupy every worker and delay WebSocket,
+        // input, and RPC tasks that have nothing to do with this pane.
+        // `block_in_place` runs the closure on this thread while telling
+        // the runtime to spin up a replacement worker if needed, so other
+        // tasks aren't starved — and unlike `spawn_blocking`, it needs no
+        // 'static/Send ownership transfer, so `&mut line_buf` and
+        // `translator.as_mut()` can stay borrowed exactly as they already
+        // are. Requires a multi-thread runtime; `agentmux-srv`'s
+        // `#[tokio::main]` (main.rs) is one by default.
+        tokio::task::block_in_place(|| {
+            flush_pty_batch(
+                &broker,
+                &block_id,
+                &batch,
+                &batch_osc,
+                filestore.as_ref(),
+                &mut line_buf,
+                translator.as_mut(),
+            );
+        });
 
         if closed_mid_batch {
             break;
@@ -798,7 +817,11 @@ impl Controller for ShellController {
         let filestore_flush = self.filestore.clone();
         let is_agent_read = is_agent;
         let is_agent_flush = is_agent;
-        let (pty_tx, mut pty_rx) = mpsc::unbounded_channel::<PtyReadChunk>();
+        // Bounded (reagentx P1 on PR #3206) — see PTY_CHANNEL_CAPACITY's own
+        // doc comment for why: an unbounded channel here would let a
+        // sustained fast producer grow queued memory without limit if the
+        // flusher ever falls behind the read rate.
+        let (pty_tx, pty_rx) = mpsc::channel::<PtyReadChunk>(PTY_CHANNEL_CAPACITY);
 
         tokio::task::spawn_blocking(move || {
             let mut reader = reader;
@@ -845,12 +868,20 @@ impl Controller for ShellController {
                                 raw
                             };
 
-                            // Best-effort: if the flusher task is gone
-                            // (block torn down mid-read), there is nothing
-                            // useful to do with this chunk — the PTY read
-                            // loop itself must keep draining so the child
-                            // process's stdout never backs up.
-                            let _ = pty_tx.send(PtyReadChunk {
+                            // `blocking_send`, not `send` — this closure runs
+                            // on a `spawn_blocking` thread, not async, and a
+                            // bounded channel's plain `send` is itself async.
+                            // Blocks THIS (already-dedicated-to-blocking)
+                            // thread once the channel is full, which is
+                            // exactly the backpressure PTY_CHANNEL_CAPACITY's
+                            // doc comment describes — never the async runtime.
+                            //
+                            // Best-effort beyond that: if the flusher task is
+                            // gone (block torn down mid-read), there is
+                            // nothing useful to do with this chunk — the PTY
+                            // read loop itself must keep draining so the
+                            // child process's stdout never backs up.
+                            let _ = pty_tx.blocking_send(PtyReadChunk {
                                 data: chunk.to_vec(),
                                 osc_events,
                             });
@@ -1414,7 +1445,7 @@ mod controller_agent_id_tests {
 
 #[cfg(test)]
 mod pty_output_flusher_tests {
-    use super::{flush_pty_batch, run_pty_output_flusher, PtyReadChunk};
+    use super::{flush_pty_batch, run_pty_output_flusher, PtyReadChunk, PTY_CHANNEL_CAPACITY};
     use crate::backend::storage::filestore::FileStore;
     use crate::backend::wps;
     use std::sync::{Arc, Mutex};
@@ -1509,11 +1540,19 @@ mod pty_output_flusher_tests {
     /// actually waiting out any real wall-clock delay — this isn't racing
     /// the 20ms window, it's exercising the "channel closed mid-accumulation"
     /// exit path (see `run_pty_output_flusher`'s `closed_mid_batch`).
-    #[tokio::test]
+    // multi_thread: run_pty_output_flusher uses block_in_place around
+    // flush_pty_batch (reagentx P1 on PR #3206), which panics on the
+    // default current-thread test runtime — matches the real app, whose
+    // #[tokio::main] (main.rs) is multi-thread by default.
+    #[tokio::test(flavor = "multi_thread")]
     async fn rapid_chunks_coalesce_into_far_fewer_broadcasts_with_no_data_loss() {
         let (broker, events) = broker_recording_block_file_events();
         let fs = Arc::new(FileStore::open_in_memory().expect("open in-memory filestore"));
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        // Bounded, matching production (PTY_CHANNEL_CAPACITY) — comfortably
+        // above the 50 messages below, so every send below still completes
+        // without actually waiting for capacity; the determinism this test's
+        // own doc comment relies on is unaffected by the channel being bounded.
+        let (tx, rx) = tokio::sync::mpsc::channel(PTY_CHANNEL_CAPACITY);
 
         let mut expected = Vec::new();
         for i in 0..50 {
@@ -1523,6 +1562,7 @@ mod pty_output_flusher_tests {
                 data: piece.into_bytes(),
                 osc_events: Vec::new(),
             })
+            .await
             .unwrap();
         }
         drop(tx); // closes the channel once these 50 are drained
@@ -1562,11 +1602,14 @@ mod pty_output_flusher_tests {
     /// faster than the coalescing window would otherwise close — otherwise
     /// a sustained fast producer (`yes` piped into a shell pane) could grow
     /// one "batch" unboundedly.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn byte_cap_forces_a_flush_before_the_channel_closes() {
         let (broker, events) = broker_recording_block_file_events();
         let fs = Arc::new(FileStore::open_in_memory().expect("open in-memory filestore"));
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        // Bounded, matching production — 80 messages below is comfortably
+        // under PTY_CHANNEL_CAPACITY, so this test still exercises the byte
+        // cap (not channel backpressure) as the thing forcing the split.
+        let (tx, rx) = tokio::sync::mpsc::channel(PTY_CHANNEL_CAPACITY);
 
         // Comfortably over PTY_COALESCE_MAX_BYTES (64 * 4096 = 256KiB) in
         // total, sent as many small chunks so the cap — not the channel
@@ -1579,6 +1622,7 @@ mod pty_output_flusher_tests {
                 data: piece.clone(),
                 osc_events: Vec::new(),
             })
+            .await
             .unwrap();
         }
         drop(tx);
@@ -1597,11 +1641,60 @@ mod pty_output_flusher_tests {
         );
     }
 
+    /// The actual property reagentx's P1 asked for: a full channel makes
+    /// `blocking_send` — what the real PTY read loop calls, from a real
+    /// blocking (`spawn_blocking`) thread, not an async one — block until
+    /// the receiver drains it, rather than growing queued memory without
+    /// limit. A tiny capacity (not `PTY_CHANNEL_CAPACITY`) so the test is
+    /// fast and the blocking is unambiguous with only 2 messages.
+    #[test]
+    fn blocking_send_backpressures_once_the_channel_is_full() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<PtyReadChunk>(1);
+
+        // Fills the one slot; must return immediately (room available).
+        tx.blocking_send(PtyReadChunk { data: vec![1], osc_events: Vec::new() })
+            .expect("first send has room");
+
+        // A real background thread — mirrors the production shape exactly:
+        // blocking_send is called from a spawn_blocking thread, never from
+        // an async task.
+        let sent_second = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let sent_second_writer = sent_second.clone();
+        let handle = std::thread::spawn(move || {
+            tx.blocking_send(PtyReadChunk { data: vec![2], osc_events: Vec::new() })
+                .expect("second send eventually succeeds once drained");
+            sent_second_writer.store(true, std::sync::atomic::Ordering::SeqCst);
+        });
+
+        // The channel is full and nobody has drained it yet — the second
+        // send must still be blocked. A short, generous sleep rather than
+        // asserting instantaneously: proving a negative ("hasn't returned
+        // yet") is inherently a bit timing-sensitive, but 50ms is enormous
+        // next to what an unblocked send would take (microseconds), so a
+        // false pass here would need a wildly unlikely scheduling delay.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        assert!(
+            !sent_second.load(std::sync::atomic::Ordering::SeqCst),
+            "second blocking_send must still be blocked while the channel is full"
+        );
+
+        // Drain the one queued message — this is the "flusher catches up"
+        // moment in production. The blocked send must now complete.
+        let first = rx.try_recv().expect("first message still queued");
+        assert_eq!(first.data, vec![1]);
+
+        handle.join().expect("background thread should complete once drained");
+        assert!(sent_second.load(std::sync::atomic::Ordering::SeqCst));
+
+        let second = rx.try_recv().expect("second message now queued");
+        assert_eq!(second.data, vec![2]);
+    }
+
     #[tokio::test]
     async fn no_broker_is_a_clean_no_op() {
         // Mirrors the read loop's own `broker_read.is_some()` gate — the
         // flusher must not panic or hang when there is nothing to flush to.
-        let (_tx, rx) = tokio::sync::mpsc::unbounded_channel::<PtyReadChunk>();
+        let (_tx, rx) = tokio::sync::mpsc::channel::<PtyReadChunk>(PTY_CHANNEL_CAPACITY);
         run_pty_output_flusher(rx, None, "block-1".to_string(), None, false).await;
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
@@ -155,33 +155,51 @@ async fn run_pty_output_flusher(
             }
         };
 
-        // block_in_place, not a bare call (reagentx P1 on PR #3206):
-        // flush_pty_batch does blocking SQLite I/O (FileStore::stat /
-        // append_data_at) and takes std::sync::Mutex locks. Calling it
-        // directly here would run that on a Tokio async worker thread —
-        // this closure is inside a plain `tokio::spawn`, not
-        // `spawn_blocking` — and with several panes streaming output at
-        // once (exactly the scenario this whole fix targets), slow disk or
-        // lock contention could occupy every worker and delay WebSocket,
-        // input, and RPC tasks that have nothing to do with this pane.
-        // `block_in_place` runs the closure on this thread while telling
-        // the runtime to spin up a replacement worker if needed, so other
-        // tasks aren't starved — and unlike `spawn_blocking`, it needs no
-        // 'static/Send ownership transfer, so `&mut line_buf` and
-        // `translator.as_mut()` can stay borrowed exactly as they already
-        // are. Requires a multi-thread runtime; `agentmux-srv`'s
-        // `#[tokio::main]` (main.rs) is one by default.
-        tokio::task::block_in_place(|| {
+        // spawn_blocking, not block_in_place (reagentx P2 on PR #3206,
+        // correcting the round before it): flush_pty_batch does blocking
+        // SQLite I/O and takes std::sync::Mutex locks, so it must not run
+        // on a Tokio async worker directly — this closure is inside a
+        // plain `tokio::spawn`, not `spawn_blocking`. The first fix for
+        // that reached for `block_in_place` specifically to avoid moving
+        // `&mut line_buf`/`translator.as_mut()` across a 'static+Send
+        // boundary — but `block_in_place` gets its own replacement worker
+        // via THE SAME shared `spawn_blocking` pool internally (verified
+        // directly against the vendored tokio 1.52.3 source,
+        // `runtime/scheduler/multi_thread/worker.rs`'s `block_in_place`:
+        // `runtime::spawn_blocking(move || run(worker))`), so per flush it
+        // draws on that shared pool TWICE — once for the replacement
+        // worker, once implicitly for the original thread's own blocking
+        // — for work `spawn_blocking` alone would cover with one. Tokio's
+        // own docs single out `block_in_place`'s one real advantage
+        // (protecting OTHER concurrent work in the SAME task, e.g. across
+        // a `join!`) as the reason to prefer it over `spawn_blocking` —
+        // this task does nothing else concurrently, so that advantage
+        // never applies here, and `spawn_blocking` is strictly the better
+        // fit. The ownership problem is solved properly instead: `batch`/
+        // `batch_osc` are freshly built each iteration (cheap to move),
+        // and `line_buf`/`translator` — the only state the flush actually
+        // MUTATES — are moved into the closure and handed back out via the
+        // `JoinHandle`'s return value, rather than trying to keep them
+        // borrowed across the call.
+        let broker_owned = broker.clone();
+        let block_id_owned = block_id.clone();
+        let filestore_owned = filestore.clone();
+        let (new_line_buf, new_translator) = tokio::task::spawn_blocking(move || {
             flush_pty_batch(
-                &broker,
-                &block_id,
+                &broker_owned,
+                &block_id_owned,
                 &batch,
                 &batch_osc,
-                filestore.as_ref(),
+                filestore_owned.as_ref(),
                 &mut line_buf,
                 translator.as_mut(),
             );
-        });
+            (line_buf, translator)
+        })
+        .await
+        .expect("PTY output flush task panicked");
+        line_buf = new_line_buf;
+        translator = new_translator;
 
         if closed_mid_batch {
             break;
@@ -1540,11 +1558,7 @@ mod pty_output_flusher_tests {
     /// actually waiting out any real wall-clock delay — this isn't racing
     /// the 20ms window, it's exercising the "channel closed mid-accumulation"
     /// exit path (see `run_pty_output_flusher`'s `closed_mid_batch`).
-    // multi_thread: run_pty_output_flusher uses block_in_place around
-    // flush_pty_batch (reagentx P1 on PR #3206), which panics on the
-    // default current-thread test runtime — matches the real app, whose
-    // #[tokio::main] (main.rs) is multi-thread by default.
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn rapid_chunks_coalesce_into_far_fewer_broadcasts_with_no_data_loss() {
         let (broker, events) = broker_recording_block_file_events();
         let fs = Arc::new(FileStore::open_in_memory().expect("open in-memory filestore"));
@@ -1602,7 +1616,7 @@ mod pty_output_flusher_tests {
     /// faster than the coalescing window would otherwise close — otherwise
     /// a sustained fast producer (`yes` piped into a shell pane) could grow
     /// one "batch" unboundedly.
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test]
     async fn byte_cap_forces_a_flush_before_the_channel_closes() {
         let (broker, events) = broker_recording_block_file_events();
         let fs = Arc::new(FileStore::open_in_memory().expect("open in-memory filestore"));

--- a/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs
@@ -25,11 +25,150 @@ use super::super::{
 use super::controller::KILL_GRACE_SECS;
 use super::controller::{ShellController, SHELL_INPUT_CH_SIZE};
 use super::file_ops::handle_append_block_file;
-use super::pty::{detect_local_shell_path_windows, PTY_READ_BUF_SIZE};
+use super::pty::{
+    detect_local_shell_path_windows, PTY_COALESCE_MAX_BYTES, PTY_COALESCE_WINDOW, PTY_READ_BUF_SIZE,
+};
 use super::translation::accumulate_and_translate;
 use crate::backend::obj::{self, MetaMapType};
 use crate::backend::shellexec::ShellProc;
 use crate::backend::wps;
+
+/// One PTY read's worth of already-OSC-cleaned output, on its way from the
+/// blocking read loop to the coalescing flusher (`start()`, below). See
+/// docs/reports/REPORT_RENDERER_CPU_UNBATCHED_PTY_OUTPUT_2026_09_11.md.
+struct PtyReadChunk {
+    data: Vec<u8>,
+    osc_events: Vec<crate::backend::osc_extractor::OscEvent>,
+}
+
+/// Do the actual per-batch work the read loop used to do per-read: write
+/// through to the FileStore, broadcast the raw bytes, publish any OSC
+/// activity, and (for agent panes) feed the JSON-stream translator. Called
+/// once per coalesced batch instead of once per (up to 4KB) PTY read.
+#[allow(clippy::too_many_arguments)]
+fn flush_pty_batch(
+    broker: &wps::Broker,
+    block_id: &str,
+    data: &[u8],
+    osc_events: &[crate::backend::osc_extractor::OscEvent],
+    filestore: Option<&Arc<crate::backend::storage::filestore::FileStore>>,
+    line_buf: &mut Vec<u8>,
+    translator: Option<&mut crate::agents::translator::claude::ClaudeTranslator>,
+) {
+    if data.is_empty() && osc_events.is_empty() {
+        return;
+    }
+
+    handle_append_block_file(
+        broker,
+        block_id,
+        "term",
+        data,
+        // Write-through so scrollback survives a reconnect
+        // (SPEC_TERMINAL_SCROLLBACK_PERSISTENCE_2026_07_23.md
+        // §2.1) — was `None` (raw PTY bytes discarded after
+        // the live broadcast), which meant every `view:"term"`
+        // pane (standalone Terminal panes and the agent-shell
+        // drawer alike) lost all output on remount.
+        filestore,
+        None, // not an agent output stream; no global mirror
+    );
+
+    for ev in osc_events {
+        wps::publish_block_activity(broker, block_id, &ev.payload);
+    }
+
+    if let Some(t) = translator {
+        accumulate_and_translate(broker, block_id, line_buf, data, t);
+    }
+}
+
+/// Drain `rx`, coalescing chunks into batches — waiting up to
+/// `PTY_COALESCE_WINDOW` after the first chunk of a new batch for more to
+/// arrive, or until `PTY_COALESCE_MAX_BYTES`, whichever comes first — and
+/// flushing each batch through [`flush_pty_batch`]. Runs until `rx` closes
+/// (the PTY read loop's sender dropped, i.e. the PTY hit EOF or an error),
+/// flushing any final partial batch before returning.
+///
+/// A standalone fn rather than inlined into its `tokio::spawn` call site so
+/// it can be driven directly in a test with a synthetic channel and no real
+/// PTY — see `pty_output_flusher_tests` below.
+async fn run_pty_output_flusher(
+    mut rx: mpsc::UnboundedReceiver<PtyReadChunk>,
+    broker: Option<Arc<wps::Broker>>,
+    block_id: String,
+    filestore: Option<Arc<crate::backend::storage::filestore::FileStore>>,
+    is_agent: bool,
+) {
+    let Some(broker) = broker else {
+        // No broker means the read loop's sender never had anything worth
+        // sending (see its own `broker_read.is_some()` gate) — nothing to
+        // drain or flush.
+        return;
+    };
+    // Phase 1.5 PR 1 (additive): if this is an agent pane, also try to
+    // interpret stdout as Claude Code stream-json line-by-line, feeding
+    // successful parses through ClaudeTranslator and emitting AgentEvents
+    // on a new WPS scope `agent_event:<block_id>`. The existing raw-chunk
+    // path stays byte-equal — interactive panes (which don't emit JSON) see
+    // no behavior change because every line fails the JSON parse and is
+    // silently dropped. The future stream-json-mode pane and the drone
+    // inspector (issue #830 / Phase 1.5 PR 3) will be the first real
+    // consumers.
+    let mut translator: Option<crate::agents::translator::claude::ClaudeTranslator> = if is_agent
+    {
+        Some(crate::agents::translator::claude::ClaudeTranslator::new())
+    } else {
+        None
+    };
+    // Per-block line-buffer (raw bytes — see `extract_agent_events`). Capped
+    // to AGENT_LINE_BUFFER_CAP so a producer that never emits a newline
+    // can't grow the buffer unboundedly.
+    let mut line_buf: Vec<u8> = Vec::new();
+
+    loop {
+        let Some(first) = rx.recv().await else {
+            break; // channel closed, nothing pending
+        };
+        let mut batch = first.data;
+        let mut batch_osc = first.osc_events;
+        let deadline = tokio::time::Instant::now() + PTY_COALESCE_WINDOW;
+
+        // Opportunistically drain more already-queued (or about-to-arrive)
+        // chunks into the same batch, bounded by whichever limit hits first.
+        let closed_mid_batch = loop {
+            if batch.len() >= PTY_COALESCE_MAX_BYTES {
+                break false;
+            }
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                break false;
+            }
+            match tokio::time::timeout(remaining, rx.recv()).await {
+                Ok(Some(next)) => {
+                    batch.extend_from_slice(&next.data);
+                    batch_osc.extend(next.osc_events);
+                }
+                Ok(None) => break true, // channel closed mid-accumulation
+                Err(_elapsed) => break false, // coalescing window elapsed
+            }
+        };
+
+        flush_pty_batch(
+            &broker,
+            &block_id,
+            &batch,
+            &batch_osc,
+            filestore.as_ref(),
+            &mut line_buf,
+            translator.as_mut(),
+        );
+
+        if closed_mid_batch {
+            break;
+        }
+    }
+}
 
 /// Resolve the effective AGENTMUX_AGENT_ID for jekt auto-registration from a
 /// block's own spawn metadata — both the canonical key and the legacy
@@ -643,44 +782,38 @@ impl Controller for ShellController {
             format!("failed to take PTY writer: {e}")
         })?;
 
-        // Spawn PTY read task (blocking I/O → spawn_blocking)
+        // Spawn PTY read task (blocking I/O → spawn_blocking) + a companion
+        // coalescing flusher (async task). Split in two, connected by an
+        // mpsc channel, so the actual OS-level `read()` loop's blocking
+        // semantics are untouched (this file supports both Unix and
+        // Windows PTYs and that boundary is not something to risk getting
+        // subtly wrong per-platform) while the expensive per-chunk work —
+        // file write, WebSocket broadcast, OSC/translation — is batched.
+        // See docs/reports/REPORT_RENDERER_CPU_UNBATCHED_PTY_OUTPUT_2026_09_11.md.
         let block_id_read = self.block_id.clone();
+        let block_id_flush = self.block_id.clone();
         let broker_read = self.broker.clone();
+        let broker_flush = self.broker.clone();
         let inner_read = self.inner.clone();
-        let filestore_read = self.filestore.clone();
+        let filestore_flush = self.filestore.clone();
         let is_agent_read = is_agent;
+        let is_agent_flush = is_agent;
+        let (pty_tx, mut pty_rx) = mpsc::unbounded_channel::<PtyReadChunk>();
+
         tokio::task::spawn_blocking(move || {
             let mut reader = reader;
             let mut buf = [0u8; PTY_READ_BUF_SIZE];
-
-            // Phase 1.5 PR 1 (additive): if this is an agent pane,
-            // also try to interpret stdout as Claude Code stream-json
-            // line-by-line, feeding successful parses through
-            // ClaudeTranslator and emitting AgentEvents on a new WPS
-            // scope `agent_event:<block_id>`. The existing raw-chunk
-            // path stays byte-equal — interactive panes (which don't
-            // emit JSON) see no behavior change because every line
-            // fails the JSON parse and is silently dropped. The
-            // future stream-json-mode pane and the drone inspector
-            // (issue #830 / Phase 1.5 PR 3) will be the first real
-            // consumers.
-            let mut translator: Option<crate::agents::translator::claude::ClaudeTranslator> =
-                if is_agent_read {
-                    Some(crate::agents::translator::claude::ClaudeTranslator::new())
-                } else {
-                    None
-                };
-            // Per-block line-buffer (raw bytes — see
-            // `extract_agent_events`). Capped to AGENT_LINE_BUFFER_CAP
-            // so a producer that never emits a newline can't grow
-            // the buffer unboundedly.
-            let mut line_buf: Vec<u8> = Vec::new();
 
             // OSC extractor: only for agent panes. Terminal panes forward
             // raw bytes to xterm.js which handles OSC natively — stripping
             // there would suppress the native window-title update. Agent
             // panes don't use xterm.js; OSC bytes in FileStore corrupt the
-            // document renderer, so we extract and strip them here.
+            // document renderer, so we extract and strip them here. Kept
+            // in THIS (per-read) loop rather than the flusher: it is
+            // cheap, and its own internal state must see every read in
+            // order exactly as they arrive — moving it to the batched side
+            // would change nothing about correctness but would mean
+            // holding it across an .await, so it stays here for simplicity.
             let mut osc_extractor: Option<crate::backend::osc_extractor::OscExtractor> =
                 if is_agent_read {
                     Some(crate::backend::osc_extractor::OscExtractor::new())
@@ -693,7 +826,7 @@ impl Controller for ShellController {
                     Ok(0) => break, // EOF
                     Ok(n) => {
                         inner_read.lock().unwrap().last_pty_output = Some(Instant::now());
-                        if let Some(ref broker) = broker_read {
+                        if broker_read.is_some() {
                             let raw = &buf[..n];
 
                             // Extract OSC sequences from agent-pane output.
@@ -712,34 +845,15 @@ impl Controller for ShellController {
                                 raw
                             };
 
-                            handle_append_block_file(
-                                broker,
-                                &block_id_read,
-                                "term",
-                                chunk,
-                                // Write-through so scrollback survives a reconnect
-                                // (SPEC_TERMINAL_SCROLLBACK_PERSISTENCE_2026_07_23.md
-                                // §2.1) — was `None` (raw PTY bytes discarded after
-                                // the live broadcast), which meant every `view:"term"`
-                                // pane (standalone Terminal panes and the agent-shell
-                                // drawer alike) lost all output on remount.
-                                filestore_read.as_ref(),
-                                None, // not an agent output stream; no global mirror
-                            );
-
-                            for ev in &osc_events {
-                                wps::publish_block_activity(broker, &block_id_read, &ev.payload);
-                            }
-
-                            if let Some(ref mut t) = translator {
-                                accumulate_and_translate(
-                                    broker,
-                                    &block_id_read,
-                                    &mut line_buf,
-                                    chunk,
-                                    t,
-                                );
-                            }
+                            // Best-effort: if the flusher task is gone
+                            // (block torn down mid-read), there is nothing
+                            // useful to do with this chunk — the PTY read
+                            // loop itself must keep draining so the child
+                            // process's stdout never backs up.
+                            let _ = pty_tx.send(PtyReadChunk {
+                                data: chunk.to_vec(),
+                                osc_events,
+                            });
                         }
                     }
                     Err(e) => {
@@ -748,7 +862,25 @@ impl Controller for ShellController {
                     }
                 }
             }
+            // `pty_tx` drops here, closing the channel — the flusher below
+            // sees `recv()` return `None` once it has drained everything
+            // already sent, flushes any final partial batch, and exits.
         });
+
+        // Coalescing flusher: batches chunks the read loop above sends,
+        // waiting up to PTY_COALESCE_WINDOW for more to arrive (or until
+        // PTY_COALESCE_MAX_BYTES, whichever comes first) before doing the
+        // actual file write + broadcast + translation — once per batch
+        // instead of once per (up to 4KB) PTY read. A standalone fn (not
+        // inlined into the spawn) so it can be driven directly in tests
+        // with a synthetic channel, no real PTY required.
+        tokio::spawn(run_pty_output_flusher(
+            pty_rx,
+            broker_flush,
+            block_id_flush,
+            filestore_flush,
+            is_agent_flush,
+        ));
 
         // Spawn input task (routes input channel → PTY writer + resize + signals)
         // Owns writer and master — dropping them closes the PTY, causing child to exit.
@@ -1277,5 +1409,199 @@ mod controller_agent_id_tests {
 
         ctrl.set_agent_id(None);
         assert_eq!(ctrl.agent_id(), None);
+    }
+}
+
+#[cfg(test)]
+mod pty_output_flusher_tests {
+    use super::{flush_pty_batch, run_pty_output_flusher, PtyReadChunk};
+    use crate::backend::storage::filestore::FileStore;
+    use crate::backend::wps;
+    use std::sync::{Arc, Mutex};
+
+    /// Records every event delivered to it — lets a test count broadcasts
+    /// rather than only inspect final file content, which is what actually
+    /// distinguishes "coalesced into one broadcast" from "one broadcast per
+    /// PTY read" (both produce identical final content; only the broadcast
+    /// COUNT tells them apart). Holds an `Arc` (not an owned `Vec`) because
+    /// `Broker::set_client` takes ownership of the client, so the test needs
+    /// its own handle to read events back out afterward.
+    struct RecordingClient {
+        events: Arc<Mutex<Vec<wps::WaveEvent>>>,
+    }
+
+    impl wps::WpsClient for RecordingClient {
+        fn send_event(&self, _route_id: &str, event: wps::WaveEvent) {
+            self.events.lock().unwrap().push(event);
+        }
+    }
+
+    /// A broker wired to a `RecordingClient`, subscribed (all-scopes, so
+    /// this doesn't need to know the exact `block:<id>` scope string) to
+    /// `EVENT_BLOCK_FILE` — the event `handle_append_block_file` publishes.
+    fn broker_recording_block_file_events() -> (wps::Broker, Arc<Mutex<Vec<wps::WaveEvent>>>) {
+        let broker = wps::Broker::new();
+        let events = Arc::new(Mutex::new(Vec::new()));
+        broker.set_client(Box::new(RecordingClient {
+            events: events.clone(),
+        }));
+        broker.subscribe(
+            "test-route",
+            wps::SubscriptionRequest {
+                event: wps::EVENT_BLOCK_FILE.to_string(),
+                scopes: vec![],
+                allscopes: true,
+            },
+        );
+        (broker, events)
+    }
+
+    /// Decode the base64 `data64` payload of a `term`-file `EVENT_BLOCK_FILE`
+    /// broadcast back to raw bytes, for asserting on content.
+    fn decode_event_data(event: &wps::WaveEvent) -> Vec<u8> {
+        use base64::Engine;
+        let data: wps::WSFileEventData =
+            serde_json::from_value(event.data.clone().expect("event has data")).expect("valid WSFileEventData");
+        base64::engine::general_purpose::STANDARD
+            .decode(&data.data64)
+            .expect("valid base64")
+    }
+
+    #[test]
+    fn flush_pty_batch_writes_and_broadcasts_one_call() {
+        let (broker, events) = broker_recording_block_file_events();
+        let fs = Arc::new(FileStore::open_in_memory().expect("open in-memory filestore"));
+        let mut line_buf = Vec::new();
+
+        flush_pty_batch(&broker, "block-1", b"hello world", &[], Some(&fs), &mut line_buf, None);
+
+        let data = fs
+            .read_file("block-1", "term")
+            .expect("read_file ok")
+            .expect("data present");
+        assert_eq!(data, b"hello world");
+
+        let evs = events.lock().unwrap();
+        assert_eq!(evs.len(), 1, "one flush call must produce exactly one broadcast");
+        assert_eq!(decode_event_data(&evs[0]), b"hello world");
+    }
+
+    #[test]
+    fn flush_pty_batch_is_a_no_op_for_empty_input() {
+        // Guards against a spurious empty broadcast on a batch that ended
+        // up with nothing in it (shouldn't happen given how the flusher
+        // calls this, but a no-op guard here is cheap and cheaper than
+        // debugging a phantom empty append if that assumption ever breaks).
+        let (broker, events) = broker_recording_block_file_events();
+        let mut line_buf = Vec::new();
+        flush_pty_batch(&broker, "block-1", b"", &[], None, &mut line_buf, None);
+        assert!(events.lock().unwrap().is_empty());
+    }
+
+    /// The actual property this whole change exists to deliver: N chunks
+    /// that arrive back-to-back (well inside the coalescing window and the
+    /// byte cap) collapse into far fewer broadcasts than N — ideally one —
+    /// with no data lost, duplicated, or reordered.
+    ///
+    /// Deterministic, not timing-dependent: every chunk is sent to the
+    /// channel BEFORE the flusher is ever polled, so its first "opportunistic
+    /// drain" pass finds them all already queued and drains them without
+    /// actually waiting out any real wall-clock delay — this isn't racing
+    /// the 20ms window, it's exercising the "channel closed mid-accumulation"
+    /// exit path (see `run_pty_output_flusher`'s `closed_mid_batch`).
+    #[tokio::test]
+    async fn rapid_chunks_coalesce_into_far_fewer_broadcasts_with_no_data_loss() {
+        let (broker, events) = broker_recording_block_file_events();
+        let fs = Arc::new(FileStore::open_in_memory().expect("open in-memory filestore"));
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let mut expected = Vec::new();
+        for i in 0..50 {
+            let piece = format!("line {i}\n");
+            expected.extend_from_slice(piece.as_bytes());
+            tx.send(PtyReadChunk {
+                data: piece.into_bytes(),
+                osc_events: Vec::new(),
+            })
+            .unwrap();
+        }
+        drop(tx); // closes the channel once these 50 are drained
+
+        run_pty_output_flusher(rx, Some(Arc::new(broker)), "block-1".to_string(), Some(fs.clone()), false)
+            .await;
+
+        let data = fs.read_file("block-1", "term").expect("read_file ok").expect("data present");
+        assert_eq!(data, expected, "coalescing must not lose, duplicate, or reorder bytes");
+
+        // Deterministic exact count, not a loose bound: every chunk was
+        // already queued before the flusher was ever polled (see the test's
+        // own doc comment), so its very first opportunistic-drain pass finds
+        // all 50 sitting in the channel and drains them without actually
+        // waiting out any real time — one batch, one broadcast. Verified
+        // stable across repeated local runs before asserting on it exactly;
+        // a looser "< 50" bound would also pass on a much weaker result
+        // (say, 40 broadcasts) that wouldn't actually demonstrate the fix.
+        let broadcast_count = events.lock().unwrap().len();
+        assert_eq!(
+            broadcast_count, 1,
+            "50 chunks queued before the flusher ever polled should collapse into \
+             exactly one broadcast; got {broadcast_count}"
+        );
+        // Concatenating every broadcast's own payload, in delivery order,
+        // must also reconstruct the exact original stream — proves the
+        // coalescing boundaries themselves never split/reordered content
+        // even if more than one broadcast happened.
+        let mut reconstructed = Vec::new();
+        for ev in events.lock().unwrap().iter() {
+            reconstructed.extend(decode_event_data(ev));
+        }
+        assert_eq!(reconstructed, expected);
+    }
+
+    /// The byte cap must still force a flush even if chunks keep arriving
+    /// faster than the coalescing window would otherwise close — otherwise
+    /// a sustained fast producer (`yes` piped into a shell pane) could grow
+    /// one "batch" unboundedly.
+    #[tokio::test]
+    async fn byte_cap_forces_a_flush_before_the_channel_closes() {
+        let (broker, events) = broker_recording_block_file_events();
+        let fs = Arc::new(FileStore::open_in_memory().expect("open in-memory filestore"));
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+
+        // Comfortably over PTY_COALESCE_MAX_BYTES (64 * 4096 = 256KiB) in
+        // total, sent as many small chunks so the cap — not the channel
+        // closing — is what has to trigger the split.
+        let piece = vec![b'x'; 4096];
+        let mut expected = Vec::new();
+        for _ in 0..80 {
+            expected.extend_from_slice(&piece);
+            tx.send(PtyReadChunk {
+                data: piece.clone(),
+                osc_events: Vec::new(),
+            })
+            .unwrap();
+        }
+        drop(tx);
+
+        run_pty_output_flusher(rx, Some(Arc::new(broker)), "block-1".to_string(), Some(fs.clone()), false)
+            .await;
+
+        let data = fs.read_file("block-1", "term").expect("read_file ok").expect("data present");
+        assert_eq!(data, expected);
+
+        let broadcast_count = events.lock().unwrap().len();
+        assert!(
+            broadcast_count >= 2,
+            "80 * 4096 bytes exceeds PTY_COALESCE_MAX_BYTES; expected at least 2 broadcasts \
+             (the cap forcing an early flush), got {broadcast_count}"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_broker_is_a_clean_no_op() {
+        // Mirrors the read loop's own `broker_read.is_some()` gate — the
+        // flusher must not panic or hang when there is nothing to flush to.
+        let (_tx, rx) = tokio::sync::mpsc::unbounded_channel::<PtyReadChunk>();
+        run_pty_output_flusher(rx, None, "block-1".to_string(), None, false).await;
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/shell/pty.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/pty.rs
@@ -31,6 +31,23 @@ pub(super) const PTY_COALESCE_WINDOW: std::time::Duration = std::time::Duration:
 /// real bursts (a build's stdout in a 20ms window) while still bounded.
 pub(super) const PTY_COALESCE_MAX_BYTES: usize = 64 * PTY_READ_BUF_SIZE;
 
+/// Capacity of the channel handing PTY-read chunks from the blocking read
+/// loop to the async coalescing flusher (reagentx P1 on PR #3206).
+/// `PTY_COALESCE_MAX_BYTES` only bounds the batch currently being
+/// assembled — it does nothing about chunks still sitting in the channel
+/// if the flusher falls behind the read rate (slow disk, lock contention,
+/// several busy panes at once). An unbounded channel there would let a
+/// sustained fast producer (`yes`, a large `cat`) grow queued memory
+/// without limit. 128 chunks x up to ~PTY_READ_BUF_SIZE each is ~512KiB of
+/// worst-case queued-but-not-yet-batched data per pane — real headroom
+/// above one coalesced batch, but strictly bounded. The read loop sends
+/// via `blocking_send`, which blocks the calling (already-blocking-pool)
+/// thread once the channel is full, propagating real backpressure to the
+/// PTY read rate — and from there, via the kernel's own PTY buffer, to the
+/// child process itself, the same way a slow terminal reader naturally
+/// backpressures a fast writer.
+pub(super) const PTY_CHANNEL_CAPACITY: usize = 128;
+
 /// Detect the best available interactive shell on Windows.
 ///
 /// Mirrors the original Go logic from pkg/util/shellutil/shellutil.go DetectLocalShellPath():

--- a/agentmux-srv/src/backend/blockcontroller/shell/pty.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell/pty.rs
@@ -11,6 +11,26 @@ use crate::backend::obj::RuntimeOpts;
 /// PTY read buffer size (matches Go's 4096).
 pub(super) const PTY_READ_BUF_SIZE: usize = 4096;
 
+/// How long the PTY output flusher waits, after the first chunk of a new
+/// batch, for more chunks to arrive before broadcasting — see
+/// `docs/reports/REPORT_RENDERER_CPU_UNBATCHED_PTY_OUTPUT_2026_09_11.md`.
+/// A fast producer (a build, a verbose test run, a busy agent) delivers
+/// output across many separate `read()` returns in quick succession; without
+/// this window, each one fired its own file write + WebSocket broadcast +
+/// OSC/translation pass, and the aggregate IPC/wakeup rate was measurably
+/// costing real CPU in the renderer and GPU-helper processes. 20ms is well
+/// under human-perceptible latency (and under round-trip costs already
+/// elsewhere in this pipeline), so a single short burst — a keystroke echo,
+/// a one-line response — still appears with no felt delay.
+pub(super) const PTY_COALESCE_WINDOW: std::time::Duration = std::time::Duration::from_millis(20);
+
+/// Hard cap on how many bytes one coalesced batch accumulates before it is
+/// flushed regardless of the time window — bounds both broadcast latency and
+/// memory during a sustained, very fast burst (e.g. `yes` piped through a
+/// shell pane). 64x a single PTY_READ_BUF_SIZE read: generous headroom for
+/// real bursts (a build's stdout in a 20ms window) while still bounded.
+pub(super) const PTY_COALESCE_MAX_BYTES: usize = 64 * PTY_READ_BUF_SIZE;
+
 /// Detect the best available interactive shell on Windows.
 ///
 /// Mirrors the original Go logic from pkg/util/shellutil/shellutil.go DetectLocalShellPath():

--- a/docs/reports/REPORT_RENDERER_CPU_UNBATCHED_PTY_OUTPUT_2026_09_11.md
+++ b/docs/reports/REPORT_RENDERER_CPU_UNBATCHED_PTY_OUTPUT_2026_09_11.md
@@ -139,8 +139,10 @@ contributor, consistent with everything measured.
 read loop's blocking `read()` semantics are completely untouched (this file
 supports both Unix and Windows PTYs, and that boundary is not something to
 risk getting subtly platform-wrong). Instead, the loop now sends each
-already-OSC-cleaned chunk through an `mpsc::unbounded_channel` to a new,
-standalone async fn, `run_pty_output_flusher`, which:
+already-OSC-cleaned chunk through a **bounded** `mpsc::channel` (capacity
+`PTY_CHANNEL_CAPACITY` = 128, via `blocking_send` from the read loop's
+own blocking thread — see §7's review-round fixes for why this matters) to
+a new, standalone async fn, `run_pty_output_flusher`, which:
 
 - waits for the first chunk of a new batch, then opportunistically drains
   any more that are already queued (or arrive within `PTY_COALESCE_WINDOW`
@@ -194,3 +196,57 @@ action on shared state, not something to do unasked mid-investigation.
 Left for the repo owner to trigger deliberately (a `task package:macos`
 build + manual swap, or simply picking this fix up in the next normal
 release) rather than done silently here.
+
+## 8. Review round — two real gaps in the first cut (reagentx P1 x2, PR #3206)
+
+Both caught before merge, both would have undermined the fix under the
+exact load scenario it targets (several busy panes streaming at once):
+
+1. **The channel itself was unbounded.** `PTY_COALESCE_MAX_BYTES` only
+   bounds the batch currently being assembled — nothing bounded chunks
+   still queued in the channel if the flusher fell behind the read rate
+   (slow disk, lock contention, several busy panes at once). A sustained
+   fast producer (`yes`, a large `cat`) could have grown queued memory
+   without limit — the exact failure mode §4's fix was supposed to close,
+   reintroduced one layer up.
+
+   Fixed: bounded `mpsc::channel(PTY_CHANNEL_CAPACITY = 128)`. The read
+   loop's send moved from `send` to `blocking_send` (correct because that
+   closure runs on a `spawn_blocking` thread, not async — a bounded
+   channel's plain `send` is itself async). `blocking_send` blocks the
+   calling thread once the channel is full, propagating real backpressure
+   to the PTY read rate and, via the kernel's own PTY buffer, to the child
+   process itself.
+
+2. **`flush_pty_batch` ran synchronously inside a plain `tokio::spawn`
+   task.** It does blocking SQLite I/O and takes `std::sync::Mutex`
+   locks — previously safe inside `spawn_blocking`, now running directly
+   on a Tokio async worker thread. With several streaming panes at once,
+   slow disk or lock contention could occupy every worker and delay
+   WebSocket/input/RPC tasks unrelated to the pane that's actually slow.
+
+   Fixed: wrapped the flush call in `tokio::task::block_in_place` rather
+   than `spawn_blocking` — the latter needs `'static + Send` ownership of
+   everything the closure touches, and `flush_pty_batch` borrows `&mut
+   line_buf` / `translator.as_mut()` from the flusher's own stack;
+   `block_in_place` runs inline on the current thread with no such
+   transfer, while telling the runtime to spin up a replacement worker so
+   other tasks aren't starved. Requires a multi-thread runtime —
+   `agentmux-srv`'s `#[tokio::main]` is one by default.
+
+**Verification, this round:**
+
+- New test, `blocking_send_backpressures_once_the_channel_is_full`: fills
+  a capacity-1 channel, confirms a second `blocking_send` from a real
+  background thread (mirroring the production call shape — a genuine OS
+  thread, not an async task) stays blocked while the channel is full, then
+  completes once drained. Stable across 6 repeated local runs before
+  trusting the timing-based negative assertion.
+- The two existing end-to-end coalescing tests needed
+  `#[tokio::test(flavor = "multi_thread")]` — plain `#[tokio::test]`
+  defaults to a current-thread runtime, which panics on
+  `block_in_place`. This is a test-harness-only requirement; production
+  is unaffected, since `#[tokio::main]` already defaults multi-thread.
+  Caught immediately by the test suite itself the moment `block_in_place`
+  was added — exactly the way it's supposed to work.
+- `cargo test -p agentmux-srv -- --test-threads=1`: 3332 passed, 0 failed.

--- a/docs/reports/REPORT_RENDERER_CPU_UNBATCHED_PTY_OUTPUT_2026_09_11.md
+++ b/docs/reports/REPORT_RENDERER_CPU_UNBATCHED_PTY_OUTPUT_2026_09_11.md
@@ -1,0 +1,196 @@
+# Report: renderer/GPU-helper CPU during active agent output — RCA and fix
+
+**Date:** 2026-09-11
+**Trigger:** repo owner, live: *"figure out why the agentmux helper takes up
+so much CPU. we can feel the slowdown."*
+**Status:** Active — RCA complete, fix implemented and unit-verified (§6-7). Live production CPU comparison deliberately deferred — see §7.
+**Method:** Live measurement on the affected machine (this is not doc
+archaeology or a synthetic repro) — `ps`/`top` for real-time CPU, macOS
+`sample` for a stack-level profile of the hot process, `muxspect` for live
+pane state, then a direct read of the current PTY read path on `main`.
+
+---
+
+## 1. Symptom
+
+`AgentMux Helper (Renderer)` and `AgentMux Helper (GPU)` — CEF helper
+processes belonging to a long-running installed AgentMux window (channel
+`local-clare06219-734214c7f-20260906t141543`, up 4+ days) — were observed
+consuming sustained, user-perceptible CPU. Confirmed real via four
+consecutive live `top -pid` reads, ~1s apart:
+
+```
+PID    COMMAND          %CPU
+39396  AgentMux Helper  0.0
+39396  AgentMux Helper  27.7
+39396  AgentMux Helper  18.3
+39396  AgentMux Helper  18.4
+
+39391  AgentMux Helper  0.0
+39391  AgentMux Helper  17.8
+39391  AgentMux Helper  16.0
+39391  AgentMux Helper  16.4
+```
+
+Bursty — roughly once-per-second peaks, not a flat 100%-of-one-core spin —
+but real and sustained over the whole observation window, not a one-off
+transient.
+
+## 2. What the CPU is actually doing (profiled, not guessed)
+
+`sample`d PID 39396 (the renderer) for 15 seconds at 1ms resolution. The
+"sort by top of stack" breakdown — which function each thread was inside at
+the moment of each sample — was overwhelmingly:
+
+| Frame | Samples (of ~253k total) |
+|---|---|
+| `mach_msg2_trap` | 176,807 |
+| `kevent64` | 50,192 |
+| `__workq_kernreturn` | 12,719 |
+| `read` | 12,697 |
+| every actual "doing work" frame (memmove, memset, CEF-internal) | single/double digits each |
+
+This is the signature of **many small, frequent wakeups and IPC round-trips**
+— threads constantly blocking on `mach_msg`/`kevent`/`read` and getting woken
+again — not a single hot function spinning. If this were a stuck computation
+or a busy-loop bug, one or a few frames would dominate the "doing work"
+column instead. They don't; that column is nearly empty by comparison to the
+wakeup frames.
+
+## 3. What was live on this window at the time
+
+`muxspect list` against this exact instance showed two agent panes, **both
+`turn_active: true`** at the moment of investigation — one of them this very
+investigating session. This machine has run multiple concurrent, long-lived
+agent sessions (confirmed separately via `ps`: at least three resumed
+`claude` processes) producing continuous, high-volume terminal/build output
+(cargo builds, git operations, test suites, log tails) for hours in this
+window.
+
+## 4. Root cause
+
+`agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs`'s PTY output
+read loop (the thread that owns each pane's PTY):
+
+```rust
+let mut buf = [0u8; PTY_READ_BUF_SIZE];   // PTY_READ_BUF_SIZE = 4096, pty.rs:12
+loop {
+    match reader.read(&mut buf) {
+        Ok(0) => break,
+        Ok(n) => {
+            // ... OSC extraction ...
+            handle_append_block_file(broker, &block_id_read, "term", chunk, ...);
+            //  ^ file-store write AND live WebSocket broadcast to the
+            //    renderer, unconditionally, on EVERY read() return.
+            for ev in &osc_events { wps::publish_block_activity(...); }
+            if let Some(ref mut t) = translator {
+                accumulate_and_translate(...);   // agent-pane JSON-stream path
+            }
+        }
+        Err(_) => break,
+    }
+}
+```
+
+**There is no batching or coalescing between consecutive reads.** `read()`
+returns as soon as the OS has *any* data ready, up to 4KB — it does not wait
+to fill the buffer. A fast producer (exactly what `cargo build`, `git log`,
+or a verbose test run is) causes the OS to deliver output across many
+separate `read()` returns in quick succession, and **every single one**
+triggers the full downstream pipeline: a disk write, a live WebSocket
+broadcast to the renderer, OSC extraction, and — for agent panes — a
+JSON-stream-translation pass.
+
+Each of those broadcasts is individually cheap. The *rate* is not: a burst
+of output that could be delivered as one or two renderer updates instead
+generates dozens of small ones, each carrying its own IPC round-trip
+(browser process → renderer, `mach_msg` under the hood) and its own paint /
+xterm.js write. That matches §2's profile exactly — CPU dominated by wakeup
+and IPC-wait frames, not by any single expensive operation — and matches §3:
+it only shows up as *user-perceptible* when a pane is actively streaming
+fast, which two panes on this exact window were doing at the time.
+
+This is not a stuck process, a leak, or an infinite loop. It is the
+aggregate cost of firing one full render update per 4KB PTY chunk instead of
+coalescing a burst into fewer, larger ones — paid continuously by every
+agent/terminal pane that is actively producing fast output, which on a
+machine running several long, verbose agent sessions concurrently is close
+to constant.
+
+## 5. What this report does NOT claim
+
+No direct browser-side (DevTools/CEF) profile correlating individual
+WebSocket message timestamps to the observed CPU bursts was taken — this
+agent's shell has no screen access on this machine (established earlier this
+session; see memory `macos-agent-shell-verification-limits`). §2–§4 are
+strong, convergent circumstantial evidence — a live measurement, a stack
+profile, live pane state, and a direct code read that all point the same
+way — not a single smoking-gun trace. A human with DevTools access could
+tighten this further by watching the WS message rate during a live `cargo
+build` in an agent pane against the same CPU counters.
+
+This report also does not claim every renderer/GPU CPU cost on this machine
+traces to this one path — only that it is a real, evidenced, and structural
+contributor, consistent with everything measured.
+
+## 6. Fix — implemented
+
+`agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs`: the PTY
+read loop's blocking `read()` semantics are completely untouched (this file
+supports both Unix and Windows PTYs, and that boundary is not something to
+risk getting subtly platform-wrong). Instead, the loop now sends each
+already-OSC-cleaned chunk through an `mpsc::unbounded_channel` to a new,
+standalone async fn, `run_pty_output_flusher`, which:
+
+- waits for the first chunk of a new batch, then opportunistically drains
+  any more that are already queued (or arrive within `PTY_COALESCE_WINDOW`
+  = 20ms) into the same batch;
+- stops early, regardless of the time window, once the batch reaches
+  `PTY_COALESCE_MAX_BYTES` (64 × the 4KB single-read size = 256KiB) — bounds
+  both broadcast latency and memory during a sustained fast burst (`yes`
+  piped into a shell pane);
+- flushes the whole batch through one call to `flush_pty_batch` (the file
+  write, WebSocket broadcast, OSC-activity publish, and agent-translation
+  step that used to run once per raw read, now once per batch);
+- flushes any final partial batch when the channel closes (PTY EOF/error)
+  rather than dropping it.
+
+Content is unaffected — same bytes, same order, just batched into fewer
+calls; scrollback persistence, OSC title extraction, and the agent
+JSON-stream translator all see identical input to before.
+
+## 7. Verification
+
+**Done:**
+
+- `cargo test -p agentmux-srv`: 3280 passed, 0 failed — no regression in
+  the existing PTY/lifecycle/scrollback/OSC/translation test coverage.
+- Five new tests directly exercise the new logic (not just the surrounding
+  code), against a real in-memory `FileStore` and a real `wps::Broker` with
+  a recording `WpsClient` so broadcast *count* — not just final content —
+  is observable:
+  - `flush_pty_batch_writes_and_broadcasts_one_call` / `..._is_a_no_op_for_empty_input`
+    — the single-batch flush primitive in isolation.
+  - `rapid_chunks_coalesce_into_far_fewer_broadcasts_with_no_data_loss` —
+    50 chunks sent back-to-back (deterministic, not timing-dependent: every
+    chunk is queued before the flusher is ever polled) collapsed into
+    **exactly 1 broadcast**, verified stable across 8 repeated local runs
+    before asserting on the exact count rather than a loose bound. Final
+    content, and the concatenation of every individual broadcast payload in
+    delivery order, both reconstruct the exact original byte stream.
+  - `byte_cap_forces_a_flush_before_the_channel_closes` — 80 × 4KB chunks
+    (over the 256KiB cap) forced ≥2 broadcasts rather than growing one
+    batch unboundedly, with no data loss.
+  - `no_broker_is_a_clean_no_op` — mirrors the read loop's own
+    `broker.is_some()` gate.
+
+**Deliberately not done, and why:** a live before/after CPU comparison
+against the actual production instance (§1-3's evidence) would mean
+building and swapping in this binary on the shared AgentMux window this
+investigation was run from — restarting it, which tears down every open
+pane, including the sessions that were actively `turn_active: true` at the
+time of the original measurement. That is a real, visible, disruptive
+action on shared state, not something to do unasked mid-investigation.
+Left for the repo owner to trigger deliberately (a `task package:macos`
+build + manual swap, or simply picking this fix up in the next normal
+release) rather than done silently here.

--- a/docs/reports/REPORT_RENDERER_CPU_UNBATCHED_PTY_OUTPUT_2026_09_11.md
+++ b/docs/reports/REPORT_RENDERER_CPU_UNBATCHED_PTY_OUTPUT_2026_09_11.md
@@ -250,3 +250,39 @@ exact load scenario it targets (several busy panes streaming at once):
   Caught immediately by the test suite itself the moment `block_in_place`
   was added — exactly the way it's supposed to work.
 - `cargo test -p agentmux-srv -- --test-threads=1`: 3332 passed, 0 failed.
+
+## 9. Second review round — `block_in_place` itself was the wrong tool (reagentx P1, PR #3206)
+
+`block_in_place`, added in §8 specifically to avoid `spawn_blocking`'s
+`'static + Send` ownership requirement, was flagged as risking worker-thread
+growth under this fix's own target scenario (many panes, each flushing
+every ~20ms, concurrently, on a long-running process).
+
+Checked the claim against the actual mechanism rather than taking it on
+either side's word — read the vendored `tokio` 1.52.3 source directly
+(`runtime/scheduler/multi_thread/worker.rs`). `block_in_place`'s own
+replacement-worker path is `runtime::spawn_blocking(move || run(worker))` —
+it draws on the *same* shared `spawn_blocking` pool internally, so "unbounded
+growth" distinct from that pool doesn't hold literally. What does hold: using
+`block_in_place` here drew on that shared pool **twice** per flush (once for
+the replacement worker, once implicitly for the original thread continuing
+to run) for work `spawn_blocking` alone covers with one call — and tokio's
+own docs name `block_in_place`'s one genuine advantage over `spawn_blocking`
+as protecting other concurrent work *in the same task* (e.g. across a
+`join!`). This flusher task does nothing else concurrently, so that
+advantage never applied here — `spawn_blocking` was strictly the better fit,
+and the extra indirection was pure waste under exactly the high-throughput,
+many-panes scenario this whole fix targets.
+
+**Fix:** switched to `spawn_blocking`, solving the original ownership
+problem properly instead of routing around it — `batch`/`batch_osc` are
+freshly built every iteration (cheap to move), and `line_buf`/`translator`
+(the only state the flush mutates) are moved into the closure and handed
+back out via the `JoinHandle`'s return value, rather than kept borrowed
+across the call.
+
+**Verification:** the two coalescing tests no longer need
+`#[tokio::test(flavor = "multi_thread")]` — that requirement came from
+`block_in_place` specifically (panics on a current-thread runtime);
+`spawn_blocking` has none. Reverted to plain `#[tokio::test]`.
+`cargo test -p agentmux-srv -- --test-threads=1`: 3332 passed, 0 failed.


### PR DESCRIPTION
RCA + fix. Full investigation: `docs/reports/REPORT_RENDERER_CPU_UNBATCHED_PTY_OUTPUT_2026_09_11.md`.

Repo owner, live: *"figure out why the agentmux helper takes up so much CPU. we can feel the slowdown."*

## What I found (measured, not guessed)

- **Real, sustained CPU** confirmed via live `top -pid` reads: `AgentMux Helper (Renderer)` and `(GPU)` sustained 16–28% CPU in roughly-once-per-second bursts on a long-running production window.
- **Profiled** the renderer with macOS `sample` (15s @ 1ms resolution). The CPU time was overwhelmingly `mach_msg2_trap`/`kevent64` — 176,807 + 50,192 of ~253k samples — versus single/double-digit counts for every actual "doing work" frame. That's the signature of **many small, frequent wakeups**, not one hot function.
- **`muxspect`** showed two agent panes `turn_active: true` on that exact window at the time — one of them the investigating session itself.

## Root cause

`agentmux-srv/src/backend/blockcontroller/shell/lifecycle.rs`'s PTY output read loop reads in 4KB chunks with **zero batching**. Every single `read()` return fired its own file write, WebSocket broadcast, OSC extraction, and (for agent panes) JSON-stream translation pass. A fast producer — `cargo build`, `git log`, a verbose test run, all things this multi-agent session ran constantly — delivers output across many separate `read()` returns in quick succession, so what could have been one or two renderer updates became dozens of small ones, each its own IPC round-trip. Matches the profile exactly.

## Fix

The blocking `read()` loop's semantics are **completely untouched** — this file supports both Unix and Windows PTYs, and that boundary isn't something to risk getting subtly platform-wrong. Instead, reads now go through an `mpsc::unbounded_channel` to a new standalone async fn, `run_pty_output_flusher`, which:

- waits up to `PTY_COALESCE_WINDOW` (20ms) after the first chunk of a batch for more to arrive,
- or stops early at `PTY_COALESCE_MAX_BYTES` (256KiB) regardless of the window,
- does the file write + broadcast + OSC publish + translation **once per batch** instead of once per read,
- flushes any final partial batch when the channel closes (PTY EOF/error) rather than dropping it.

Content is byte-identical either way — same bytes, same order — only the call *frequency* changes.

## Verification

- `cargo test -p agentmux-srv`: **3280 passed, 0 failed** — no regression in existing PTY/lifecycle/scrollback/OSC/translation coverage.
- **5 new tests**, against a real in-memory `FileStore` + a real `wps::Broker` with a recording `WpsClient`, so broadcast **count** (not just final content) is directly observable — that's the property that actually matters here:
  - `rapid_chunks_coalesce_into_far_fewer_broadcasts_with_no_data_loss` — 50 back-to-back chunks collapse into **exactly 1 broadcast** (deterministic: every chunk is queued before the flusher is ever polled; verified stable across 8 repeated local runs before asserting the exact count rather than a loose bound), with content losslessly reconstructed both from the final file and from concatenating every broadcast payload in delivery order.
  - `byte_cap_forces_a_flush_before_the_channel_closes` — 80×4KB (over the cap) forces ≥2 broadcasts rather than growing one batch unboundedly.
  - Plus the single-batch flush primitive and the no-broker no-op path in isolation.

**Deliberately not done:** a live before/after CPU comparison against the actual production instance this investigation was run from. That would mean restarting the shared AgentMux window mid-investigation — tearing down every open pane, including ones that were actively `turn_active: true` at measurement time. That's a real, visible, disruptive action on shared state, not something to do unasked. Left for a deliberate follow-up (a `task package:macos` build + manual swap, or the next normal release) — see the report's §7 for exactly what would close this out.

<!-- agentmux:agent_id=agento -->